### PR TITLE
Add render db drop to HootApiDb::deleteMap(long)

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -223,6 +223,15 @@ public:
   long reserveElementId(const ElementType::Type type);
 
   /**
+   * Drops the specified database. No warning or error will be given if the DB doesn't exist.
+   *
+   * No validation is done on the DB name. In other words, don't pass in user provided strings.
+   *
+   * @param databaseName
+   */
+  void dropDatabase(const QString& databaseName);
+
+  /**
    * Drops the specified table and cascades (removes depedants). No warning or error will be given
    * if the table does not exist.
    *
@@ -335,6 +344,15 @@ private:
   unsigned long _nodesFlushedFromCache;
 
   /**
+   * There are some statements that cannot be executed within a transaction
+   * (like DROP DATABASE). There are times (when deleting a map) where we
+   * want to do such things, if the current transaction succeeds. So we build
+   * this list, and after a successful commit, all of these statements will
+   * be executed.
+   */
+  QVector<QString> _postTransactionStatements;
+
+  /**
    * This is here to improve query caching. In most cases users open a single ServiceDb and then
    * access one map ID over and over again. In these cases this class should perform pretty well
    * by lazily creating queries and caching them. This method checks the last map id against the
@@ -388,6 +406,15 @@ private:
   void _updateChangesetEnvelopeRelationNodes(const std::vector<long>& relationIds);
 
   void _updateChangesetEnvelopeRelationWays(const std::vector<long>& relationIds);
+
+  /**
+   * Builds the expected renderdb name from our current database & map
+   * display name.
+   *
+   * @param mapId id of the map for which we want the associated renderdb
+   * @return should be <dbname>_renderdb_<map_display_name>
+   */
+  QString _getRenderDBName(long mapId);
 };
 
 }

--- a/test-files/cmd/slow/ServiceExportRenderDbTest.sh
+++ b/test-files/cmd/slow/ServiceExportRenderDbTest.sh
@@ -23,5 +23,8 @@ hoot --convert $HOOT_OPTS test-files/$INPUT.osm $DB_URL/$INPUT
 scripts/exportrenderdb.sh # || true # Don't error out so test will continue to clean up
 
 # Clean up
-dropdb $AUTH $RENDER_DB
 hoot delete-map $HOOT_OPTS $DB_URL/$INPUT
+
+# Assert that hoot map and render db have been deleted
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME -c "select display_name from maps;" | grep -qw ExRenDb && echo "Error: delete-map did not remove ExRenDb dataset"
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME -lqt | cut -d \| -f 1 | grep -qw $RENDER_DB && echo "Error: delete-map did not remove ExRenDb render db"


### PR DESCRIPTION
Now when you call HootApiDb::DeleteMap(long mapId), the associated _renderdb will also be deleted.

The tricky thing here was that Postgres won't let you DROP DATABASE within a transaction, and the test suite does a lot of that sort of thing. So a mechanism was added to allow a list of post-transaction tasks, that will be executed after a transaction, if the transaction commit was successful.

--quick test looked good.
--slow test looked good.
Conflating two datasets (through the UI) on my local VM, then deleteing the conflated dataset showed the associated _renderdb was indeed removed.

ref issue #500  