### PR TITLE
Add stability and improvements to schema switcher cuke test

### DIFF
--- a/test-files/ui/features/advanced_options.feature
+++ b/test-files/ui/features/advanced_options.feature
@@ -7,11 +7,11 @@ Feature: Advanced Conflation Options
 	    And I press "Add Reference Dataset"
 	    And I click the "AllDataTypesACucumber" Dataset
 	    And I press "Add Layer"
-	    Then I wait 30 "seconds" to see "AllDataTypesACucumber"
+	    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
 	    And I press "Add Secondary Dataset"
 	    And I click the "AllDataTypesBCucumber" Dataset
 	    And I press "Add Layer"
-	    Then I wait 30 "seconds" to see "AllDataTypesBCucumber"
+	    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
 
 	Scenario: I can set up standard conflation parameters
 	    Then I should see "Conflate"
@@ -221,11 +221,11 @@ Feature: Advanced Conflation Options
 		And I press "Add Reference Dataset"
 	    And I click the "AllDataTypesACucumber" Dataset
 	    And I press "Add Layer"
-	    Then I wait 30 "seconds" to see "AllDataTypesACucumber"
+	    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
 	    And I press "Add Secondary Dataset"
 	    And I click the "AllDataTypesBCucumber" Dataset
 	    And I press "Add Layer"
-	    Then I wait 30 "seconds" to see "AllDataTypesBCucumber"
+	    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
 
 	Scenario: I can set up standard conflation parameters
 	    Then I should see "Conflate"

--- a/test-files/ui/features/clip.feature
+++ b/test-files/ui/features/clip.feature
@@ -13,7 +13,7 @@ Feature: Clip Dataset
         When I press "Add Reference Dataset"
         And I click the "DcGisRoadsCucumber" Dataset
         And I press "Add Layer"
-        Then I wait 30 "seconds" to see "DcGisRoadsCucumber"
+        Then I wait 5 "seconds" to see "span.strong" element with text "DcGisRoadsCucumber"
         Then I change the reference layer color to blue
     Scenario: I can change coordinates for clip
         When I press "Tools"

--- a/test-files/ui/features/conflate_with_stats.feature
+++ b/test-files/ui/features/conflate_with_stats.feature
@@ -7,11 +7,11 @@ Feature: Conflate feature with stats
     And I press "Add Reference Dataset"
     And I click the "AllDataTypesACucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "AllDataTypesACucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
     And I press "Add Secondary Dataset"
     And I click the "AllDataTypesBCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "AllDataTypesBCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
     Then I should see "Conflate"
     And I press "Conflate"
     And I fill "saveAs" input with "AllDataTypesMergedCucumber"

--- a/test-files/ui/features/manually_resolve_reviews.feature
+++ b/test-files/ui/features/manually_resolve_reviews.feature
@@ -7,11 +7,11 @@ Feature: Manually resolve reviews feature
     And I press "Add Reference Dataset"
     And I click the "AllDataTypesACucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "AllDataTypesACucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
     And I press "Add Secondary Dataset"
     And I click the "AllDataTypesBCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "AllDataTypesBCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
     Then I should see "Conflate"
     And I press "Conflate"
     And I append "saveAs" input with "_Cucumber"
@@ -53,8 +53,8 @@ Feature: Manually resolve reviews feature
     Then I wait 30 "seconds" to see "Reviews remaining: 6 (Resolved: 2)"
     And I press "Resolved"
     Then I wait 30 "seconds" to see "Reviews remaining: 5 (Resolved: 3)"
-    Then I wait 5 seconds to see "g.activeReviewFeature" on the map 
-    Then I should see a "g.activeReviewFeature2" on the map 
+    Then I wait 5 seconds to see "g.activeReviewFeature" on the map
+    Then I should see a "g.activeReviewFeature2" on the map
     And I press "Resolved"
     Then I wait 30 "seconds" to see "Reviews remaining: 4 (Resolved: 4)"
     And I press "Resolved"

