### PR TITLE
#698 - add cuke test for checking layer visibility

### DIFF
--- a/test-files/ui/features/basemap_ingest.feature
+++ b/test-files/ui/features/basemap_ingest.feature
@@ -17,7 +17,7 @@ Feature: Basemap Ingest
     Scenario: Add Basemap To Map
         When I click the "closedeye" classed element under "span.fill-white.small" with text "RomanColosseumCucumber"
         Then I select the "sprocket" div
-        And I click the map background button
+        And I click the Background settings button
         And I click the "RomanColosseumCucumber" map layer
         And I wait
         And I accept the alert

--- a/test-files/ui/features/check_layer_visbility.feature
+++ b/test-files/ui/features/check_layer_visbility.feature
@@ -16,22 +16,16 @@ Feature: Check Layer Visibility
         When I click the Background settings button
         And I should see checkbox "DcGisRoadsCucumber" checked
         And I should see checkbox "DcOsmRoadsCucumber" checked
-        And I hover over "#map"
-        When I select a way map feature with class "w28_53"
-        Then I wait 10 "seconds" to see "Edit feature:"
-        When I select a way map feature with class "w189_67"
-        Then I wait 10 "seconds" to see "Edit feature:" 
+        When I should see a way map feature with OSM id "stroke w220_ tag-hoot-DcGisRoadsCucumber"
+        When I should see a way map feature with OSM id "stroke w189_ tag-hoot-DcOsmRoadsCucumber"
 
     Scenario: Toggle Layers and Check Visibility
-        When I click the Background settings button
         Then I uncheck the "DcGisRoadsCucumber" checkbox
         Then I should see checkbox "DcGisRoadsCucumber" unchecked
-        And I hover over "#map"
-        And I should not see an element "w28_53"
-        When I select a way map feature with class "w189_67"
-        Then I wait 10 "seconds" to see "Edit feature:"
-        When I click the Background settings button
+        When I should not see a way map feature with OSM id "tag-hoot-DcGisRoadsCucumber"
+        When I should see a way map feature with OSM id "stroke w189_ tag-hoot-DcOsmRoadsCucumber"
         Then I uncheck the "DcOsmRoadsCucumber" checkbox
         Then I should see checkbox "DcOsmRoadsCucumber" unchecked
-        And I hover over "#map"
-        And I should not see an element "w189_67"
+        When I should not see a way map feature with OSM id "tag-hoot-DcOsmRoadsCucumber"
+        Then I check the "DcGisRoadsCucumber" checkbox
+        When I should see a way map feature with OSM id "stroke w220_ tag-hoot-DcGisRoadsCucumber"

--- a/test-files/ui/features/check_layer_visbility.feature
+++ b/test-files/ui/features/check_layer_visbility.feature
@@ -1,0 +1,19 @@
+Feature: Check Layer Visibility
+
+    Scenario: Open Hootenanny and add data
+        Given I am on Hootenanny
+        And I click Get Started
+        And I press "Add Reference Dataset"
+        And I click the "DcGisRoadsCucumber" Dataset
+        And I press "Add Layer"
+        Then I wait 15 "seconds" to see "span.strong" element with text "DcGisRoadsCucumber"
+        And I press "Add Secondary Dataseet"
+        And I click the "DcOsmRoadsCucumber" Dataset
+        And I press "Add Layer"
+        Then I wait 15 "seconds" to see "span.strong" element with text "DcOsmRoadsCucumber"
+
+    Scenario: Check Layer Visbility
+        When I click to expand Background settings
+        And I should see checkbox "DcGisRoadsCucumber" checked
+        And I should see checkbox "DcOsmRoadsCucumber" checked
+        And I hover over "#{map}"

--- a/test-files/ui/features/check_layer_visbility.feature
+++ b/test-files/ui/features/check_layer_visbility.feature
@@ -1,19 +1,37 @@
 Feature: Check Layer Visibility
 
-    Scenario: Open Hootenanny and add data
+    Scenario: Open Hootenanny and Add Data
         Given I am on Hootenanny
         And I click Get Started
         And I press "Add Reference Dataset"
         And I click the "DcGisRoadsCucumber" Dataset
         And I press "Add Layer"
         Then I wait 15 "seconds" to see "span.strong" element with text "DcGisRoadsCucumber"
-        And I press "Add Secondary Dataseet"
+        And I press "Add Secondary Dataset"
         And I click the "DcOsmRoadsCucumber" Dataset
         And I press "Add Layer"
         Then I wait 15 "seconds" to see "span.strong" element with text "DcOsmRoadsCucumber"
 
     Scenario: Check Layer Visbility
-        When I click to expand Background settings
+        When I click the Background settings button
         And I should see checkbox "DcGisRoadsCucumber" checked
         And I should see checkbox "DcOsmRoadsCucumber" checked
-        And I hover over "#{map}"
+        And I hover over "#map"
+        When I select a way map feature with class "w28_53"
+        Then I wait 10 "seconds" to see "Edit feature:"
+        When I select a way map feature with class "w189_67"
+        Then I wait 10 "seconds" to see "Edit feature:" 
+
+    Scenario: Toggle Layers and Check Visibility
+        When I click the Background settings button
+        Then I uncheck the "DcGisRoadsCucumber" checkbox
+        Then I should see checkbox "DcGisRoadsCucumber" unchecked
+        And I hover over "#map"
+        And I should not see an element "w28_53"
+        When I select a way map feature with class "w189_67"
+        Then I wait 10 "seconds" to see "Edit feature:"
+        When I click the Background settings button
+        Then I uncheck the "DcOsmRoadsCucumber" checkbox
+        Then I should see checkbox "DcOsmRoadsCucumber" unchecked
+        And I hover over "#map"
+        And I should not see an element "w189_67"

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -50,6 +50,11 @@ When(/^I select a way map feature with OSM id "([^"]*)"$/) do |id|
   Capybara.default_max_wait_time = oldTimeout
 end
 
+When(/^I should (not )?see a way map feature with OSM id "([^"]*)"$/) do |negate, id|
+  expectation = negate ? 0 : 1
+  find('div.layer-data').assert_selector('path[class*=" ' + id + '"]',:maximum => expectation)
+end
+
 When(/^I select a way map feature with class "([^"]*)"$/) do |cls|
   oldTimeout = Capybara.default_max_wait_time
   Capybara.default_max_wait_time = 10

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -781,3 +781,8 @@ Then(/^I turn on highlight edited features$/) do
   el = find('div.highlight-edited')
   el.click
 end
+
+When(/^I click to expand Background settings$/) do
+  el = find('div.map-control.background-control')
+  el.click
+end

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -660,7 +660,7 @@ When(/^I select "([^"]*)" basemap/) do |file|
   end
 end
 
-When(/^I click the map background button$/) do
+When(/^I click the Background settings button$/) do
   find('div.background-control').find('button').click
 end
 
@@ -779,10 +779,5 @@ end
 
 Then(/^I turn on highlight edited features$/) do
   el = find('div.highlight-edited')
-  el.click
-end
-
-When(/^I click to expand Background settings$/) do
-  el = find('div.map-control.background-control')
   el.click
 end


### PR DESCRIPTION
My first cucumber test :smile:

I added a new test to check for layer visibility in two scenarios. Scenario one adds two layers, ensures the layer checkboxes are checked, and ensures that both layers are selectable on the map. Scenario two unchecks one box, makes sure that layer is not visible on the map, then does the same for the second layer. 

I also rewrote one of the steps (click background settings button) so it made more sense (background settings instead of map background button) and fixed `basemap_ingest.feature` (the only other test that step was used in) accordingly.