### PR TITLE
New test for generating Conflation Report

### DIFF
--- a/test-files/ui/features/report_generation.feature
+++ b/test-files/ui/features/report_generation.feature
@@ -21,11 +21,11 @@ Feature: Generate Conflation Report
         Then I wait 15 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
         Then I should see "Conflate"
         And I press "Conflate"
-        And I fill "saveAs" input with "Conflate_Report"
+        And I fill "saveAs" input with "Conflate_Report_Cucumber"
         And I select the "true" option in "#containerofisGenerateReport"
         And I scroll element into view and press "conflate2"
         Then I wait 30 "seconds" to see "Conflating …"
-        Then I wait 3 "minutes" to see "Conflate_Report"
+        Then I wait 3 "minutes" to see "Conflate_Report_Cucumber"
         Then I should see "Complete Review"
         And I click the "Complete Review" link
         Then I should see "Resolve all remaining reviews"
@@ -36,21 +36,20 @@ Feature: Generate Conflation Report
     Scenario: Check out the Report
         When I select the "sprocket" div
         And I click on the "Reports" option in the "settingsSidebar"
-        And I should see "Conflate_Report"
-        When I click the "up" icon under the "Conflate_Report" link
+        And I should see "Conflate_Report_Cucumber"
+        When I click the "up" icon under the "Conflate_Report_Cucumber" link
         Then I press "round" span with text "Download"
         And I wait 30 seconds
         Then the download file "Conflate_Report.pdf" should exist
 
     Scenario: Delete the Datasets
-        When I click the "trash" icon under the "Conflate_Report" link
+        When I click the "trash" icon under the "Conflate_Report_Cucumber" link
         And I wait
         And I accept the alert
         Then I click on the "Datasets" option in the "settingsSidebar"
-        When I click the "Conflate_Report" Dataset
-        And I context click the "Conflate_Report" Dataset
+        When I click the "Conflate_Report_Cucumber" Dataset
+        And I context click the "Conflate_Report_Cucumber" Dataset
         And I click the "Delete" context menu item
         And I wait
         And I accept the alert
-        And I wait 30 "seconds" to not see "Conflate_Report"
-        
+        And I wait 30 "seconds" to not see "Conflate_Report_Cucumber"

--- a/test-files/ui/features/report_generation.feature
+++ b/test-files/ui/features/report_generation.feature
@@ -1,0 +1,44 @@
+Feature: Generate Conflation Report
+
+    Scenario: Enable test mode
+        Given I am on Hootenanny
+        And I resize the window
+        And I click Get Started
+        When I select the "sprocket" div
+        When I click on the "About" option in the "settingsSidebar"
+        And I should see checkbox "Enable Test Mode" unchecked
+        And I check the "Enable Test Mode" checkbox
+        And I select the "sprocket" div
+
+    Scenario: Add and Conflate Data
+        And I press "Add Reference Dataset"
+        And I click the "AllDataTypesACucumber" Dataset
+        And I press "Add Layer"
+        Then I wait 15 "seconds" to see "span.strong" element with text "AllDataTypesACucumber"
+        And I press "Add Secondary Dataset"
+        And I click the "AllDataTypesBCucumber" Dataset
+        And I press "Add Layer"
+        Then I wait 15 "seconds" to see "span.strong" element with text "AllDataTypesBCucumber"
+        Then I should see "Conflate"
+        And I press "Conflate"
+        And I fill "saveAs" input with "Conflate_Report"
+        And I should see "Generate Report?"
+        And I select the "true" option in "#containerofisGenerateReport"
+        And I press tab
+        And I press tab
+        And I press enter
+        Then I wait 30 "seconds" to see "Conflating …"
+        Then I wait 3 "minutes" to see "Conflate_Report"
+        Then I should see "Complete Review"
+        And I click the "Complete Review" link
+        Then I should see "Resolve all remaining reviews"
+        And I press "Resolve all remaining reviews"
+
+    Scenario: Check out the Report
+        When I select the "sprocket" div
+        And I click on the "Reports" option in the "settingsSidebar"
+        And I should see "Conflate_Report"
+        And I click the "_icon.up" button
+        Then I press "Download"
+        And I wait 30 seconds
+        Then the download file "Conflate_Report.pdf" should exist

