### PR TITLE
Fix initialization order error.

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
@@ -57,7 +57,7 @@ using namespace Tgs;
 namespace hoot
 {
 
-auto_ptr<ProbabilityOfMatch> ProbabilityOfMatch::_default;
+shared_ptr<ProbabilityOfMatch> ProbabilityOfMatch::_theInstance;
 bool ProbabilityOfMatch::debug = false;
 
 ProbabilityOfMatch::ProbabilityOfMatch()
@@ -159,11 +159,11 @@ double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const shared
 
 ProbabilityOfMatch& ProbabilityOfMatch::getInstance()
 {
-  if (!_default.get())
+  if (!_theInstance.get())
   {
-    _default.reset(new ProbabilityOfMatch());
+    _theInstance.reset(new ProbabilityOfMatch());
   }
-  return *_default;
+  return *_theInstance;
 }
 
 double ProbabilityOfMatch::lengthScore(const ConstOsmMapPtr &map, const shared_ptr<const Way>& w1,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
@@ -57,7 +57,7 @@ using namespace Tgs;
 namespace hoot
 {
 
-ProbabilityOfMatch ProbabilityOfMatch::_default;
+auto_ptr<ProbabilityOfMatch> ProbabilityOfMatch::_default;
 bool ProbabilityOfMatch::debug = false;
 
 ProbabilityOfMatch::ProbabilityOfMatch()
@@ -155,6 +155,15 @@ double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const shared
   }
 
   return p;
+}
+
+ProbabilityOfMatch& ProbabilityOfMatch::getInstance()
+{
+  if (!_default.get())
+  {
+    _default.reset(new ProbabilityOfMatch());
+  }
+  return *_default;
 }
 
 double ProbabilityOfMatch::lengthScore(const ConstOsmMapPtr &map, const shared_ptr<const Way>& w1,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
@@ -72,7 +72,7 @@ public:
   static bool debug;
 
 private:
-  static auto_ptr<ProbabilityOfMatch> _default;
+  static shared_ptr<ProbabilityOfMatch> _theInstance;
   double _parallelExp;
   double _dMax;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
@@ -47,7 +47,7 @@ class ProbabilityOfMatch
 public:
   ProbabilityOfMatch();
 
-  static ProbabilityOfMatch& getInstance() { return _default; }
+  static ProbabilityOfMatch& getInstance();
 
   double attributeScore(const ConstOsmMapPtr &map, const shared_ptr<const Way>& w1,
     const shared_ptr<const Way> &w2);
@@ -72,7 +72,7 @@ public:
   static bool debug;
 
 private:
-  static ProbabilityOfMatch _default;
+  static auto_ptr<ProbabilityOfMatch> _default;
   double _parallelExp;
   double _dMax;
 


### PR DESCRIPTION
1. refs #815 Error when running HGIS Prepare for Validation and Filter
   non-HGIS POIs
 * Though it may not appear to be related the ProbabilityOfMatch default
   instance was being instantiated during the initialization which was
   calling into Settings. Since Settings weren't properly configured
   yet this caused an error. Now the ProbabilityOfMatch default instance
   isn't constructed until it is needed.