### PR TITLE
There is no error message if a user tries to import a dataset using an invalid translation file

### DIFF
--- a/hoot-js/src/main/cpp/hoot/js/JavaScriptTranslator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/JavaScriptTranslator.cpp
@@ -43,6 +43,7 @@
 #include <hoot/core/util/UuidHelper.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/js/util/DataConvertJs.h>
+#include <hoot/js/util/HootExceptionJs.h>
 #include <hoot/js/PluginContext.h>
 
 // Qt
@@ -866,8 +867,10 @@ QVariantList JavaScriptTranslator::_translateToOgrVariants(Tags& tags,
                         "(Missing translateToOgr)");
   }
 
+  TryCatch trycatch;
   // Hardcoded to 3 arguments
   Handle<Value> translated = tFunc->Call(tObj, 3, args);
+  HootExceptionJs::checkV8Exception(translated, trycatch);
 
   if (Log::getInstance().getLevel() <= Log::Debug)
   {
@@ -922,7 +925,9 @@ void JavaScriptTranslator::_translateToOsm(Tags& t, const char *layerName)
 
   // This has a variable since we don't know if it will be "translateToOsm" or "translateAttributes"
   Handle<v8::Function> tFunc = Handle<v8::Function>::Cast(tObj->Get(toV8(_toOsmFunctionName)));
+  TryCatch trycatch;
   Handle<Value> newTags = tFunc->Call(tObj, 2, args);
+  HootExceptionJs::checkV8Exception(newTags, trycatch);
 
   double start = 0.00; // to stop warnings
   if (Log::getInstance().getLevel() <= Log::Debug)

--- a/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
@@ -30,6 +30,7 @@
 #include <hoot/js/JsRegistrar.h>
 #include <hoot/js/util/DataConvertJs.h>
 #include <hoot/js/util/PopulateConsumersJs.h>
+#include <hoot/js/util/StringUtilsJs.h>
 
 namespace hoot
 {
@@ -138,6 +139,14 @@ void HootExceptionJs::throwAsHootException(TryCatch& tc)
       {
         throw HootException(toJson(exception));
       }
+    }
+    else if (exception->IsNativeError())
+    {
+      throw HootException(str(exception->ToDetailString()));
+    }
+    else if (exception->IsString())
+    {
+      throw HootException(str(exception));
     }
     else
     {

--- a/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
@@ -140,7 +140,9 @@ void HootExceptionJs::throwAsHootException(TryCatch& tc)
         throw HootException(toJson(exception));
       }
     }
-    else if (exception->IsNativeError())
+    // if this is a generic error (e.g. throw new Errro("blah");) then just report the string.
+    else if (exception->IsNativeError() &&
+      str(exception->ToObject()->GetConstructorName()) == "Error")
     {
       throw HootException(str(exception->ToDetailString()));
     }

--- a/plugins/translation_assistant.js
+++ b/plugins/translation_assistant.js
@@ -37,8 +37,7 @@ translation_assistant = {
 
         //Throw error if no matching attribute mapping could be found
         if (!l) {
-            var msg = 'No matching attribute mapping could be found!';
-            throw new Error(msg);
+            throw new Error('No matching attribute mapping could be found!');
         }
 
         for (var key in attrs)
@@ -100,8 +99,7 @@ translation_assistant = {
 
         //Throw error if no attrs were translated to tags
         if (Object.keys(tags).length === 0) {
-            var msg = 'No attributes could be translated to tags!';
-            throw new Error(msg);
+            throw new Error('No attributes could be translated to tags!');
         }
 
         return tags;


### PR DESCRIPTION
This pull request includes changes in translation assistant so that an error is thrown if no attributes can be translated (i.e. the translation file references doesn't match the attribute schema if the input source).
Hoot commands will now exit with an error status if the javascript translation raises an error.