### PR TITLE
Cucumber test to check for invalid inputs in advanced options

### DIFF
--- a/test-files/ui/features/advanced_options.feature
+++ b/test-files/ui/features/advanced_options.feature
@@ -213,7 +213,7 @@ Feature: Advanced Conflation Options
 	    And I context click the "Merged_AllDataTypes_Advanced" Dataset
 	    And I click the "Delete (1)" context menu item
 	    Then I accept the alert
-	    And I wait 30 "seconds" to not see "Merged_AllDataTypes_Advanced"
+	  # And I wait 30 "seconds" to not see "Merged_AllDataTypes_Advanced"
 	    Then I select the "sprocket" div
 
 	Scenario: Check for previous settings

--- a/test-files/ui/features/advanced_options.feature
+++ b/test-files/ui/features/advanced_options.feature
@@ -213,7 +213,7 @@ Feature: Advanced Conflation Options
 	    And I context click the "Merged_AllDataTypes_Advanced" Dataset
 	    And I click the "Delete (1)" context menu item
 	    Then I accept the alert
-	    #And I wait 30 "seconds" to not see "Merged_AllDataTypes_Advanced"
+	    And I wait 30 "seconds" to not see "Merged_AllDataTypes_Advanced"
 	    Then I select the "sprocket" div
 
 	Scenario: Check for previous settings

--- a/test-files/ui/features/advanced_options.feature
+++ b/test-files/ui/features/advanced_options.feature
@@ -105,7 +105,7 @@ Feature: Advanced Conflation Options
 		And I should see "Cookie Cutter & Horizontal Options"
 		Then I click on "#horizontal_conflation_options_label"
 		And I should see element "#horizontal_cookie_cutter_alpha_shape_buffer" with no value and placeholder "0"
-		Then I fill "horizontal_cookie_cutter_alpha_shape_buffer" with "5"
+		Then I fill "#horizontal_cookie_cutter_alpha_shape_buffer" with "5"
 		Then I click on "#horizontal_conflation_options_label"
 	 	Then I press "big.loud-red" span with text "Cancel"
 	 	And I should see "►"

--- a/test-files/ui/features/advanced_options_invalid_input.feature
+++ b/test-files/ui/features/advanced_options_invalid_input.feature
@@ -48,49 +48,77 @@ Feature: Advanced Conflation Options
 		Then I click on "#<option id>"
 
 		Examples:
-			| option name | option id | element | placeholder | 
+			| option name | option id | element | placeholder |   
 			| Cleaning Options | hoot_cleaning_options_label | small_way_merger_threshold | 15 | 
 			| General Conflation Options | hoot_general_conflation_options_label | unify_optimizer_time_limit | 30 |
-			| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_relation | 200000 |
+			# fix thefollowing in ui code
+			#| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_node | 2000000 |
+			#| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_relation | 200000 |
+			#| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_way | 200000 |
+			| Waterway Options | hoot_waterway_options_label | waterway_way_angle_sample_distance | "20.0" |
+			| Waterway Options | hoot_waterway_options_label | waterway_way_matcher_heading_delta | "150.0" |
+			| Waterway Options | hoot_waterway_options_label | waterway_rubber_sheet_minimum_ties | 5 |
 
