### PR TITLE
Minor changes to developer docs improving GitHub asciidoc rendering

### DIFF
--- a/docs/developer/HootenannyDevelopmentEnvironmentSetupInstructions.asciidoc
+++ b/docs/developer/HootenannyDevelopmentEnvironmentSetupInstructions.asciidoc
@@ -121,26 +121,25 @@ Download the ISO image for the latest 64-bit LTS release of 64-bit Ubuntu (14.04
 sudo apt-get purge automake
 sudo apt-get remove qt5-default postgresql-9.3
 sudo apt-get autoremove
---------------
+---------------
 
-. `sudo` `apt-get` `install` `texinfo` `g++` `libicu-dev` `libqt4-dev`
-  `git-core` `libboost-dev` `libcppunit-dev` `libcv-dev` `libopencv-dev`
-  `libopencv-core-dev` `libopencv-imgproc-dev`
-  `libgdal-dev` `liblog4cxx10-dev` `libnewmat10-dev` `libproj-dev` `python-dev`
-  `libjson-spirit-dev` `automake1.11` `protobuf-compiler` `libprotobuf-dev` `make` `gdb`
-  `libqt4-sql-psql` `libgeos-dev` `libgeos++-dev` `swig` `lcov` `tomcat6` `openjdk-7-jdk`
-  `openjdk-7-dbg` `maven` `libstxxl-dev` `zip` `nodejs-dev` `doxygen` `xsltproc`
-  `asciidoc` `pgadmin3` `curl` `npm` `postgresql-9.1-postgis` `libxerces-c-dev` `libxerces-c28` `libglpk-dev`
-  `libboost-all-dev` `source-highlight` `texlive-lang-all` `graphviz` `w3m``libhdf5-dev` `libgif-dev`
-  `gfortran` `python-setuptools` `python` `python-pip` `git` `postgresql-contrib-9.1`
-  `ccache` `libogdi3.2-dev` `gnuplot` `python-matplotlib` `postgresql-server-dev-9.1` `libxml-simple-perl`
-  `wamerican-insane`
+. `sudo apt-get install texinfo g++ libicu-dev libqt4-dev
+  git-core libboost-dev libcppunit-dev libcv-dev libopencv-dev
+  libopencv-core-dev libopencv-imgproc-dev
+  libgdal-dev liblog4cxx10-dev libnewmat10-dev libproj-dev python-dev
+  libjson-spirit-dev automake1.11 protobuf-compiler libprotobuf-dev make gdb
+  libqt4-sql-psql libgeos-dev libgeos++-dev swig lcov tomcat6 openjdk-7-jdk
+  openjdk-7-dbg maven libstxxl-dev zip nodejs-dev doxygen xsltproc
+  asciidoc pgadmin3 curl npm postgresql-9.1-postgis libxerces-c-dev libxerces-c28 libglpk-dev
+  libboost-all-dev source-highlight texlive-lang-all graphviz w3m libhdf5-dev libgif-dev
+  gfortran python-setuptools python python-pip git postgresql-contrib-9.1
+  ccache libogdi3.2-dev gnuplot python-matplotlib postgresql-server-dev-9.1 libxml-simple-perl
+  wamerican-insane`
 +
-
--------------
+--------------
 sudo apt-get autoremove
 --------------
-
++
 NOTE: In some cases, the package `libqt4-dev` may not install properly due to unmet dependencies. If an error message appears when attempting to compile Hoot core, it may be useful to remove all of the unmet dependencies listed when executing `sudo apt-get install libqt4-dev`, then remove `libqt4-dev` (`sudo apt-get remove libqt4-dev`) and reinstall without the unmet dependencies present.  Typically these will get installed by the dependent package.
 +
 . Modify `~/.profile` and append the following to the bottom of the file:


### PR DESCRIPTION
 * Removes extra backticks (`) in one long command (making it easier to copy
   and paste)
 * Corrects length of two delimited block separators so a large block of
   content doesn't render as pre-formatted / raw asciidoc text (missing
   hyphen -)
 * Adds a missing list continuation (+) character