### PR TITLE
Conflation fails for clipped Port Au Prince data when stats are turned on

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.cpp
@@ -89,7 +89,7 @@ Meters ElementConverter::calculateLength(const ConstElementPtr &e) const
   }
 }
 
-shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Element>& e, const bool throwError,
+shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Element>& e, bool throwError,
                                                          const bool statsFlag) const
 {
   switch(e->getElementType().getEnum())

--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.cpp
@@ -89,7 +89,7 @@ Meters ElementConverter::calculateLength(const ConstElementPtr &e) const
   }
 }
 
-shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Element>& e,
+shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Element>& e, const bool throwError,
                                                          const bool statsFlag) const
 {
   switch(e->getElementType().getEnum())
@@ -97,14 +97,15 @@ shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const 
   case ElementType::Node:
     return convertToGeometry(dynamic_pointer_cast<const Node>(e));
   case ElementType::Way:
-    return convertToGeometry(dynamic_pointer_cast<const Way>(e), statsFlag);
+    return convertToGeometry(dynamic_pointer_cast<const Way>(e), throwError, statsFlag);
   case ElementType::Relation:
-    return convertToGeometry(dynamic_pointer_cast<const Relation>(e), statsFlag);
+    return convertToGeometry(dynamic_pointer_cast<const Relation>(e), throwError, statsFlag);
   default:
     LOG_WARN(e->toString());
     throw HootException("Unexpected element type: " + e->getElementType().toString());
   }
 }
+
 
 shared_ptr<Point> ElementConverter::convertToGeometry(const shared_ptr<const Node>& n) const
 {
@@ -116,9 +117,9 @@ shared_ptr<Geometry> ElementConverter::convertToGeometry(const WayPtr& w) const
   return convertToGeometry((ConstWayPtr)w);
 }
 
-shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Way>& e, const bool statsFlag) const
+shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Way>& e, bool throwError, const bool statsFlag) const
 {
-  GeometryTypeId gid = getGeometryType(e, true, statsFlag);
+  GeometryTypeId gid = getGeometryType(e, throwError, statsFlag);
   if (gid == GEOS_POLYGON)
   {
     return convertToPolygon(e);
@@ -135,9 +136,9 @@ shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const 
   }
 }
 
-shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Relation>& e, const bool statsFlag) const
+shared_ptr<Geometry> ElementConverter::convertToGeometry(const shared_ptr<const Relation>& e, bool throwError, const bool statsFlag) const
 {
-  GeometryTypeId gid = getGeometryType(e, true, statsFlag);
+  GeometryTypeId gid = getGeometryType(e, throwError, statsFlag);
 
   if (gid == GEOS_MULTIPOLYGON)
   {

--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
@@ -93,7 +93,7 @@ public:
    * Converts the given element to a geos geometry object. The tags are used with OsmSchema to
    * determine the geometry type.
    */
-  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Element>& e, const bool throwError=true, const bool statsFlag=false) const;
+  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Element>& e, bool throwError=true, const bool statsFlag=false) const;
   shared_ptr<geos::geom::Point> convertToGeometry(const ConstNodePtr& n) const;
   shared_ptr<geos::geom::Geometry> convertToGeometry(const WayPtr& w) const;
   shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Way>& w, bool throwError, const bool statsFlag=false) const;

--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
@@ -93,11 +93,11 @@ public:
    * Converts the given element to a geos geometry object. The tags are used with OsmSchema to
    * determine the geometry type.
    */
-  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Element>& e, const bool statsFlag=false) const;
+  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Element>& e, const bool throwError=true, const bool statsFlag=false) const;
   shared_ptr<geos::geom::Point> convertToGeometry(const ConstNodePtr& n) const;
   shared_ptr<geos::geom::Geometry> convertToGeometry(const WayPtr& w) const;
-  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Way>& w, const bool statsFlag=false) const;
-  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Relation>& r, const bool statsFlag=false) const;
+  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Way>& w, bool throwError, const bool statsFlag=false) const;
+  shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<const Relation>& r, bool throwError, const bool statsFlag=false) const;
   shared_ptr<geos::geom::Geometry> convertToGeometry(const shared_ptr<Relation>& r) const;
   shared_ptr<geos::geom::LineString> convertToLineString(const ConstWayPtr& w) const;
   shared_ptr<geos::geom::Polygon> convertToPolygon(const ConstWayPtr& w) const;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaForStatsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaForStatsVisitor.cpp
@@ -49,7 +49,7 @@ Meters CalculateAreaForStatsVisitor::getArea(const OsmMapPtr& map, ElementPtr e)
 
 void CalculateAreaForStatsVisitor::visit(const ConstElementPtr& e)
 {
-  shared_ptr<Geometry> g = ElementConverter(_map->shared_from_this()).convertToGeometry(e, true);
+  shared_ptr<Geometry> g = ElementConverter(_map->shared_from_this()).convertToGeometry(e, true, true);
   _total += g->getArea();
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/TranslatedTagCountVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/TranslatedTagCountVisitor.cpp
@@ -90,7 +90,7 @@ void TranslatedTagCountVisitor::visit(const ConstElementPtr& e)
 {
   if (e->getTags().getInformationCount() > 0)
   {
-    shared_ptr<Geometry> g = ElementConverter(_map->shared_from_this()).convertToGeometry(e);
+    shared_ptr<Geometry> g = ElementConverter(_map->shared_from_this()).convertToGeometry(e, false);
 
     Tags t = e->getTags();
     t["error:circular"] = QString::number(e->getCircularError());


### PR DESCRIPTION
Refs #418 
Refs ngageoint/hootenanny-ui#270
Added throwError parameter to ElementConverter::convertToGeometry functions so that statistics don't fail when certain unknown types of relations are processed.  This also allows for the function to fail in other circumstances that might require the previous behavior such as conflation of elements.