### PR TITLE
Added an option to remove OSM XML formatting.

### DIFF
--- a/conf/ConfigOptions.asciidoc
+++ b/conf/ConfigOptions.asciidoc
@@ -1111,6 +1111,13 @@ from the URL.
 Specifies the writer that the OsmMapWriterFactory will use. This overrides any information derived
 from the URL.
 
+=== osm.map.writer.format.xml
+
+* Data Type: bool
+* Default Value: `true`
+
+Turns on autoformatting (line breaks, indentation etc) for XML output.
+
 === osm2ogr.ops
 
 * Data Type: list

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmWriter.cpp
@@ -53,6 +53,7 @@ HOOT_FACTORY_REGISTER(OsmMapWriter, OsmWriter)
 
 OsmWriter::OsmWriter()
 {
+  _formatXml = ConfigOptions().getOsmMapWriterFormatXml();
   _includeIds = false;
   _includeDebug = ConfigOptions().getWriterIncludeDebug();
   _includePointInWays = false;
@@ -161,7 +162,12 @@ void OsmWriter::write(boost::shared_ptr<const OsmMap> map)
   }
   QXmlStreamWriter writer(_fp.get());
   writer.setCodec("UTF-8");
-  writer.setAutoFormatting(true);
+
+  if (_formatXml)
+  {
+    writer.setAutoFormatting(true);
+  }
+
   writer.writeStartDocument();
 
   writer.writeStartElement("osm");

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmWriter.h
@@ -103,6 +103,7 @@ public:
   QString removeInvalidCharacters(const QString& s);
 
 protected:
+  bool _formatXml;
   bool _includeIds;
   bool _includeDebug;
   bool _includePointInWays;


### PR DESCRIPTION
1. refs #990 

Very simple :-)

@mschicker Can you have a look at this and merge please.

@brianhatchl FYI.  We should pull this into #916