### PR TITLE
720 - completely separate hoot api and osm api db credentials

### DIFF
--- a/conf/DatabaseConfig.sh.orig
+++ b/conf/DatabaseConfig.sh.orig
@@ -1,8 +1,15 @@
 #hoot services variables
+
 export DB_NAME=hoot
 export DB_USER=hoot
 export DB_PASSWORD=hoottest
 export DB_HOST=localhost
 export DB_PORT=5432
+
 export WFS_DB_NAME=wfsstoredb
+
 export DB_NAME_OSMAPI=osmapi_test
+export DB_USER_OSMAPI=hoot
+export DB_PASSWORD_OSMAPI=hoottest
+export DB_HOST_OSMAPI=localhost
+export DB_PORT_OSMAPI=5432

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -150,10 +150,10 @@ QUrl ServicesDbTestUtils::getOsmApiDbUrl()
   Settings s = _readDbConfig();
   QUrl result;
   result.setScheme("osmapidb");
-  result.setHost(s.get("DB_HOST").toString());
-  result.setPort(s.get("DB_PORT").toInt());
-  result.setUserName(s.get("DB_USER").toString());
-  result.setPassword(s.get("DB_PASSWORD").toString());
+  result.setHost(s.get("DB_HOST_OSMAPI").toString());
+  result.setPort(s.get("DB_PORT_OSMAPI").toInt());
+  result.setUserName(s.get("DB_USER_OSMAPI").toString());
+  result.setPassword(s.get("DB_PASSWORD_OSMAPI").toString());
   result.setPath("/" + s.get("DB_NAME_OSMAPI").toString());
   return result;
 }

