### PR TITLE
TA should return null if no attributes could be translated to tags

### DIFF
--- a/plugins/test/translation_assistant.js
+++ b/plugins/test/translation_assistant.js
@@ -348,11 +348,11 @@ describe('translateAttributes', function(){
     it('should translate shapefile attributes to osm tags', function(){
         assert.equal(JSON.stringify(translation.translateAttributes(attrs, layerName, mapping)), JSON.stringify(tags));
     })
-    it('should throw an error if no attributes could be translated to tags', function(){
-        assert.throws(function() { translation.translateAttributes(attrsNoMatch, layerName, mapping); }, Error);
+    it('should return null if no attributes could be translated to tags', function(){
+        assert.equal(translation.translateAttributes(attrsNoMatch, layerName, mapping), null);
     })
-    it('should throw an error if no layere name matched and no attributes could be translated to tags', function(){
-        assert.throws(function() { translation.translateAttributes(attrsLNoMatch, 'foo', mapping); }, Error);
+    it('should return null if no layer name matched and no attributes could be translated to tags', function(){
+        assert.equal(translation.translateAttributes(attrsNoMatch, 'foo', mapping), null);
     })
     it('for duplicate tag keys, values should be appended', function(){
         assert.equal(JSON.stringify(translation.translateAttributes(attrs, layerName, mappingWithDuplicateTags)), JSON.stringify(tagsWithDuplicateKeys));

--- a/plugins/translation_assistant.js
+++ b/plugins/translation_assistant.js
@@ -35,9 +35,9 @@ translation_assistant = {
             }
         }
 
-        //Throw error if no matching attribute mapping could be found
+        //Don't translate feature if no matching attribute mapping could be found
         if (!l) {
-            throw new Error('No matching attribute mapping could be found!');
+            return null;
         }
 
         for (var key in attrs)
@@ -97,9 +97,9 @@ translation_assistant = {
             }
         }
 
-        //Throw error if no attrs were translated to tags
+        //Don't translate feature if no attrs were translated to tags
         if (Object.keys(tags).length === 0) {
-            throw new Error('No attributes could be translated to tags!');
+            return null;
         }
 
         return tags;


### PR DESCRIPTION
This effectively drops the feature from the translated output,
instead of throwing an error.

See https://github.com/ngageoint/hootenanny-ui/issues/205