### PR TITLE
OsmChangesetXmlFileWriter doesn't honor changeset.max.size

### DIFF
--- a/docs/commands/derive-changeset.asciidoc
+++ b/docs/commands/derive-changeset.asciidoc
@@ -9,12 +9,12 @@ output changeset is not meant to be written to a Hootenanny API database.
 * +input1+ - Input 1 (e.g. .osm file).
 * +input2+ - Input 2 (e.g. .osm file).
 * +output+ - Output location (e.g. .osc or .osc.sql file).
-* +databaseUrl+ - Database the changeset will eventually be written to (but not by this command).
+* +databaseUrl+ - Database the changeset will eventually be written to (but not by this command). Only applicable for .osc.sql files.
 
 === Usage
 
 --------------------------------------
-derive-changeset (input1) (input2) (output.osc) [databaseUrl]
+derive-changeset (input1) (input2) (output.osc|output.osc.sql) [databaseUrl]
 --------------------------------------
 
 ==== Example

--- a/hoot-core-test/hoot-core-test.pro
+++ b/hoot-core-test/hoot-core-test.pro
@@ -250,6 +250,7 @@ SOURCES += \
 
 HEADERS += \
     src/test/cpp/hoot/core/test/ConflateCaseTest.h \
-    src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
+    src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h \
+    src/test/cpp/hoot/core/io/OsmChangesetTestProvider.h
 
 

--- a/hoot-core-test/hoot-core-test.pro
+++ b/hoot-core-test/hoot-core-test.pro
@@ -251,6 +251,6 @@ SOURCES += \
 HEADERS += \
     src/test/cpp/hoot/core/test/ConflateCaseTest.h \
     src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h \
-    src/test/cpp/hoot/core/io/OsmChangesetTestProvider.h
+    src/test/cpp/hoot/core/io/TestOsmChangesetProvider.h
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmChangesetTestProvider.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmChangesetTestProvider.h
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef OSMCHANGESETTESTPROVIDER_H
+#define OSMCHANGESETTESTPROVIDER_H
+
+// Hoot
+#include <hoot/core/elements/Node.h>
+#include <hoot/core/elements/Relation.h>
+#include <hoot/core/elements/Way.h>
+#include <hoot/core/elements/ElementType.h>
+#include <hoot/core/io/ChangesetProvider.h>
+#include <hoot/core/io/ElementInputStream.h>
+#include <hoot/core/io/OsmApiDb.h>
+
+// TGS
+#include <tgs/Statistics/Random.h>
+using namespace Tgs;
+
+namespace hoot
+{
+
+/**
+ * @brief The SqlTestChangesetProvider class
+ * Implementation of ChangeSetProvider that psuedo-randomly creates, modifies, and deletes
+ * nodes, ways, and relations for use with both the SQL and OSM changeset writers.
+ */
+class SqlTestChangesetProvider : public ChangeSetProvider
+{
+public:
+  SqlTestChangesetProvider() : _ctr(0), _max(10), _node(0), _way(0), _rel(0)
+  {
+    Random::instance()->seed(0);
+  }
+
+  ~SqlTestChangesetProvider() { }
+
+  boost::shared_ptr<OGRSpatialReference> getProjection() const
+  {
+    return boost::shared_ptr<OGRSpatialReference>();
+  }
+
+  void close() { }
+
+  bool hasMoreChanges() { return _ctr < _max; }
+
+  Change readNextChange()
+  {
+    Change change;
+    change.type = (Change::ChangeType)(Random::instance()->generateInt() % 3);
+
+    ElementType::Type element_type = (ElementType::Type)(Random::instance()->generateInt() % 3);
+    switch (element_type)
+    {
+    default:
+    case ElementType::Node:
+      {
+        NodePtr node(new Node(Status::Unknown1, ++_node, getLon(), getLat(), 15.0));
+        change.e = node;
+      }
+      break;
+    case ElementType::Way:
+      {
+        NodePtr node1(new Node(Status::Unknown1, ++_node, getLon(), getLat(), 15.0));
+        NodePtr node2(new Node(Status::Unknown1, ++_node, getLon(), getLat(), 15.0));
+        WayPtr way(new Way(Status::Unknown1, ++_way, 15.0));
+        way->addNode(node1->getId());
+        way->addNode(node2->getId());
+        way->setTag("key1", "value1");
+        change.e = way;
+      }
+      break;
+    case ElementType::Relation:
+      {
+        NodePtr node1(new Node(Status::Unknown1, ++_node, getLon(), getLat(), 15.0));
+        NodePtr node2(new Node(Status::Unknown1, ++_node, getLon(), getLat(), 15.0));
+        WayPtr way(new Way(Status::Unknown1, ++_way, 15.0));
+        way->addNode(node1->getId());
+        way->addNode(node2->getId());
+        way->setTag("key1", "value1");
+        RelationPtr relation(new Relation(Status::Unknown1, ++_rel, 15.0));
+        relation->addElement("role1", node1->getElementId());
+        relation->addElement("role2", way->getElementId());
+        relation->setTag("key2", "value2");
+        change.e = relation;
+      }
+      break;
+    }
+    _ctr++;
+    return change;
+  }
+
+private:
+  double getLat() { return (Random::instance()->generateInt() % 180 -  90.0) / ApiDb::COORDINATE_SCALE; }
+  double getLon() { return (Random::instance()->generateInt() % 360 - 180.0) / ApiDb::COORDINATE_SCALE; }
+
+  int _ctr;
+  int _max;
+  int _node;
+  int _way;
+  int _rel;
+
+};
+
+}
+
+#endif // OSMCHANGESETTESTPROVIDER_H

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmChangesetXmlFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmChangesetXmlFileWriterTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include "OsmChangesetTestProvider.h"
 #include <hoot/core/io/ChangesetProvider.h>
 #include <hoot/core/io/ElementInputStream.h>
 #include <hoot/core/io/OsmChangesetXmlFileWriter.h>
