### PR TITLE
#732: add cucumber test for minimap visibility

### DIFF
--- a/scripts/jenkins/TestInitialNightly.sh
+++ b/scripts/jenkins/TestInitialNightly.sh
@@ -30,7 +30,7 @@ echo "Building core coverage reports..."
 make -sj`nproc` core-coverage
 
 echo "Building services coverage reports..."
-make -sj`nproc` services-coverage
+make -s services-coverage
 
 echo "Building UI coverage reports..."
 make ui-coverage

--- a/scripts/jenkins/TestInitialNightly.sh
+++ b/scripts/jenkins/TestInitialNightly.sh
@@ -30,7 +30,7 @@ echo "Building core coverage reports..."
 make -sj`nproc` core-coverage
 
 echo "Building services coverage reports..."
-make -s services-coverage
+make -sj`nproc` services-coverage
 
 echo "Building UI coverage reports..."
 make ui-coverage

--- a/test-files/ui/features/display_inset.feature
+++ b/test-files/ui/features/display_inset.feature
@@ -5,10 +5,21 @@ Feature: Display inset map
         And I resize the window
         And I click Get Started
         When I click the "/" key
-        Then I should see a ".map-in-map" on the map
+        Then I should see the previously hidden "div.map-in-map" on the page
         When I click the "/" key
+        Then I should not see the "div.map-in-map" on the page
+
+    Scenario: I can check minimap and see the inset map
+        When I click the map background button
+        And I should see checkbox "Minimap" unchecked
+        And I check the "Minimap" checkbox
+        Then I should see the previously hidden "div.map-in-map" on the page
+        And I uncheck the "Minimap" checkbox
+        Then I should not see the "div.map-in-map" on the page
 
     Scenario: I can resize the sidebar
         When I expand the sidebar
         When I click the "/" key
-        Then I should see a ".map-in-map" on the map
+        Then I should see the previously hidden "div.map-in-map" on the page
+        When I click the "/" key
+        Then I should not see the "div.map-in-map" on the page

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -784,5 +784,14 @@ end
 
 When(/^I expand the sidebar$/) do
   resizer = page.find('#resizer')
-  resizer.drag_by(350, 0)
+  resizer.drag_by(150, 0)
+end
+
+#for hidden features
+Then(/^I should see the previously hidden "([^"]*)" on the page$/) do |input|
+  el = page.find(input).should be_visible
+end
+
+Then(/^I should not see the "([^"]*)" on the page$/) do |input| 
+  el = page.should have_no_css(input, :visible => true)
 end

--- a/test-files/ui/features/support/capybara.rb
+++ b/test-files/ui/features/support/capybara.rb
@@ -1,16 +1,3 @@
-# features/support/mouse_click.rb
-Capybara::Node::Element.class_eval do
-  def click_at(x, y)
-    driver.browser.action.move_to(native, x.to_i, y.to_i).click.perform
-  end
-  def double_click_at(x, y)
-    driver.browser.action.move_to(native, x.to_i, y.to_i).double_click.perform
-  end
-  def context_click
-    driver.browser.action.context_click(self.native).perform
-  end
-end
-
 module CapybaraExtension
   def drag_by(right_by, down_by)
     base.drag_by(right_by, down_by)

--- a/test-files/ui/features/support/env.rb
+++ b/test-files/ui/features/support/env.rb
@@ -31,3 +31,4 @@ World(Capybara::DSL, Helpers)
 
 # Keep only the screenshots generated from the last failing test suite
 Capybara::Screenshot.prune_strategy = :keep_last_run
+

--- a/test-files/ui/features/support/mouse_click.rb
+++ b/test-files/ui/features/support/mouse_click.rb
@@ -10,18 +10,3 @@ Capybara::Node::Element.class_eval do
     driver.browser.action.context_click(self.native).perform
   end
 end
-
-module CapybaraExtension
-  def drag_by(right_by, down_by)
-    base.drag_by(right_by, down_by)
-  end
-end
-
-module CapybaraSeleniumExtension
-  def drag_by(right_by, down_by)
-    driver.browser.action.drag_and_drop_by(native, right_by, down_by).perform
-  end
-end
-
-::Capybara::Selenium::Node.send :include, CapybaraSeleniumExtension
-::Capybara::Node::Element.send :include, CapybaraExtension


### PR DESCRIPTION
This test should run through the following:

Scenario 1: Toggle "/" turns inset map on, toggle "/" again turns it off
Scenario 2: Toggle inset map on/off by checking "Minimap" checkbox on/off
Scenario 3: Resizing the sidebar won't affect inset map visibility (on/off)

Had trouble coming up with a solution for testing that the inset map was not visible since it remains in the DOM even when it's not visible, but this seems to work:

<pre>
Then(/^I should not see the "([^"]*)" on the page$/) do |input| 
  el = page.should have_no_css(input, :visible => true)
end
</pre>