### PR TITLE
Modified CalcStatsOp so that it doesn't need to be modified for new feature types

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/point/PlacesPoiMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/point/PlacesPoiMatchTest.cpp
@@ -162,7 +162,7 @@ public:
         shared_ptr<const Element> e1 = map->getElement(it->first);
         shared_ptr<const Element> e2 = map->getElement(it->second);
         //LOG_INFO(e1->getTags()["note"] << " <=> " << e2->getTags()["note"]);
-        CPPUNIT_ASSERT_EQUAL(e1->getTags()["note"], e2->getTags()["note"]);
+        CPPUNIT_ASSERT_EQUAL(e1->getTags()["note"].toStdString(), e2->getTags()["note"].toStdString());
       }
     }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/point/PlacesPoiMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/point/PlacesPoiMatchTest.cpp
@@ -162,7 +162,7 @@ public:
         shared_ptr<const Element> e1 = map->getElement(it->first);
         shared_ptr<const Element> e2 = map->getElement(it->second);
         //LOG_INFO(e1->getTags()["note"] << " <=> " << e2->getTags()["note"]);
-        HOOT_STR_EQUALS(e1->getTags()["note"], e2->getTags()["note"])
+        HOOT_STR_EQUALS(e1->getTags()["note"], e2->getTags()["note"]);
       }
     }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/point/PlacesPoiMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/point/PlacesPoiMatchTest.cpp
@@ -162,7 +162,7 @@ public:
         shared_ptr<const Element> e1 = map->getElement(it->first);
         shared_ptr<const Element> e2 = map->getElement(it->second);
         //LOG_INFO(e1->getTags()["note"] << " <=> " << e2->getTags()["note"]);
-        CPPUNIT_ASSERT_EQUAL(e1->getTags()["note"].toStdString(), e2->getTags()["note"].toStdString());
+        HOOT_STR_EQUALS(e1->getTags()["note"], e2->getTags()["note"])
       }
     }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MatchCreator.h
@@ -30,6 +30,11 @@
 // hoot
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/conflate/MatchThreshold.h>
+#include <hoot/core/filters/BuildingCriterion.h>
+#include <hoot/core/filters/PoiCriterion.h>
+#include <hoot/core/filters/WaterwayCriterion.h>
+#include <hoot/core/filters/HighwayFilter.h>
+
 
 // Standard
 #include <string>
