### PR TITLE
Modify HOOT_FACTORY_REGISTER_BASE macro to take only one parameter (469)

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
@@ -68,7 +68,7 @@ public:
   int b;
 };
 
-HOOT_FACTORY_REGISTER_BASE(TestClass, TestClass)
+HOOT_FACTORY_REGISTER_BASE(TestClass)
 
 class ObjectInputStreamTest : public CppUnit::TestFixture
 {

--- a/hoot-core/src/main/cpp/hoot/core/Factory.h
+++ b/hoot-core/src/main/cpp/hoot/core/Factory.h
@@ -203,9 +203,9 @@ public:
  * It is very unusual to register the base class, so you have to call this method to do it.
  * Otherwise you'll get a nasty exception.
  */
-#define HOOT_FACTORY_REGISTER_BASE(Base, ClassName)      \
-  static hoot::AutoRegister<Base, ClassName> ClassName##AutoRegister(Base::className(), \
-    ClassName::className(), true);
+#define HOOT_FACTORY_REGISTER_BASE(Base)      \
+  static hoot::AutoRegister<Base, Base> Base##AutoRegister(Base::className(), \
+    Base::className(), true);
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.cpp
@@ -34,7 +34,7 @@ namespace hoot
 
 // the base class is a special case that doesn't need to be registered with the
 // HootExceptionThrower.
-HOOT_FACTORY_REGISTER_BASE(HootException, HootException)
+HOOT_FACTORY_REGISTER_BASE(HootException)
 HOOT_REGISTER_EXCEPTION(FileNotFoundException)
 HOOT_REGISTER_EXCEPTION(IllegalArgumentException)
 HOOT_REGISTER_EXCEPTION(InternalErrorException)

--- a/hoot-js/src/main/cpp/hoot/js/HelloWorld.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/HelloWorld.cpp
@@ -51,7 +51,7 @@ public:
   static string className() { return "hoot::HootJsLoaded"; }
 };
 
-HOOT_FACTORY_REGISTER_BASE(HootJsLoaded, HootJsLoaded)
+HOOT_FACTORY_REGISTER_BASE(HootJsLoaded)
 
 void init(Handle<Object> exports)
 {


### PR DESCRIPTION
ref #469 

No need to pass base class name twice!