### PR TITLE
Simplify parameters in mergeTags with toCpp

### DIFF
--- a/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
+++ b/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
@@ -2,4 +2,3 @@
 
 echo Hello World.
 echo This is an error. 1>&2
-echo break again

--- a/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
+++ b/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
@@ -2,3 +2,4 @@
 
 echo Hello World.
 echo This is an error. 1>&2
+echo break again

--- a/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
+++ b/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
@@ -2,4 +2,3 @@
 
 echo Hello World.
 echo This is an error. 1>&2
-echo artificial failure

--- a/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
+++ b/hoot-core-test/src/test/resources/cmd/quick/HelloWorld.sh
@@ -2,3 +2,4 @@
 
 echo Hello World.
 echo This is an error. 1>&2
+echo artificial failure

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.cpp
@@ -53,8 +53,8 @@ void TagMergerFactoryJs::Init(Handle<Object> exports)
 Handle<Value> TagMergerFactoryJs::mergeTags(const Arguments& args) {
   HandleScope scope;
 
-  Tags& t1 = ObjectWrap::Unwrap<TagsJs>(args[0]->ToObject())->getTags();
-  Tags& t2 = ObjectWrap::Unwrap<TagsJs>(args[1]->ToObject())->getTags();
+  Tags t1 = toCpp<Tags>(args[0]->ToObject());
+  Tags t2 = toCpp<Tags>(args[1]->ToObject());
 
   return scope.Close(TagsJs::New(TagMergerFactory::mergeTags(t1, t2, ElementType::Unknown)));
 }


### PR DESCRIPTION
1. refs #211 TagMergerFactory requires using Tag objects instead of {}