### PR TITLE
User ogrinfo to check for errors with format related dependent libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,13 @@ m4_include([m4/ax_lib_gdal.m4])
 AX_LIB_GDAL([1.4.4])
 LIBS="$LIBS $GDAL_LDFLAGS $GDAL_DEP_LDFLAGS"
 CPPFLAGS="$CPPFLAGS $GDAL_CFLAGS"
+if test "${GDAL_OGR_ENABLED}" = "yes" ; then
+  ogrinfo --formats > /dev/null
+  OGR_FORMAT_EXIT_STATUS=`echo $?`
+  if test "$OGR_FORMAT_EXIT_STATUS" != "0"; then
+    AC_MSG_ERROR(["There is an error with one or more GDAL file formats."]);
+  fi
+fi
 if test "${GDAL_VERSION}" = "1.9.1" ; then
   AC_MSG_WARN(["GDAL v1.9.1 is known to have a bug in FileGDB export where the file can't be opened by ArcMap 10.2. GDAL v1.10.1 is known to work."]);
 fi


### PR DESCRIPTION
1. refs #214 
@mattjdnv Can you look at this one?  This should catch the situation where someone has GDAL compiled with FGDB support and the FGDB library isn't there.