### PR TITLE
Modifying Vagrantfile to work with OSX

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/home/vagrant/hoot"#, group: "tomcat6", mount_options: ["dmode=775,fmode=664"]
+  config.vm.synced_folder ".", "/home/vagrant/hoot"#, group: "tomcat6", mount_options: ["dmode=775,fmode=775"]
   # UNCOMMENT group after initial provisioning, then run vagrant reload
 
   # Provider-specific configuration so you can fine-tune various

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/home/vagrant/hoot"#, group: "tomcat6"
+  config.vm.synced_folder ".", "/home/vagrant/hoot"#, group: "tomcat6", mount_options: ["dmode=775,fmode=664"]
   # UNCOMMENT group after initial provisioning, then run vagrant reload
 
   # Provider-specific configuration so you can fine-tune various


### PR DESCRIPTION
This commit adds filemode settings so that
Hoot can write to the shared folders on an
OS X host.

Please let me know if you have any questions or deem any modification necessary - I will be happy to adjust the code.