-		# And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
-		# When I fill "rubber_sheet_minimum_ties" with "abc"
-		# When I press enter in the "#rubber_sheet_minimum_ties" input
-		# Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
-		# When I fill "rubber_sheet_minimum_ties" with ""
-		# When I press tab in the "#rubber_sheet_minimum_ties" input
-		# And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
-		# When I fill "rubber_sheet_minimum_ties" with "-789"
-		# When I press enter in the "#rubber_sheet_minimum_ties" input
-		# Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
-		# When I fill "rubber_sheet_minimum_ties" with ""
-		# When I press tab in the "#rubber_sheet_minimum_ties" input
-		# And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
-		# When I fill "rubber_sheet_minimum_ties" with "#%$@%"
-		# When I press enter in the "#rubber_sheet_minimum_ties" input
-		# Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
-		# When I fill "rubber_sheet_minimum_ties" with ""
-		# When I press tab in the "#rubber_sheet_minimum_ties" input
-		# Then I click on "#hoot_rubber_sheeting_options_label"
-		# And I should see "Waterway Options"
-		# Then I click on "#hoot_waterway_options_label"
-		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
-		# When I fill "waterway_way_matcher_heading_delta" with "abc"
-		# When I press enter in the "waterway_way_matcher_heading_delta" input
-		# Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
-		# When I fill "waterway_way_matcher_heading_delta" with ""
-		# When I press tab in the "waterway_way_matcher_heading_delta" input
-		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
-		# When I fill "waterway_way_matcher_heading_delta" with "-483290432"
-		# When I press enter in the "waterway_way_matcher_heading_delta" input
-		# Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
-		# When I fill "waterway_way_matcher_heading_delta" with ""
-		# When I press tab in the "waterway_way_matcher_heading_delta" input
-		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
-		# When I fill "waterway_way_matcher_heading_delta" with "^&#$*^"
-		# When I press enter in the "waterway_way_matcher_heading_delta" input
-		# Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
-		# When I fill "waterway_way_matcher_heading_delta" with ""
-		# When I press tab in the "waterway_way_matcher_heading_delta" input
-		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		Scenario: Open options that require checkbox for input
+			Then I should see "Rubber Sheeting Options"
+			Then I click on "#hoot_rubber_sheeting_options_label"
+			Then I check the "Enabled" checkbox
+			Then I check the "Rubber Sheet Ref" checkbox
+			Then I should see "Waterway Options"
+			Then I click on "#hoot_waterway_options_label"
+			Then I uncheck the "Waterway Auto Calc Search Radius" checkbox
 
+			Scenario Outline: Check for Invalid Inputs that require checkboxes
+				And I should see element "#<element>" with no value and placeholder <placeholder>
+				When I fill "#<element>" with <invalid argument>
+				When I press enter in the "#<element>" input
+				Then I should see an invalid input warning for "#<element>"
+				When I fill "#<element>" with ""
+				When I press tab in the "#<element>" input
+
+				Examples:
+				| element | placeholder | invalid argument |
+				| rubber_sheet_minimum_ties | 10 | "abcdef" |
+				| rubber_sheet_minimum_ties | 10 | "-10000" |
+				| rubber_sheet_minimum_ties | 10 | "&*^@(!" |
+				| search_radius_waterway | "-1" | "abcdef" |
+				| search_radius_waterway | "-1" | "-10000" |
+				| search_radius_waterway | "-1" | "&*^@(!" |
+
+	Scenario: Test Cookie Cutter Options that are different than Reference or Average Options
+		Then I press "big.loud-red" span with text "Cancel"
+		When I select the "Cookie Cutter & Horizontal" option in "#containerofConfType"
+		Then I click the "►" link
+		And I should see "Advanced Conflation Options"
+
+		Scenario Outline:
+			Then I should see "<option name>"
+			Then I click on "#<option id>"
+			And I should see element "#<element>" with no value and placeholder <placeholder>
+			When I fill "#<element>" with "abc"
+			When I press enter in the "#<element>" input
+			Then I should see an invalid input warning for "#<element>"
+			When I fill "#<element>" with ""
+			When I press tab in the "#<element>" input
+			And I should see element "#<element>" with no value and placeholder <placeholder>
+			When I fill "#<element>" with "-10000000"
+			When I press enter in the "#<element>" input
+			Then I should see an invalid input warning for "#<element>"
+			When I fill "#<element>" with ""
+			When I press tab in the "#<element>" input
+			And I should see element "#<element>" with no value and placeholder <placeholder>
+			When I fill "#<element>" with "!@("
+			When I press enter in the "#<element>" input
+			Then I should see an invalid input warning for "#<element>"
+			When I fill "#<element>" with ""
+			When I press tab in the "#<element>" input
+			And I should see element "#<element>" with no value and placeholder <placeholder>
+			Then I click on "#<option id>"
+				
+			Examples:
+				| option name | option id | element | placeholder |
+				| Road Options | hoot_road_options_label | search_radius_highway | "-1" |
+				| Road Options | hoot_road_options_label | highway_matcher_heading_delta | "5.0" |
+				| Road Options | hoot_road_options_label | highway_matcher_max_angle | 60 |
+				| Road Options | hoot_road_options_label | way_merger_min_split_size | 5 |
+				#| Cookie Cutter & Horizontal Options | horizontal_conflation_options_label | horizontal_cookie_cutter_alpha_shape_buffer | 0 |