--- a/test-files/ui/features/report_generation.feature
+++ b/test-files/ui/features/report_generation.feature
@@ -24,9 +24,11 @@ Feature: Generate Conflation Report
         And I fill "saveAs" input with "Conflate_Report"
         And I should see "Generate Report?"
         And I select the "true" option in "#containerofisGenerateReport"
-        And I press tab
-        And I press tab
-        And I press enter
+        # And I press tab
+        # And I press tab
+        # And I press enter
+        And I hover over "#conflate2"
+        And I scroll element into view and press "conflate2"
         Then I wait 30 "seconds" to see "Conflating …"
         Then I wait 3 "minutes" to see "Conflate_Report"
         Then I should see "Complete Review"

--- a/test-files/ui/features/report_generation.feature
+++ b/test-files/ui/features/report_generation.feature
@@ -22,12 +22,7 @@ Feature: Generate Conflation Report
         Then I should see "Conflate"
         And I press "Conflate"
         And I fill "saveAs" input with "Conflate_Report"
-        And I should see "Generate Report?"
         And I select the "true" option in "#containerofisGenerateReport"
-        # And I press tab
-        # And I press tab
-        # And I press enter
-        And I hover over "#conflate2"
         And I scroll element into view and press "conflate2"
         Then I wait 30 "seconds" to see "Conflating …"
         Then I wait 3 "minutes" to see "Conflate_Report"
@@ -35,12 +30,27 @@ Feature: Generate Conflation Report
         And I click the "Complete Review" link
         Then I should see "Resolve all remaining reviews"
         And I press "Resolve all remaining reviews"
+        When I click on "input#export_data"
+        And I click on "input#exit_conflate"
 
     Scenario: Check out the Report
         When I select the "sprocket" div
         And I click on the "Reports" option in the "settingsSidebar"
         And I should see "Conflate_Report"
-        And I click the "_icon.up" button
-        Then I press "Download"
+        When I click the "up" icon under the "Conflate_Report" link
+        Then I press "round" span with text "Download"
         And I wait 30 seconds
         Then the download file "Conflate_Report.pdf" should exist
+
+    Scenario: Delete the Datasets
+        When I click the "trash" icon under the "Conflate_Report" link
+        And I wait
+        And I accept the alert
+        Then I click on the "Datasets" option in the "settingsSidebar"
+        When I click the "Conflate_Report" Dataset
+        And I context click the "Conflate_Report" Dataset
+        And I click the "Delete" context menu item
+        And I wait
+        And I accept the alert
+        And I wait 30 "seconds" to not see "Conflate_Report"
+        

--- a/test-files/ui/features/report_generation.feature
+++ b/test-files/ui/features/report_generation.feature
@@ -30,8 +30,8 @@ Feature: Generate Conflation Report
         And I click the "Complete Review" link
         Then I should see "Resolve all remaining reviews"
         And I press "Resolve all remaining reviews"
-        When I click on "input#export_data"
-        And I click on "input#exit_conflate"
+        When I press "Export Data"
+        And I press "Exit"
 
     Scenario: Check out the Report
         When I select the "sprocket" div
@@ -40,7 +40,7 @@ Feature: Generate Conflation Report
         When I click the "up" icon under the "Conflate_Report_Cucumber" link
         Then I press "round" span with text "Download"
         And I wait 30 seconds
-        Then the download file "Conflate_Report.pdf" should exist
+        Then the download file "Conflate_Report_Cucumber.pdf" should exist
 
     Scenario: Delete the Datasets
         When I click the "trash" icon under the "Conflate_Report_Cucumber" link

--- a/test-files/ui/features/step_definitions/custom_steps.rb
+++ b/test-files/ui/features/step_definitions/custom_steps.rb
@@ -383,6 +383,14 @@ When(/^I press the left arrow key$/) do
   find('body').native.send_keys(:arrow_left)
 end
 
+When(/^I press tab$/) do
+  find('body').native.send_keys(:tab)
+end
+
+When(/^I press enter$/) do
+  find('body').native.send_keys(:enter)
+end
+
 When(/^I press the right arrow key$/) do
   find('body').native.send_keys(:arrow_right)
 end


### PR DESCRIPTION
See ngageoint/hootenanny-ui#728

This test will conflate 2 datasets and generate a report, exit conflation (necessary for deleting the dataset later), download the conflation report, delete the report from hoot, and then delete the dataset.