### PR TITLE
Network conflation crashes on empty files

### DIFF
--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/ConflictsNetworkMatcher.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/ConflictsNetworkMatcher.cpp
@@ -127,6 +127,11 @@ void ConflictsNetworkMatcher::_removeDupes()
 {
   QHash<ConstEdgeMatchPtr,double>::iterator it1 = _edgeMatches->getAllMatches().begin();
   QHash<ConstEdgeMatchPtr,double>::iterator it2 = _edgeMatches->getAllMatches().begin();
+
+  //  Check for empty edge matches, only test it1 because currently it1 == it2
+  if (it1 == _edgeMatches->getAllMatches().end())
+    return;
+
   ++it2;
 
   while (it1 != _edgeMatches->getAllMatches().end())

--- a/test-files/cmd/slow/NetworkConflateCmdTest.sh
+++ b/test-files/cmd/slow/NetworkConflateCmdTest.sh
@@ -9,5 +9,5 @@ hoot is-match test-output/cmd/NetworkConflateCmdTest/output.osm test-files/cmd/s
 
 # Check to make sure we don't bomb out on empty files
 # TODO: this fails; see #1282
-#hoot conflate -C Network.conf --warn test-files/Empty.osm test-files/Empty.osm tmp/dum.osm
-#hoot is-match test-files/Empty.osm tmp/dum.osm || cat tmp/dum.osm
+hoot conflate -C Network.conf --warn test-files/Empty.osm test-files/Empty.osm tmp/dum.osm
+hoot is-match test-files/Empty.osm tmp/dum.osm || cat tmp/dum.osm


### PR DESCRIPTION
Enabled and fixed the NetworkConflateCmdTest by checking the iterators before incrementing it2.