@@ -44,20 +49,119 @@ class Match;
 class MatchCreator
 {
 public:
+
+  // This is how we map various match creators to the feature
+  // they operate on. Helpful when generating stats later.
+  enum BaseFeatureType
+  {
+    POI = 0,
+    Highway = 1,
+    Building = 2,
+    Waterway = 3,
+    Unknown = 4 // Unknown must always be last
+  };
+
+  enum FeatureCalcType
+  {
+    CalcTypeNone = 0,
+    CalcTypeLength = 1,
+    CalcTypeArea = 2
+  };
+
+  static QString BaseFeatureTypeToString(BaseFeatureType t)
+  {
+    switch (t)
+    {
+      case POI:
+        return "POI";
+      case Highway:
+        return "Highway";
+      case Building:
+        return "Building";
+      case Waterway:
+        return "Waterway";
+      case Unknown:
+      default:
+        return "Unknown";
+    }
+  }
+
+  static BaseFeatureType StringToBaseFeatureType(QString s)
+  {
+    s = s.toLower();
+    if (0 == s.compare("poi"))
+      return POI;
+    else if (0 == s.compare("highway"))
+      return Highway;
+    else if (0 == s.compare("building"))
+      return Building;
+    else if (0 == s.compare("waterway"))
+      return Waterway;
+    else
+      return Unknown;
+  }
+
+  /* These two functions, getFeatureCalcType & getElementCriterion could be
+   * pushed down into the classes that are derived from MatchCreator, and
+   * that would seem logical and clean - BUT ScriptMatchCreator becomes
+   * problematic, as those match creators are generated at runtime. So you'd
+   * have to hard code the mappings between featureTypes and FeatureCalcTypes
+   * and the ElementCriterions for each script down in the ScriptMatchCreator
+   * class. SO, rather than that - we'll just keep all of this feature type
+   * stuff grouped together in one place.
+   */
+  static FeatureCalcType getFeatureCalcType (BaseFeatureType t)
+  {
+    switch (t)
+    {
+      case POI:
+        return CalcTypeNone;
+      case Highway:
+        return CalcTypeLength;
+      case Building:
+        return CalcTypeArea;
+      case Waterway:
+        return CalcTypeLength;
+      case Unknown:
+      default:
+        return CalcTypeNone;
+    }
+  }
+
+  static ElementCriterion * getElementCriterion (BaseFeatureType t, ConstOsmMapPtr map)
+  {
+    switch (t)
+    {
+      case POI:
+        return new PoiCriterion();
+      case Highway:
+        return new HighwayFilter(Filter::KeepMatches);
+      case Building:
+        return new BuildingCriterion(map);
+      case Waterway:
+        return new WaterwayCriterion();
+      case Unknown:
+      default:
+        return NULL;
+    }
+  }
+
   class Description
   {
   public:
     Description() : experimental() {}
-    Description(string className, QString description, bool experimental)
+    Description(string className, QString description, BaseFeatureType featureType, bool experimental)
     {
       this->className = className;
       this->experimental = experimental;
       this->description = description;
+      this->baseFeatureType = featureType;
     }
 
     bool experimental;
     string className;
     QString description;
+    BaseFeatureType baseFeatureType;
   };
 
   static string className() { return "hoot::MatchCreator"; }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -220,7 +220,7 @@ vector<MatchCreator::Description> HighwayMatchCreator::getAllCreators() const
 {
   vector<Description> result;
 
-  result.push_back(Description(className(), "Highway Match Creator", false));
+  result.push_back(Description(className(), "Highway Match Creator", MatchCreator::Highway, false));
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/point/CustomPoiMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/point/CustomPoiMatchCreator.cpp
@@ -180,7 +180,7 @@ vector<MatchCreator::Description> CustomPoiMatchCreator::getAllCreators() const
 {
   vector<Description> result;
 
-  result.push_back(Description(className(), "Custom POI Match Creator", true));
+  result.push_back(Description(className(), "Custom POI Match Creator", MatchCreator::POI, true));
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/point/PlacesPoiMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/point/PlacesPoiMatchCreator.cpp
@@ -354,7 +354,7 @@ vector<MatchCreator::Description> PlacesPoiMatchCreator::getAllCreators() const
 {
   vector<Description> result;
 
-  result.push_back(Description(className(), "PLACES Match Creator", false));
+  result.push_back(Description(className(), "PLACES Match Creator", MatchCreator::POI, false));
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -207,7 +207,7 @@ vector<MatchCreator::Description> BuildingMatchCreator::getAllCreators() const
 {
   vector<Description> result;
 
-  result.push_back(Description(className(), "Building Match Creator", false));
+  result.push_back(Description(className(), "Building Match Creator", MatchCreator::Building, false));
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
@@ -86,6 +86,29 @@ CalculateStatsOp::CalculateStatsOp(ElementCriterionPtr criterion, QString mapNam
   LOG_VARD(_inputIsConflatedMapOutput);
 }
 
+shared_ptr<MatchCreator> CalculateStatsOp::getMatchCreator(
+    const vector< shared_ptr<MatchCreator> > &matchCreators,
+    const QString &matchCreatorName,
+    MatchCreator::BaseFeatureType &featureType)
+{
+  for (vector< shared_ptr<MatchCreator> >::const_iterator matchIt = matchCreators.begin();
+       matchIt != matchCreators.end(); ++matchIt)
+  {
+    vector<MatchCreator::Description> desc = (*matchIt)->getAllCreators();
+    for (vector<MatchCreator::Description>::const_iterator descIt = desc.begin();
+         descIt != desc.end(); ++descIt)
+    {
+      QString testName = QString::fromStdString(descIt->className);
+      if (0 == matchCreatorName.compare(testName))
+      {
+        featureType = descIt->baseFeatureType;
+        return (*matchIt);
+      }
+    }
+  }
+  return shared_ptr<MatchCreator>(); // empty if not found
+}
+
 void CalculateStatsOp::apply(const shared_ptr<OsmMap>& map)
 {
   QString logMsg = "Calculating map statistics";
@@ -229,12 +252,14 @@ void CalculateStatsOp::apply(const shared_ptr<OsmMap>& map)
         ((double)unconflatableFeatureCount / (double)featureCount) * 100.0));
 
     _stats.append(SingleStat("Number of Match Creators", matchCreators.size()));
-    double conflatablePoiCount = 0.0;
-    double conflatableHighwayCount = 0.0;
-    double conflatableBuildingCount = 0.0;
-    double conflatableWaterwayCount = 0.0;
+    QMap<MatchCreator::BaseFeatureType, double> featureCounts;
+    for(MatchCreator::BaseFeatureType ft = MatchCreator::POI; ft < MatchCreator::Unknown; ft = MatchCreator::BaseFeatureType(ft+1))
+    {
+      featureCounts[ft] = 0.0;
+    }
+
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-        any_cast<QMap<QString, long> >(matchCandidateCountsData);
+            any_cast<QMap<QString, long> >(matchCandidateCountsData);
     LOG_VARD(matchCandidateCountsByMatchCreator.size());
     LOG_VARD(matchCandidateCountsByMatchCreator);
     for (QMap<QString, long >::const_iterator iterator = matchCandidateCountsByMatchCreator.begin();
@@ -242,6 +267,9 @@ void CalculateStatsOp::apply(const shared_ptr<OsmMap>& map)
     {
       const QString matchCreatorName = iterator.key();
       LOG_VARD(matchCreatorName);
+      MatchCreator::BaseFeatureType featureType = MatchCreator::Unknown;
+      shared_ptr<MatchCreator> matchCreator = getMatchCreator(matchCreators, iterator.key(), featureType);
+
       double conflatableFeatureCountForFeatureType = 0.0;
       if (!_inputIsConflatedMapOutput)
       {
@@ -253,36 +281,9 @@ void CalculateStatsOp::apply(const shared_ptr<OsmMap>& map)
             SingleStat(
               "Features Conflatable by: " + matchCreatorName,
               conflatableFeatureCountForFeatureType));
-      /// @todo This isn't very extensible to hardcode the matchup between each match creator and each
-      /// feature count type (e.g. hoot::PlacesPoiMatchCreator matches up with POI count type).  Need
-      /// a more maintainable way to do this if many more feature types get added.
-      if (matchCreatorName == "hoot::PlacesPoiMatchCreator")
-      {
-        conflatablePoiCount += conflatableFeatureCountForFeatureType;
-      }
-      else if (matchCreatorName == "hoot::HighwayMatchCreator")
-      {
-        conflatableHighwayCount = conflatableFeatureCountForFeatureType;
-      }
-      else if (matchCreatorName == "hoot::BuildingMatchCreator")
-      {
-        conflatableBuildingCount = conflatableFeatureCountForFeatureType;
-      }
-      //Not all of the non-experimental script match creator types are being accounted for
-      //yet.
-      else if (matchCreatorName.contains("PoiGeneric"))
-      {
-        conflatablePoiCount += conflatableFeatureCountForFeatureType;
-      }
-      else if (matchCreatorName.contains("LinearWaterway"))
-      {
-        conflatableWaterwayCount = conflatableFeatureCountForFeatureType;
-      }
+
+      featureCounts[featureType] += conflatableFeatureCountForFeatureType;
     }
-    LOG_VARD(conflatablePoiCount);
-    LOG_VARD(conflatableHighwayCount);
-    LOG_VARD(conflatableBuildingCount);
-    LOG_VARD(conflatableWaterwayCount);
 
     _stats.append(SingleStat("Total Conflated Features", conflatedFeatureCount));
     _stats.append(
@@ -309,10 +310,15 @@ void CalculateStatsOp::apply(const shared_ptr<OsmMap>& map)
         "Percentage of Total Features Unmatched",
         ((double)unconflatedFeatureCount / (double)featureCount) * 100.0));
 
-    _generateFeatureStats(constMap, "POI", conflatablePoiCount, None, new PoiCriterion());
-    _generateFeatureStats(constMap, "Highway", conflatableHighwayCount, Length, new HighwayFilter(keep));
-    _generateFeatureStats(constMap, "Building", conflatableBuildingCount, Area, new BuildingCriterion(map));
-    _generateFeatureStats(constMap, "Waterway", conflatableWaterwayCount, Length, new WaterwayCriterion());
+    for (QMap<MatchCreator::BaseFeatureType, double>::iterator it = featureCounts.begin();
+         it != featureCounts.end(); ++it)
+    {
+      _generateFeatureStats(constMap,
+                            MatchCreator::BaseFeatureTypeToString(it.key()),
+                            it.value(),
+                            MatchCreator::getFeatureCalcType(it.key()),
+                            MatchCreator::getElementCriterion(it.key(), map));
+    }
 
     LongestTagVisitor v2;
     _applyVisitor(constMap, &v2);
@@ -453,7 +459,8 @@ void CalculateStatsOp::printStats()
 }
 
 void CalculateStatsOp::_generateFeatureStats(shared_ptr<const OsmMap> &map, QString description,
-                                             float conflatableCount, FeatureCalcType type,
+                                             float conflatableCount,
+                                             MatchCreator::FeatureCalcType type,
                                              ElementCriterion* criterion)
 {
   shared_ptr<ElementCriterion> e_criterion(criterion);
@@ -487,13 +494,13 @@ void CalculateStatsOp::_generateFeatureStats(shared_ptr<const OsmMap> &map, QStr
           e_criterion->clone()),
         new FeatureCountVisitor()));
   _stats.append(SingleStat(QString("Unmatched %1s").arg(description), unconflatedFeatureCount));
-  if (type == Length)
+  if (type == MatchCreator::CalcTypeLength)
   {
     _stats.append(SingleStat(QString("Meters of %1 Processed by Conflation").arg(description),
       _applyVisitor(map, FilteredVisitor(ChainCriterion(new StatusCriterion(Status::Conflated),
         e_criterion->clone()), new LengthOfWaysVisitor()))));
   }
-  else if (type == Area)
+  else if (type == MatchCreator::CalcTypeArea)
   {
     _stats.append(SingleStat(QString("Meters Squared of %1s Processed by Conflation").arg(description),
       _applyVisitor(map, FilteredVisitor(ChainCriterion(new StatusCriterion(Status::Conflated),

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.h
@@ -47,13 +47,6 @@ class CalculateStatsOp : public ConstOsmMapOperation
 {
 public:
 
-  enum FeatureCalcType
-  {
-    None,
-    Length,
-    Area
-  };
-
   CalculateStatsOp(QString mapName = "", bool inputIsConflatedMapOutput = false);
   CalculateStatsOp(ElementCriterionPtr criterion, QString mapName = "", bool inputIsConflatedMapOutput = false);
 
@@ -92,6 +85,17 @@ private:
   bool _inputIsConflatedMapOutput;
   QList<SingleStat> _stats;
 
+  /**
+   * @brief getMatchCreator finds the match creator (in the supplied vector) by name
+   * @param [in]  matchCreators vector of matchCreators to search
+   * @param [in]  matchCreatorName name for which to search
+   * @param [out] featureType base feature type for the found matchCreator
+   * @return ptr to match creator, if found, otherwise shared_ptr to null
+   */
+  shared_ptr<MatchCreator> getMatchCreator(const vector< shared_ptr<MatchCreator> > &matchCreators,
+                                           const QString &matchCreatorName,
+                                           MatchCreator::BaseFeatureType &featureType);
+
   double _applyVisitor(shared_ptr<const OsmMap>& map, const hoot::FilteredVisitor &v);
 
   double _applyVisitor(shared_ptr<const OsmMap>& map, const hoot::FilteredVisitor &v,
@@ -102,7 +106,7 @@ private:
   static bool _matchDescriptorCompare(const MatchCreator::Description& m1,
                                       const MatchCreator::Description& m2);
 
-  void _generateFeatureStats(shared_ptr<const OsmMap>& map, QString description, float conflatableCount, FeatureCalcType type, ElementCriterion* criterion);
+  void _generateFeatureStats(shared_ptr<const OsmMap>& map, QString description, float conflatableCount, MatchCreator::FeatureCalcType type, ElementCriterion* criterion);
 };
 
 }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
@@ -542,6 +542,12 @@ MatchCreator::Description ScriptMatchCreator::_getScriptDescription(QString path
     Handle<v8::Value> value = plugin->Get(experimentalStr);
     result.experimental = toCpp<bool>(value);
   }
+  Handle<String> featureTypeStr = String::New("baseFeatureType");
+  if (plugin->Has(featureTypeStr))
+  {
+    Handle<v8::Value> value = plugin->Get(featureTypeStr);
+    result.baseFeatureType = MatchCreator::StringToBaseFeatureType(toCpp<QString>(value));
+  }
 
   QFileInfo fi(path);
   result.className = (QString::fromStdString(className()) + "," + fi.fileName()).toStdString();

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -176,7 +176,7 @@ vector<MatchCreator::Description> PoiPolygonMatchCreator::getAllCreators() const
 {
   vector<Description> result;
 
-  result.push_back(Description(className(), "POI to Polygon Match Creator", true));
+  result.push_back(Description(className(), "POI to Polygon Match Creator", MatchCreator::POI, true));
 
   return result;
 }

--- a/rules/LinearWaterway.js
+++ b/rules/LinearWaterway.js
@@ -5,6 +5,7 @@ var MISS_OVERLAP_THRESHOLD = 0.15;
 
 exports.description = "Linear Waterway";
 exports.experimental = false;
+exports.baseFeatureType = "Waterway";
 
 exports.candidateDistanceSigma = 1.0; // 1.0 * (CE95 + Worst CE95);
 exports.matchThreshold = parseFloat(hoot.get("waterway.match.threshold"));

--- a/rules/PoiGeneric.js
+++ b/rules/PoiGeneric.js
@@ -5,6 +5,7 @@
 
 exports.description = "POI Generic";
 exports.experimental = false;
+exports.baseFeatureType = "POI";
 
 exports.candidateDistanceSigma = 1.0; // 1.0 * (CE95 + Worst CE95);
 exports.matchThreshold = parseFloat(hoot.get("poi.match.threshold"));


### PR DESCRIPTION
Modified CalcStatsOp so that it doesn't need to be changed in the future if/when new feature types are added (ref issue #487 ).

Added a "baseFeatureType" to the MatchCreator base class - the idea being that if/when new MatchCreators are written, their virtual implementation of getAllCreators (which in turn creates a Description) will associate the new MatchCreator with the type of match (POI, Highway, Waterway, etc.) it creates.

"baseFeatureType" was also added to the ScriptMatchCreator, to pull the feature types out of runtime, script-based match creators.

CalcStatsOp now simply builds a list of feature types to gather stats for, based upon the new MatchCreator::BaseFeatureType enumeration, collects stats for the types, and then loops through to generate the stats report.