### PR TITLE
attempt to fix cuke test failing on jenkins

### DIFF
--- a/test-files/ui/features/review_bookmarks.feature
+++ b/test-files/ui/features/review_bookmarks.feature
@@ -82,6 +82,7 @@ Feature: Review Bookmarks
         Then I click on the "Sort By" label
         And I wait 30 "seconds" to see "Created At (asc)"
         Then I choose "Created At (dsc)" radio button
+        Then I hover over "#utilReviewBookmarks"
         And I should see "Cucumber Bookmark 2" bookmark first and "Cucumber Bookmark 1" bookmark second
         Then I click on the "Filter By Creator" label
         And I wait 30 "seconds" to see "cucumber1@hootenanny.digitalglobe.com"


### PR DESCRIPTION
>stale element reference: element is not attached to the page document
  (Session info: chrome=49.0.2623.87)
  (Driver info: chromedriver=2.14.313457 (3d645c400edf2e2c500566c9aa096063e707c9cf),platform=Linux 3.13.0-107-generic x86_64) (Selenium::WebDriver::Error::StaleElementReferenceError)
features/review_bookmarks.feature:85:in `And I should see "Cucumber Bookmark 2" bookmark first and "Cucumber Bookmark 1" bookmark second'