### PR TITLE
Adding Parallels Provider

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -12,15 +12,25 @@ Once Vagrant has been installed, you can start an environment by checking out th
     git submodule update
     vagrant up
 
+If you would like to use Parallels instead of VirtualBox, please run the following command:
+    ```
+    vagrant up --provider=parallels
+    ```
+Please note that this requires the Parallels Vagrant plugin, which can be installed:
+
+    ```
+    vagrant plugin install vagrant-parallels
+    ```
+
 *On Windows hosts,*
 
 * Be sure to clone with the `--config core.autocrlf=input` option.
 * Windows hosts will also have to create a symlink that's in the git repo, but seems to be treated as a file when cloning to windows.
 
-    `vagrant ssh`  
-    `cd hoot`  
-    `rm test-files`  
-    `ln -s hoot-core-test/src/test/resources test-files`  
+    `vagrant ssh`
+    `cd hoot`
+    `rm test-files`
+    `ln -s hoot-core-test/src/test/resources test-files`
 
 The initialization of the vagrant vm will take a up to two hours to download required software from the internet and set it up as a running system. Once it is complete, uncomment the `#, group: "tomcat6"` portion of the in Vagrantfile to allow the webapp to write to shared folders.
 
@@ -55,3 +65,4 @@ If you've updated the code, you must connect to the vm via ssh to build and rede
     scripts/ezClean.sh
     scripts/ezBuildAll.sh
     sudo -u tomcat6 scripts/vagrantDeployTomcat.sh
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,15 @@ Vagrant.configure(2) do |config|
   #   vb.memory = 16384
     vb.cpus = 4
   end
+
+  # This is a provider for the Parallels Virtualization Software
+  # Run "vagrant up --provider=parallels" to spin up using parallels.
+  config.vm.provider "parallels" do |para, override|
+        para.memory = 8192
+        para.cpus = 4
+        override.vm.box = "parallels/ubuntu-14.04"
+        override.vm.box_url = "https://atlas.hashicorp.com/parallels/boxes/ubuntu-14.04"
+  end
   #
   # View the documentation for the provider you are using for more
   # information on available options.


### PR DESCRIPTION
Recreation of PR #33 against the develop branch.  Original PR description is as follows:

I recently switched my virtualization tools from VirtualBox to Parallels. In order to run Hoot on Parallels, I had to write a custom Vagrant provider specific to Parallels. I thought this might be useful to other Parallels users in the future. I've verified that this provider works by running vagrant up --provider=parallels. If Parallels is not installed, it should not make any difference in the provisioning process as it currently works.

This PR also contains a minor amount of documentation clean up, removing extraneous whitespace from the end of certain lines.

This might only be useful in my particular situation at the moment, so I would certainly understand if this is rejected from the main build pipe.

An interesting tidbit, on my box Hoot provisions in about 23 minutes using Parallels versus over an hour via VirtualBox.