### PR TITLE
HootApiDb and OsmApiDb table name duplication

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -125,25 +125,19 @@ public:
 
     CPPUNIT_ASSERT(database.mapExists(mapId));
 
-    HOOT_STR_EQUALS(true, database.hasTable("current_nodes" + database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(true, database.hasTable("current_relation_members" +
-      database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(true, database.hasTable("current_relations" +
-      database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(true, database.hasTable("current_way_nodes" +
-      database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(true, database.hasTable("current_ways" + database.getMapIdString(mapId)));
+    HOOT_STR_EQUALS(true, database.hasTable(HootApiDb::getCurrentNodesTableName(mapId)));
+    HOOT_STR_EQUALS(true, database.hasTable(HootApiDb::getCurrentRelationMembersTableName(mapId)));
+    HOOT_STR_EQUALS(true, database.hasTable(HootApiDb::getCurrentRelationsTableName(mapId)));
+    HOOT_STR_EQUALS(true, database.hasTable(HootApiDb::getCurrentWayNodesTableName(mapId)));
+    HOOT_STR_EQUALS(true, database.hasTable(HootApiDb::getCurrentWaysTableName(mapId)));
 
     database.deleteMap(mapId);
 
-    HOOT_STR_EQUALS(false, database.hasTable("current_nodes" + database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(false, database.hasTable("current_relation_members" +
-      database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(false, database.hasTable("current_relations" +
-      database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(false, database.hasTable("current_way_nodes" +
-      database.getMapIdString(mapId)));
-    HOOT_STR_EQUALS(false, database.hasTable("current_ways" + database.getMapIdString(mapId)));
+    HOOT_STR_EQUALS(false, database.hasTable(HootApiDb::getCurrentNodesTableName(mapId)));
+    HOOT_STR_EQUALS(false, database.hasTable(HootApiDb::getCurrentRelationMembersTableName(mapId)));
+    HOOT_STR_EQUALS(false, database.hasTable(HootApiDb::getCurrentRelationsTableName(mapId)));
+    HOOT_STR_EQUALS(false, database.hasTable(HootApiDb::getCurrentWayNodesTableName(mapId)));
+    HOOT_STR_EQUALS(false, database.hasTable(HootApiDb::getCurrentWaysTableName(mapId)));
   }
 
   const shared_ptr<QList<long> > insertTestMap1(HootApiDb& database)
@@ -517,7 +511,7 @@ public:
 
     ServicesDbTestUtils::compareRecords(
           "SELECT latitude, longitude, visible, tile, version FROM " +
-          HootApiDb::getNodesTableName(mapId) +
+          HootApiDb::getCurrentNodesTableName(mapId) +
           " WHERE id=:id "
           "ORDER BY longitude",
           "38;-104;true;1329332431;1",
@@ -530,7 +524,7 @@ public:
 
     ServicesDbTestUtils::compareRecords(
           "SELECT latitude, longitude, visible, tile, version FROM " +
-          HootApiDb::getNodesTableName(mapId) +
+          HootApiDb::getCurrentNodesTableName(mapId) +
           " WHERE id=:id "
           "ORDER BY longitude",
           "3.1415;2.71828;true;3222453693;1",

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -116,7 +116,7 @@ public:
 
     long mapId = writer.getMapId();
 
-    compareRecords("SELECT tags FROM " + HootApiDb::getNodesTableName(mapId) +
+    compareRecords("SELECT tags FROM " + HootApiDb::getCurrentNodesTableName(mapId) +
                    " ORDER BY longitude",
                    "\"note\"=>\"n1',\n\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"10\"\n"
                    "\"note\"=>\"n2\\\\\\\"\", \"hoot:status\"=>\"2\", \"error:circular\"=>\"11\"\n"
@@ -165,13 +165,13 @@ public:
 
     long mapId = writer.getMapId();
 
-    compareRecords("SELECT email, display_name FROM users "
-                   "WHERE email LIKE :email",
+    compareRecords("SELECT email, display_name FROM " + ApiDb::getUsersTableName() +
+                   " WHERE email LIKE :email",
                    "ServiceHootApiDbWriterTest@hoottestcpp.org;ServiceHootApiDbWriterTest",
                    userEmail());
 
     compareRecords("SELECT latitude, longitude, visible, tile, version, tags FROM " +
-                   HootApiDb::getNodesTableName(mapId) +
+                   HootApiDb::getCurrentNodesTableName(mapId) +
                    " ORDER BY longitude",
                    "0;0;true;3221225472;1;\"note\"=>\"n1\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"10\"\n"
                    "0;0.1;true;3221225992;1;\"note\"=>\"n2\", \"hoot:status\"=>\"2\", \"error:circular\"=>\"11\"\n"
@@ -179,14 +179,14 @@ public:
                    (qlonglong)mapId);
 
     compareRecords("SELECT id, visible, version, tags FROM " +
-                   HootApiDb::getWaysTableName(mapId) +
+                   HootApiDb::getCurrentWaysTableName(mapId) +
                    " ORDER BY id",
                    "1;true;1;\"note\"=>\"w1\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"13\"\n"
                    "2;true;1;\"note\"=>\"w2\", \"hoot:status\"=>\"2\", \"error:circular\"=>\"14\"",
                    (qlonglong)mapId);
 
     compareRecords("SELECT way_id, node_id, sequence_id FROM " +
-                   HootApiDb::getWayNodesTableName(mapId) +
+                   HootApiDb::getCurrentWayNodesTableName(mapId) +
                    " ORDER BY way_id, node_id, sequence_id",
                    "1;1;0\n"
                    "1;2;1\n"
@@ -195,13 +195,13 @@ public:
                    (qlonglong)mapId);
 
     compareRecords("SELECT id, visible, version, tags FROM " +
-                   HootApiDb::getRelationsTableName(mapId),
+                   HootApiDb::getCurrentRelationsTableName(mapId),
                    "1;true;1;\"note\"=>\"r1\", \"type\"=>\"collection\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"15\"",
                    (qlonglong)mapId);
 
     compareRecords("SELECT relation_id, member_type, member_id, member_role, sequence_id "
                    "FROM " +
-                   HootApiDb::getRelationMembersTableName(mapId) +
+                   HootApiDb::getCurrentRelationMembersTableName(mapId) +
                    " ORDER BY relation_id, member_type",
                    "1;node;1;n1;0\n"
                    "1;way;1;w1;1",
@@ -211,9 +211,9 @@ public:
     db.open(ServicesDbTestUtils::getDbModifyUrl());
 
     QStringList tableNames;
-    tableNames.append(HootApiDb::getNodesTableName(mapId));
-    tableNames.append(HootApiDb::getWaysTableName(mapId));
-    tableNames.append(HootApiDb::getRelationsTableName(mapId));
+    tableNames.append(HootApiDb::getCurrentNodesTableName(mapId));
+    tableNames.append(HootApiDb::getCurrentWaysTableName(mapId));
+    tableNames.append(HootApiDb::getCurrentRelationsTableName(mapId));
 
     for (int i = 0; i < tableNames.length(); i++)
     {
@@ -273,13 +273,13 @@ public:
     writer.write(map);
     long mapId = writer.getMapId();
 
-    compareRecords("SELECT email, display_name FROM users "
-                   "WHERE email LIKE :email",
+    compareRecords("SELECT email, display_name FROM " + ApiDb::getUsersTableName() +
+                   " WHERE email LIKE :email",
                    "ServiceHootApiDbWriterTest@hoottestcpp.org;ServiceHootApiDbWriterTest",
                    userEmail());
 
     compareRecords("SELECT latitude, longitude, visible, tile, version, tags FROM " +
-                   HootApiDb::getNodesTableName(mapId) +
+                   HootApiDb::getCurrentNodesTableName(mapId) +
                    " ORDER BY longitude",
                    "0;0;true;3221225472;1;\"note\"=>\"n1\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"10\"\n"
                    "0;0.1;true;3221225992;1;\"note\"=>\"n2\", \"hoot:status\"=>\"2\", \"error:circular\"=>\"11\"\n"
@@ -287,14 +287,14 @@ public:
                    (qlonglong)mapId);
 
     compareRecords("SELECT visible, version, tags FROM " +
-                   HootApiDb::getWaysTableName(mapId) +
+                   HootApiDb::getCurrentWaysTableName(mapId) +
                    " ORDER BY id",
                    "true;1;\"note\"=>\"w2\", \"hoot:status\"=>\"2\", \"error:circular\"=>\"14\"\n"
                    "true;1;\"note\"=>\"w1\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"13\"",
                    (qlonglong)mapId);
 
     compareRecords("SELECT sequence_id FROM " +
-                   HootApiDb::getWayNodesTableName(mapId) +
+                   HootApiDb::getCurrentWayNodesTableName(mapId) +
                    " ORDER BY way_id, node_id, sequence_id",
                    "1\n"
                    "0\n"
@@ -303,7 +303,7 @@ public:
                    (qlonglong)mapId);
 
     compareRecords("SELECT visible, version, tags FROM " +
-                   HootApiDb::getRelationsTableName(mapId) +
+                   HootApiDb::getCurrentRelationsTableName(mapId) +
                    " ORDER BY id",
                    "true;1;\"note\"=>\"r2\", \"type\"=>\"collection\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"15\"\n"
                    "true;1;\"note\"=>\"r1\", \"type\"=>\"collection\", \"hoot:status\"=>\"1\", \"error:circular\"=>\"15\"",
@@ -311,7 +311,7 @@ public:
 
     compareRecords("SELECT member_type, member_role, sequence_id "
                    "FROM " +
-                   HootApiDb::getRelationMembersTableName(mapId) +
+                   HootApiDb::getCurrentRelationMembersTableName(mapId) +
                    " ORDER BY relation_id, member_type",
                    "relation;r1;0\n"
                    "node;n1;0\n"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetWriterTest.cpp
@@ -101,7 +101,8 @@ public:
     LOG_VARD(boundsStr);
     LOG_VARD(createdAt.toString(OsmApiDb::TIME_FORMAT));
     const QString sql =
-      QString("INSERT INTO changesets (id, user_id, created_at, closed_at, min_lat, max_lat, min_lon, max_lon) ") +
+      QString("INSERT INTO %1 (id, user_id, created_at, closed_at, min_lat, max_lat, min_lon, max_lon) ")
+        .arg(ApiDb::getChangesetsTableName()) +
       QString("VALUES (1, 1, '%1', '%2', %3, %4, %5, %6)")
         .arg(createdAt.toString(OsmApiDb::TIME_FORMAT))
         .arg(createdAt.toString(OsmApiDb::TIME_FORMAT))
@@ -151,15 +152,17 @@ public:
     nodesCountBefore--;
     LOG_VARD(nodesCountBefore);
 
-    const long nextNodeId = database.getNextId("current_nodes");
+    const long nextNodeId = database.getNextId(ApiDb::getCurrentNodesTableName());
     LOG_VARD(nextNodeId);
 
     const long nextChangesetId = existingChangesetId + 1;
     QString sql =
-      QString("INSERT INTO changesets (id, user_id, created_at, closed_at) VALUES (%1, 1, now(), now());\n")
+      QString("INSERT INTO %1 (id, user_id, created_at, closed_at) VALUES (%2, 1, now(), now());\n")
+        .arg(ApiDb::getChangesetsTableName())
         .arg(nextChangesetId);
     sql +=
-      QString("INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, \"timestamp\", tile,  version) VALUES (%1, 0, 0, %2, true, now(), 3221225472, 1);")
+      QString("INSERT INTO %1 (id, latitude, longitude, changeset_id, visible, \"timestamp\", tile,  version) VALUES (%2, 0, 0, %3, true, now(), 3221225472, 1);")
+        .arg(ApiDb::getCurrentNodesTableName())
         .arg(nextNodeId)
         .arg(nextChangesetId);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
@@ -167,7 +167,7 @@ long ApiDb::getUserId(const QString email, bool throwWhenMissing)
   if (_selectUserByEmail == 0)
   {
     _selectUserByEmail.reset(new QSqlQuery(_db));
-    _selectUserByEmail->prepare("SELECT email, id, display_name FROM users WHERE email LIKE :email");
+    _selectUserByEmail->prepare("SELECT email, id, display_name FROM " + ApiDb::getUsersTableName() + " WHERE email LIKE :email");
   }
   _selectUserByEmail->bindValue(":email", email);
   if (_selectUserByEmail->exec() == false)
@@ -207,7 +207,7 @@ long ApiDb::insertUser(const QString email, const QString displayName)
   if (_insertUser == 0)
   {
     _insertUser.reset(new QSqlQuery(_db));
-    _insertUser->prepare("INSERT INTO users (email, display_name) "
+    _insertUser->prepare("INSERT INTO " + ApiDb::getUsersTableName() + " (email, display_name) "
                          "VALUES (:email, :display_name) "
                          "RETURNING id");
   }
@@ -443,12 +443,12 @@ shared_ptr<QSqlQuery> ApiDb::selectNodesByBounds(const Envelope& bounds)
     _selectNodesByBounds.reset(new QSqlQuery(_db));
     _selectNodesByBounds->setForwardOnly(true);
   }
-  QString sql = "select * from " + tableTypeToTableName(TableType::Node) + " where";
+  QString sql = "SELECT * FROM " + tableTypeToTableName(TableType::Node) + " WHERE";
   sql += " visible = true";
-  sql += " and (" + _getTileWhereCondition(tileRanges) + ")";
-  sql += " and longitude >= :minLon and longitude <= :maxLon and latitude >= :minLat ";
-  sql += " and latitude <= :maxLat";
-  sql += " order by id desc";
+  sql += " AND (" + _getTileWhereCondition(tileRanges) + ")";
+  sql += " AND longitude >= :minLon AND longitude <= :maxLon AND latitude >= :minLat ";
+  sql += " AND latitude <= :maxLat";
+  sql += " ORDER BY id DESC";
   _selectNodesByBounds->prepare(sql);
   if (!_floatingPointCoords)
   {
@@ -490,9 +490,9 @@ shared_ptr<QSqlQuery> ApiDb::selectWayIdsByWayNodeIds(const QSet<QString>& nodeI
     _selectWayIdsByWayNodeIds->setForwardOnly(true);
   }
   //this has to be prepared every time due to the varying number of IDs passed in
-  QString sql = "select distinct way_id from " + tableTypeToTableName(TableType::WayNode) + " where";
-  sql += " node_id in (" + QStringList(nodeIds.toList()).join(",") + ")";
-  //sql += " order by way_id desc";
+  QString sql = "SELECT DISTINCT way_id FROM " + tableTypeToTableName(TableType::WayNode) + " WHERE";
+  sql += " node_id IN (" + QStringList(nodeIds.toList()).join(",") + ")";
+  //sql += " ORDER BY way_id desc";
   _selectWayIdsByWayNodeIds->prepare(sql);
   LOG_VARD(_selectWayIdsByWayNodeIds->lastQuery());
 
@@ -520,10 +520,10 @@ shared_ptr<QSqlQuery> ApiDb::selectElementsByElementIdList(const QSet<QString>& 
     _selectElementsByElementIdList->setForwardOnly(true);
   }
   //this has to be prepared every time due to the varying number of IDs passed in
-  QString sql = "select * from " + tableTypeToTableName(tableType) + " where";
+  QString sql = "SELECT * FROM " + tableTypeToTableName(tableType) + " WHERE";
   sql += " visible = true";
-  sql += " and id in (" + QStringList(elementIds.toList()).join(",") + ")";
-  sql += " order by id desc";
+  sql += " AND id IN (" + QStringList(elementIds.toList()).join(",") + ")";
+  sql += " ORDER BY id DESC";
   _selectElementsByElementIdList->prepare(sql);
   LOG_VARD(_selectElementsByElementIdList->lastQuery());
 
@@ -550,9 +550,9 @@ shared_ptr<QSqlQuery> ApiDb::selectWayNodeIdsByWayIds(const QSet<QString>& wayId
     _selectWayNodeIdsByWayIds->setForwardOnly(true);
   }
   //this has to be prepared every time due to the varying number of IDs passed in
-  QString sql = "select distinct node_id from " + tableTypeToTableName(TableType::WayNode) + " where";
-  sql += " way_id in (" + QStringList(wayIds.toList()).join(",") + ")";
-  //sql += " order by sequence_id";
+  QString sql = "SELECT DISTINCT node_id FROM " + tableTypeToTableName(TableType::WayNode) + " WHERE";
+  sql += " way_id IN (" + QStringList(wayIds.toList()).join(",") + ")";
+  //sql += " ORDER BY sequence_id";
   _selectWayNodeIdsByWayIds->prepare(sql);
   LOG_VARD(_selectWayNodeIdsByWayIds->lastQuery());
 
@@ -580,11 +580,11 @@ shared_ptr<QSqlQuery> ApiDb::selectRelationIdsByMemberIds(const QSet<QString>& m
     _selectRelationIdsByMemberIds->setForwardOnly(true);
   }
   //this has to be prepared every time due to the varying number of IDs passed in
-  QString sql = "select distinct relation_id from " +
-    tableTypeToTableName(TableType::RelationMember) + " where";
+  QString sql = "SELECT DISTINCT relation_id FROM " +
+    tableTypeToTableName(TableType::RelationMember) + " WHERE";
   sql += " member_type = :elementType";
-  sql += " and member_id in (" + QStringList(memberIds.toList()).join(",") + ")";
-  //sql += " order by relation_id desc";
+  sql += " AND member_id IN (" + QStringList(memberIds.toList()).join(",") + ")";
+  //sql += " ORDER BY relation_id DESC";
   _selectRelationIdsByMemberIds->prepare(sql);
   if (!_capitalizeRelationMemberType)
   {
@@ -660,7 +660,7 @@ shared_ptr<QSqlQuery> ApiDb::getChangesetsCreatedAfterTime(const QString timeStr
   {
     _selectChangesetsCreatedAfterTime.reset(new QSqlQuery(_db));
     _selectChangesetsCreatedAfterTime->prepare(
-      QString("SELECT min_lon, max_lon, min_lat, max_lat FROM changesets ") +
+      QString("SELECT min_lon, max_lon, min_lat, max_lat FROM %1 ").arg(ApiDb::getChangesetsTableName()) +
       QString("WHERE created_at > :createdAt"));
     _selectChangesetsCreatedAfterTime->bindValue(":createdAt", "'" + timeStr + "'");
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
@@ -270,6 +270,42 @@ public:
 
   QSqlError getLastError() const { return _db.lastError(); }
 
+  inline static QString getChangesetsTableName()                { return "changesets"; }
+  inline static QString getChangesetsSubscribersTableName()     { return "changesets_subscribers"; }
+  inline static QString getChangesetTagsTableName()             { return "changeset_tags"; }
+  inline static QString getCurrentNodeTagsTableName()           { return "current_node_tags"; }
+  inline static QString getCurrentNodesTableName()              { return "current_nodes"; }
+  inline static QString getCurrentRelationMembersTableName()    { return "current_relation_members"; }
+  inline static QString getCurrentRelationTagsTableName()       { return "current_relation_tags"; }
+  inline static QString getCurrentRelationsTableName()          { return "current_relations"; }
+  inline static QString getCurrentWayNodesTableName()           { return "current_way_nodes"; }
+  inline static QString getCurrentWayTagsTableName()            { return "current_way_tags"; }
+  inline static QString getCurrentWaysTableName()               { return "current_ways"; }
+
+  inline static QString getNodeTagsTableName()                  { return "node_tags"; }
+  inline static QString getNodesTableName()                     { return "nodes"; }
+  inline static QString getRelationMembersTableName()           { return "relation_members"; }
+  inline static QString getRelationTagsTableName()              { return "relation_tags"; }
+  inline static QString getRelationsTableName()                 { return "relations"; }
+  inline static QString getWayNodesTableName()                  { return "way_nodes"; }
+  inline static QString getWayTagsTableName()                   { return "way_tags"; }
+  inline static QString getWaysTableName()                      { return "ways"; }
+
+  inline static QString getMapsTableName()                      { return "maps"; }
+  inline static QString getUsersTableName()                     { return "users"; }
+
+  inline static QString getSequenceId()                         { return "_id_seq"; }
+
+  inline static QString getChangesetsSequenceName()             { return getChangesetsTableName() + getSequenceId(); }
+  inline static QString getCurrentNodesSequenceName()           { return getCurrentNodesTableName() + getSequenceId(); }
+  inline static QString getCurrentRelationMembersSequenceName() { return getCurrentRelationMembersTableName() + getSequenceId(); }
+  inline static QString getCurrentRelationsSequenceName()       { return getCurrentRelationsTableName() + getSequenceId(); }
+  inline static QString getCurrentWayNodesSequenceName()        { return getCurrentWayNodesTableName() + getSequenceId(); }
+  inline static QString getCurrentWaysSequenceName()            { return getCurrentWaysTableName() + getSequenceId(); }
+
+  inline static QString getMapsSequenceName()                   { return getMapsTableName() + getSequenceId(); }
+  inline static QString getUsersSequenceName()                  { return getUsersTableName() + getSequenceId(); }
+
 protected:
 
   //osm api db stores coords as integers and hoot api db as floating point

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -111,7 +111,7 @@ Envelope HootApiDb::calculateEnvelope() const
   // http://www.postgresql.org/docs/8.0/static/functions-aggregate.html
   QSqlQuery boundsQuery = _exec("SELECT MIN(latitude) as minLat, MAX(latitude) AS maxLat "
                              ", MIN(longitude) as minLon, MAX(longitude) AS maxLon"
-                             " FROM " + getNodesTableName(mapId));
+                             " FROM " + getCurrentNodesTableName(mapId));
 
   if (boundsQuery.next())
   {
@@ -274,19 +274,18 @@ void HootApiDb::createPendingMapIndexes()
       "ADD CONSTRAINT current_nodes_changeset_id_fkey_%2 FOREIGN KEY (changeset_id) "
         "REFERENCES %3 (id) MATCH SIMPLE "
         "ON UPDATE NO ACTION ON DELETE NO ACTION ")
-        .arg(getNodesTableName(mapId))
+        .arg(getCurrentNodesTableName(mapId))
         .arg(getMapIdString(mapId))
         .arg(getChangesetsTableName(mapId)));
 
-    _execNoPrepare(QString("CREATE INDEX %1_tile_idx ON %2 USING btree (tile)")
-        .arg(getNodesTableName(mapId))
-        .arg(getNodesTableName(mapId)));
+    _execNoPrepare(QString("CREATE INDEX %1_tile_idx ON %1 USING btree (tile)")
+        .arg(getCurrentNodesTableName(mapId)));
 
     _execNoPrepare(QString("ALTER TABLE %1 "
       "ADD CONSTRAINT current_relations_changeset_id_fkey_%2 FOREIGN KEY (changeset_id) "
         "REFERENCES %3 (id) MATCH SIMPLE "
         "ON UPDATE NO ACTION ON DELETE NO ACTION ")
-        .arg(getRelationsTableName(mapId))
+        .arg(getCurrentRelationsTableName(mapId))
         .arg(getMapIdString(mapId))
         .arg(getChangesetsTableName(mapId)));
 
@@ -297,16 +296,16 @@ void HootApiDb::createPendingMapIndexes()
       "ADD CONSTRAINT current_way_nodes_way_id_fkey_%2 FOREIGN KEY (way_id) "
         "REFERENCES %4 (id) MATCH SIMPLE "
         "ON UPDATE NO ACTION ON DELETE NO ACTION")
-        .arg(getWayNodesTableName(mapId))
+        .arg(getCurrentWayNodesTableName(mapId))
         .arg(getMapIdString(mapId))
-        .arg(getNodesTableName(mapId))
-        .arg(getWaysTableName(mapId)));
+        .arg(getCurrentNodesTableName(mapId))
+        .arg(getCurrentWaysTableName(mapId)));
 
     _execNoPrepare(QString("ALTER TABLE %1 "
       "ADD CONSTRAINT current_ways_changeset_id_fkey_%2 FOREIGN KEY (changeset_id) "
         "REFERENCES %3 (id) MATCH SIMPLE "
         "ON UPDATE NO ACTION ON DELETE NO ACTION ")
-        .arg(getWaysTableName(mapId))
+        .arg(getCurrentWaysTableName(mapId))
         .arg(getMapIdString(mapId))
         .arg(getChangesetsTableName(mapId)));
   }
@@ -320,20 +319,20 @@ void HootApiDb::deleteMap(long mapId)
   dropDatabase(_getRenderDBName(mapId));
 
   // Drop related tables
-  dropTable(getRelationMembersTableName(mapId));
-  dropTable(getRelationsTableName(mapId));
-  dropTable(getWayNodesTableName(mapId));
-  dropTable(getWaysTableName(mapId));
-  dropTable(getNodesTableName(mapId));
+  dropTable(getCurrentRelationMembersTableName(mapId));
+  dropTable(getCurrentRelationsTableName(mapId));
+  dropTable(getCurrentWayNodesTableName(mapId));
+  dropTable(getCurrentWaysTableName(mapId));
+  dropTable(getCurrentNodesTableName(mapId));
   dropTable(getChangesetsTableName(mapId));
 
   // Drop related sequences
-  _execNoPrepare("DROP SEQUENCE IF EXISTS " + getNodeSequenceName(mapId) + " CASCADE");
-  _execNoPrepare("DROP SEQUENCE IF EXISTS " + getWaySequenceName(mapId) + " CASCADE");
-  _execNoPrepare("DROP SEQUENCE IF EXISTS " + getRelationSequenceName(mapId) + " CASCADE");
+  _execNoPrepare("DROP SEQUENCE IF EXISTS " + getCurrentNodesSequenceName(mapId) + " CASCADE");
+  _execNoPrepare("DROP SEQUENCE IF EXISTS " + getCurrentWaysSequenceName(mapId) + " CASCADE");
+  _execNoPrepare("DROP SEQUENCE IF EXISTS " + getCurrentRelationsSequenceName(mapId) + " CASCADE");
 
   // Delete map last
-  _exec("DELETE FROM maps WHERE id=:id", (qlonglong)mapId);
+  _exec("DELETE FROM " + ApiDb::getMapsTableName() + " WHERE id=:id", (qlonglong)mapId);
 }
 
 bool HootApiDb::hasTable(const QString& tableName)
@@ -380,7 +379,7 @@ void HootApiDb::dropTable(const QString& tableName)
 
 void HootApiDb::deleteUser(long userId)
 {
-  QSqlQuery maps = _exec("SELECT id FROM maps WHERE user_id=:user_id", (qlonglong)userId);
+  QSqlQuery maps = _exec("SELECT id FROM " + ApiDb::getMapsTableName() + " WHERE user_id=:user_id", (qlonglong)userId);
 
   // delete all the maps owned by this user
   while (maps.next())
@@ -389,7 +388,7 @@ void HootApiDb::deleteUser(long userId)
     deleteMap(mapId);
   }
 
-  _exec("DELETE FROM users WHERE id=:id", (qlonglong)userId);
+  _exec("DELETE FROM " + ApiDb::getUsersTableName() + " WHERE id=:id", (qlonglong)userId);
 }
 
 QString HootApiDb::_escapeTags(const Tags& tags) const
@@ -505,7 +504,7 @@ long HootApiDb::_getNextNodeId()
   _checkLastMapId(mapId);
   if (_nodeIdReserver == 0)
   {
-    _nodeIdReserver.reset(new InternalIdReserver(_db, getNodeSequenceName(mapId)));
+    _nodeIdReserver.reset(new InternalIdReserver(_db, getCurrentNodesSequenceName(mapId)));
   }
 
   return _nodeIdReserver->getNextId();
@@ -517,7 +516,7 @@ long HootApiDb::_getNextRelationId()
   _checkLastMapId(mapId);
   if (_relationIdReserver == 0)
   {
-    _relationIdReserver.reset(new InternalIdReserver(_db, getRelationSequenceName(mapId)));
+    _relationIdReserver.reset(new InternalIdReserver(_db, getCurrentRelationsSequenceName(mapId)));
   }
   return _relationIdReserver->getNextId();
 }
@@ -528,7 +527,7 @@ long HootApiDb::_getNextWayId()
   _checkLastMapId(mapId);
   if (_wayIdReserver == 0)
   {
-    _wayIdReserver.reset(new InternalIdReserver(_db, getWaySequenceName(mapId)));
+    _wayIdReserver.reset(new InternalIdReserver(_db, getCurrentWaysSequenceName(mapId)));
   }
   return _wayIdReserver->getNextId();
 }
@@ -570,9 +569,9 @@ void HootApiDb::beginChangeset(const Tags& tags)
     _insertChangeSet.reset(new QSqlQuery(_db));
     _insertChangeSet->prepare(
       QString("INSERT INTO %1 (user_id, created_at, min_lat, max_lat, min_lon, max_lon, "
-          "closed_at, tags) "
-      "VALUES (:user_id, NOW(), :min_lat, :max_lat, :min_lon, :max_lon, NOW(), " + _escapeTags(tags) + ") "
-      "RETURNING id")
+        "closed_at, tags) "
+        "VALUES (:user_id, NOW(), :min_lat, :max_lat, :min_lon, :max_lon, NOW(), " + _escapeTags(tags) + ") "
+        "RETURNING id")
         .arg(getChangesetsTableName(mapId)));
   }
   _insertChangeSet->bindValue(":user_id", (qlonglong)userId);
@@ -594,7 +593,7 @@ long HootApiDb::insertMap(QString displayName, bool publicVisibility)
   if (_insertMap == 0)
   {
     _insertMap.reset(new QSqlQuery(_db));
-    _insertMap->prepare("INSERT INTO maps (display_name, user_id, public, created_at) "
+    _insertMap->prepare("INSERT INTO " + ApiDb::getMapsTableName() + " (display_name, user_id, public, created_at) "
                         "VALUES (:display_name, :user_id, :public, NOW()) "
                         "RETURNING id");
   }
@@ -604,36 +603,35 @@ long HootApiDb::insertMap(QString displayName, bool publicVisibility)
 
   long mapId = _insertRecord(*_insertMap);
 
-  QString mapIdStr = getMapIdString(mapId);
-  _copyTableStructure("changesets", getChangesetsTableName(mapId));
-  _copyTableStructure("current_nodes", "current_nodes" + mapIdStr);
-  _copyTableStructure("current_relation_members", "current_relation_members" + mapIdStr);
-  _copyTableStructure("current_relations", "current_relations" + mapIdStr);
-  _copyTableStructure("current_way_nodes", "current_way_nodes" + mapIdStr);
-  _copyTableStructure("current_ways", "current_ways" + mapIdStr);
+  _copyTableStructure(ApiDb::getChangesetsTableName(), getChangesetsTableName(mapId));
+  _copyTableStructure(ApiDb::getCurrentNodesTableName(), getCurrentNodesTableName(mapId));
+  _copyTableStructure(ApiDb::getCurrentRelationMembersTableName(), getCurrentRelationMembersTableName(mapId));
+  _copyTableStructure(ApiDb::getCurrentRelationsTableName(), getCurrentRelationsTableName(mapId));
+  _copyTableStructure(ApiDb::getCurrentWayNodesTableName(), getCurrentWayNodesTableName(mapId));
+  _copyTableStructure(ApiDb::getCurrentWaysTableName(), getCurrentWaysTableName(mapId));
 
-  _execNoPrepare("CREATE SEQUENCE " + getNodeSequenceName(mapId));
-  _execNoPrepare("CREATE SEQUENCE " + getRelationSequenceName(mapId));
-  _execNoPrepare("CREATE SEQUENCE " + getWaySequenceName(mapId));
-
-  _execNoPrepare(QString("ALTER TABLE %1 "
-    "ALTER COLUMN id SET DEFAULT NEXTVAL('%4'::regclass)")
-      .arg(getNodesTableName(mapId))
-      .arg(getNodeSequenceName(mapId)));
+  _execNoPrepare("CREATE SEQUENCE " + getCurrentNodesSequenceName(mapId));
+  _execNoPrepare("CREATE SEQUENCE " + getCurrentRelationsSequenceName(mapId));
+  _execNoPrepare("CREATE SEQUENCE " + getCurrentWaysSequenceName(mapId));
 
   _execNoPrepare(QString("ALTER TABLE %1 "
     "ALTER COLUMN id SET DEFAULT NEXTVAL('%4'::regclass)")
-      .arg(getRelationsTableName(mapId))
-      .arg(getRelationSequenceName(mapId)));
+      .arg(getCurrentNodesTableName(mapId))
+      .arg(getCurrentNodesSequenceName(mapId)));
 
   _execNoPrepare(QString("ALTER TABLE %1 "
     "ALTER COLUMN id SET DEFAULT NEXTVAL('%4'::regclass)")
-      .arg(getWaysTableName(mapId))
-      .arg(getWaySequenceName(mapId)));
+      .arg(getCurrentRelationsTableName(mapId))
+      .arg(getCurrentRelationsSequenceName(mapId)));
+
+  _execNoPrepare(QString("ALTER TABLE %1 "
+    "ALTER COLUMN id SET DEFAULT NEXTVAL('%4'::regclass)")
+      .arg(getCurrentWaysTableName(mapId))
+      .arg(getCurrentWaysSequenceName(mapId)));
 
   // remove the index to speed up inserts. It'll be added back by createPendingMapIndexes
   _execNoPrepare(QString("DROP INDEX %1_tile_idx")
-      .arg(getNodesTableName(mapId)));
+      .arg(getCurrentNodesTableName(mapId)));
 
   _pendingMapIndexes.append(mapId);
 
@@ -661,7 +659,7 @@ bool HootApiDb::insertNode(const long id, const double lat, const double lon, co
     columns << "id" << "latitude" << "longitude" << "changeset_id" << "timestamp" <<
                "tile" << "version" << "tags";
 
-    _nodeBulkInsert.reset(new SqlBulkInsert(_db, getNodesTableName(mapId), columns));
+    _nodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentNodesTableName(mapId), columns));
   }
 
   QList<QVariant> v;
@@ -713,7 +711,7 @@ bool HootApiDb::insertRelation(const long relationId, const Tags &tags)
     QStringList columns;
     columns << "id" << "changeset_id" << "timestamp" << "version" << "tags";
 
-    _relationBulkInsert.reset(new SqlBulkInsert(_db, getRelationsTableName(mapId), columns));
+    _relationBulkInsert.reset(new SqlBulkInsert(_db, getCurrentRelationsTableName(mapId), columns));
   }
 
   QList<QVariant> v;
@@ -746,7 +744,7 @@ bool HootApiDb::insertRelationMember(const long relationId, const ElementType& t
   {
     _insertRelationMembers.reset(new QSqlQuery(_db));
     _insertRelationMembers->prepare(
-      "INSERT INTO " + getRelationMembersTableName(mapId) +
+      "INSERT INTO " + getCurrentRelationMembersTableName(mapId) +
         " (relation_id, member_type, member_id, member_role, sequence_id) "
       "VALUES (:relation_id, :member_type, :member_id, :member_role, :sequence_id)");
   }
@@ -970,7 +968,7 @@ set<long> HootApiDb::selectMapIds(QString name)
   {
       LOG_DEBUG("inside first test inside selectMapIds");
     _selectMapIds.reset(new QSqlQuery(_db));
-    _selectMapIds->prepare("SELECT id FROM maps WHERE display_name LIKE :name AND user_id=:userId");
+    _selectMapIds->prepare("SELECT id FROM " + ApiDb::getMapsTableName() + " WHERE display_name LIKE :name AND user_id=:userId");
   }
 
   _selectMapIds->bindValue(":name", name);
@@ -1011,23 +1009,23 @@ QString HootApiDb::tableTypeToTableName(const TableType& tableType) const
 {
   if (tableType == TableType::Node)
   {
-    return getNodesTableName(_currMapId);
+    return getCurrentNodesTableName(_currMapId);
   }
   else if (tableType == TableType::Way)
   {
-    return getWaysTableName(_currMapId);
+    return getCurrentWaysTableName(_currMapId);
   }
   else if (tableType == TableType::Relation)
   {
-    return getRelationsTableName(_currMapId);
+    return getCurrentRelationsTableName(_currMapId);
   }
   else if (tableType == TableType::WayNode)
   {
-    return getWayNodesTableName(_currMapId);
+    return getCurrentWayNodesTableName(_currMapId);
   }
   else if (tableType == TableType::RelationMember)
   {
-    return getRelationMembersTableName(_currMapId);
+    return getCurrentRelationMembersTableName(_currMapId);
   }
   else
   {
@@ -1040,7 +1038,7 @@ bool HootApiDb::mapExists(const long id)
   if (_mapExists == 0)
   {
     _mapExists.reset(new QSqlQuery(_db));
-    _mapExists->prepare("SELECT display_name FROM maps WHERE id = :mapId");
+    _mapExists->prepare("SELECT display_name FROM " + ApiDb::getMapsTableName() + " WHERE id = :mapId");
   }
   _mapExists->bindValue(":mapId", (qlonglong)id);
   if (_mapExists->exec() == false)
@@ -1123,7 +1121,7 @@ vector<long> HootApiDb::selectNodeIdsForWay(long wayId)
 {
   const long mapId = _currMapId;
   _checkLastMapId(mapId);
-  QString sql = "SELECT node_id FROM " + getWayNodesTableName(mapId) +
+  QString sql = "SELECT node_id FROM " + getCurrentWayNodesTableName(mapId) +
       " WHERE way_id = :wayId ORDER BY sequence_id";
 
   return ApiDb::selectNodeIdsForWay(wayId, sql);
@@ -1133,7 +1131,7 @@ shared_ptr<QSqlQuery> HootApiDb::selectNodesForWay(long wayId)
 {
   const long mapId = _currMapId;
   _checkLastMapId(mapId);
-  QString sql = "SELECT node_id FROM " + getWayNodesTableName(mapId) +
+  QString sql = "SELECT node_id FROM " + getCurrentWayNodesTableName(mapId) +
       " WHERE way_id = :wayId ORDER BY sequence_id";
 
   return ApiDb::selectNodesForWay(wayId, sql);
@@ -1149,7 +1147,7 @@ vector<RelationData::Entry> HootApiDb::selectMembersForRelation(long relationId)
     _selectMembersForRelation.reset(new QSqlQuery(_db));
     _selectMembersForRelation->setForwardOnly(true);
     _selectMembersForRelation->prepare(
-      "SELECT member_type, member_id, member_role FROM " + getRelationMembersTableName(mapId) +
+      "SELECT member_type, member_id, member_role FROM " + getCurrentRelationMembersTableName(mapId) +
       " WHERE relation_id = :relationId ORDER BY sequence_id");
     _selectMembersForRelation->bindValue(":mapId", (qlonglong)mapId);
   }
@@ -1193,7 +1191,7 @@ void HootApiDb::updateNode(const long id, const double lat, const double lon, co
   {
     _updateNode.reset(new QSqlQuery(_db));
     _updateNode->prepare(
-      "UPDATE " + getNodesTableName(mapId) +
+      "UPDATE " + getCurrentNodesTableName(mapId) +
       " SET latitude=:latitude, longitude=:longitude, changeset_id=:changeset_id, "
       " timestamp=:timestamp, tile=:tile, version=:version, tags=" + _escapeTags(tags) + " WHERE id=:id");
   }
@@ -1231,7 +1229,7 @@ void HootApiDb::updateRelation(const long id, const long version, const Tags& ta
   {
     _updateRelation.reset(new QSqlQuery(_db));
     _updateRelation->prepare(
-      "UPDATE " + getRelationsTableName(mapId) +
+      "UPDATE " + getCurrentRelationsTableName(mapId) +
       " SET changeset_id=:changeset_id, timestamp=:timestamp, version=:version, tags=" + _escapeTags(tags) + " WHERE id=:id");
   }
 
@@ -1263,7 +1261,7 @@ void HootApiDb::updateWay(const long id, const long version, const Tags& tags)
   {
     _updateWay.reset(new QSqlQuery(_db));
     _updateWay->prepare(
-      "UPDATE " + getWaysTableName(mapId) +
+      "UPDATE " + getCurrentWaysTableName(mapId) +
       " SET changeset_id=:changeset_id, timestamp=:timestamp, version=:version, tags=" + _escapeTags(tags) + " WHERE id=:id");
   }
 
@@ -1305,7 +1303,7 @@ bool HootApiDb::insertWay(const long wayId, const Tags &tags)
     QStringList columns;
     columns << "id" << "changeset_id" << "timestamp" << "version" << "tags";
 
-    _wayBulkInsert.reset(new SqlBulkInsert(_db, getWaysTableName(mapId), columns));
+    _wayBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWaysTableName(mapId), columns));
   }
 
   QList<QVariant> v;
@@ -1343,7 +1341,7 @@ void HootApiDb::insertWayNodes(long wayId, const vector<long>& nodeIds)
     QStringList columns;
     columns << "way_id" << "node_id" << "sequence_id";
 
-    _wayNodeBulkInsert.reset(new SqlBulkInsert(_db, getWayNodesTableName(mapId), columns));
+    _wayNodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWayNodesTableName(mapId), columns));
   }
 
   QList<QVariant> v;
@@ -1414,12 +1412,12 @@ long HootApiDb::reserveElementId(const ElementType::Type type)
 QString HootApiDb::_getRenderDBName(long mapId)
 {
   // Get current database & maps.display_name
+  QString table = ApiDb::getMapsTableName();
   QString dbName = "";
   QString mapDisplayName = "";
   QString mapIdNumber = QString::number(mapId);
-  QString sql = "SELECT current_database(), maps.display_name "
-                "FROM maps "
-                "WHERE maps.id=" + mapIdNumber;
+  QString sql = "SELECT current_database(), " + table + ".display_name "
+                "FROM " + table + " WHERE " + table + ".id=" + mapIdNumber;
   QSqlQuery q = _exec(sql);
 
   if (q.next())

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -248,28 +248,23 @@ public:
   /**
    * Returns a map ID string suitable for using in table names. E.g. _1
    */
-  static QString getMapIdString(long id) { return QString("_%1").arg(id); }
+  inline static QString getMapIdString(long id) { return QString("_%1").arg(id); }
 
   // Services DB table strings
-  static QString getNodeSequenceName(long mapId)
-  { return "current_nodes" + getMapIdString(mapId) + "_id_seq"; }
-  static QString getRelationSequenceName(long mapId)
-  { return "current_relations" + getMapIdString(mapId) + "_id_seq"; }
-  static QString getWaySequenceName(long mapId)
-  { return "current_ways" + getMapIdString(mapId) + "_id_seq"; }
+  inline static QString getChangesetsTableName(long mapId)                { return ApiDb::getChangesetsTableName() + getMapIdString(mapId); }
+  inline static QString getCurrentNodesTableName(long mapId)              { return ApiDb::getCurrentNodesTableName() + getMapIdString(mapId); }
+  inline static QString getCurrentRelationMembersTableName(long mapId)    { return ApiDb::getCurrentRelationMembersTableName() + getMapIdString(mapId); }
+  inline static QString getCurrentRelationsTableName(long mapId)          { return ApiDb::getCurrentRelationsTableName() + getMapIdString(mapId); }
+  inline static QString getCurrentWayNodesTableName(long mapId)           { return ApiDb::getCurrentWayNodesTableName() + getMapIdString(mapId); }
+  inline static QString getCurrentWaysTableName(long mapId)               { return ApiDb::getCurrentWaysTableName() + getMapIdString(mapId); }
 
-  static QString getChangesetsTableName(long mapId)
-  { return "changesets" + getMapIdString(mapId); }
-  static QString getNodesTableName(long mapId)
-  { return "current_nodes" + getMapIdString(mapId); }
-  static QString getRelationMembersTableName(long mapId)
-  { return "current_relation_members" + getMapIdString(mapId); }
-  static QString getRelationsTableName(long mapId)
-  { return "current_relations" + getMapIdString(mapId); }
-  static QString getWayNodesTableName(long mapId)
-  { return "current_way_nodes" + getMapIdString(mapId); }
-  static QString getWaysTableName(long mapId)
-  { return "current_ways" + getMapIdString(mapId); }
+  inline static QString getChangesetsSequenceName(long mapId)             { return ApiDb::getChangesetsTableName() + getMapIdString(mapId) + ApiDb::getSequenceId(); }
+  inline static QString getCurrentNodesSequenceName(long mapId)           { return ApiDb::getCurrentNodesTableName() + getMapIdString(mapId) + ApiDb::getSequenceId(); }
+  inline static QString getCurrentRelationMembersSequenceName(long mapId) { return ApiDb::getCurrentRelationMembersTableName() + getMapIdString(mapId) + ApiDb::getSequenceId(); }
+  inline static QString getCurrentRelationsSequenceName(long mapId)       { return ApiDb::getCurrentRelationsTableName() + getMapIdString(mapId) + ApiDb::getSequenceId(); }
+  inline static QString getCurrentWayNodesSequenceName(long mapId)        { return ApiDb::getCurrentWayNodesTableName() + getMapIdString(mapId) + ApiDb::getSequenceId(); }
+  inline static QString getCurrentWaysSequenceName(long mapId)            { return ApiDb::getCurrentWaysTableName() + getMapIdString(mapId) + ApiDb::getSequenceId(); }
+
 
   /**
    * Very handy for testing.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDb.cpp
@@ -98,39 +98,39 @@ void OsmApiDb::close()
 void OsmApiDb::deleteData()
 {
   // delete ways data first
-  _execNoPrepare("DELETE FROM current_relation_members CASCADE");
-  _execNoPrepare("DELETE FROM current_relation_tags CASCADE");
-  _execNoPrepare("DELETE FROM current_relations CASCADE");
-  _execNoPrepare("ALTER SEQUENCE current_relations_id_seq RESTART WITH 1");
-  _execNoPrepare("DELETE FROM relation_members CASCADE");
-  _execNoPrepare("DELETE FROM relation_tags CASCADE");
-  _execNoPrepare("DELETE FROM relations CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentRelationMembersTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentRelationTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentRelationsTableName() + " CASCADE");
+  _execNoPrepare("ALTER SEQUENCE " + ApiDb::getCurrentRelationsSequenceName() + " RESTART WITH 1");
+  _execNoPrepare("DELETE FROM " + ApiDb::getRelationMembersTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getRelationTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getRelationsTableName() + " CASCADE");
 
   // delete relations data 2nd
-  _execNoPrepare("DELETE FROM current_way_nodes CASCADE");
-  _execNoPrepare("DELETE FROM current_way_tags CASCADE");
-  _execNoPrepare("DELETE FROM current_ways CASCADE");
-  _execNoPrepare("ALTER SEQUENCE current_ways_id_seq RESTART WITH 1");
-  _execNoPrepare("DELETE FROM way_nodes CASCADE");
-  _execNoPrepare("DELETE FROM way_tags CASCADE");
-  _execNoPrepare("DELETE FROM ways CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentWayNodesTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentWayTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentWaysTableName() + " CASCADE");
+  _execNoPrepare("ALTER SEQUENCE " + ApiDb::getCurrentWaysSequenceName() + " RESTART WITH 1");
+  _execNoPrepare("DELETE FROM " + ApiDb::getWayNodesTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getWayTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getWaysTableName() + " CASCADE");
 
   // delete nodes data 3rd
-  _execNoPrepare("DELETE FROM current_node_tags CASCADE");
-  _execNoPrepare("DELETE FROM current_nodes CASCADE");
-  _execNoPrepare("ALTER SEQUENCE current_nodes_id_seq RESTART WITH 1");
-  _execNoPrepare("DELETE FROM node_tags CASCADE");
-  _execNoPrepare("DELETE FROM nodes CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentNodeTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getCurrentNodesTableName() + " CASCADE");
+  _execNoPrepare("ALTER SEQUENCE " + ApiDb::getCurrentNodesSequenceName() + " RESTART WITH 1");
+  _execNoPrepare("DELETE FROM " + ApiDb::getNodeTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getNodesTableName() + " CASCADE");
 
   // delete changesets
-  _execNoPrepare("DELETE FROM changesets_subscribers CASCADE");
-  _execNoPrepare("DELETE FROM changeset_tags CASCADE");
-  _execNoPrepare("DELETE FROM changesets CASCADE");
-  _execNoPrepare("ALTER SEQUENCE changesets_id_seq RESTART WITH 1");
+  _execNoPrepare("DELETE FROM " + ApiDb::getChangesetsSubscribersTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getChangesetTagsTableName() + " CASCADE");
+  _execNoPrepare("DELETE FROM " + ApiDb::getChangesetsTableName() + " CASCADE");
+  _execNoPrepare("ALTER SEQUENCE " + ApiDb::getChangesetsSequenceName() + " RESTART WITH 1");
 
   // delete users
-  _execNoPrepare("DELETE FROM users CASCADE");
-  _execNoPrepare("ALTER SEQUENCE users_id_seq RESTART WITH 1");
+  _execNoPrepare("DELETE FROM " + ApiDb::getUsersTableName() + " CASCADE");
+  _execNoPrepare("ALTER SEQUENCE " + ApiDb::getUsersSequenceName() + " RESTART WITH 1");
 }
 
 bool OsmApiDb::isSupported(QUrl url)
@@ -169,7 +169,7 @@ void OsmApiDb::open(const QUrl& url)
 
 void OsmApiDb::deleteUser(long userId)
 {
-  _exec("DELETE FROM users WHERE id=:id", (qlonglong)userId);
+  _exec("DELETE FROM " + ApiDb::getUsersTableName() + " WHERE id=:id", (qlonglong)userId);
 }
 
 void OsmApiDb::_resetQueries()
@@ -240,23 +240,23 @@ QString OsmApiDb::tableTypeToTableName(const TableType& tableType) const
 {
   if (tableType == TableType::Node)
   {
-    return "current_nodes";
+    return ApiDb::getCurrentNodesTableName();
   }
   else if (tableType == TableType::Way)
   {
-    return "current_ways";
+    return ApiDb::getCurrentWaysTableName();
   }
   else if (tableType == TableType::Relation)
   {
-    return "current_relations";
+    return ApiDb::getCurrentRelationsTableName();
   }
   else if (tableType == TableType::WayNode)
   {
-    return "current_way_nodes";
+    return ApiDb::getCurrentWayNodesTableName();
   }
   else if (tableType == TableType::RelationMember)
   {
-    return "current_relation_members";
+    return ApiDb::getCurrentRelationMembersTableName();
   }
   else
   {
@@ -270,17 +270,23 @@ QString OsmApiDb::_elementTypeToElementTableName(const ElementType& elementType)
   if (elementType == ElementType::Node)
   {
     return QString("id, latitude, longitude, changeset_id, visible, timestamp, tile, version, k, v ") +
-      QString("from current_nodes left outer join current_node_tags on current_nodes.id=current_node_tags.node_id");
+      QString("FROM %1 LEFT OUTER JOIN %2 ON %1.id=%2.node_id")
+      .arg(ApiDb::getCurrentNodesTableName())
+      .arg(ApiDb::getCurrentNodeTagsTableName());
   }
   else if (elementType == ElementType::Way)
   {
-    return QString("id, changeset_id, timestamp, visible, version, k, v ")+
-      QString("from current_ways left outer join current_way_tags on current_ways.id=current_way_tags.way_id");
+    return QString("id, changeset_id, timestamp, visible, version, k, v ") +
+      QString("FROM %1 LEFT OUTER JOIN %2 ON %1.id=%2.way_id")
+      .arg(ApiDb::getCurrentWaysTableName())
+      .arg(ApiDb::getCurrentWayTagsTableName());
   }
   else if (elementType == ElementType::Relation)
   {
-    return QString("id, changeset_id, timestamp, visible, version, k, v ")+
-      QString("from current_relations left outer join current_relation_tags on current_relations.id=current_relation_tags.relation_id");
+    return QString("id, changeset_id, timestamp, visible, version, k, v ") +
+      QString("FROM %1 LEFT OUTER JOIN %2 ON %1.id=%2.relation_id")
+      .arg(ApiDb::getCurrentRelationsTableName())
+      .arg(ApiDb::getCurrentRelationTagsTableName());
   }
   else
   {
@@ -290,16 +296,19 @@ QString OsmApiDb::_elementTypeToElementTableName(const ElementType& elementType)
 
 vector<long> OsmApiDb::selectNodeIdsForWay(long wayId)
 {
-  QString sql =  "SELECT ";
-  sql += "node_id FROM " + _getWayNodesTableName() + " WHERE way_id = :wayId ORDER BY sequence_id";
+  QString sql =  "SELECT node_id FROM " +
+                  getCurrentWayNodesTableName() +
+                 " WHERE way_id = :wayId ORDER BY sequence_id";
 
   return ApiDb::selectNodeIdsForWay(wayId, sql);
 }
 
 shared_ptr<QSqlQuery> OsmApiDb::selectNodesForWay(long wayId)
 {
-  QString sql =  "SELECT ";
-  sql += "node_id, latitude, longitude FROM current_way_nodes inner join current_nodes on current_way_nodes.node_id=current_nodes.id and way_id = :wayId ORDER BY sequence_id";
+  QString sql =  QString("SELECT node_id, latitude, longitude FROM %1 INNER JOIN %2 ON "
+                         "%1.node_id=%2.id AND way_id = :wayId ORDER BY sequence_id")
+                         .arg(ApiDb::getCurrentWayNodesTableName())
+                         .arg(ApiDb::getCurrentNodesTableName());
   return ApiDb::selectNodesForWay(wayId, sql);
 }
 
@@ -312,7 +321,7 @@ vector<RelationData::Entry> OsmApiDb::selectMembersForRelation(long relationId)
     _selectMembersForRelation.reset(new QSqlQuery(_db));
     _selectMembersForRelation->setForwardOnly(true);
     _selectMembersForRelation->prepare(
-      "SELECT member_type, member_id, member_role FROM " + _getRelationMembersTableName() +
+      "SELECT member_type, member_id, member_role FROM " + getCurrentRelationMembersTableName() +
       " WHERE relation_id = :relationId ORDER BY sequence_id");
   }
 
@@ -406,8 +415,7 @@ shared_ptr<QSqlQuery> OsmApiDb::selectTagsForRelation(long relId)
   {
     _selectTagsForRelation.reset(new QSqlQuery(_db));
     _selectTagsForRelation->setForwardOnly(true);
-    QString sql =  "SELECT ";
-    sql += "relation_id, k, v FROM current_relation_tags where relation_id = :relId";
+    QString sql =  "SELECT relation_id, k, v FROM " + ApiDb::getCurrentRelationTagsTableName() + " WHERE relation_id = :relId";
     _selectTagsForRelation->prepare( sql );
   }
 
@@ -427,8 +435,7 @@ shared_ptr<QSqlQuery> OsmApiDb::selectTagsForWay(long wayId)
   {
     _selectTagsForWay.reset(new QSqlQuery(_db));
     _selectTagsForWay->setForwardOnly(true);
-    QString sql =  "SELECT ";
-    sql += "way_id, k, v FROM current_way_tags where way_id = :wayId";
+    QString sql =  "SELECT way_id, k, v FROM " + ApiDb::getCurrentWayTagsTableName() + " WHERE way_id = :wayId";
     _selectTagsForWay->prepare( sql );
   }
 
@@ -448,8 +455,7 @@ shared_ptr<QSqlQuery> OsmApiDb::selectTagsForNode(long nodeId)
   {
     _selectTagsForNode.reset(new QSqlQuery(_db));
     _selectTagsForNode->setForwardOnly(true);
-    QString sql =  "SELECT ";
-    sql += "node_id, k, v FROM current_node_tags where node_id = :nodeId";
+    QString sql =  "SELECT node_id, k, v FROM " + ApiDb::getCurrentNodeTagsTableName() + " WHERE node_id = :nodeId";
     _selectTagsForNode->prepare( sql );
   }
 
@@ -485,9 +491,7 @@ long OsmApiDb::getNextId(const ElementType& type)
   switch (type.getEnum())
   {
     case ElementType::Node:
-      return getNextId("current_" + type.toString().toLower() + "s");
     case ElementType::Way:
-      return getNextId("current_" + type.toString().toLower() + "s");
     case ElementType::Relation:
       return getNextId("current_" + type.toString().toLower() + "s");
     default:
@@ -502,7 +506,9 @@ long OsmApiDb::getNextId(const QString tableName)
   {
     _seqQueries[tableName].reset(new QSqlQuery(_db));
     _seqQueries[tableName]->setForwardOnly(true);
-    _seqQueries[tableName]->prepare(QString("SELECT NEXTVAL('%1_id_seq')").arg(tableName.toLower()));
+    _seqQueries[tableName]->prepare(QString("SELECT NEXTVAL('%1%2')")
+                                    .arg(tableName.toLower())
+                                    .arg(ApiDb::getSequenceId()));
   }
 
   shared_ptr<QSqlQuery> query = _seqQueries[tableName];

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDb.h
@@ -165,10 +165,6 @@ private:
 
   void _init();
 
-  // Osm Api DB table strings
-  static QString _getWayNodesTableName() { return "current_way_nodes"; }
-  static QString _getRelationMembersTableName() { return "current_relation_members"; }
-
   QString _elementTypeToElementTableName(const ElementType& elementType) const;
 
 };

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetWriter.cpp
@@ -117,7 +117,7 @@ void OsmApiDbSqlChangesetWriter::write(const QString sql)
         changesetStatType = statementParts[2] + "-" + statementParts[1]; //e.g. "node-create"
         //LOG_VARD(changesetStatType);
       }
-      else if (sqlStatement.contains("UPDATE changesets"))
+      else if (sqlStatement.contains("UPDATE " + ApiDb::getChangesetsTableName()))
       {
         //some tight coupling here to OsmChangesetSqlFileWriter
         changesetStatType = "";
@@ -209,8 +209,8 @@ QString OsmApiDbSqlChangesetWriter::getChangesetStats() const
 
 bool OsmApiDbSqlChangesetWriter::conflictExistsInTarget(const QString boundsStr, const QString timeStr)
 {
-  LOG_INFO("Checking for OSM API DB conflicts for changesets within " << boundsStr << " and " <<
-           "created after " << timeStr << "...");
+  LOG_INFO("Checking for OSM API DB conflicts for " << ApiDb::getChangesetsTableName() << " within " <<
+           boundsStr << " and created after " << timeStr << "...");
 
   const Envelope bounds = GeometryUtils::envelopeFromConfigString(boundsStr);
   LOG_VARD(bounds.toString());


### PR DESCRIPTION
refs #1238 
Consolidated all table names referenced in code into ApiDb functions.
Changed function names to distinguish between tables like nodes and current_nodes.
Added in other tables not listed previous (non-current)
Put SQL commands in caps for consistency.