### PR TITLE
Added quiet options to the pom.xml.in file

### DIFF
--- a/hoot-services/pom.xml.in
+++ b/hoot-services/pom.xml.in
@@ -53,6 +53,8 @@
         <configuration>
           <forkCount></forkCount>
           <reuseForks>true</reuseForks>
+          <showSuccess>false</showSuccess>
+          <printSummary>false</printSummary>
           <groups>hoot.services.UnitTest</groups>
           <skipTests>${skip.hoot.services.tests}</skipTests>
           <excludes>
@@ -81,6 +83,8 @@
         </dependencies>
         <configuration>
           <groups>hoot.services.IntegrationTest</groups>
+          <showSuccess>false</showSuccess>
+          <printSummary>false</printSummary>
           <skipTests>${skip.hoot.services.integrationTests}</skipTests>
           <redirectTestOutputToFile>${redirect-test-output-to-file}</redirectTestOutputToFile>
         </configuration>


### PR DESCRIPTION
1. refs #435 Added quiet options to the pom.xml.in file

@bwitham This really cuts down the maven test output. Could you review and merge please.

E.g. Old version:
 T E S T S
parallel='none', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
Running hoot.services.controllers.job.JobResourceTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 sec
Running hoot.services.controllers.wps.CustomScriptGetListProcessletTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.395 sec
Running hoot.services.controllers.wps.CustomScriptGetScriptProcessletTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 sec
Running hoot.services.controllers.wps.CustomScriptSaveProcessletTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 sec
Running hoot.services.controllers.wps.ETLProcessletTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec
Running hoot.services.controllers.wps.CustomScriptDeleteScriptProcessletTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec

Results :

Tests run: 6, Failures: 0, Errors: 0, Skipped: 1


New version:
 T E S T S
Tests run: 6, Failures: 0, Errors: 0, Skipped: 1