--- a/test-files/ui/features/advanced_options_invalid_input.feature
+++ b/test-files/ui/features/advanced_options_invalid_input.feature
@@ -1,0 +1,90 @@
+Feature: Advanced Conflation Options
+
+	Scenario: I can add data
+		Given I am on Hootenanny
+	    And I resize the window
+	    And I click Get Started
+	    And I press "Add Reference Dataset"
+	    And I click the "AllDataTypesACucumber" Dataset
+	    And I press "Add Layer"
+	    Then I wait 15 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
+	    And I press "Add Secondary Dataset"
+	    And I click the "AllDataTypesBCucumber" Dataset
+	    And I press "Add Layer"
+	    Then I wait 15 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
+
+	Scenario: I can set up standard conflation parameters
+	    Then I should see "Conflate"
+	    And I press "Conflate"
+	    And I fill "saveAs" input with "Merged_AllDataTypes_Advanced"
+
+	    Scenario: Check for Invalid Inputs in Reference Advanced Options
+	    When I select the "Reference" option in "#containerofConfType"
+		Then I click the "►" link
+		And I should see "Advanced Conflation Options"
+		Then I should see "Cleaning Options"
+		Then I click on "#hoot_cleaning_options_label"
+		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
+		When I fill "small_way_merger_threshold" with "abc"
+		When I press enter in the "#small_way_merger_threshold" input
+		Then I should see an invalid input warning for "#small_way_merger_threshold"
+		When I fill "small_way_merger_threshold" with ""
+		When I press tab in the "#small_way_merger_threshold" input
+		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
+		When I fill "small_way_merger_threshold" with "-100"
+		When I press enter in the "#small_way_merger_threshold" input
+		Then I should see an invalid input warning for "#small_way_merger_threshold"
+		When I fill "small_way_merger_threshold" with ""
+		When I press tab in the "#small_way_merger_threshold" input
+		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
+		When I fill "small_way_merger_threshold" with "!@("
+		When I press enter in the "#small_way_merger_threshold" input
+		Then I should see an invalid input warning for "#small_way_merger_threshold"
+		When I fill "small_way_merger_threshold" with ""
+		When I press tab in the "#small_way_merger_threshold" input
+		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
+		Then I click on "#hoot_cleaning_options_label"
+		And I should see "Rubber Sheeting Options"
+		Then I click on "#hoot_rubber_sheeting_options_label"
+		And I check the "Enabled" checkbox
+		And I check the "Rubber Sheet Ref" checkbox
+		And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+		When I fill "rubber_sheet_minimum_ties" with "abc"
+		When I press enter in the "#rubber_sheet_minimum_ties" input
+		Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
+		When I fill "rubber_sheet_minimum_ties" with ""
+		When I press tab in the "#rubber_sheet_minimum_ties" input
+		And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+		When I fill "rubber_sheet_minimum_ties" with "-789"
+		When I press enter in the "#rubber_sheet_minimum_ties" input
+		Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
+		When I fill "rubber_sheet_minimum_ties" with ""
+		When I press tab in the "#rubber_sheet_minimum_ties" input
+		And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+		When I fill "rubber_sheet_minimum_ties" with "#%$@%"
+		When I press enter in the "#rubber_sheet_minimum_ties" input
+		Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
+		When I fill "rubber_sheet_minimum_ties" with ""
+		When I press tab in the "#rubber_sheet_minimum_ties" input
+		Then I click on "#hoot_rubber_sheeting_options_label"
+		And I should see "Waterway Options"
+		Then I click on "#hoot_waterway_options_label"
+		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		When I fill "waterway_way_matcher_heading_delta" with "abc"
+		When I press enter in the "waterway_way_matcher_heading_delta" input
+		Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
+		When I fill "waterway_way_matcher_heading_delta" with ""
+		When I press tab in the "waterway_way_matcher_heading_delta" input
+		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		When I fill "waterway_way_matcher_heading_delta" with "-483290432"
+		When I press enter in the "waterway_way_matcher_heading_delta" input
+		Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
+		When I fill "waterway_way_matcher_heading_delta" with ""
+		When I press tab in the "waterway_way_matcher_heading_delta" input
+		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		When I fill "waterway_way_matcher_heading_delta" with "^&#$*^"
+		When I press enter in the "waterway_way_matcher_heading_delta" input
+		Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
+		When I fill "waterway_way_matcher_heading_delta" with ""
+		When I press tab in the "waterway_way_matcher_heading_delta" input
+		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"