@@ -44,75 +45,18 @@ using namespace boost;
 namespace hoot
 {
 
-//dummy implementation for testing the OsmChangeWriter
-class TestChangesetProvider : public ChangeSetProvider
-{
-
-public:
-
-  TestChangesetProvider() : _ctr(0) { }
-  ~TestChangesetProvider() { }
-
-  boost::shared_ptr<OGRSpatialReference> getProjection() const
-  {
-    return boost::shared_ptr<OGRSpatialReference>();
-  }
-
-  void close() { }
-
-  bool hasMoreChanges() { while (_ctr < 3) { return true; } return false; }
-
-  Change readNextChange()
-  {
-    NodePtr node1(new Node(Status::Unknown1, 1, 0.0, 0.0, 15.0));
-    NodePtr node2(new Node(Status::Unknown1, 2, 1.0, 0.0, 15.0));
-    WayPtr way(new Way(Status::Unknown1, 3, 15.0));
-    way->addNode(node1->getId());
-    way->addNode(node2->getId());
-    way->setTag("key1", "value1");
-    RelationPtr relation(new Relation(Status::Unknown1, 1, 15.0));
-    relation->addElement("role1", node1->getElementId());
-    relation->addElement("role2", way->getElementId());
-    relation->setTag("key2", "value2");
-
-    Change change;
-    if (_ctr == 0)
-    {
-      change.e = node1;
-      change.type = Change::Create;
-    }
-    else if (_ctr == 1)
-    {
-      change.e = relation;
-      change.type = Change::Delete;
-    }
-    else if (_ctr == 2)
-    {
-      change.e = way;
-      change.type = Change::Modify;
-    }
-    _ctr++;
-
-    return change;
-  }
-
-private:
-
-  int _ctr;
-
-};
-
 class OsmChangesetXmlFileWriterTest : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE(OsmChangesetXmlFileWriterTest);
-    CPPUNIT_TEST(runTest);
+    CPPUNIT_TEST(runSimpleTest);
+    CPPUNIT_TEST(runSplitTest);
     CPPUNIT_TEST_SUITE_END();
 
 public:
 
-  void runTest()
+  void runSimpleTest()
   {
-    shared_ptr<ChangeSetProvider> changesetProvider(new TestChangesetProvider());
+    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
     QDir().mkpath("test-output/io/OsmChangesetXmlFileWriterTest");
     OsmChangesetXmlFileWriter().write(
       "test-output/io/OsmChangesetXmlFileWriterTest/changeset.osc", changesetProvider);
@@ -121,9 +65,26 @@ public:
       TestUtils::readFile("test-files/io/OsmChangesetXmlFileWriterTest/changeset.osc"),
       TestUtils::readFile("test-output/io/OsmChangesetXmlFileWriterTest/changeset.osc"));
   }
+
+  void runSplitTest()
+  {
+    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
+    QDir().mkpath("test-output/io/OsmChangesetXmlFileWriterTest");
+    OsmChangesetXmlFileWriter writer;
+    Settings testSettings = conf();
+    testSettings.set("changeset.max.size", "5");
+//    writer.setConfiguration(testSettings);
+    writer.write(
+      "test-output/io/OsmChangesetXmlFileWriterTest/changeset.split.osc", changesetProvider);
+
+    HOOT_STR_EQUALS(
+      TestUtils::readFile("test-files/io/OsmChangesetXmlFileWriterTest/changeset.split.osc"),
+      TestUtils::readFile("test-output/io/OsmChangesetXmlFileWriterTest/changeset.split.osc"));
+  }
 };
 
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "quick");
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "current");
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "quick");
 
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmChangesetXmlFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmChangesetXmlFileWriterTest.cpp
@@ -26,7 +26,7 @@
  */
 
 // Hoot
-#include "OsmChangesetTestProvider.h"
+#include "TestOsmChangesetProvider.h"
 #include <hoot/core/io/ChangesetProvider.h>
 #include <hoot/core/io/ElementInputStream.h>
 #include <hoot/core/io/OsmChangesetXmlFileWriter.h>
@@ -56,7 +56,7 @@ public:
 
   void runSimpleTest()
   {
-    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
+    shared_ptr<ChangeSetProvider> changesetProvider(new TestOsmChangesetProvider(false));
     QDir().mkpath("test-output/io/OsmChangesetXmlFileWriterTest");
     OsmChangesetXmlFileWriter().write(
       "test-output/io/OsmChangesetXmlFileWriterTest/changeset.osc", changesetProvider);
@@ -68,23 +68,26 @@ public:
 
   void runSplitTest()
   {
-    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
+    shared_ptr<ChangeSetProvider> changesetProvider(new TestOsmChangesetProvider(false));
     QDir().mkpath("test-output/io/OsmChangesetXmlFileWriterTest");
     OsmChangesetXmlFileWriter writer;
     Settings testSettings = conf();
     testSettings.set("changeset.max.size", "5");
-//    writer.setConfiguration(testSettings);
+    writer.setConfiguration(testSettings);
     writer.write(
       "test-output/io/OsmChangesetXmlFileWriterTest/changeset.split.osc", changesetProvider);
 
     HOOT_STR_EQUALS(
       TestUtils::readFile("test-files/io/OsmChangesetXmlFileWriterTest/changeset.split.osc"),
       TestUtils::readFile("test-output/io/OsmChangesetXmlFileWriterTest/changeset.split.osc"));
+    HOOT_STR_EQUALS(
+      TestUtils::readFile("test-files/io/OsmChangesetXmlFileWriterTest/changeset-001.split.osc"),
+      TestUtils::readFile("test-output/io/OsmChangesetXmlFileWriterTest/changeset-001.split.osc"));
   }
 };
 
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "current");
-//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "quick");
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "current");
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmChangesetXmlFileWriterTest, "quick");
 
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbChangesetSqlFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbChangesetSqlFileWriterTest.cpp
@@ -26,10 +26,10 @@
  */
 
 // Hoot
-#include <hoot/core/io/ChangesetProvider.h>
-#include <hoot/core/io/ElementInputStream.h>
-#include <hoot/core/io/OsmChangesetSqlFileWriter.h>
+#include "OsmChangesetTestProvider.h"
 #include "ServicesDbTestUtils.h"
+
+#include <hoot/core/io/OsmChangesetSqlFileWriter.h>
 
 // Boost
 using namespace boost;