--- a/hoot-services/src/main/java/hoot/services/nativeInterfaces/ProcessStreamInterface.java
+++ b/hoot-services/src/main/java/hoot/services/nativeInterfaces/ProcessStreamInterface.java
@@ -74,6 +74,7 @@ public class ProcessStreamInterface implements INativeInterface {
     protected static Map<String, ICommandRunner> _progProcesses = null;
 
     private static String dbUrl = null;
+    private static String osmApiDbUrl = null;
 
     public ProcessStreamInterface() {
         // for make file script based call
@@ -111,6 +112,13 @@ public class ProcessStreamInterface implements INativeInterface {
                 String pwd = HootProperties.getProperty("dbPassword");
                 String host = HootProperties.getProperty("dbHost");
                 dbUrl = "hootapidb://" + userid + ":" + pwd + "@" + host + "/" + dbname;
+            }
+            if (osmApiDbUrl == null) {
+                String dbname = HootProperties.getProperty("osmApiDbName");
+                String userid = HootProperties.getProperty("osmApiDbUserId");
+                String pwd = HootProperties.getProperty("osmApiDbPassword");
+                String host = HootProperties.getProperty("osmApiDbHost");
+                osmApiDbUrl = "osmapidb://" + userid + ":" + pwd + "@" + host + "/" + dbname;
             }
 
         }
@@ -407,6 +415,7 @@ public class ProcessStreamInterface implements INativeInterface {
             String jobid = cmd.get("jobId").toString();
             execCmd.add("jobid=" + jobid);
             execCmd.add("DB_URL=" + dbUrl);
+            execCmd.add("OSM_API_DB_URL=" + osmApiDbUrl);
         }
         catch (Exception ex) {
             log.error("Failed to parse job params. Reason: " + ex.getMessage());

--- a/hoot-services/src/main/resources/conf/hoot-services.conf.in
+++ b/hoot-services/src/main/resources/conf/hoot-services.conf.in
@@ -122,16 +122,16 @@ cleanDataMakePath=makecleandata
 # Custom Script Service folder location
 customScriptPath=customscript
 
-# Db Name
+# hoot api db Name
 dbName=${DB_NAME}
 
-# Db server user id
+# hoot api db server user id
 dbUserId=${DB_USER}
 
-# Db server user password
+# hoot api db server user password
 dbPassword=${DB_PASSWORD}
 
-# Db server user host
+# hoot api db server user host
 dbHost=${DB_HOST}:${DB_PORT}
 
 # WFS Store Connection Name
@@ -139,6 +139,18 @@ wfsStoreConnName=WFS_Connection
 
 # WFS Store db name
 wfsStoreDb=${WFS_DB_NAME}
+
+# osm api db Name
+osmApiDbName=${DB_NAME_OSMAPI}
+
+# osm api db server user id
+osmApiDbUserId=${DB_USER_OSMAPI}
+
+# osm api db server user password
+osmApiDbPassword=${DB_PASSWORD_OSMAPI}
+
+# osm api db server user host
+osmApiDbHost=${DB_HOST_OSMAPI}:${DB_PORT_OSMAPI}
 
 # Translation extension install folder
 translationExtPath=$(homeFolder)/plugins-local/script/utp

--- a/hoot-services/src/test/java/hoot/services/nativeInterfaces/ProcessStreamInterfaceTest.java
+++ b/hoot-services/src/test/java/hoot/services/nativeInterfaces/ProcessStreamInterfaceTest.java
@@ -35,6 +35,8 @@ import org.json.simple.parser.JSONParser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import hoot.services.HootProperties;
 import hoot.services.UnitTest;
@@ -42,6 +44,9 @@ import hoot.services.UnitTest;
 
 public class ProcessStreamInterfaceTest {
 
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(ProcessStreamInterfaceTest.class);
+    
     @Test
     @Category(UnitTest.class)
     public void testcreateCmd() throws Exception {
@@ -118,7 +123,14 @@ public class ProcessStreamInterfaceTest {
         String pwd = HootProperties.getProperty("dbPassword");
         String host = HootProperties.getProperty("dbHost");
         String dbUrl = "hootapidb://" + userid + ":" + pwd + "@" + host + "/" + dbname;
-        expected += ",DB_URL=" + dbUrl + "}";
+        expected += ",DB_URL=" + dbUrl;
+        
+        dbname = HootProperties.getProperty("osmApiDbName");
+        userid = HootProperties.getProperty("osmApiDbUserId");
+        pwd = HootProperties.getProperty("osmApiDbPassword");
+        host = HootProperties.getProperty("osmApiDbHost");
+        String osmApiDbUrl = "osmapidb://" + userid + ":" + pwd + "@" + host + "/" + dbname;
+        expected += ",OSM_API_DB_URL=" + osmApiDbUrl + "}";
 
         Assert.assertEquals(expected, commandStr);
     }

--- a/scripts/CleanOsmApiDB.sh
+++ b/scripts/CleanOsmApiDB.sh
@@ -3,8 +3,8 @@
 # setup db, user, and password to avoid password prompt
 source $HOOT_HOME/conf/DatabaseConfig.sh
 
-export PGPASSWORD=$DB_PASSWORD
-export AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PGPASSWORD=$DB_PASSWORD_OSMAPI
+export AUTH="-h $DB_HOST_OSMAPI -p $DB_PORT_OSMAPI -U $DB_USER_OSMAPI"
 
 # see if old db osmapi_test exists
 export flag=`psql $AUTH -lqt | cut -d \| -f 1 | grep -w $DB_NAME_OSMAPI | wc -l`

--- a/scripts/SetupOsmApiDB.sh
+++ b/scripts/SetupOsmApiDB.sh
@@ -9,8 +9,8 @@ set -e
 source $HOOT_HOME/conf/DatabaseConfig.sh
 
 # setup db, user, and password to avoid password prompt
-export AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
-export PGPASSWORD=$DB_PASSWORD
+export AUTH="-h $DB_HOST_OSMAPI -p $DB_PORT_OSMAPI -U $DB_USER_OSMAPI"
+export PGPASSWORD=$DB_PASSWORD_OSMAPI
 do_create="true"
 
 # see if old db osmapi_test exists
@@ -24,7 +24,7 @@ if [ "$flag" = "1" ]; then
                     file_name text;  
                     file_time text;  
             BEGIN  
-              SELECT INTO db_oid oid FROM pg_database WHERE datname='osmapi_test'; 
+              SELECT INTO db_oid oid FROM pg_database WHERE datname='$DB_NAME_OSMAPI'; 
               SELECT INTO data_dir setting FROM pg_settings WHERE name='data_directory';  
               file_name := data_dir || '/base/' || db_oid || '/PG_VERSION'; 
               SELECT INTO file_time modification FROM pg_stat_file(file_name); 
@@ -61,9 +61,9 @@ fi
 # create the osm apu db from the blank osm api db script
 if [ "$do_create" = "true" ]; then
   #echo "Creating osm api db"
-  #echo "DB_HOST: " $DB_HOST
-  #echo "DB_PORT: " $DB_PORT
-  #echo "DB_USER: " $DB_USER
+  #echo "DB_HOST_OSMAPI: " $DB_HOST_OSMAPI
+  #echo "DB_PORT_OSMAPI: " $DB_PORT_OSMAPI
+  #echo "DB_USER_OSMAPI: " $DB_USER_OSMAPI
   #echo "PGPASSWORD: " $PGPASSWORD
   #echo "DB_NAME_OSMAPI: " $DB_NAME_OSMAPI
   createdb $AUTH $DB_NAME_OSMAPI

--- a/test-files/cmd/glacial/ServiceOsmApiDbConflateTest.sh
+++ b/test-files/cmd/glacial/ServiceOsmApiDbConflateTest.sh
@@ -17,9 +17,9 @@ mkdir -p test-output/cmd/glacial/ServiceOsmApiDbConflateTest
 echo ""
 echo "Cleaning out the osm api db and setting it up with an initial single user..."
 source scripts/SetupOsmApiDB.sh force
-export DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
-export PGPASSWORD=$DB_PASSWORD
+export DB_URL="osmapidb://$DB_USER_OSMAPI:$DB_PASSWORD_OSMAPI@$DB_HOST_OSMAPI:$DB_PORT_OSMAPI/$DB_NAME_OSMAPI"
+export AUTH="-h $DB_HOST_OSMAPI -p $DB_PORT_OSMAPI -U $DB_USER_OSMAPI"
+export PGPASSWORD=$DB_PASSWORD_OSMAPI
 psql --quiet $AUTH -d $DB_NAME_OSMAPI -f test-files/servicesdb/users.sql
 
 export HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"

--- a/test-files/cmd/glacial/ServiceOsmApiDbTest.sh
+++ b/test-files/cmd/glacial/ServiceOsmApiDbTest.sh
@@ -9,8 +9,8 @@ source scripts/SetupOsmApiDB.sh force
 # setup DB variables for automation
 source conf/DatabaseConfig.sh
 
-export AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
-export PGPASSWORD=$DB_PASSWORD
+export AUTH="-h $DB_HOST_OSMAPI -p $DB_PORT_OSMAPI -U $DB_USER_OSMAPI"
+export PGPASSWORD=$DB_PASSWORD_OSMAPI
 
 # setup dirs
 rm -rf test-output/cmd/ServiceOsmApiDbTest
@@ -25,7 +25,7 @@ mkdir -p test-output/cmd/ServiceOsmApiDbTest
 #echo $PGDATABASE $PGHOST $PGPORT $PGUSER $PGPASSWORD
 psql --quiet $AUTH -d $DB_NAME_OSMAPI -f test-files/ToyTestA.sql
 
-export DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
+export DB_URL="osmapidb://$DB_USER_OSMAPI:$DB_PASSWORD_OSMAPI@$DB_HOST_OSMAPI:$DB_PORT_OSMAPI/$DB_NAME_OSMAPI"
 
 # do the read operation
 echo "Performing read operation"

--- a/test-files/cmd/slow/ServiceApplyChangesetCmdTest.sh
+++ b/test-files/cmd/slow/ServiceApplyChangesetCmdTest.sh
@@ -4,9 +4,9 @@ set -e
 # clean out the database
 source scripts/SetupOsmApiDB.sh force
 source conf/DatabaseConfig.sh
-export DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
-export PGPASSWORD=$DB_PASSWORD
+export DB_URL="osmapidb://$DB_USER_OSMAPI:$DB_PASSWORD_OSMAPI@$DB_HOST_OSMAPI:$DB_PORT_OSMAPI/$DB_NAME_OSMAPI"
+export AUTH="-h $DB_HOST_OSMAPI -p $DB_PORT_OSMAPI -U $DB_USER_OSMAPI"
+export PGPASSWORD=$DB_PASSWORD_OSMAPI
 psql --quiet $AUTH -d $DB_NAME_OSMAPI -f test-files/servicesdb/users.sql
 
 rm -rf test-output/cmd/ServiceApplyChangesetCmdTest

--- a/test-files/cmd/slow/ServiceDeriveChangesetCmdTest.sh
+++ b/test-files/cmd/slow/ServiceDeriveChangesetCmdTest.sh
@@ -2,9 +2,9 @@
 set -e
 
 source $HOOT_HOME/conf/DatabaseConfig.sh
-export DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
-export PGPASSWORD=$DB_PASSWORD
+export DB_URL="osmapidb://$DB_USER_OSMAPI:$DB_PASSWORD_OSMAPI@$DB_HOST_OSMAPI:$DB_PORT_OSMAPI/$DB_NAME_OSMAPI"
+export AUTH="-h $DB_HOST_OSMAPI -p $DB_PORT_OSMAPI -U $DB_USER_OSMAPI"
+export PGPASSWORD=$DB_PASSWORD_OSMAPI
 
 mkdir -p test-output/cmd/ServiceDeriveChangesetCmdTest
 


### PR DESCRIPTION
@mattjdnv Can you do this one?  All that's done here is separating the credentials between the hoot api and osm api db's, since they won't necessarily be the same in a production environment.  thanks.