### PR TITLE
175

### DIFF
--- a/hoot-core-test/src/test/resources/cmd/slow/ConflateExactTest.sh.stdout
+++ b/hoot-core-test/src/test/resources/cmd/slow/ConflateExactTest.sh.stdout
@@ -1,0 +1,6 @@
+16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 123) Tags do not match:
+16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 136) < hoot:review:note = The feature pair met neither the threshold for a match, miss, or review (review by default).
+16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 137) > hoot:review:note = BuildingMatch: Way:-718, Way:-2787 p: match: 0.55 miss: 0.45 review: 0 note: 
+16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 123) Tags do not match:
+16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 136) < hoot:review:note = The feature pair met neither the threshold for a match, miss, or review (review by default).
+16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 137) > hoot:review:note = BuildingMatch: Way:-853, Way:-2521 p: match: 0.425 miss: 0.175 review: 0.4 note: 

--- a/hoot-core-test/src/test/resources/cmd/slow/ConflateExactTest.sh.stdout
+++ b/hoot-core-test/src/test/resources/cmd/slow/ConflateExactTest.sh.stdout
@@ -1,6 +1,6 @@
-16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 123) Tags do not match:
-16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 136) < hoot:review:note = The feature pair met neither the threshold for a match, miss, or review (review by default).
-16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 137) > hoot:review:note = BuildingMatch: Way:-718, Way:-2787 p: match: 0.55 miss: 0.45 review: 0 note: 
-16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 123) Tags do not match:
-16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 136) < hoot:review:note = The feature pair met neither the threshold for a match, miss, or review (review by default).
-16:17:53.539 WARN  ...core/scoring/MapComparator.cpp( 137) > hoot:review:note = BuildingMatch: Way:-853, Way:-2521 p: match: 0.425 miss: 0.175 review: 0.4 note: 
+12:21:50.917 WARN  ...core/scoring/MapComparator.cpp( 123) Tags do not match:
+12:21:50.917 WARN  ...core/scoring/MapComparator.cpp( 136) < hoot:review:note = The feature pair met neither the threshold for a match, miss, or review (set to review by default).  match score: 0.55, miss score: 0.45, review score: 0, match threshold: 0.6, miss threshold: 0.6, review threshold: 0.6
+12:21:50.917 WARN  ...core/scoring/MapComparator.cpp( 137) > hoot:review:note = BuildingMatch: Way:-718, Way:-2787 p: match: 0.55 miss: 0.45 review: 0 note: 
+12:21:50.917 WARN  ...core/scoring/MapComparator.cpp( 123) Tags do not match:
+12:21:50.917 WARN  ...core/scoring/MapComparator.cpp( 136) < hoot:review:note = The feature pair met neither the threshold for a match, miss, or review (set to review by default).  match score: 0.425, miss score: 0.175, review score: 0.4, match threshold: 0.6, miss threshold: 0.6, review threshold: 0.6
+12:21:50.917 WARN  ...core/scoring/MapComparator.cpp( 137) > hoot:review:note = BuildingMatch: Way:-853, Way:-2521 p: match: 0.425 miss: 0.175 review: 0.4 note: 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MatchThreshold.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MatchThreshold.cpp
@@ -64,6 +64,30 @@ MatchType MatchThreshold::getType(const MatchClassification& mc) const
   }
 }
 
