### PR TITLE
Add -f option to unzipping of files to make more robust.

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmReader.cpp
@@ -327,8 +327,9 @@ void OsmReader::read(shared_ptr<OsmMap> map)
     _path.chop(std::strlen(".bz2"));
 
     // "man bunzip2" confirms success return code is zero
-    //  -k option is "keep," meaning don't delete input .osm.bz2
-    const std::string cmd(std::string("bunzip2 -k ") + originalFile.toStdString());
+    // -f option decompresses file even if decompressed file is already there
+    // -k option is "keep", meaning don't delete input .osm.bz2
+    const std::string cmd(std::string("bunzip2 -fk ") + originalFile.toStdString());
     LOG_DEBUG("Running uncompress command: " << cmd);
 
     int retVal;


### PR DESCRIPTION
Refs #1025 
Adding -f option to make unzipping more robust.  Should fix a current Jenkins test failure and will make test more robust in the future. 