### PR TITLE
OsmApiDbReader not handling nested quotes properly

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/HootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/HootApiDbTest.cpp
@@ -59,7 +59,7 @@ class HootApiDbTest : public CppUnit::TestFixture
   CPPUNIT_TEST(runSelectNodeIdsForWayTest);
   CPPUNIT_TEST(runSelectMembersForRelationTest);
   CPPUNIT_TEST(runUpdateNodeTest);
-
+  CPPUNIT_TEST(runUnescapeTags);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -535,6 +535,13 @@ public:
           "ORDER BY longitude",
           "3.1415;2.71828;true;3222453693;1",
           (qlonglong)nodeId);
+  }
+
+  void runUnescapeTags()
+  {
+    HOOT_STR_EQUALS("key = value\n", HootApiDb::unescapeTags("\"key\"=>\"value\""));
+    HOOT_STR_EQUALS("key1 = value1\nkey2 = value2\n", HootApiDb::unescapeTags("\"key1\"=>\"value1\", \"key2\"=>\"value2\""));
+    HOOT_STR_EQUALS("fixme = check: building or just a \"paved\" place\n", HootApiDb::unescapeTags("\"fixme\"=>\"check: building or just a \"paved\" place\""));
   }
 
   void setUp()

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
@@ -302,18 +302,27 @@ Tags ApiDb::unescapeTags(const QVariant &v)
 {
   assert(v.type() == QVariant::String);
   QString s = v.toString();
-  // convert backslash and double quotes to their octal form so we can safely split on double quotes
-  s.replace("\\\\", "\\134");
-  s.replace("\\\"", "\\042");
 
   Tags result;
-  QStringList l = s.split("\"");
-  for (int i = 1; i < l.size(); i+=4)
-  {
-    _unescapeString(l[i]);
-    _unescapeString(l[i + 2]);
 
-    result.insert(l[i], l[i + 2]);
+  QStringList list = s.split("=>");
+  while (list.size() > 1)
+  {
+    QString key = list.first();
+    list.pop_front();
+    QString value = list.first();
+    list.pop_front();
+    //  Split the value/key that wasn't split at the beginning
+    if (list.size() > 0)
+    {
+      QStringList vk = value.split("\", \"");
+      value = vk[0];
+      list.push_front(vk[1]);
+    }
+    //  Unescape the rest
+    _unescapeString(key);
+    _unescapeString(value);
+    result.insert(key, value);
   }
 
   return result;


### PR DESCRIPTION
refs #1195 
Updated ApiDb::unescapeTags() to do a better job at reading tags that have unescaped quotes in them, also added a test to ensure it is working correctly.  Instead of using quotes to split the tags, use `=>` and un-quoted commas as delimiters (in that order).