### PR TITLE
add step to fix intermittent failures for manage_tab.feature test

### DIFF
--- a/test-files/ui/features/manage_tab.feature
+++ b/test-files/ui/features/manage_tab.feature
@@ -52,6 +52,7 @@ Feature: Manage Tab
         Then I fill "NewFolderName" input with "ManageTabTest"
         And I press "big.loud" span with text "Add Folder"
         # Move datasets into folder
+        And I hover over "#datasettable"
         When I click the "AllDataTypesACucumber" Dataset and the "AllDataTypesBCucumber" Dataset
         And I context click "AllDataTypesACucumber"
         And I should see "Delete (2)"

--- a/test-files/ui/features/manage_tab.feature
+++ b/test-files/ui/features/manage_tab.feature
@@ -124,6 +124,7 @@ Feature: Manage Tab
 
     Scenario: Add dataset as reference and secondary dataset
         # Add as reference
+        And I hover over "#datasettable"
         And I should see "DC_poi_clip_cucumber"
         And I click the "DC_poi_clip_cucumber" Dataset
         And I context click the "DC_poi_clip_cucumber" Dataset

--- a/test-files/ui/features/manage_tab.feature
+++ b/test-files/ui/features/manage_tab.feature
@@ -124,8 +124,7 @@ Feature: Manage Tab
 
     Scenario: Add dataset as reference and secondary dataset
         # Add as reference
-        And I hover over "#datasettable"
-        And I should see "DC_poi_clip_cucumber"
+        Then I wait 5 "seconds" to see "tspan" element with text "DC_poi_clip_cucumber"
         And I click the "DC_poi_clip_cucumber" Dataset
         And I context click the "DC_poi_clip_cucumber" Dataset
         Then I should see "Add as Reference Dataset"


### PR DESCRIPTION
This should fix the problem where this test was failing every other time at the context click to `Delete (2)` features (see https://github.com/ngageoint/hootenanny/pull/1129). Currently has a 100% pass rate for me locally (5/5).