--- a/test-files/ui/features/advanced_options_invalid_input.feature
+++ b/test-files/ui/features/advanced_options_invalid_input.feature
@@ -51,10 +51,9 @@ Feature: Advanced Conflation Options
 			| option name | option id | element | placeholder |   
 			| Cleaning Options | hoot_cleaning_options_label | small_way_merger_threshold | 15 | 
 			| General Conflation Options | hoot_general_conflation_options_label | unify_optimizer_time_limit | 30 |
-			# fix thefollowing in ui code
-			#| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_node | 2000000 |
-			#| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_relation | 200000 |
-			#| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_way | 200000 |
+			| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_node | 2000000 |
+			| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_relation | 200000 |
+			| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_way | 200000 |
 			| Waterway Options | hoot_waterway_options_label | waterway_way_angle_sample_distance | "20.0" |
 			| Waterway Options | hoot_waterway_options_label | waterway_way_matcher_heading_delta | "150.0" |
 			| Waterway Options | hoot_waterway_options_label | waterway_rubber_sheet_minimum_ties | 5 |

--- a/test-files/ui/features/advanced_options_invalid_input.feature
+++ b/test-files/ui/features/advanced_options_invalid_input.feature
@@ -102,7 +102,7 @@ Feature: Advanced Conflation Options
 			And I should see element "#<element>" with no value and placeholder <placeholder>
 			When I fill "#<element>" with "-10000000"
 			When I press enter in the "#<element>" input
-			Then I should see an invalid input warning for "#<element>"
+			Then I <might> see an invalid input warning for "#<element>"
 			When I fill "#<element>" with ""
 			When I press tab in the "#<element>" input
 			And I should see element "#<element>" with no value and placeholder <placeholder>
@@ -115,9 +115,9 @@ Feature: Advanced Conflation Options
 			Then I click on "#<option id>"
 				
 			Examples:
-				| option name | option id | element | placeholder |
-				| Road Options | hoot_road_options_label | search_radius_highway | "-1" |
-				| Road Options | hoot_road_options_label | highway_matcher_heading_delta | "5.0" |
-				| Road Options | hoot_road_options_label | highway_matcher_max_angle | 60 |
-				| Road Options | hoot_road_options_label | way_merger_min_split_size | 5 |
-				#| Cookie Cutter & Horizontal Options | horizontal_conflation_options_label | horizontal_cookie_cutter_alpha_shape_buffer | 0 |
+				| option name | option id | element | placeholder | might |
+				| Road Options | hoot_road_options_label | search_radius_highway | "-1" | should |
+				| Road Options | hoot_road_options_label | highway_matcher_heading_delta | "5.0" | should|
+				| Road Options | hoot_road_options_label | highway_matcher_max_angle | 60 | should |
+				| Road Options | hoot_road_options_label | way_merger_min_split_size | 5 | should |
+				| Cookie Cutter & Horizontal Options | horizontal_conflation_options_label | horizontal_cookie_cutter_alpha_shape_buffer | 0 | should_not |

--- a/test-files/ui/features/advanced_options_invalid_input.feature
+++ b/test-files/ui/features/advanced_options_invalid_input.feature
@@ -18,73 +18,79 @@ Feature: Advanced Conflation Options
 	    And I press "Conflate"
 	    And I fill "saveAs" input with "Merged_AllDataTypes_Advanced"
 
-	    Scenario: Check for Invalid Inputs in Reference Advanced Options
+	Scenario: I set up the Advanced Conflation Options menu
 	    When I select the "Reference" option in "#containerofConfType"
 		Then I click the "►" link
 		And I should see "Advanced Conflation Options"
