### PR TITLE
Remove the db test URLs from config

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -145,9 +145,6 @@ conf/DatabaseConfig.sh: conf/DatabaseConfig.sh.orig
 	# This will copy conf/DatabaseConfig.sh.orig to conf/DatabaseConfig.sh if necessary
 	if [ ! -f conf/DatabaseConfig.sh ]; then echo "Using default database configuration. You can safely customize: conf/DatabaseConfig.sh"; cp conf/DatabaseConfig.sh.orig conf/DatabaseConfig.sh; else echo; echo; echo "Check your conf/DatabaseConfig.sh to see if it needs updating with conf/DatabaseConfig.sh.orig, if not just 'touch conf/DatabaseConfig.sh'"; echo; echo; false; fi
 
-conf/LocalHoot.json: conf/LocalHoot.json.in conf/DatabaseConfig.sh
-	export HOOT_HOME=`pwd`; scripts/ReplaceEnvironmentVariables.sh conf/LocalHoot.json.in conf/LocalHoot.json
-
 # We now have different versions of the NFDD Schema that are built from Excel files:
 # LTDSv40.csv.gz - Local TDS v4.0
 # SUTDSv40.csv.gz - Specialized Urban TDS v4.0
@@ -214,7 +211,7 @@ model-build: $(RF_MODELS)
 conf/%.rf: conf/%.arff.bz2 qt-make
 	[ $< -nt $@ ] && hoot build-rf $< $@ || true
 
-qt-make: HOOT_VERSION_FILE Makefile.qmake hoot-core/src/main/cpp/hoot/core/HootConfig.h conf/LocalHoot.json tgs/src/main/cpp/tgs/TgsConfig.h hoot-core/src/main/cpp/hoot/core/util/ConfigOptions.h hoot-core/src/main/cpp/hoot/core/util/ConfigDefaults.h bin/hoot bin/HootTest
+qt-make: HOOT_VERSION_FILE Makefile.qmake hoot-core/src/main/cpp/hoot/core/HootConfig.h tgs/src/main/cpp/tgs/TgsConfig.h hoot-core/src/main/cpp/hoot/core/util/ConfigOptions.h hoot-core/src/main/cpp/hoot/core/util/ConfigDefaults.h bin/hoot bin/HootTest
 	$(MAKE) -f Makefile.qmake 2>&1 | grep -v -e ".*WARNING: Failure to find: tmp/swig/HootSwig.cxx.*" \
 	  || true \
 	  ; [ "$${PIPESTATUS[0]}" == "0" ] && true || false

--- a/conf/ConfigOptions.asciidoc
+++ b/conf/ConfigOptions.asciidoc
@@ -1570,21 +1570,6 @@ Email address of the DG reader user.  Can be set here for debugging and testing.
 
 The maximum number of OSM elements that may be read from the services database into a single OSM map during a partial map read.
 
-=== services.db.test.url
-
-* Data Type: string
-* Default Value: `postgresql://hoot:hoottest@localhost:5432/hoot/testMap`
-
-Contains the DB URL for unit testing. This is typically only used by developers.
-
-=== services.db.test.url.osmapi
-
-* Data Type: string
-* Default Value: `postgresql://hoot:hoottest@localhost:5432/osmapi_test`
-
-Contains the DB URL for an OpenStreetMaps (OSM) API database for unit testing. This is
-typically only used by developers.
-
 === services.db.writer.create.user
 
 * Data Type: bool

--- a/conf/LocalHoot.json.in
+++ b/conf/LocalHoot.json.in
@@ -1,4 +1,0 @@
-{
-    "#" : "Do not modify this file directly, modify conf/DatabaseConfig.sh instead.",
-    "services.db.test.url" : "postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}/testMap"
-}

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbReaderTest.cpp
@@ -483,8 +483,7 @@ public:
     ServicesDb database;
     database.open(ServicesDbTestUtils::getOsmApiDbUrl());
 
-    Settings s = conf();
-    reader.open(ConfigOptions(s).getServicesDbTestUrlOsmapi());
+    reader.open(ServicesDbTestUtils::getOsmApiDbUrl().toString());
     reader.read(map);
     verifyFullReadOutput_OsmApi(map);
     reader.close();

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTest.cpp
@@ -121,13 +121,10 @@ public:
     Settings s = conf();
     ServicesDb db;
     CPPUNIT_ASSERT_EQUAL(ServicesDb::DBTYPE_UNSUPPORTED, db.getDatabaseType());
