### PR TITLE
Fixed LogLog4Cxx log level for Verbose

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/util/Log.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.cpp
@@ -136,6 +136,8 @@ QString Log::getLevelString(WarningLevel l)
     return "NONE";
   case Debug:
     return "DEBUG";
+  case Verbose:
+    return "VERBOSE";
   case Info:
     return "INFO";
   case Warn:

--- a/hoot-core/src/main/cpp/hoot/core/util/LogLog4Cxx.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/LogLog4Cxx.cpp
@@ -67,6 +67,9 @@ LevelPtr toLog4CxxLevel(Log::WarningLevel l)
   case Log::Info:
     return Level::getInfo();
     break;
+  case Log::Verbose:
+    return Level::getInfo();
+    break;
   case Log::Warn:
     return Level::getWarn();
     break;


### PR DESCRIPTION
1. refs #268 Fixed LogLog4Cxx log level for Verbose

Added Verbose to the Log4Cxx Info level.