### PR TITLE
Handle "Unknown Geometry" types during OSM ingest

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.cpp
@@ -307,7 +307,6 @@ geos::geom::GeometryTypeId ElementConverter::getGeometryType(const ConstElementP
 
       // We are going to throw an error so we save the type of relation
       relationType = r->getType();
-
       break;
 
     }
@@ -330,7 +329,7 @@ geos::geom::GeometryTypeId ElementConverter::getGeometryType(const ConstElementP
   }
   else
   {
-    return GeometryTypeId(-1);
+    return GeometryTypeId(UNKNOWN_GEOMETRY);
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
@@ -111,6 +111,8 @@ public:
   static geos::geom::GeometryTypeId getGeometryType(const ConstElementPtr& e,
     bool throwError=true, const bool statsFlag=false);
 
+  static const int UNKNOWN_GEOMETRY = -1;
+
 protected:
   ConstElementProviderPtr                 _constProvider;
   boost::shared_ptr<OGRSpatialReference>  _spatialReference;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/TranslationVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/TranslationVisitor.cpp
@@ -122,7 +122,6 @@ void TranslationVisitor::visit(const ConstElementPtr& ce)
         geomType = "Collection";
         break;
       default:
-        LOG_ERROR("TransVisit Geometry Type = " << gtype);
         throw InternalErrorException("Unexpected geometry type.");
       }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/TranslationVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/TranslationVisitor.cpp
@@ -73,6 +73,12 @@ void TranslationVisitor::visit(const ConstElementPtr& ce)
   {
     GeometryTypeId gtype = ElementConverter::getGeometryType(e, false);
 
+    // If we don't know what it is, no point in translating it.
+    if (gtype == ElementConverter::UNKNOWN_GEOMETRY)
+    {
+      return;
+    }
+
     if (_toOgr)
     {
 
@@ -116,6 +122,7 @@ void TranslationVisitor::visit(const ConstElementPtr& ce)
         geomType = "Collection";
         break;
       default:
+        LOG_ERROR("TransVisit Geometry Type = " << gtype);
         throw InternalErrorException("Unexpected geometry type.");
       }
 


### PR DESCRIPTION
@jasonsurratt The fix works but I'm not too happy with what we return from ElementConverter.cpp for Reviews and probably Collections as well.  Should a Review return something like "NoGeometry" instead of a "GEOS_GEOMETRYCOLLECTION" ?