-    db.open(QUrl(ConfigOptions(s).getServicesDbTestUrlOsmapi()));
+    db.open(ServicesDbTestUtils::getOsmApiDbUrl());
     CPPUNIT_ASSERT_EQUAL(ServicesDb::DBTYPE_OSMAPI, db.getDatabaseType());
     db.close();
     CPPUNIT_ASSERT_EQUAL(ServicesDb::DBTYPE_UNSUPPORTED, db.getDatabaseType());
-
-    // Reset this back to default value
-    s.set(ConfigOptions(s).getServicesDbTestUrlOsmapiKey(), ConfigOptions(s).getServicesDbTestUrlOsmapiDefaultValue());
   }
 
   /***********************************************************************************************

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -34,8 +34,10 @@
 // Hoot
 #include <hoot/core/io/ServicesDb.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/ConfPath.h>
 
 // Qt
+#include <QFile>
 #include <QStringList>
 
 // Tgs
@@ -77,10 +79,16 @@ void ServicesDbTestUtils::compareRecords(QString sql, QString expected, QVariant
 
 QUrl ServicesDbTestUtils::getDbModifyUrl()
 {
-  // don't use the default settings b/c they've been cleared for unit testing.
-  Settings s;
-  s.loadDefaults();
-  return QUrl(ConfigOptions(s).getServicesDbTestUrl());
+  // read the DB values from the DB config file.
+  Settings s = _readDbConfig();
+  QUrl result;
+  result.setScheme("postgresql");
+  result.setHost(s.get("DB_HOST").toString());
+  result.setPort(s.get("DB_PORT").toInt());
+  result.setUserName(s.get("DB_USER").toString());
+  result.setPassword(s.get("DB_PASSWORD").toString());
+  result.setPath("/" + s.get("DB_NAME").toString() + "/testMap");
+  return result;
 }
 
 QUrl ServicesDbTestUtils::getDbReadUrl(const long mapId)
@@ -100,8 +108,16 @@ QUrl ServicesDbTestUtils::getDbReadUrl(const long mapId)
 
 QUrl ServicesDbTestUtils::getOsmApiDbUrl()
 {
-  Settings s = conf();
-  return QUrl(ConfigOptions(s).getServicesDbTestUrlOsmapi());
+  // read the DB values from the DB config file.
+  Settings s = _readDbConfig();
+  QUrl result;
+  result.setScheme("postgresql");
+  result.setHost(s.get("DB_HOST").toString());
+  result.setPort(s.get("DB_PORT").toInt());
+  result.setUserName(s.get("DB_USER").toString());
+  result.setPassword(s.get("DB_PASSWORD").toString());
+  result.setPath("/" + s.get("DB_NAME_OSMAPI").toString());
+  return result;
 }
 
 void ServicesDbTestUtils::deleteUser(QString email)
@@ -125,6 +141,31 @@ int ServicesDbTestUtils::findIndex(const QList<QString>& keys, const QString& ke
 
   // didn't find a match so return -1
   return -1;
+}
+
+Settings ServicesDbTestUtils::_readDbConfig()
+{
+  Settings result;
+  QFile fp(ConfPath::getHootHome() + "/conf/DatabaseConfig.sh");
+  if (fp.open(QIODevice::ReadOnly) == false)
+  {
+    throw HootException("Error opening: " + fp.fileName());
+  }
+  QString s = QString::fromUtf8(fp.readAll());
+
+  QStringList sl = s.split('\n', QString::SkipEmptyParts);
+
+  foreach (QString s, sl)
+  {
+    QString key = s.section("=", 0, 0).remove("export ").trimmed();
+    QString value = s.section("=", 1).trimmed();
+    if (!key.startsWith("#") && key.length() > 0)
+    {
+      result.set(key, value);
+    }
+  }
+
+  return result;
 }
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
@@ -27,7 +27,11 @@
 #ifndef SERVICESDBTESTUTILS_H
 #define SERVICESDBTESTUTILS_H
 
+// hoot
+#include <hoot/core/util/Settings.h>
+
 // Qt
+#include <QHash>
 #include <QUrl>
 #include <QVariant>
 
@@ -74,6 +78,9 @@ public:
    * Find a match in the test key list and return the index
    */
   static int findIndex(const QList<QString>& keys, const QString& key);
+
+private:
+  static Settings _readDbConfig();
 };
 
 }


### PR DESCRIPTION
1. refs #464 - Read the DB test URLs straight from the DatabaseConfig.sh
   rather than the convoluted makefile step we used before.