### PR TITLE
Remove reference to property_map header refd by older versions of boo…

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/match-graph/MatchGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/match-graph/MatchGraph.cpp
@@ -37,9 +37,6 @@
 #include <boost/graph/properties.hpp>
 #if HOOT_HAVE_BOOST_PROPERTY_MAP_PROPERTY_MAP_HPP
 # include <boost/property_map/property_map.hpp>
-#elif HOOT_HAVE_BOOST_PROPERTY_MAP_HPP
-// use the old include file so it works on boost releases < 1.40 (e.g. RHEL 5)
-# include <boost/property_map.hpp>
 #else
 # error "Boost properties include not found during configure."
 #endif

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -36,9 +36,6 @@
 #include <boost/graph/properties.hpp>
 #if HOOT_HAVE_BOOST_PROPERTY_MAP_PROPERTY_MAP_HPP
 # include <boost/property_map/property_map.hpp>
-#elif HOOT_HAVE_BOOST_PROPERTY_MAP_HPP
-// use the old include file so it works on boost releases < 1.40 (e.g. RHEL 5)
-# include <boost/property_map.hpp>
 #else
 # error "Boost properties include not found during configure."
 #endif

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -1,7 +1,7 @@
 AC_DEFUN([AX_LIB_BOOST],
 [
     AC_LANG_PUSH([C++])
-    AC_CHECK_HEADERS([boost/property_map.hpp boost/property_map/property_map.hpp], [hootFoundBoostPropHeaders=yes; break;])
+    AC_CHECK_HEADERS([boost/property_map/property_map.hpp], [hootFoundBoostPropHeaders=yes; break;])
     AS_IF([test "x$hootFoundBoostPropHeaders" != "xyes"], [AC_MSG_ERROR([Unable to find the boost property_map headers])])
     AC_LANG_POP
     


### PR DESCRIPTION
…st than hoot uses

1. refs #278 

@jasonsurratt I fixed this by removing the header check for the propery_map header in the old location used by the versions of boost older than what hoot is configured with now.  Since we're controlling the rpm install and determining the version of boost, that's an ok solution, right?