--- a/test-files/ui/features/osm_tds_switcher.feature
+++ b/test-files/ui/features/osm_tds_switcher.feature
@@ -6,7 +6,7 @@ Feature: OSM/TDS Switcher
         And I press "Add Reference Dataset"
         And I click the "DcGisRoadsCucumber" Dataset
         And I press "Add Layer"
-        Then I wait 30 "seconds" to see "DcGisRoadsCucumber"
+        Then I wait 5 "seconds" to see "span.strong" element with text "DcGisRoadsCucumber"
 
     Scenario: I can select a feature and switch between attribute schemas
         When I select a way map feature with OSM id "w309"

--- a/test-files/ui/features/osm_tds_switcher.feature
+++ b/test-files/ui/features/osm_tds_switcher.feature
@@ -52,7 +52,7 @@ Feature: OSM/TDS Switcher
         And I append "preset-search-input" input with "i"
         And I append "preset-search-input" input with "l"
         And I append "preset-search-input" input with "d"
-        And I wait 5 "seconds" to see "Building Superstructure (AL018)"
+        And I wait 10 "seconds" to see "Building Superstructure (AL018)"
         And I click the "div.label" with text "Building (AL013)"
         And I should see a "g.tag-building" on the map
         And I click the "map" at "440","425"

--- a/test-files/ui/features/osm_tds_switcher.feature
+++ b/test-files/ui/features/osm_tds_switcher.feature
@@ -26,21 +26,43 @@ Feature: OSM/TDS Switcher
         # Add a point with OSM schema
         When I click the "add-point" button
         And I hover over "#map"
-        And I click the "map" at "300","300"
+        And I click the "map" at "350","300"
         Then I wait 5 "seconds" to see "Select feature type"
         Then I select the "OSM" option labelled "Filter By Type"
         And I click the "div.label" with text "Park"
         And I should see a "g.tag-leisure-park" on the map
         And I click the "map" at "400","400"
+
+        # Translate this point to TDSv61 and get Feature out of spec error
+        When I select a node map feature with class "tag-leisure-park"
+        And I should see "Edit feature: "
+        And I select the "TDSv61" option labelled "Filter By Type"
+        Then I wait 5 "seconds" to see "Feature out of spec"
+
         # Add a point with TDSv61 schema
         When I click the "add-point" button
         And I hover over "#map"
-        And I click the "map" at "100","100"
+        And I click the "map" at "50","120"
         Then I wait 5 "seconds" to see "Select feature type"
         Then I select the "TDSv61" option labelled "Filter By Type"
+
+        # Use the preset search feature
+        And I append "preset-search-input" input with "b"
+        And I append "preset-search-input" input with "u"
+        And I append "preset-search-input" input with "i"
+        And I append "preset-search-input" input with "l"
+        And I append "preset-search-input" input with "d"
+        And I wait 5 "seconds" to see "Building Superstructure (AL018)"
         And I click the "div.label" with text "Building (AL013)"
         And I should see a "g.tag-building" on the map
-        And I click the "map" at "400","400"
+        And I click the "map" at "440","425"
+
+        # Translate this point to MGCP and get valid translation
+        When I select a node map feature with class "tag-building"
+        And I should see "Edit feature: "
+        And I select the "MGCP" option labelled "Filter By Type"
+        Then I wait 5 "seconds" to see "label" element with text "Condition of Facility"
+
         # Add a point with MGCP schema
         When I click the "add-point" button
         And I hover over "#map"

--- a/test-files/ui/features/resolve_all_reviews.feature
+++ b/test-files/ui/features/resolve_all_reviews.feature
@@ -7,11 +7,11 @@ Feature: Resolve all reviews feature
     And I press "Add Reference Dataset"
     And I click the "DcGisRoadsCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "DcGisRoadsCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "DcGisRoadsCucumber"
     And I press "Add Secondary Dataset"
     And I click the "DcTigerRoadsCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "DcTigerRoadsCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "DcTigerRoadsCucumber"
     Then I should see "Conflate"
     And I press "Conflate"
     And I scroll element into view and press "conflate2"
