### PR TITLE
Updated services doc creation to ignore the liquibase commands

### DIFF
--- a/scripts/mvn-build
+++ b/scripts/mvn-build
@@ -111,6 +111,7 @@ while [ $# -gt 0 ] ; do
         ;;
     "docs") 
         PHASE="docs"
+	ARGS=$ARGS" -Dliquibase.should.run=false"
         shift 1
         ;;
     "-f" | "--failfast")


### PR DESCRIPTION
refs #472 
Removed liquibase from the services documentation creation script
Resolves issue we were seeing where a parallel make caused a race condition