### PR TITLE
Fix '--build-model' to produce output the same as '--build-rf'

### DIFF
--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForest.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForest.cpp
@@ -163,6 +163,8 @@ namespace Tgs
       if(!data->empty())
       {
         _forest.reserve(numTrees);
+        //  Reset the ids so that all forests are created alike
+        RandomTree::resetIds();
 
         for(unsigned int i = 0; i < numTrees; i++)
         {

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomTree.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomTree.h
@@ -174,6 +174,12 @@ namespace Tgs
     */
     void trainRoundRobin(boost::shared_ptr<DataFrame> data, unsigned int numFactors, std::string posClass,
       std::string negClass, unsigned int nodeSize = 1, bool balanced = false);
+    /**
+    * Resets the id counter.  Only needed in build-model when a model is loaded, increasing the ids,
+    * and then a model is created, subsequently creating a new model where the random forest's first tree doesn't start
+    * with an id of zero like it should
+    */
+    static void resetIds() { _idCtr = 0; }
 
   private:
     /**


### PR DESCRIPTION
refs #948 
Updated RandomForest to reset the tree id for each new forest (i.e. all tree ids are 0-39 instead of 0-39 or 40-79 depending on the command used)

Ensure that this passes the `model-training.child/jakarta-buildings.child` test