+QString MatchThreshold::getTypeDetail(const MatchClassification& mc) const
+{
+  if (mc.getReviewP() >= _reviewThreshold)
+  {
+    return "The feature pair met the threshold for review.";
+  }
+  else if (mc.getMatchP() >= _matchThreshold && mc.getMissP() >= _missThreshold)
+  {
+    return "The feature pair met neither the threshold for a match or a miss.";
+  }
+  else if (mc.getMatchP() >= _matchThreshold)
+  {
+    return "The feature pair met the threshold for a match.";
+  }
+  else if (mc.getMissP() >= _missThreshold)
+  {
+    return "The feature pair met the threshold for a miss.";
+  }
+  else
+  {
+    return "The feature pair met neither the threshold for a match, miss, or review (review by default).";
+  }
+}
+
 QString MatchThreshold::toString() const
 {
   return QString("Thresholds; Match: %1 Miss: %2 Review: %3").arg(_matchThreshold).

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MatchThreshold.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MatchThreshold.cpp
@@ -68,23 +68,45 @@ QString MatchThreshold::getTypeDetail(const MatchClassification& mc) const
 {
   if (mc.getReviewP() >= _reviewThreshold)
   {
-    return "The feature pair met the threshold for review.";
+    return QString("The feature pair met the threshold for review.") +
+           QString("  review score: %1, review threshold: %2")
+             .arg(mc.getReviewP())
+             .arg(_reviewThreshold);
   }
   else if (mc.getMatchP() >= _matchThreshold && mc.getMissP() >= _missThreshold)
   {
-    return "The feature pair met neither the threshold for a match or a miss.";
+    return QString("The feature pair met neither the threshold for a match or a miss.")  +
+           QString("  match score: %1, miss score: %2, match threshold: %3, miss threshold: %4")
+             .arg(mc.getMatchP())
+             .arg(mc.getMissP())
+             .arg(_matchThreshold)
+             .arg(_missThreshold);
+
   }
   else if (mc.getMatchP() >= _matchThreshold)
   {
-    return "The feature pair met the threshold for a match.";
+    return QString("The feature pair met the threshold for a match.") +
+           QString("  match score: %1, match threshold: %2")
+             .arg(mc.getMatchP())
+             .arg(_matchThreshold);
   }
   else if (mc.getMissP() >= _missThreshold)
   {
-    return "The feature pair met the threshold for a miss.";
+    return QString("The feature pair met the threshold for a miss.");
+           QString("  miss score: %1, miss threshold: %2")
+             .arg(mc.getMissP())
+             .arg(_missThreshold);
   }
   else
   {
-    return "The feature pair met neither the threshold for a match, miss, or review (review by default).";
+    return QString("The feature pair met neither the threshold for a match, miss, or review (set to review by default).") +
+           QString("  match score: %1, miss score: %2, review score: %3, match threshold: %4, miss threshold: %5, review threshold: %6")
+             .arg(mc.getMatchP())
+             .arg(mc.getMissP())
+             .arg(mc.getReviewP())
+             .arg(_matchThreshold)
+             .arg(_missThreshold)
+             .arg(_reviewThreshold);
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MatchThreshold.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MatchThreshold.h
@@ -58,6 +58,14 @@ public:
   MatchType getType(const Match& m) const { return getType(m.getClassification()); }
   MatchType getType(const MatchClassification& mc) const;
 
+  /**
+   * Returns human readable information about the match type
+   *
+   * @param mc match classification
+   * @return match type information
+   */
+  QString getTypeDetail(const MatchClassification& mc) const;
+
   QString toString() const;
 
 private:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
@@ -74,9 +74,12 @@ HighwayMatch::HighwayMatch(const shared_ptr<HighwayClassifier>& classifier,
       // calculate the match score
       _c = _classifier->classify(map, eid1, eid2, _sublineMatch);
       stringstream ss;
-      ss << "HighwayMatch " << _eid1.toString() << " " << _eid2.toString() << " P: "
-         << _c.toString() << " features: " << getFeatures(map);
+      ss << mt->getTypeDetail(_c);
       _explainText = QString::fromUtf8(ss.str().data());
+
+      stringstream ss2;
+      ss2 << toString() << " features: " << getFeatures(map);
+      //LOG_DEBUG(QString::fromUtf8(ss2.str().data()));
     }
     else
     {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
@@ -86,6 +86,11 @@ BuildingMatch::BuildingMatch(const ConstOsmMapPtr& map, shared_ptr<const Buildin
     _p.setReviewP(1.0);
     _explainText = "Unmatched buildings are overlapping.";
   }
+  else
+  {
+    _explainText = mt->getTypeDetail(_p);
+  }
+  //LOG_DEBUG(toString());
 }
 
 map<QString, double> BuildingMatch::getFeatures(const shared_ptr<const OsmMap>& m) const
@@ -122,20 +127,11 @@ QString BuildingMatch::toString() const
 {
   stringstream ss;
   ss << "BuildingMatch: " << _eid1 << ", " << _eid2 << " p: " << _p.toString();
-  if (getType() == MatchType::Review)
-  {
-    ss << " note: " << _explainText;
-  }
+  //if (getType() == MatchType::Review)
+  //{
+    //ss << " note: " << _explainText;
+  //}
   return QString::fromStdString(ss.str());
-}
-
-QString BuildingMatch::explain() const
-{
-  if (!_explainText.isEmpty())
-  {
-    return _explainText;
-  }
-  return toString();
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.h
@@ -82,7 +82,7 @@ public:
 
   virtual QString toString() const;
 
-  virtual QString explain() const;
+  virtual QString explain() const { return _explainText; }
 
 private:
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatch.cpp
@@ -105,6 +105,10 @@ void ScriptMatch::_calculateClassification(const ConstOsmMapPtr& map, Handle<Obj
     _p.setReviewP(_script->toNumber(v, "review", 0));
 
     _explainText = vm["explain"].toString();
+    if (_explainText.isEmpty())
+    {
+      _explainText = _threshold->getTypeDetail(_p);
+    }
     if (_threshold->getType(_p) == MatchType::Review)
     {
       if (_explainText.isEmpty())


### PR DESCRIPTION
@mattjdnv Can you look at this?  Basically, I made the review note message more readable for road, building, and generic reviews.  You'll see the new text I added for any reviews that weren't flagged specifically by the system as needing review with review score = 1.0 as a result of an exception case  (e.g. won't see it in the note for unmatched overlapping buildings...will just see the original message there).