-		Then I should see "Cleaning Options"
-		Then I click on "#hoot_cleaning_options_label"
-		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
-		When I fill "small_way_merger_threshold" with "abc"
-		When I press enter in the "#small_way_merger_threshold" input
-		Then I should see an invalid input warning for "#small_way_merger_threshold"
-		When I fill "small_way_merger_threshold" with ""
-		When I press tab in the "#small_way_merger_threshold" input
-		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
-		When I fill "small_way_merger_threshold" with "-100"
-		When I press enter in the "#small_way_merger_threshold" input
-		Then I should see an invalid input warning for "#small_way_merger_threshold"
-		When I fill "small_way_merger_threshold" with ""
-		When I press tab in the "#small_way_merger_threshold" input
-		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
-		When I fill "small_way_merger_threshold" with "!@("
-		When I press enter in the "#small_way_merger_threshold" input
-		Then I should see an invalid input warning for "#small_way_merger_threshold"
-		When I fill "small_way_merger_threshold" with ""
-		When I press tab in the "#small_way_merger_threshold" input
-		And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
-		Then I click on "#hoot_cleaning_options_label"
-		And I should see "Rubber Sheeting Options"
-		Then I click on "#hoot_rubber_sheeting_options_label"
-		And I check the "Enabled" checkbox
-		And I check the "Rubber Sheet Ref" checkbox
-		And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
-		When I fill "rubber_sheet_minimum_ties" with "abc"
-		When I press enter in the "#rubber_sheet_minimum_ties" input
-		Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
-		When I fill "rubber_sheet_minimum_ties" with ""
-		When I press tab in the "#rubber_sheet_minimum_ties" input
-		And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
-		When I fill "rubber_sheet_minimum_ties" with "-789"
-		When I press enter in the "#rubber_sheet_minimum_ties" input
-		Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
-		When I fill "rubber_sheet_minimum_ties" with ""
-		When I press tab in the "#rubber_sheet_minimum_ties" input
-		And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
-		When I fill "rubber_sheet_minimum_ties" with "#%$@%"
-		When I press enter in the "#rubber_sheet_minimum_ties" input
-		Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
-		When I fill "rubber_sheet_minimum_ties" with ""
-		When I press tab in the "#rubber_sheet_minimum_ties" input
-		Then I click on "#hoot_rubber_sheeting_options_label"
-		And I should see "Waterway Options"
-		Then I click on "#hoot_waterway_options_label"
-		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
-		When I fill "waterway_way_matcher_heading_delta" with "abc"
-		When I press enter in the "waterway_way_matcher_heading_delta" input
-		Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
-		When I fill "waterway_way_matcher_heading_delta" with ""
-		When I press tab in the "waterway_way_matcher_heading_delta" input
-		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
-		When I fill "waterway_way_matcher_heading_delta" with "-483290432"
-		When I press enter in the "waterway_way_matcher_heading_delta" input
-		Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
-		When I fill "waterway_way_matcher_heading_delta" with ""
-		When I press tab in the "waterway_way_matcher_heading_delta" input
-		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
-		When I fill "waterway_way_matcher_heading_delta" with "^&#$*^"
-		When I press enter in the "waterway_way_matcher_heading_delta" input
-		Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
-		When I fill "waterway_way_matcher_heading_delta" with ""
-		When I press tab in the "waterway_way_matcher_heading_delta" input
-		And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+
+	Scenario Outline: Check for Invalid Inputs in Reference Advanced Options
+		Then I should see "<option name>"
+		Then I click on "#<option id>"
+		And I should see element "#<element>" with no value and placeholder <placeholder>
+		When I fill "#<element>" with "abc"
+		When I press enter in the "#<element>" input
+		Then I should see an invalid input warning for "#<element>"
+		When I fill "#<element>" with ""
+		When I press tab in the "#<element>" input
+		And I should see element "#<element>" with no value and placeholder <placeholder>
+		When I fill "#<element>" with "-100"
+		When I press enter in the "#<element>" input
+		Then I should see an invalid input warning for "#<element>"
+		When I fill "#<element>" with ""
+		When I press tab in the "#<element>" input
+		And I should see element "#<element>" with no value and placeholder <placeholder>
+		When I fill "#<element>" with "!@("
+		When I press enter in the "#<element>" input
+		Then I should see an invalid input warning for "#<element>"
+		When I fill "#<element>" with ""
+		When I press tab in the "#<element>" input
+		And I should see element "#<element>" with no value and placeholder <placeholder>
+		Then I click on "#<option id>"
+
+		Examples:
+			| option name | option id | element | placeholder | 
+			| Cleaning Options | hoot_cleaning_options_label | small_way_merger_threshold | 15 | 
+			| General Conflation Options | hoot_general_conflation_options_label | unify_optimizer_time_limit | 30 |
+			| General Conflation Options | hoot_general_conflation_options_label | element_cache_size_relation | 200000 |
+
+		# And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+		# When I fill "rubber_sheet_minimum_ties" with "abc"
+		# When I press enter in the "#rubber_sheet_minimum_ties" input
+		# Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
+		# When I fill "rubber_sheet_minimum_ties" with ""
+		# When I press tab in the "#rubber_sheet_minimum_ties" input
+		# And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+		# When I fill "rubber_sheet_minimum_ties" with "-789"
+		# When I press enter in the "#rubber_sheet_minimum_ties" input
+		# Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
+		# When I fill "rubber_sheet_minimum_ties" with ""
+		# When I press tab in the "#rubber_sheet_minimum_ties" input
+		# And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+		# When I fill "rubber_sheet_minimum_ties" with "#%$@%"
+		# When I press enter in the "#rubber_sheet_minimum_ties" input
+		# Then I should see an invalid input warning for "#rubber_sheet_minimum_ties"
+		# When I fill "rubber_sheet_minimum_ties" with ""
+		# When I press tab in the "#rubber_sheet_minimum_ties" input
+		# Then I click on "#hoot_rubber_sheeting_options_label"
+		# And I should see "Waterway Options"
+		# Then I click on "#hoot_waterway_options_label"
+		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		# When I fill "waterway_way_matcher_heading_delta" with "abc"
+		# When I press enter in the "waterway_way_matcher_heading_delta" input
+		# Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
+		# When I fill "waterway_way_matcher_heading_delta" with ""
+		# When I press tab in the "waterway_way_matcher_heading_delta" input
+		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		# When I fill "waterway_way_matcher_heading_delta" with "-483290432"
+		# When I press enter in the "waterway_way_matcher_heading_delta" input
+		# Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
+		# When I fill "waterway_way_matcher_heading_delta" with ""
+		# When I press tab in the "waterway_way_matcher_heading_delta" input
+		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+		# When I fill "waterway_way_matcher_heading_delta" with "^&#$*^"
+		# When I press enter in the "waterway_way_matcher_heading_delta" input
+		# Then I should see an invalid input warning for "#waterway_way_matcher_heading_delta"
+		# When I fill "waterway_way_matcher_heading_delta" with ""
+		# When I press tab in the "waterway_way_matcher_heading_delta" input
+		# And I should see element "#waterway_way_matcher_heading_delta" with no value and placeholder "150.0"
+

