### PR TITLE
Added clean-ccache to the clean-all target to clear ccache

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -8,6 +8,8 @@ endif
 
 SHELL=/bin/bash
 
+.PHONY: clean-ccache
+
 # If you're adding another schema file be sure and update the archive target
 # too.
 #SCHEMA_FILES=plugins/script/tds40/schema/__init__.js plugins/script/tds61/schema/__init__.js plugins/script/mgcp/schema/__init__.js plugins/script/etds/rules/__init__.js plugins/script/etds61/rules/__init__.js plugins/script/etds61_osm/rules/__init__.js
@@ -61,11 +63,17 @@ endif
 clean-db: services-clean-db
 
 # start over as close to a new build as is reasonable
-clean-all: clean clean-db
+clean-all: clean clean-db clean-ccache
 
 clean-coverage: services-clean-coverage
 	rm -rf coverage
 	rm -f `find . -name *.gcda`
+
+# clean-all should call `ccache -C` to clear the cache if ccache is available
+clean-ccache:
+ifneq (, $(shell command -v ccache))
+	@ccache -C >/dev/null 2>&1
+endif
 
 check: test
 test: build services-test pp-test plugins-test


### PR DESCRIPTION
refs #535 
Sometimes during a failed or crashed build there is a message of a `corrupt .o file` that requires a `ccache -C` command to clear it

Steps to verify:
* `make` hoot
* check ccache stats `ccache -s` (important stats are `files in cache` and `cache size`)
```
cache directory                     /home/user/.ccache
cache hit (direct)                  2466
cache hit (preprocessed)            1264
cache miss                          9121
compile failed                         2
files in cache                      1624
cache size                         820.9 Mbytes
max cache size                       1.0 Gbytes
```
* clear cache `make clean-all`
* check ccache stats again to verify that the cache is empty (`files in cache` and `cache size` are 0)
```
cache directory                     /home/user/.ccache
cache hit (direct)                  2466
cache hit (preprocessed)            1264
cache miss                          8252
compile failed                         2
files in cache                         0
cache size                             0 Kbytes
max cache size                       1.0 Gbytes
```