### PR TITLE
Compress words1.sqlite

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -349,8 +349,12 @@ conf/words.sqlite: conf/words1.sqlite
 # If you create a new words.sqlite please just increment the number rather than
 # replacing the old file. This way we can maintain the history.
 conf/words1.sqlite:
-	([ -e /tmp/words1.sqlite ] && test "`sha1sum /tmp/words1.sqlite`" == '4f7333e8e084927fafda3047183302407961b851  /tmp/words1.sqlite' && cp /tmp/words1.sqlite conf/) || \
-	wget -N -P conf/ https://github.com/ngageoint/hootenanny/releases/download/v0.2.16/words1.sqlite || echo "Failure downloading words1.sqlite. Build will continue, but conflation accuracy may suffer."
+	([ -e /tmp/words1.sqlite.bz2 ] && \
+	 test "`sha1sum /tmp/words1.sqlite.bz2`" == 'cdf47302fec4c8ec6c576849ae877feb1a9cf220  /tmp/words1.sqlite.bz2' && \
+	 bzcat /tmp/words1.sqlite.bz2 > conf/words1.sqlite) || \
+	(wget -N -P /tmp/ https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2 && \
+	 bzcat /tmp/words1.sqlite.bz2 > conf/words1.sqlite) || \
+	echo "Failure downloading words1.sqlite. Build will continue, but conflation accuracy may suffer."
 
 bin/HootEnv.sh: scripts/HootEnv.sh
 	mkdir -p bin

--- a/conf/ConfigOptions.asciidoc
+++ b/conf/ConfigOptions.asciidoc
@@ -2099,7 +2099,7 @@ Location of the word frequency dictionary. If the absolute file path isn't found
 the local `conf` and `$HOOT_HOME/conf` directories will be searched.
 
 This file is typically downloaded from:
-https://github.com/ngageoint/hootenanny/releases/download/v0.2.16/words1.sqlite
+https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2
 
 === weighted.word.distance.p
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/WeightedWordDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/WeightedWordDistance.cpp
@@ -69,7 +69,7 @@ WeightedWordDistance::WeightedWordDistance()
   {
     LOG_WARN("Unable to locate words.sqlite. This should be downloaded during the make "
       "process. It can be manually downloaded from "
-      "https://github.com/ngageoint/hootenanny/releases/download/v0.2.16/words1.sqlite "
+      "https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2 "
       "or similar. You can also override the default name with the " +
       ConfigOptions().getWeightedWordDistanceDictionaryKey() + " config option.");
     dictPath = ConfPath::search(ConfigOptions().getWeightedWordDistanceAbridgedDictionary());


### PR DESCRIPTION
Refs #317 
Updated Makefile to download the compressed words1.sqlite file to the /tmp folder and extract it to $HOOT_HOME/conf.  Also updated documentation to use the new location for the file.