--- a/test-files/ui/features/bulk_import_multidelete.feature
+++ b/test-files/ui/features/bulk_import_multidelete.feature
@@ -34,7 +34,7 @@ Feature: Bulk Import and Multiselect Delete Datasets
         And I select in row 1 the "/test-files/mapcruzinpoi_clip.osm" dataset
         And I should see row 1 input "Save As" with value "mapcruzinpoi_clip"
         Then I fill row 1 input "Save As" with value "mapcruzinpoi_clip"
-        Then I fill "customSuffix" with "_customSuffix"
+        Then I fill "#customSuffix" with "_customSuffix"
         Then I press "big.loud" span with text "Import"
         And I should see "Initializing...Starting bulk import process..."
         Then I wait 2 "minutes" to see "dcpoi_clip_customSuffix"

--- a/test-files/ui/features/clip.feature
+++ b/test-files/ui/features/clip.feature
@@ -27,10 +27,10 @@ Feature: Clip Dataset
         And I should see "#minlon" with a value between "-78" and "-76"
         And I should see "#maxlon" with a value greater than "#minlon"
         Then I click the "Use Visual Extent" link
-        And I fill "maxlat" with "38.901164"
-        And I fill "maxlon" with "-77.016836"
-        And I fill "minlat" with "38.882563"
-        And I fill "minlon" with "-77.071161"
+        And I fill "#maxlat" with "38.901164"
+        And I fill "#maxlon" with "-77.016836"
+        And I fill "#minlat" with "38.882563"
+        And I fill "#minlon" with "-77.071161"
         Then I click the "Clip to Bounding Box" link
         And I click the "map" at "100","100"
         And I click the "map" at "400","400"