@@ -39,7 +39,7 @@ Feature: Resolve all reviews feature
     And I press "Add Secondary Dataset"
     And I click the "DcOsmRoadsCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "DcOsmRoadsCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "DcOsmRoadsCucumber"
     Then I should see "Conflate"
     And I press "Conflate"
     And I scroll element into view and press "conflate2"

--- a/test-files/ui/features/review_bookmarks.feature
+++ b/test-files/ui/features/review_bookmarks.feature
@@ -6,11 +6,11 @@ Feature: Review Bookmarks
         And I press "Add Reference Dataset"
         And I click the "AllDataTypesACucumber" Dataset
         And I press "Add Layer"
-        Then I wait 30 "seconds" to see "AllDataTypesACucumber"
+        Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
         And I press "Add Secondary Dataset"
         And I click the "AllDataTypesBCucumber" Dataset
         And I press "Add Layer"
-        Then I wait 30 "seconds" to see "AllDataTypesBCucumber"
+        Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
         Then I wait 30 "seconds" to see "Conflate"
         And I press "Conflate"
         Then I fill "saveAs" input with "mergedBookmarkTest"
@@ -100,11 +100,11 @@ Feature: Review Bookmarks
         And I wait 30 "seconds" to not see "Cucumber Bookmark 2"
         And I check the "mergedBookmarkTest" checkbox
         And I wait 30 "seconds" to see "Cucumber Bookmark 1"
-        And I wait 30 "seconds" to see "Cucumber Bookmark 2"   
+        And I wait 30 "seconds" to see "Cucumber Bookmark 2"
         Then I uncheck the "mergedBookmarkTest" checkbox
         And I press "big.loud" span with text "Reset"
         And I wait 30 "seconds" to see "Cucumber Bookmark 1"
-        And I wait 30 "seconds" to see "Cucumber Bookmark 2"   
+        And I wait 30 "seconds" to see "Cucumber Bookmark 2"
         And I should see checkbox "mergedBookmarkTest" checked
 
     Scenario: Delete Bookmark

--- a/test-files/ui/features/z_conflate_export_osm_api_db.feature
+++ b/test-files/ui/features/z_conflate_export_osm_api_db.feature
@@ -7,7 +7,7 @@ Feature: Conflate and Export OSM API Database Dataset
     And I press "Add Reference Dataset"
     And I click the "DcTigerRoadsCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "DcTigerRoadsCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "DcTigerRoadsCucumber"
     And I press "Add Secondary Dataset"
     And I should not see "OSM_API_DB_osmapi_test"
 
@@ -18,11 +18,11 @@ Feature: Conflate and Export OSM API Database Dataset
     And I press "Add Reference Dataset"
     And I click the "OSM_API_DB_osmapi_test" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "OSM_API_DB_osmapi_test"
+    Then I wait 5 "seconds" to see "span.strong" element with text "OSM_API_DB_osmapi_test"
     And I press "Add Secondary Dataset"
     And I click the "AllDataTypesBCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "AllDataTypesBCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
     Then I wait 30 "seconds" to see "Conflate"
     And I press "Conflate"
     And I scroll element into view and press "conflate2"
@@ -54,11 +54,11 @@ Feature: Conflate and Export OSM API Database Dataset
     And I press "Add Reference Dataset"
     And I click the "OSM_API_DB_osmapi_test" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "OSM_API_DB_osmapi_test"
+    Then I wait 5 "seconds" to see "span.strong" element with text "OSM_API_DB_osmapi_test"
     And I press "Add Secondary Dataset"
     And I click the "DcTigerRoadsCucumber" Dataset
     And I press "Add Layer"
-    Then I wait 30 "seconds" to see "DcTigerRoadsCucumber"
+    Then I wait 5 "seconds" to see "span.strong" element with text "DcTigerRoadsCucumber"
     Then I wait 30 "seconds" to see "Conflate"
     And I press "Conflate"
     And I scroll element into view and press "conflate2"


### PR DESCRIPTION
* Add out of spec and preset search steps to cuke test
* Add a step to troubleshoot a cuke test failure in nightly job:
When adding a dataset the previous method can't be used becuase it
matches on the dataset name in the available dataset list