@@ -45,68 +45,11 @@ using namespace boost;
 namespace hoot
 {
 
-//dummy implementation for testing
-class TestChangesetProvider : public ChangeSetProvider
-{
-
-public:
-
-  TestChangesetProvider() : _ctr(0) { }
-  ~TestChangesetProvider() { }
-
-  boost::shared_ptr<OGRSpatialReference> getProjection() const
-  {
-    return boost::shared_ptr<OGRSpatialReference>();
-  }
-
-  void close() { }
-
-  bool hasMoreChanges() { while (_ctr < 3) { return true; } return false; }
-
-  Change readNextChange()
-  {
-    NodePtr node1(new Node(Status::Unknown1, 1, 0.0, 0.0, 15.0));
-    NodePtr node2(new Node(Status::Unknown1, 2, 1.0, 0.0, 15.0));
-    WayPtr way(new Way(Status::Unknown1, 3, 15.0));
-    way->addNode(node1->getId());
-    way->addNode(node2->getId());
-    way->setTag("key1", "value1");
-    RelationPtr relation(new Relation(Status::Unknown1, 1, 15.0));
-    relation->addElement("role1", node1->getElementId());
-    relation->addElement("role2", way->getElementId());
-    relation->setTag("key2", "value2");
-
-    Change change;
-    if (_ctr == 0)
-    {
-      change.e = node1;
-      change.type = Change::Create;
-    }
-    else if (_ctr == 1)
-    {
-      change.e = relation;
-      change.type = Change::Delete;
-    }
-    else if (_ctr == 2)
-    {
-      change.e = way;
-      change.type = Change::Modify;
-    }
-    _ctr++;
-
-    return change;
-  }
-
-private:
-
-  int _ctr;
-
-};
-
 class ServiceOsmApiDbChangesetSqlFileWriterTest : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE(ServiceOsmApiDbChangesetSqlFileWriterTest);
     CPPUNIT_TEST(runBasicTest);
+    CPPUNIT_TEST(runSplitTest);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -123,7 +66,7 @@ public:
   void runBasicTest()
   {
     QDir().mkpath("test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest");
-    shared_ptr<ChangeSetProvider> changesetProvider(new TestChangesetProvider());
+    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
 
     //clear out the db so we get consistent next id results
     database.open(ServicesDbTestUtils::getOsmApiDbUrl());
@@ -139,8 +82,33 @@ public:
       TestUtils::readFile("test-files/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.osc.sql"),
       TestUtils::readFile("test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.osc.sql"));
   }
+
+  void runSplitTest()
+  {
+    QDir().mkpath("test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest");
+    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
+
+    //clear out the db so we get consistent next id results
+    database.open(ServicesDbTestUtils::getOsmApiDbUrl());
+    database.deleteData();
+    ServicesDbTestUtils::execOsmApiDbSqlTestScript("users.sql");
+
+    OsmChangesetSqlFileWriter writer(ServicesDbTestUtils::getOsmApiDbUrl());
+    //  Set the changeset max size to 5 (half of the changes) for this test only
+    Settings testSettings = conf();
+    testSettings.set("changeset.max.size", "5");
+    writer.setConfiguration(testSettings);
+    writer
+      .write(
+        "test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.split.osc.sql",
+        changesetProvider);
+    HOOT_STR_EQUALS(
+      TestUtils::readFile("test-files/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.split.osc.sql"),
+      TestUtils::readFile("test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.split.osc.sql"));
+  }
 };
 
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "slow");
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "current");
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "quick");
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbChangesetSqlFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbChangesetSqlFileWriterTest.cpp
@@ -26,7 +26,7 @@
  */
 
 // Hoot
-#include "OsmChangesetTestProvider.h"
+#include "TestOsmChangesetProvider.h"
 #include "ServicesDbTestUtils.h"
 
 #include <hoot/core/io/OsmChangesetSqlFileWriter.h>
@@ -66,7 +66,7 @@ public:
   void runBasicTest()
   {
     QDir().mkpath("test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest");
-    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
+    shared_ptr<ChangeSetProvider> changesetProvider(new TestOsmChangesetProvider(true));
 
     //clear out the db so we get consistent next id results
     database.open(ServicesDbTestUtils::getOsmApiDbUrl());
@@ -86,7 +86,7 @@ public:
   void runSplitTest()
   {
     QDir().mkpath("test-output/io/ServiceOsmApiDbChangesetSqlFileWriterTest");
-    shared_ptr<ChangeSetProvider> changesetProvider(new SqlTestChangesetProvider());
+    shared_ptr<ChangeSetProvider> changesetProvider(new TestOsmChangesetProvider(true));
 
     //clear out the db so we get consistent next id results
     database.open(ServicesDbTestUtils::getOsmApiDbUrl());
@@ -108,7 +108,7 @@ public:
   }
 };
 
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "current");
-//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "quick");
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "current");
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbChangesetSqlFileWriterTest, "quick");
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/TestOsmChangesetProvider.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/TestOsmChangesetProvider.h
@@ -49,15 +49,24 @@ namespace hoot
  * Implementation of ChangeSetProvider that psuedo-randomly creates, modifies, and deletes
  * nodes, ways, and relations for use with both the SQL and OSM changeset writers.
  */