--- a/test-files/ui/features/manage_tab.feature
+++ b/test-files/ui/features/manage_tab.feature
@@ -86,7 +86,7 @@ Feature: Manage Tab
         And I click the "Add Dataset" context menu item
         And I select the "File (osm,osm.zip,pbf)" option in the "Select Import Type" combobox
         And I select "/test-files/dcpoi_clip.osm" dataset
-        And I fill "importDatasetLayerName" with "dcpoi_clip_Cucumber_manage"
+        And I fill "#importDatasetLayerName" with "dcpoi_clip_Cucumber_manage"
         Then I should see element "[id='importDatasetLayerName']" with value "dcpoi_clip_Cucumber_manage"
         And I should see element "#importDatasetPathName" with no value and placeholder "TestFolder/TestSubFolder"
         When I press "big.loud" span with text "Import"

--- a/test-files/ui/features/osm_tds_switcher.feature
+++ b/test-files/ui/features/osm_tds_switcher.feature
@@ -78,7 +78,7 @@ Feature: OSM/TDS Switcher
         # I can add a new tag using a TDSv61 field
         Then I wait 5 seconds
         Then I select the "Floor Count" option labelled "Add field:"
-        Then I fill "preset-input-TDSv61\/BNF" with "3"
+        Then I fill "#preset-input-TDSv61\/BNF" with "3"
         And I click the "map" at "440","425"
 
         # Translate this point to MGCP and get valid translation

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -806,3 +806,10 @@ Then(/^I should see an invalid input warning for "([^"]*)"/) do |input|
   el = find(input)
   el[:class].include?('invalid-input').should eq true
 end
+
+# for placeholders 
+Then(/^I should see element "([^"]*)" with no value and placeholder (\w+)$/) do |id, value|
+  el = find(id)
+  el.value.should eq ""
+  el['placeholder'].should eq value
+end

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -808,7 +808,7 @@ Then(/^I should see an invalid input warning for "([^"]*)"/) do |input|
 end
 
 # for placeholders 
-Then(/^I should see element "([^"]*)" with no value and placeholder (\w+)$/) do |id, value|
+Then(/^I should see element "([^"]*)" with no value and placeholder (\d+)$/) do |id, value|
   el = find(id)
   el.value.should eq ""
   el['placeholder'].should eq value

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -322,7 +322,7 @@ When(/^I double-click the "([^"]*)"$/) do |el|
 end
 
 When(/^I fill "([^"]*)" with "([^"]*)"$/) do |el, value|
-  find('#' + el).set(value)
+  find(el).set(value)
   sleep 1
 end
 

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -848,6 +848,12 @@ Then(/^I should see an invalid input warning for "([^"]*)"/) do |input|
   el[:class].include?('invalid-input').should eq true
 end
 
+Then(/^I should_not see an invalid input warning for "([^"]*)"/) do |input|
+  el = find(input)
+  el[:class].include?('invalid-input').should eq false
+end
+
+
 # for placeholders 
 Then(/^I should see element "([^"]*)" with no value and placeholder (\d+)$/) do |id, value|
   el = find(id)

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -800,3 +800,9 @@ end
 Then(/^I should not see the "([^"]*)" on the page$/) do |input| 
   el = page.should have_no_css(input, :visible => true)
 end
+
+# for invalid features
+Then(/^I should see an invalid input warning for "([^"]*)"/) do |input|
+  el = find(input)
+  el[:class].include?('invalid-input').should eq true
+end


### PR DESCRIPTION
From ngageoint/hootenanny-ui#723

I created a separate feature test from `advanced_options.feature` since that one is super freakin long and can probably be refactored using scenario outlines + example tables similar to this one (and yes I volunteer myself to refactor it). When that test gets refactored these two can be combined. That's what I'm thinking.