-class SqlTestChangesetProvider : public ChangeSetProvider
+class TestOsmChangesetProvider : public ChangeSetProvider
 {
 public:
-  SqlTestChangesetProvider() : _ctr(0), _max(10), _node(0), _way(0), _rel(0)
+  /**
+   * Constructor
+   *
+   * @param useCoordScale SQL changeset provider uses the ApiDb::COORDINATE_SCALE
+   *  while the OSM changeset does not
+   */
+  TestOsmChangesetProvider(bool useCoordScale)
+    : _ctr(0), _max(10), _node(0), _way(0), _rel(0), _coordinateScale(1.0)
   {
     Random::instance()->seed(0);
+    if (useCoordScale)
+      _coordinateScale = ApiDb::COORDINATE_SCALE;
   }
 
-  ~SqlTestChangesetProvider() { }
+  ~TestOsmChangesetProvider() { }
 
   boost::shared_ptr<OGRSpatialReference> getProjection() const
   {
@@ -73,8 +82,7 @@ public:
     Change change;
     change.type = (Change::ChangeType)(Random::instance()->generateInt() % 3);
 
-    ElementType::Type element_type = (ElementType::Type)(Random::instance()->generateInt() % 3);
-    switch (element_type)
+    switch ((ElementType::Type)(Random::instance()->generateInt() % 3))
     {
     default:
     case ElementType::Node:
@@ -115,14 +123,15 @@ public:
   }
 
 private:
-  double getLat() { return (Random::instance()->generateInt() % 180 -  90.0) / ApiDb::COORDINATE_SCALE; }
-  double getLon() { return (Random::instance()->generateInt() % 360 - 180.0) / ApiDb::COORDINATE_SCALE; }
+  double getLat() { return (Random::instance()->generateInt() % 180 -  90.0) / _coordinateScale; }
+  double getLon() { return (Random::instance()->generateInt() % 360 - 180.0) / _coordinateScale; }
 
   int _ctr;
   int _max;
   int _node;
   int _way;
   int _rel;
+  double _coordinateScale;
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetSqlFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetSqlFileWriter.h
@@ -34,6 +34,7 @@
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/elements/ElementType.h>
+#include <hoot/core/util/Configurable.h>
 
 // Qt
 #include <QUrl>
@@ -49,7 +50,7 @@ namespace hoot
  * Writes out a set of SQL commands, that when executed, will update the contents of
  * an OSM API database with an OSM changeset.
  */
-class OsmChangesetSqlFileWriter
+class OsmChangesetSqlFileWriter : public Configurable
 {
 
 public:
@@ -64,6 +65,13 @@ public:
    * @param changesetProvider changeset data
    */
   void write(const QString path, ChangeSetProviderPtr changesetProvider);
+
+  /**
+   * Set the configuration settings
+   *
+   * @param conf Settings object containing updated value for changeset.max.size setting
+   */
+  virtual void setConfiguration(const Settings &conf);
 
 private:
 
@@ -101,6 +109,11 @@ private:
 
   long _changesetId;
   Envelope _changesetBounds;
+
+  /** Settings from the config file */
+  long _changesetMaxSize;
+  double _changesetUserId;
+  bool _changesetGenerateNewIds;
 
   friend class ServiceOsmApiDbChangesetSqlFileWriterTest;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.cpp
@@ -39,10 +39,10 @@
 namespace hoot
 {
 
-/// @todo this writer isn't set up to honor ConfigOptions().getChangesetMaxSize()
 OsmChangesetXmlFileWriter::OsmChangesetXmlFileWriter()
+  : _precision(ConfigOptions().getWriterPrecision()),
+    _changesetMaxSize(ConfigOptions().getChangesetMaxSize())
 {
-  _precision = ConfigOptions().getWriterPrecision();
 }
 
 void OsmChangesetXmlFileWriter::write(QString path, ChangeSetProviderPtr cs)
@@ -279,6 +279,13 @@ void OsmChangesetXmlFileWriter::writeRelation(QXmlStreamWriter& writer, ConstRel
   }
 
   writer.writeEndElement();
+}
+
+void OsmChangesetXmlFileWriter::setConfiguration(const Settings &conf)
+{
+  ConfigOptions co(conf);
+  _precision = co.getWriterPrecision();
+  _changesetMaxSize = co.getChangesetMaxSize();
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.cpp
@@ -34,6 +34,7 @@
 
 // Qt
 #include <QFile>
+#include <QFileInfo>
 #include <QXmlStreamWriter>
 
 namespace hoot
@@ -47,82 +48,99 @@ OsmChangesetXmlFileWriter::OsmChangesetXmlFileWriter()
 
 void OsmChangesetXmlFileWriter::write(QString path, ChangeSetProviderPtr cs)
 {
-  LOG_INFO("Writing changeset to " << path);
+  QFileInfo info(path);
+  info.setCaching(false);
+  QString file = info.baseName();
+  QString dir = info.path();
+  QString ext = info.completeSuffix();
+  int fileCount = 0;
 
-  QFile f;
-  f.setFileName(path);
-  if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
-  {
-    throw HootException(QObject::tr("Error opening %1 for writing").arg(path));
-  }
-
-  write(f, cs);
-
-  f.close();
-}
-
-void OsmChangesetXmlFileWriter::write(QIODevice &d, ChangeSetProviderPtr cs)
-{
-  QXmlStreamWriter writer(&d);
-  writer.setCodec("UTF-8");
-  writer.setAutoFormatting(true);
-  writer.writeStartDocument();
-
-  writer.writeStartElement("osmChange");
-  writer.writeAttribute("version", "0.6");
-  writer.writeAttribute("generator", "hootenanny");
-
-  Change::ChangeType last = Change::Unknown;
+  QString filepath = path;
 
   while (cs->hasMoreChanges())
   {
-    _change = cs->readNextChange();
-    LOG_VARD(_change.toString());
-    if (_change.type != last)
+    long changesetProgress = 1;
+    //  Create a new filepath if the file is split in multiple files because of the changeset.max.size setting
+    //   i.e. <filepath>/<filename>-001.<ext>
+    if (fileCount > 0)
+      filepath = QString("%1/%2-%3.%4").arg(dir).arg(file).arg(fileCount, 3, 10, QChar('0')).arg(ext);
+
+    LOG_INFO("Writing changeset to " << filepath);
+
+    QFile f;
+    f.setFileName(filepath);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
     {
-      if (last != Change::Unknown)
+      throw HootException(QObject::tr("Error opening %1 for writing").arg(path));
+    }
+
+    QXmlStreamWriter writer(&f);
+    writer.setCodec("UTF-8");
+    writer.setAutoFormatting(true);
+    writer.writeStartDocument();
+
+    writer.writeStartElement("osmChange");
+    writer.writeAttribute("version", "0.6");
+    writer.writeAttribute("generator", "hootenanny");
+
+    Change::ChangeType last = Change::Unknown;
+
+    while (cs->hasMoreChanges() && changesetProgress <= _changesetMaxSize)
+    {
+      _change = cs->readNextChange();
+      LOG_VARD(_change.toString());
+      if (_change.type != last)
       {
-        writer.writeEndElement();
+        if (last != Change::Unknown)
+        {
+          writer.writeEndElement();
+        }
+        switch (_change.type)
+        {
+          case Change::Create:
+            writer.writeStartElement("create");
+            break;
+          case Change::Delete:
+            writer.writeStartElement("delete");
+            break;
+          case Change::Modify:
+            writer.writeStartElement("modify");
+            break;
+          default:
+            throw IllegalArgumentException("Unexepected change type.");
+        }
+        last = _change.type;
       }
-      switch (_change.type)
+
+      switch (_change.e->getElementType().getEnum())
       {
-        case Change::Create:
-          writer.writeStartElement("create");
+        case ElementType::Node:
+          writeNode(writer, dynamic_pointer_cast<const Node>(_change.e));
           break;
-        case Change::Delete:
-          writer.writeStartElement("delete");
+        case ElementType::Way:
+          writeWay(writer, dynamic_pointer_cast<const Way>(_change.e));
           break;
-        case Change::Modify:
-          writer.writeStartElement("modify");
+        case ElementType::Relation:
+          writeRelation(writer, dynamic_pointer_cast<const Relation>(_change.e));
           break;
         default:
-          throw IllegalArgumentException("Unexepected change type.");
+          throw IllegalArgumentException("Unexpected element type.");
       }
-      last = _change.type;
+      //  Increment the changeset progress
+      changesetProgress++;
     }
 
-    switch (_change.e->getElementType().getEnum())
+    if (last != Change::Unknown)
     {
-      case ElementType::Node:
-        writeNode(writer, dynamic_pointer_cast<const Node>(_change.e));
-        break;
-      case ElementType::Way:
-        writeWay(writer, dynamic_pointer_cast<const Way>(_change.e));
-        break;
-      case ElementType::Relation:
-        writeRelation(writer, dynamic_pointer_cast<const Relation>(_change.e));
-        break;
-      default:
-        throw IllegalArgumentException("Unexpected element type.");
+      writer.writeEndElement();
     }
-  }
-
-  if (last != Change::Unknown)
-  {
     writer.writeEndElement();
+    writer.writeEndDocument();
+
+    f.close();
+    //  Increment the file number if needed for split files
+    fileCount++;
   }
-  writer.writeEndElement();
-  writer.writeEndDocument();
 }
 
 void OsmChangesetXmlFileWriter::writeNode(QXmlStreamWriter& writer, ConstNodePtr n)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.h
@@ -54,11 +54,19 @@ public:
 
   OsmChangesetXmlFileWriter();
 
-  QString writeToString(ChangeSetProviderPtr cs);
-
+  /**
+   * Write the changeset out to the specified file and any changes over changeset.max.size
+   * will be written to another file with a path like this:
+   *  <filepath>/<filename>.<ext>
+   *  <filepath>/<filename>-001.<ext>
+   *  <filepath>/<filename>-002.<ext>
+   *  ...
+   *  <filepath>/<filename>-00n.<ext>
+   *
+   * @param path Pathname for the output file(s)
+   * @param cs Changeset provider to stream the changes from
+   */
   void write(QString path, ChangeSetProviderPtr cs);
-
-  void write(QIODevice& d, ChangeSetProviderPtr cs);
 
   /**
    * Set the configuration settings
@@ -69,6 +77,7 @@ public:
 
 private:
 
+  /** Helper functions to write nodes, ways, and relations. */
   void writeNode(QXmlStreamWriter& writer, ConstNodePtr n);
   void writeWay(QXmlStreamWriter& writer, ConstWayPtr w);
   void writeRelation(QXmlStreamWriter& writer, ConstRelationPtr n);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetXmlFileWriter.h
@@ -27,10 +27,12 @@
 #ifndef OSMCHANGESETXMLFILEWRITER_H
 #define OSMCHANGESETXMLFILEWRITER_H
 
-#include <hoot/core/io/ChangesetProvider.h>
+// Hoot
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/io/ChangesetProvider.h>
+#include <hoot/core/util/Configurable.h>
 
 // Qt
 class QXmlStreamWriter;
@@ -45,7 +47,7 @@ namespace hoot
  * would have to be created using the API.  Optionally, after writing this the changeset
  * can be closed via the API.
  */
-class OsmChangesetXmlFileWriter
+class OsmChangesetXmlFileWriter : public Configurable
 {
 
 public:
@@ -58,13 +60,22 @@ public:
 
   void write(QIODevice& d, ChangeSetProviderPtr cs);
 
+  /**
+   * Set the configuration settings
+   *
+   * @param conf Settings object containing updated value for changeset.max.size setting
+   */
+  virtual void setConfiguration(const Settings &conf);
+
+private:
+
   void writeNode(QXmlStreamWriter& writer, ConstNodePtr n);
   void writeWay(QXmlStreamWriter& writer, ConstWayPtr w);
   void writeRelation(QXmlStreamWriter& writer, ConstRelationPtr n);
 
-private:
-
+  /** Settings from the config file */
   int _precision;
+  long _changesetMaxSize;
 
   Change _change;
 

--- a/test-files/io/OsmChangesetXmlFileWriterTest/changeset-001.split.osc
+++ b/test-files/io/OsmChangesetXmlFileWriterTest/changeset-001.split.osc
@@ -1,32 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
-    <modify>
-        <way id="1" version="0">
-            <nd ref="1"/>
-            <nd ref="2"/>
-            <tag k="key1" v="value1"/>
-            <tag k="error:circular" v="15"/>
-        </way>
-        <node id="3" version="0" lat="-89.0000000000000000" lon="69.0000000000000000"/>
-    </modify>
     <delete>
-        <way id="2" version="0">
-            <nd ref="4"/>
-            <nd ref="5"/>
-            <tag k="key1" v="value1"/>
-            <tag k="error:circular" v="15"/>
-        </way>
-    </delete>
-    <create>
-        <node id="6" version="0" lat="46.0000000000000000" lon="-128.0000000000000000"/>
-    </create>
-    <delete>
-        <relation id="1" version="0">
-            <member type="node" ref="7" role="role1"/>
-            <member type="way" ref="3" role="role2"/>
-            <tag k="key2" v="value2"/>
-            <tag k="error:circular" v="15"/>
-        </relation>
         <way id="4" version="0">
             <nd ref="9"/>
             <nd ref="10"/>

--- a/test-files/io/OsmChangesetXmlFileWriterTest/changeset.osc
+++ b/test-files/io/OsmChangesetXmlFileWriterTest/changeset.osc
@@ -1,22 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
-    <create>
-        <node id="1" version="0" lat="0.0000000000000000" lon="0.0000000000000000"/>
-    </create>
-    <delete>
-        <relation id="1" version="0">
-            <member type="node" ref="1" role="role1"/>
-            <member type="way" ref="3" role="role2"/>
-            <tag k="key2" v="value2"/>
-            <tag k="error:circular" v="15"/>
-        </relation>
-    </delete>
     <modify>
-        <way id="3" version="0">
+        <way id="1" version="0">
             <nd ref="1"/>
             <nd ref="2"/>
             <tag k="key1" v="value1"/>
             <tag k="error:circular" v="15"/>
         </way>
+        <node id="3" version="0" lat="-0.0000089000000000" lon="0.0000069000000000"/>
     </modify>
+    <delete>
+        <way id="2" version="0">
+            <nd ref="4"/>
+            <nd ref="5"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </delete>
+    <create>
+        <node id="6" version="0" lat="0.0000046000000000" lon="-0.0000128000000000"/>
+    </create>
+    <delete>
+        <relation id="1" version="0">
+            <member type="node" ref="7" role="role1"/>
+            <member type="way" ref="3" role="role2"/>
+            <tag k="key2" v="value2"/>
+            <tag k="error:circular" v="15"/>
+        </relation>
+        <way id="4" version="0">
+            <nd ref="9"/>
+            <nd ref="10"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </delete>
+    <create>
+        <node id="11" version="0" lat="0.0000057000000000" lon="-0.0000031000000000"/>
+    </create>
+    <modify>
+        <way id="5" version="0">
+            <nd ref="12"/>
+            <nd ref="13"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </modify>
+    <create>
+        <relation id="2" version="0">
+            <member type="node" ref="14" role="role1"/>
+            <member type="way" ref="6" role="role2"/>
+            <tag k="key2" v="value2"/>
+            <tag k="error:circular" v="15"/>
+        </relation>
+    </create>
+    <delete>
+        <node id="16" version="0" lat="-0.0000044000000000" lon="-0.0000007000000000"/>
+    </delete>
 </osmChange>

--- a/test-files/io/OsmChangesetXmlFileWriterTest/changeset.split.osc
+++ b/test-files/io/OsmChangesetXmlFileWriterTest/changeset.split.osc
@@ -7,7 +7,7 @@
             <tag k="key1" v="value1"/>
             <tag k="error:circular" v="15"/>
         </way>
-        <node id="3" version="0" lat="-0.0000089000000000" lon="0.0000069000000000"/>
+        <node id="3" version="0" lat="-89.0000000000000000" lon="69.0000000000000000"/>
     </modify>
     <delete>
         <way id="2" version="0">
@@ -18,7 +18,7 @@
         </way>
     </delete>
     <create>
-        <node id="6" version="0" lat="0.0000046000000000" lon="-0.0000128000000000"/>
+        <node id="6" version="0" lat="46.0000000000000000" lon="-128.0000000000000000"/>
     </create>
     <delete>
         <relation id="1" version="0">
@@ -27,33 +27,5 @@
             <tag k="key2" v="value2"/>
             <tag k="error:circular" v="15"/>
         </relation>
-        <way id="4" version="0">
-            <nd ref="9"/>
-            <nd ref="10"/>
-            <tag k="key1" v="value1"/>
-            <tag k="error:circular" v="15"/>
-        </way>
-    </delete>
-    <create>
-        <node id="11" version="0" lat="0.0000057000000000" lon="-0.0000031000000000"/>
-    </create>
-    <modify>
-        <way id="5" version="0">
-            <nd ref="12"/>
-            <nd ref="13"/>
-            <tag k="key1" v="value1"/>
-            <tag k="error:circular" v="15"/>
-        </way>
-    </modify>
-    <create>
-        <relation id="2" version="0">
-            <member type="node" ref="14" role="role1"/>
-            <member type="way" ref="6" role="role2"/>
-            <tag k="key2" v="value2"/>
-            <tag k="error:circular" v="15"/>
-        </relation>
-    </create>
-    <delete>
-        <node id="16" version="0" lat="-0.0000044000000000" lon="-0.0000007000000000"/>
     </delete>
 </osmChange>

--- a/test-files/io/OsmChangesetXmlFileWriterTest/changeset.split.osc
+++ b/test-files/io/OsmChangesetXmlFileWriterTest/changeset.split.osc
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+    <modify>
+        <way id="1" version="0">
+            <nd ref="1"/>
+            <nd ref="2"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+        <node id="3" version="0" lat="-0.0000089000000000" lon="0.0000069000000000"/>
+    </modify>
+    <delete>
+        <way id="2" version="0">
+            <nd ref="4"/>
+            <nd ref="5"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </delete>
+    <create>
+        <node id="6" version="0" lat="0.0000046000000000" lon="-0.0000128000000000"/>
+    </create>
+    <delete>
+        <relation id="1" version="0">
+            <member type="node" ref="7" role="role1"/>
+            <member type="way" ref="3" role="role2"/>
+            <tag k="key2" v="value2"/>
+            <tag k="error:circular" v="15"/>
+        </relation>
+        <way id="4" version="0">
+            <nd ref="9"/>
+            <nd ref="10"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </delete>
+    <create>
+        <node id="11" version="0" lat="0.0000057000000000" lon="-0.0000031000000000"/>
+    </create>
+    <modify>
+        <way id="5" version="0">
+            <nd ref="12"/>
+            <nd ref="13"/>
+            <tag k="key1" v="value1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </modify>
+    <create>
+        <relation id="2" version="0">
+            <member type="node" ref="14" role="role1"/>
+            <member type="way" ref="6" role="role2"/>
+            <tag k="key2" v="value2"/>
+            <tag k="error:circular" v="15"/>
+        </relation>
+    </create>
+    <delete>
+        <node id="16" version="0" lat="-0.0000044000000000" lon="-0.0000007000000000"/>
+    </delete>
+</osmChange>

--- a/test-files/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.osc.sql
+++ b/test-files/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.osc.sql
@@ -1,8 +1,33 @@
 INSERT INTO changesets (id, user_id, created_at, closed_at) VALUES (1, 1, (now() at time zone 'utc'), (now() at time zone 'utc'));
 INSERT INTO changeset_tags (changeset_id, k, v) VALUES (1, 'written_by', 'Hootenanny');
+/* modify way 1*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (1, 1, true, (now() at time zone 'utc'), 1);
+UPDATE current_ways SET changeset_id=1, visible=true, "timestamp"=(now() at time zone 'utc'), version=1 WHERE id=1;
+DELETE FROM current_way_tags WHERE way_id = 1;
+DELETE FROM way_tags WHERE way_id = 1;
+INSERT INTO current_way_tags (way_id, k, v) VALUES (1, 'key1', 'value1');
+INSERT INTO way_tags (way_id, k, v, version) VALUES (1, 'key1', 'value1', 1);
+DELETE FROM current_way_nodes WHERE way_id = 1;
+DELETE FROM way_nodes WHERE way_id = 1;
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (1, 1, 1, 1);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (1, 1, 1);
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (1, 2, 1, 2);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (1, 2, 2);
+/* modify node 3*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (3, -88, 69, 1, true, (now() at time zone 'utc'), 2505397589, 1);
+UPDATE current_nodes SET latitude=-88, longitude=69, changeset_id=1, visible=true, "timestamp"=(now() at time zone 'utc'), tile=2505397589, version=1 WHERE id=3;
+DELETE FROM current_node_tags WHERE node_id = 3;
+DELETE FROM node_tags WHERE node_id = 3;
+/* delete way 2*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (2, 1, false, (now() at time zone 'utc'), 1);
+DELETE FROM current_way_tags WHERE way_id = 2;
+DELETE FROM way_tags WHERE way_id = 2;
+DELETE FROM current_way_nodes WHERE way_id=2;
+DELETE FROM current_relation_members WHERE member_type = 'Way' AND member_id = 2;
+UPDATE current_ways SET changeset_id=1, visible=false, version=1 WHERE id=2;
 /* create node 1*/
-INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (1, 0, 0, 1, true, (now() at time zone 'utc'), 3221225472, 1);
-INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (1, 0, 0, 1, true, (now() at time zone 'utc'), 3221225472, 1);
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (1, 46, -127, 1, true, (now() at time zone 'utc'), 1789569706, 1);
+INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (1, 46, -127, 1, true, (now() at time zone 'utc'), 1789569706, 1);
 /* delete relation 1*/
 INSERT INTO relations (relation_id, changeset_id, visible, "timestamp", version) VALUES (1, 1, false, (now() at time zone 'utc'), 1);
 DELETE FROM current_relation_tags WHERE relation_id = 1;
@@ -10,17 +35,45 @@ DELETE FROM relation_tags WHERE relation_id = 1;
 DELETE FROM current_relation_members WHERE relation_id=1;
 DELETE FROM current_relation_members WHERE member_type = 'Relation' AND member_id = 1;
 UPDATE current_relations SET changeset_id=1, visible=false, version=1 WHERE id=1;
-/* modify way 3*/
-INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (3, 1, true, (now() at time zone 'utc'), 1);
-UPDATE current_ways SET changeset_id=1, visible=true, "timestamp"=(now() at time zone 'utc'), version=1 WHERE id=3;
-DELETE FROM current_way_tags WHERE way_id = 3;
-DELETE FROM way_tags WHERE way_id = 3;
-INSERT INTO current_way_tags (way_id, k, v) VALUES (3, 'key1', 'value1');
-INSERT INTO way_tags (way_id, k, v, version) VALUES (3, 'key1', 'value1', 1);
-DELETE FROM current_way_nodes WHERE way_id = 3;
-DELETE FROM way_nodes WHERE way_id = 3;
-INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (3, 1, 1, 1);
-INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (3, 1, 1);
-INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (3, 2, 1, 2);
-INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (3, 2, 2);
-UPDATE changesets SET min_lat=0, max_lat=0, min_lon=0, max_lon=0, num_changes=3 WHERE id=1;
+/* delete way 4*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (4, 1, false, (now() at time zone 'utc'), 1);
+DELETE FROM current_way_tags WHERE way_id = 4;
+DELETE FROM way_tags WHERE way_id = 4;
+DELETE FROM current_way_nodes WHERE way_id=4;
+DELETE FROM current_relation_members WHERE member_type = 'Way' AND member_id = 4;
+UPDATE current_ways SET changeset_id=1, visible=false, version=1 WHERE id=4;
+/* create node 2*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (2, 57, -30, 1, true, (now() at time zone 'utc'), 1789569706, 1);
+INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (2, 57, -30, 1, true, (now() at time zone 'utc'), 1789569706, 1);
+/* modify way 5*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (5, 1, true, (now() at time zone 'utc'), 1);
+UPDATE current_ways SET changeset_id=1, visible=true, "timestamp"=(now() at time zone 'utc'), version=1 WHERE id=5;
+DELETE FROM current_way_tags WHERE way_id = 5;
+DELETE FROM way_tags WHERE way_id = 5;
+INSERT INTO current_way_tags (way_id, k, v) VALUES (5, 'key1', 'value1');
+INSERT INTO way_tags (way_id, k, v, version) VALUES (5, 'key1', 'value1', 1);
+DELETE FROM current_way_nodes WHERE way_id = 5;
+DELETE FROM way_nodes WHERE way_id = 5;
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (5, 12, 1, 1);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (5, 12, 1);
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (5, 13, 1, 2);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (5, 13, 2);
+/* create relation 1*/
+INSERT INTO relations (relation_id, changeset_id, visible, "timestamp", version) VALUES (1, 1, true, (now() at time zone 'utc'), 1);
+INSERT INTO current_relations (id, changeset_id, visible, "timestamp", version) VALUES (1, 1, true, (now() at time zone 'utc'), 1);
+INSERT INTO current_relation_tags (relation_id, k, v) VALUES (1, 'key2', 'value2');
+INSERT INTO relation_tags (relation_id, k, v, version) VALUES (1, 'key2', 'value2', 1);
+INSERT INTO current_relation_tags (relation_id, k, v) VALUES (1, 'type', '');
+INSERT INTO relation_tags (relation_id, k, v, version) VALUES (1, 'type', '', 1);
+INSERT INTO relation_members (relation_id, member_type, member_id, member_role, version, sequence_id) VALUES (1, 'Node', 14, 'role1', 1, 1);
+INSERT INTO current_relation_members (relation_id, member_type, member_id, member_role, sequence_id) VALUES (1, 'Node', 14, 'role1', 1);
+INSERT INTO relation_members (relation_id, member_type, member_id, member_role, version, sequence_id) VALUES (1, 'Way', 6, 'role2', 1, 2);
+INSERT INTO current_relation_members (relation_id, member_type, member_id, member_role, sequence_id) VALUES (1, 'Way', 6, 'role2', 2);
+/* delete node 16*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (16, -43, -6, 1, false, (now() at time zone 'utc'), 1073741823, 1);
+DELETE FROM current_node_tags WHERE node_id = 16;
+DELETE FROM node_tags WHERE node_id = 16;
+DELETE FROM current_way_nodes WHERE node_id=16;
+DELETE FROM current_relation_members WHERE member_type = 'Node' AND member_id = 16;
+UPDATE current_nodes SET changeset_id=1, visible=false, version=1 WHERE id=16;
+UPDATE changesets SET min_lat=-88, max_lat=57, min_lon=-127, max_lon=69, num_changes=10 WHERE id=1;

--- a/test-files/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.split.osc.sql
+++ b/test-files/io/ServiceOsmApiDbChangesetSqlFileWriterTest/changeset.split.osc.sql
@@ -1,0 +1,82 @@
+INSERT INTO changesets (id, user_id, created_at, closed_at) VALUES (1, 1, (now() at time zone 'utc'), (now() at time zone 'utc'));
+INSERT INTO changeset_tags (changeset_id, k, v) VALUES (1, 'written_by', 'Hootenanny');
+/* modify way 1*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (1, 1, true, (now() at time zone 'utc'), 1);
+UPDATE current_ways SET changeset_id=1, visible=true, "timestamp"=(now() at time zone 'utc'), version=1 WHERE id=1;
+DELETE FROM current_way_tags WHERE way_id = 1;
+DELETE FROM way_tags WHERE way_id = 1;
+INSERT INTO current_way_tags (way_id, k, v) VALUES (1, 'key1', 'value1');
+INSERT INTO way_tags (way_id, k, v, version) VALUES (1, 'key1', 'value1', 1);
+DELETE FROM current_way_nodes WHERE way_id = 1;
+DELETE FROM way_nodes WHERE way_id = 1;
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (1, 1, 1, 1);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (1, 1, 1);
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (1, 2, 1, 2);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (1, 2, 2);
+/* modify node 3*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (3, -88, 69, 1, true, (now() at time zone 'utc'), 2505397589, 1);
+UPDATE current_nodes SET latitude=-88, longitude=69, changeset_id=1, visible=true, "timestamp"=(now() at time zone 'utc'), tile=2505397589, version=1 WHERE id=3;
+DELETE FROM current_node_tags WHERE node_id = 3;
+DELETE FROM node_tags WHERE node_id = 3;
+/* delete way 2*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (2, 1, false, (now() at time zone 'utc'), 1);
+DELETE FROM current_way_tags WHERE way_id = 2;
+DELETE FROM way_tags WHERE way_id = 2;
+DELETE FROM current_way_nodes WHERE way_id=2;
+DELETE FROM current_relation_members WHERE member_type = 'Way' AND member_id = 2;
+UPDATE current_ways SET changeset_id=1, visible=false, version=1 WHERE id=2;
+/* create node 1*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (1, 46, -127, 1, true, (now() at time zone 'utc'), 1789569706, 1);
+INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (1, 46, -127, 1, true, (now() at time zone 'utc'), 1789569706, 1);
+/* delete relation 1*/
+INSERT INTO relations (relation_id, changeset_id, visible, "timestamp", version) VALUES (1, 1, false, (now() at time zone 'utc'), 1);
+DELETE FROM current_relation_tags WHERE relation_id = 1;
+DELETE FROM relation_tags WHERE relation_id = 1;
+DELETE FROM current_relation_members WHERE relation_id=1;
+DELETE FROM current_relation_members WHERE member_type = 'Relation' AND member_id = 1;
+UPDATE current_relations SET changeset_id=1, visible=false, version=1 WHERE id=1;
+/* delete way 4*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (4, 1, false, (now() at time zone 'utc'), 1);
+DELETE FROM current_way_tags WHERE way_id = 4;
+DELETE FROM way_tags WHERE way_id = 4;
+DELETE FROM current_way_nodes WHERE way_id=4;
+DELETE FROM current_relation_members WHERE member_type = 'Way' AND member_id = 4;
+UPDATE current_ways SET changeset_id=1, visible=false, version=1 WHERE id=4;
+UPDATE changesets SET min_lat=-88, max_lat=46, min_lon=-127, max_lon=69, num_changes=6 WHERE id=1;
+INSERT INTO changesets (id, user_id, created_at, closed_at) VALUES (2, 1, (now() at time zone 'utc'), (now() at time zone 'utc'));
+INSERT INTO changeset_tags (changeset_id, k, v) VALUES (2, 'written_by', 'Hootenanny');
+/* create node 2*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (2, 57, -30, 2, true, (now() at time zone 'utc'), 1789569706, 1);
+INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (2, 57, -30, 2, true, (now() at time zone 'utc'), 1789569706, 1);
+/* modify way 5*/
+INSERT INTO ways (way_id, changeset_id, visible, "timestamp", version) VALUES (5, 2, true, (now() at time zone 'utc'), 1);
+UPDATE current_ways SET changeset_id=2, visible=true, "timestamp"=(now() at time zone 'utc'), version=1 WHERE id=5;
+DELETE FROM current_way_tags WHERE way_id = 5;
+DELETE FROM way_tags WHERE way_id = 5;
+INSERT INTO current_way_tags (way_id, k, v) VALUES (5, 'key1', 'value1');
+INSERT INTO way_tags (way_id, k, v, version) VALUES (5, 'key1', 'value1', 1);
+DELETE FROM current_way_nodes WHERE way_id = 5;
+DELETE FROM way_nodes WHERE way_id = 5;
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (5, 12, 1, 1);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (5, 12, 1);
+INSERT INTO way_nodes (way_id, node_id, version, sequence_id) VALUES (5, 13, 1, 2);
+INSERT INTO current_way_nodes (way_id, node_id, sequence_id) VALUES (5, 13, 2);
+/* create relation 1*/
+INSERT INTO relations (relation_id, changeset_id, visible, "timestamp", version) VALUES (1, 2, true, (now() at time zone 'utc'), 1);
+INSERT INTO current_relations (id, changeset_id, visible, "timestamp", version) VALUES (1, 2, true, (now() at time zone 'utc'), 1);
+INSERT INTO current_relation_tags (relation_id, k, v) VALUES (1, 'key2', 'value2');
+INSERT INTO relation_tags (relation_id, k, v, version) VALUES (1, 'key2', 'value2', 1);
+INSERT INTO current_relation_tags (relation_id, k, v) VALUES (1, 'type', '');
+INSERT INTO relation_tags (relation_id, k, v, version) VALUES (1, 'type', '', 1);
+INSERT INTO relation_members (relation_id, member_type, member_id, member_role, version, sequence_id) VALUES (1, 'Node', 14, 'role1', 1, 1);
+INSERT INTO current_relation_members (relation_id, member_type, member_id, member_role, sequence_id) VALUES (1, 'Node', 14, 'role1', 1);
+INSERT INTO relation_members (relation_id, member_type, member_id, member_role, version, sequence_id) VALUES (1, 'Way', 6, 'role2', 1, 2);
+INSERT INTO current_relation_members (relation_id, member_type, member_id, member_role, sequence_id) VALUES (1, 'Way', 6, 'role2', 2);
+/* delete node 16*/
+INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) VALUES (16, -43, -6, 2, false, (now() at time zone 'utc'), 1073741823, 1);
+DELETE FROM current_node_tags WHERE node_id = 16;
+DELETE FROM node_tags WHERE node_id = 16;
+DELETE FROM current_way_nodes WHERE node_id=16;
+DELETE FROM current_relation_members WHERE member_type = 'Node' AND member_id = 16;
+UPDATE current_nodes SET changeset_id=2, visible=false, version=1 WHERE id=16;
+UPDATE changesets SET min_lat=-43, max_lat=57, min_lon=-30, max_lon=-6, num_changes=4 WHERE id=2;


### PR DESCRIPTION
Refs #1100 
Split changesets that are more than `changeset.max.size` into multiple files.  Updated documentation and unit tests.  The investigation into this resulted in the follow-on work of #1320