### PR TITLE
fix for #1388 - unnecessary search radius calculations during conflation

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/MarkForReviewMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MarkForReviewMergerCreator.cpp
@@ -45,7 +45,7 @@ MarkForReviewMergerCreator::MarkForReviewMergerCreator()
 bool MarkForReviewMergerCreator::createMergers(const MatchSet& matches,
                                                vector<Merger*>& mergers) const
 {
-  LOG_TRACE("Creating mergers...");
+  LOG_TRACE("Creating mergers with " << className() << "...");
 
   bool result = false;
 
@@ -59,14 +59,16 @@ bool MarkForReviewMergerCreator::createMergers(const MatchSet& matches,
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* match = (*it);
+    const Match* match = *it;
+    LOG_VART(match->toString());
     MatchType type = match->getType();
+    LOG_VART(type);
     if (type == MatchType::Review)
     {
-      set< pair<ElementId, ElementId> > s = (*it)->getMatchPairs();
+      set< pair<ElementId, ElementId> > s = match->getMatchPairs();
       eids.insert(s.begin(), s.end());
-      matchStrings.append((*it)->explain());
-      score = max<double>((*it)->getClassification().getReviewP(), score);
+      matchStrings.append(match->explain());
+      score = max<double>(match->getClassification().getReviewP(), score);
       reviewCount++;
       if (reviewType.contains(match->getMatchName()) == false)
       {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MarkForReviewMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MarkForReviewMergerCreator.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -39,6 +39,8 @@ namespace hoot
 class MarkForReviewMergerCreator : public MergerCreator
 {
 public:
+
+  static string className() { return "hoot::MarkForReviewMergerCreator"; }
 
   MarkForReviewMergerCreator();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -141,7 +141,6 @@ void UnifyingConflator::apply(shared_ptr<OsmMap>& map)
     _stats.append(SingleStat("Write Debug Map Time (sec)", timer.getElapsedAndRestart()));
   }
 
-  LOG_INFO("Creating matches...");
   // find all the matches in this map
   if (_matchThreshold.get())
   {
@@ -267,7 +266,6 @@ void UnifyingConflator::apply(shared_ptr<OsmMap>& map)
   {
     LOG_TRACE(
       "Applying merger: " << i + 1 << " / " << _mergers.size() << " - " << _mergers[i]->toString());
-
     _mergers[i]->apply(map, replaced);
 
     // update any mergers that reference the replaced values

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -271,7 +271,7 @@ Match* HighwayMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid
 void HighwayMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const Match *> &matches,
   ConstMatchThresholdPtr threshold)
 {
-  LOG_INFO("Using match creator: " << className());
+  LOG_INFO("Creating matches with: " << className() << "...");
   LOG_VARD(*threshold);
   HighwayMatchVisitor v(
     map, matches, _classifier, _sublineMatcher, Status::Unknown1, threshold, _tagAncestorDiff);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.cpp
@@ -283,7 +283,7 @@ void HighwayRfClassifier::_init() const
     _createTestExtractors();
 
     QString path = ConfPath::search(ConfigOptions().getConflateMatchHighwayModel());
-    LOG_INFO("Loading highway model from: " << path);
+    LOG_DEBUG("Loading highway model from: " << path);
 
     QFile file(path.toAscii().data());
     if (!file.open(QIODevice::ReadOnly))

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMergerCreator.cpp
@@ -46,7 +46,7 @@ HighwaySnapMergerCreator::HighwaySnapMergerCreator()
 
 bool HighwaySnapMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
 {
-  LOG_TRACE("Creating mergers...");
+  LOG_TRACE("Creating mergers with " << className() << "...");
 
   bool result = false;
   assert(matches.size() > 0);
@@ -57,8 +57,11 @@ bool HighwaySnapMergerCreator::createMergers(const MatchSet& matches, vector<Mer
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const HighwayMatch* hm = dynamic_cast<const HighwayMatch*>(*it);
+    const Match* m = *it;
+    LOG_VART(m->toString());
+    const HighwayMatch* hm = dynamic_cast<const HighwayMatch*>(m);
     // check to make sure all the input matches are building matches.
+    LOG_VART(hm == 0);
     if (hm == 0)
     {
       // return an empty result

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -338,7 +338,7 @@ Match* PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId 
 void PoiPolygonMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const Match*>& matches,
                                            ConstMatchThresholdPtr threshold)
 {
-  LOG_INFO("Using match creator: " << className());
+  LOG_INFO("Creating matches with: " << className() << "...");
   LOG_VARD(*threshold);
 
   PoiPolygonMatch::resetMatchDistanceInfo();

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
@@ -59,7 +59,7 @@ Match* PoiPolygonMergerCreator::_createMatch(const ConstOsmMapPtr& map, ElementI
 
 bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
 {
-  LOG_TRACE("Creating mergers...");
+  LOG_TRACE("Creating mergers with " << className() << "...");
 
   bool result = false;
   assert(matches.size() > 0);
@@ -71,6 +71,7 @@ bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merg
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
     const Match* m = *it;
+    LOG_VART(m->toString());
     if (m->getMatchMembers() & MatchMembers::Poi)
     {
       foundAPoi = true;
@@ -94,14 +95,22 @@ bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merg
     // go through all the matches
     for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      set< pair<ElementId, ElementId> > s = (*it)->getMatchPairs();
+      const Match* m = *it;
+      LOG_VART(m->toString());
+
+      //All of the other merger creators check the type of the match and do nothing if it isn't
+      //the correct type (in this case a PoiPolygon match).  Adding that logic in here can cause
+      //problems where some matches are passed up completely by all mergers, which results in an
+      //exception.  If this merger is meant to be catch all for pois/polygons, then this is ok.  If
+      //not, then some rework may need to be done here.
+      set< pair<ElementId, ElementId> > s = m->getMatchPairs();
       eids.insert(s.begin(), s.end());
     }
 
     if (_isConflictingSet(matches))
     {
-      mergers.push_back(new MarkForReviewMerger(eids, "Conflicting information",
-        matchTypes.join(";"), 1));
+      mergers.push_back(
+        new MarkForReviewMerger(eids, "Conflicting information", matchTypes.join(";"), 1));
     }
     else
     {
@@ -117,9 +126,7 @@ bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merg
 vector<MergerCreator::Description> PoiPolygonMergerCreator::getAllCreators() const
 {
   vector<Description> result;
-
   result.push_back(Description(className(), "POI to Polygon Merge Creator", true));
-
   return result;
 }
 
@@ -128,13 +135,11 @@ bool PoiPolygonMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Mat
 {
   bool foundAPoi = false;
   bool foundAPolygon = false;
-  if (m1->getMatchMembers() & MatchMembers::Poi ||
-      m2->getMatchMembers() & MatchMembers::Poi)
+  if (m1->getMatchMembers() & MatchMembers::Poi || m2->getMatchMembers() & MatchMembers::Poi)
   {
     foundAPoi = true;
   }
-  if (m1->getMatchMembers() & MatchMembers::Polygon ||
-      m2->getMatchMembers() & MatchMembers::Polygon)
+  if (m1->getMatchMembers() & MatchMembers::Polygon || m2->getMatchMembers() & MatchMembers::Polygon)
   {
     foundAPolygon = true;
   }
@@ -186,8 +191,7 @@ bool PoiPolygonMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Mat
 
     // return conflict only if it is a miss, a review is ok.
     result = false;
-    if (ma.get() == 0 ||
-        ma->getType() == MatchType::Miss)
+    if (ma.get() == 0 || ma->getType() == MatchType::Miss)
     {
       result = true;
     }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
@@ -152,10 +152,6 @@ QString BuildingMatch::toString() const
 {
   stringstream ss;
   ss << "BuildingMatch: " << _eid1 << ", " << _eid2 << " p: " << _p.toString();
-  //if (getType() == MatchType::Review)
-  //{
-    //ss << " note: " << _explainText;
-  //}
   return QString::fromStdString(ss.str());
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -249,7 +249,7 @@ Match* BuildingMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId ei
 void BuildingMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const Match*>& matches,
   ConstMatchThresholdPtr threshold)
 {
-  LOG_INFO("Using match creator: " << className());
+  LOG_INFO("Creating matches with: " << className() << "...");
   LOG_VARD(*threshold);
   BuildingMatchVisitor v(map, matches, _getRf(), threshold, Status::Unknown1);
   map->visitRo(v);
@@ -269,7 +269,7 @@ shared_ptr<BuildingRfClassifier> BuildingMatchCreator::_getRf()
   if (!_rf)
   {
     QString path = ConfPath::search(ConfigOptions().getConflateMatchBuildingModel());
-    LOG_INFO("Loading model from: " << path);
+    LOG_DEBUG("Loading model from: " << path);
 
     QFile file(path.toAscii().data());
     if (!file.open(QIODevice::ReadOnly))

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
@@ -44,7 +44,7 @@ BuildingMergerCreator::BuildingMergerCreator()
 
 bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
 {
-  LOG_TRACE("Creating mergers...");
+  LOG_TRACE("Creating mergers with " << className() << "...");
 
   bool result = false;
   assert(matches.size() > 0);
@@ -54,7 +54,10 @@ bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<Merger
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const BuildingMatch* bm = dynamic_cast<const BuildingMatch*>(*it);
+    const Match* m = *it;
+    LOG_VART(m->toString());
+    const BuildingMatch* bm = dynamic_cast<const BuildingMatch*>(m);
+    LOG_VART(bm == 0);
     // check to make sure all the input matches are building matches.
     if (bm == 0)
     {

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateReducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateReducer.cpp
@@ -333,7 +333,6 @@ void ConflateReducer::reduce(HadoopPipes::ReduceContext& context)
 void ConflateReducer::_validate(const shared_ptr<OsmMap>& map)
 {
   LOG_INFO("Validating map.");
-  LOG_DEBUG("Testing debug.");
   Debug::printTroubled(map);
   map->validate(true);
 }

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/fourpass/TileOpReducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/fourpass/TileOpReducer.cpp
@@ -325,7 +325,6 @@ void TileOpReducer::reduce(HadoopPipes::ReduceContext& context)
 void TileOpReducer::_validate(const shared_ptr<OsmMap>& map)
 {
   LOG_INFO("Validating map.");
-  LOG_DEBUG("Testing debug.");
   Debug::printTroubled(map);
   map->validate(true);
 

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -160,13 +160,6 @@ Local<Object> PluginContext::loadText(QString text, QString loadInto, QString sc
 
   // Run the script to get the result.
   HootExceptionJs::checkV8Exception(script->Run(), try_catch);
-
-  // Matt, this may conflict w/ your branch. Please fix appropriately. I think you have better error
-  // handling. -JRS
-  // if (result.IsEmpty())
-  // {
-  //   throw HootException(toString(try_catch));
-  // }
 
   if (loadInto != "")
   {

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
@@ -538,8 +538,6 @@ bool ScriptMatchCreator::isMatchCandidate(ConstElementPtr element, const ConstOs
 
   if (!_matchCandidateChecker.get() || _matchCandidateChecker->getMap() != map)
   {
-    LOG_DEBUG("Resetting the match candidate checker...");
-
     LOG_VART(_matchCandidateChecker.get());
     QString scriptPath = _scriptPath;
     if (_matchCandidateChecker.get())
@@ -548,6 +546,9 @@ bool ScriptMatchCreator::isMatchCandidate(ConstElementPtr element, const ConstOs
       scriptPath = _matchCandidateChecker->getScriptPath();
     }
     LOG_VART(scriptPath);
+
+    QFileInfo scriptFileInfo(_scriptPath);
+    LOG_TRACE("Resetting the match candidate checker " << scriptFileInfo.fileName() << "...");
 
     vector<const Match*> emptyMatches;
     _matchCandidateChecker.reset(

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
@@ -82,7 +82,7 @@ public:
     _result(result),
     _mt(mt),
     _script(script),
-    _searchRadius(-1.0)
+    _customSearchRadius(-1.0)
   {
     _neighborCountMax = -1;
     _neighborCountSum = 0;
@@ -95,7 +95,8 @@ public:
     _candidateDistanceSigma = getNumber(plugin, "candidateDistanceSigma", 0.0, 1.0);
 
     //this is meant to have been set externally in a js rules file
-    _searchRadius = getNumber(plugin, "searchRadius", -1.0, 15.0);
+    _customSearchRadius = getNumber(plugin, "searchRadius", -1.0, 15.0);
+    LOG_VART(_customSearchRadius);
 
     Handle<v8::Value> value = plugin->Get(toV8("getSearchRadius"));
     if (value->IsUndefined())
@@ -111,7 +112,8 @@ public:
       _getSearchRadius = Persistent<Function>::New(Handle<Function>::Cast(value));
     }
 
-    boost::function<bool (ConstElementPtr e)> f = boost::bind(&ScriptMatchVisitor::isMatchCandidate, this, _1);
+    boost::function<bool (ConstElementPtr e)> f =
+      boost::bind(&ScriptMatchVisitor::isMatchCandidate, this, _1);
     ArbitraryCriterion crit(f);
     WorstCircularErrorVisitor worstV;
     FilteredVisitor filteredV(crit, worstV);
@@ -136,10 +138,8 @@ public:
     env->expandBy(searchRadius);
 
     // find other nearby candidates
-    set<ElementId> neighbors = IndexElementsVisitor::findNeighbors(*env,
-                                                                   getIndex(),
-                                                                   _indexToEid,
-                                                                   getMap());
+    set<ElementId> neighbors =
+      IndexElementsVisitor::findNeighbors(*env, getIndex(), _indexToEid, getMap());
     ElementId from = e->getElementId();
 
     _elementsEvaluated++;
@@ -225,13 +225,15 @@ public:
     Meters result;
     if (_getSearchRadius.IsEmpty())
     {
-      if (_searchRadius < 0)
+      if (_customSearchRadius < 0)
       {
+        //base the radius off of the element itself
         result = e->getCircularError() * _candidateDistanceSigma;
       }
       else
       {
-        result = _searchRadius * _candidateDistanceSigma;
+        //base the radius off some predefined radius
+        result = _customSearchRadius * _candidateDistanceSigma;
       }
     }
     else
@@ -241,6 +243,7 @@ public:
       int argc = 0;
       jsArgs[argc++] = ElementJs::New(e);
 
+      LOG_TRACE("Calling getSearchRadius...");
       Handle<Value> f = _getSearchRadius->Call(getPlugin(), argc, jsArgs);
 
       result = toCpp<Meters>(f) * _candidateDistanceSigma;
@@ -253,21 +256,24 @@ public:
   /*
    * This is meant to run one time when the match creator is initialized.
    */
-  void customScriptInit()
+  void calculateSearchRadius()
   {
     Context::Scope context_scope(_script->getContext());
     HandleScope handleScope;
 
     Persistent<Object> plugin = getPlugin();
-    Handle<String> initStr = String::New("init");
+    Handle<String> initStr = String::New("calculateSearchRadius");
+    //optional method, so don't throw an error
     if (plugin->Has(initStr) == false)
     {
-      throw HootException("Error finding 'init' function.");
+      LOG_DEBUG("calculateSearchRadius function not present.");
+      return;
     }
     Handle<v8::Value> value = plugin->Get(initStr);
     if (value->IsFunction() == false)
     {
-      throw HootException("init is not a function.");
+      LOG_DEBUG("calculateSearchRadius function not present.");
+      return;
     }
 
     Handle<v8::Function> func = v8::Handle<v8::Function>::Cast(value);
@@ -281,10 +287,11 @@ public:
     func->Call(plugin, argc, jsArgs);
 
     //this is meant to have been set externally in a js rules file
-    _searchRadius = getNumber(plugin, "searchRadius", -1.0, 15.0);
+    _customSearchRadius = getNumber(plugin, "searchRadius", -1.0, 15.0);
+    LOG_VART(_customSearchRadius);
 
-    LOG_DEBUG("Custom script init complete.");
-
+    QFileInfo scriptFileInfo(_scriptPath);
+    LOG_DEBUG("Search radius calculation complete for " << scriptFileInfo.fileName());
   }
 
   shared_ptr<HilbertRTree>& getIndex()
@@ -297,9 +304,9 @@ public:
       _index.reset(new HilbertRTree(mps, 2));
 
       // Only index elements that have Status::Unknown2 and
-      // _smv.isMatchCandidate(e)
       shared_ptr<StatusCriterion> pC1(new StatusCriterion(Status::Unknown2));
-      boost::function<bool (ConstElementPtr e)> f = boost::bind(&ScriptMatchVisitor::isMatchCandidate, this, _1);
+      boost::function<bool (ConstElementPtr e)> f =
+        boost::bind(&ScriptMatchVisitor::isMatchCandidate, this, _1);
       shared_ptr<ArbitraryCriterion> pC2(new ArbitraryCriterion(f));
       shared_ptr<ChainCriterion> pCC(new ChainCriterion());
       pCC->addCriterion(pC1);
@@ -355,6 +362,12 @@ public:
     }
   }
 
+  void setScriptPath(QString path) { _scriptPath = path; }
+  QString getScriptPath() const { return _scriptPath; }
+
+  Meters getCustomSearchRadius() const { return _customSearchRadius; }
+  void setCustomSearchRadius(Meters searchRadius) { _customSearchRadius = searchRadius; }
+
 private:
 
   // don't hold on to the map.
@@ -375,12 +388,10 @@ private:
   deque<ElementId> _indexToEid;
 
   double _candidateDistanceSigma;
-  //used for automatic search radius calculation; it is expected that this is set from the Javascript
-  //rules file used for the generic conflation
-  double _searchRadius;
-
-  double _test;
-
+  //used for automatic search radius calculation; it is expected that this is set from the
+  //Javascript rules file used for the generic conflation
+  double _customSearchRadius;
+  QString _scriptPath;
 };
 
 ScriptMatchCreator::ScriptMatchCreator() :
@@ -408,14 +419,18 @@ void ScriptMatchCreator::setArguments(QStringList args)
   //bit of a hack...see MatchCreator.h...need to refactor
   _description = QString::fromStdString(className()) + "," + args[0];
   _matchCandidateChecker.reset();
+
+  QFileInfo scriptFileInfo(_scriptPath);
+  LOG_DEBUG("Set arguments for: " << className() << " - rules: " << scriptFileInfo.fileName());
 }
 
 Match* ScriptMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2)
 {
   if (isMatchCandidate(map->getElement(eid1), map) && isMatchCandidate(map->getElement(eid2), map))
   {
-    return new ScriptMatch(_script, ScriptMatchVisitor::getPlugin(_script), map,
-      eid1, eid2, getMatchThreshold());
+    return
+      new ScriptMatch(
+        _script, ScriptMatchVisitor::getPlugin(_script), map, eid1, eid2, getMatchThreshold());
   }
   else
   {
@@ -431,12 +446,16 @@ void ScriptMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const M
     throw IllegalArgumentException("The script must be set on the ScriptMatchCreator.");
   }
 
-  QFileInfo scriptFileInfo(_scriptPath);
-  LOG_INFO("Using match creator: " << className() << " - rules: " << scriptFileInfo.fileName());
-  LOG_VARD(*threshold);
-
   ScriptMatchVisitor v(map, matches, threshold, _script);
-  v.customScriptInit();
+  v.setScriptPath(_scriptPath);
+  v.calculateSearchRadius();
+  _cachedCustomSearchRadii[_scriptPath] = v.getCustomSearchRadius();
+  LOG_VART(_scriptPath);
+  LOG_VART(_cachedCustomSearchRadii[_scriptPath]);
+  QFileInfo scriptFileInfo(_scriptPath);
+  LOG_INFO(
+    "Creating matches with: " << className() << "; rules: " << scriptFileInfo.fileName() << "...");
+  LOG_VARD(*threshold);
   map->visitRo(v);
 }
 
@@ -516,14 +535,38 @@ bool ScriptMatchCreator::isMatchCandidate(ConstElementPtr element, const ConstOs
   {
     throw IllegalArgumentException("The script must be set on the ScriptMatchCreator.");
   }
+
   if (!_matchCandidateChecker.get() || _matchCandidateChecker->getMap() != map)
   {
     LOG_DEBUG("Resetting the match candidate checker...");
+
+    LOG_VART(_matchCandidateChecker.get());
+    QString scriptPath = _scriptPath;
+    if (_matchCandidateChecker.get())
+    {
+      LOG_VART(_matchCandidateChecker->getMap() == map);
+      scriptPath = _matchCandidateChecker->getScriptPath();
+    }
+    LOG_VART(scriptPath);
+
     vector<const Match*> emptyMatches;
     _matchCandidateChecker.reset(
       new ScriptMatchVisitor(map, emptyMatches, ConstMatchThresholdPtr(), _script));
-    _matchCandidateChecker->customScriptInit();
+    _matchCandidateChecker->setScriptPath(scriptPath);
+    //If the search radius has already been calculated for this matcher once, we don't want to do
+    //it again due to the expense.
+    LOG_VART(_cachedCustomSearchRadii.contains(scriptPath));
+    if (!_cachedCustomSearchRadii.contains(scriptPath))
+    {
+      _matchCandidateChecker->calculateSearchRadius();
+    }
+    else
+    {
+      LOG_VART(_cachedCustomSearchRadii[scriptPath]);
+      _matchCandidateChecker->setCustomSearchRadius(_cachedCustomSearchRadii[scriptPath]);
+    }
   }
+
   return _matchCandidateChecker->isMatchCandidate(element);
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.h
@@ -86,7 +86,7 @@ private:
   shared_ptr<ScriptMatchVisitor> _matchCandidateChecker;
   double _worstCircularError;
   shared_ptr<MatchThreshold> _matchThreshold;
-
+  QMap<QString, Meters> _cachedCustomSearchRadii;
 };
 
 }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMerger.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMerger.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -37,7 +37,6 @@
 #include <hoot/js/util/StreamUtilsJs.h>
 
 // node.js
-// #include <nodejs/node.h>
 #include <hoot/js/SystemNodeJs.h>
 
 namespace hoot

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMergerCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMergerCreator.cpp
@@ -45,7 +45,7 @@ ScriptMergerCreator::ScriptMergerCreator()
 
 bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
 {
-  LOG_TRACE("Creating mergers...");
+  LOG_TRACE("Creating mergers with " << className() << "...");
 
   bool result = false;
   assert(matches.size() > 0);
@@ -59,8 +59,11 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const ScriptMatch* sm = dynamic_cast<const ScriptMatch*>(*it);
-    // check to make sure all the input matches are building matches.
+    const Match* m = *it;
+    LOG_VART(m->toString());
+    const ScriptMatch* sm = dynamic_cast<const ScriptMatch*>(m);
+    // check to make sure all the input matches are script matches.
+    LOG_VART(sm == 0);
     if (sm == 0)
     {
       // return an empty result
@@ -85,7 +88,7 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
   }
 
   ScriptMerger* sm = new ScriptMerger(script, plugin, eids);
-  // only add the POI merge if there are elements to merge.
+  // only add the merge if there are elements to merge.
   if (sm->hasFunction("mergeSets"))
   {
     if (eids.size() >= 1)

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkMergerCreator.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkMergerCreator.cpp
@@ -53,7 +53,7 @@ NetworkMergerCreator::NetworkMergerCreator()
 
 bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merger*>& mergers) const
 {
-  LOG_DEBUG("Creating mergers...");
+  LOG_TRACE("Creating mergers with " << className() << "...");
 
   MatchSet matches = matchesIn;
   _removeDuplicates(matches);

--- a/rules/Area.js
+++ b/rules/Area.js
@@ -21,13 +21,6 @@ nodes and polygons or a school polygon which encloses school buildings on the ca
 */
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/LineStringGeneric.js
+++ b/rules/LineStringGeneric.js
@@ -19,13 +19,6 @@ var sublineMatcher = new hoot.MaximalSublineStringMatcher({
     "way.subline.matcher": hoot.get("generic.line.subline.matcher")});
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-	
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/LineStringGenericTest.js
+++ b/rules/LineStringGenericTest.js
@@ -17,13 +17,6 @@ var sublineMatcher = new hoot.MaximalSublineStringMatcher({
     "way.subline.matcher": hoot.get("generic.line.subline.matcher")});
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/LinearWaterway.js
+++ b/rules/LinearWaterway.js
@@ -25,7 +25,7 @@ var weightedShapeDistanceExtractor = new hoot.WeightedShapeDistanceExtractor();
 /**
  * Runs before match creation occurs and provides an opportunity to perform custom initialization.
  */
-exports.init = function(map)
+exports.calculateSearchRadius = function(map)
 {
   var autoCalcSearchRadius = (hoot.get("waterway.auto.calc.search.radius") === 'true');
   if (autoCalcSearchRadius)
@@ -33,7 +33,7 @@ exports.init = function(map)
     hoot.log("Calculating search radius for waterway conflation...");
     exports.searchRadius =
       parseFloat(
-        calculateSearchRadius(
+        calculateSearchRadiusUsingRubberSheeting(
           map,
           hoot.get("waterway.rubber.sheet.ref"),
           hoot.get("waterway.rubber.sheet.minimum.ties")));

--- a/rules/PoiGeneric.js
+++ b/rules/PoiGeneric.js
@@ -119,12 +119,6 @@ exports.getSearchRadius = function(e) {
 }
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/PolygonBuilding.js
+++ b/rules/PolygonBuilding.js
@@ -10,13 +10,6 @@ exports.reviewThreshold = parseFloat(hoot.get("building.review.threshold"));
 exports.experimental = true;
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/PolygonBuildingTest.js
+++ b/rules/PolygonBuildingTest.js
@@ -15,13 +15,6 @@ exports.missThreshold = parseFloat(hoot.get("building.miss.threshold"));
 exports.reviewThreshold = parseFloat(hoot.get("building.review.threshold"));
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/PolygonGeneric.js
+++ b/rules/PolygonGeneric.js
@@ -12,13 +12,6 @@ exports.searchRadius = parseFloat(hoot.get("search.radius.generic.polygon"));
 exports.experimental = true;
 
 /**
- * Runs before match creation occurs and provides an opportunity to perform custom initialization.
- */
-exports.init = function(map) {
-
-}
-
-/**
  * Returns true if e is a candidate for a match. Implementing this method is
  * optional, but may dramatically increase speed if you can cull some features
  * early on. E.g. no need to check nodes for a polygon to polygon match.

--- a/rules/lib/HootLib.js
+++ b/rules/lib/HootLib.js
@@ -330,7 +330,7 @@ function snapWays(sublineMatcher, map, pairs, replaced)
  * @param rubberSheetMinTies The minimum number of tie points that need to be found during rubber
  * sheeting for the automatic search radius calculation to occur.
  */
-function calculateSearchRadius(map, rubberSheetRef, rubberSheetMinTies)
+function calculateSearchRadiusUsingRubberSheeting(map, rubberSheetRef, rubberSheetMinTies)
 {
   return new hoot.SearchRadiusCalculator(
       { "rubber.sheet.ref" : rubberSheetRef },

--- a/test-files/cmd/slow/PoiPolygonConflateCombinedTest.sh
+++ b/test-files/cmd/slow/PoiPolygonConflateCombinedTest.sh
@@ -4,5 +4,6 @@ set -e
 mkdir -p $HOOT_HOME/tmp/
 mkdir -p test-output/cmd/PoiPolygonConflateCombinedTest
 
-hoot conflate --warn -D uuid.helper.repeatable=true test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon1.osm test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon2.osm test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm
+# Making this info instead of warning output to catch a situation where a generic script was calculating the search radius multiple times.
+hoot conflate -D uuid.helper.repeatable=true test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon1.osm test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon2.osm test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm
 hoot is-match test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm test-files/cmd/slow/PoiPolygonConflateCombinedTest/output1.osm || diff test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm test-files/cmd/slow/PoiPolygonConflateCombinedTest/output1.osm

--- a/test-files/cmd/slow/PoiPolygonConflateCombinedTest.sh.stdout
+++ b/test-files/cmd/slow/PoiPolygonConflateCombinedTest.sh.stdout
@@ -1,13 +1,57 @@
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-4675 in Relation:-791.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-4736 in Relation:-764.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-664 in Relation:-552.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-665 in Relation:-551.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-682 in Relation:-547.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1288 in Relation:-286.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-268.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-267.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-266.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-265.
-15:25:43.744 WARN  ...portMissingElementsVisitor.cpp(  64) Reached maximum number of missing reports. No longer reporting.
-15:25:44.031 INFO  .../hoot/core/cmd/BaseCommand.cpp(  78) Loading map data from test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm ...
-15:25:44.181 INFO  .../hoot/core/cmd/BaseCommand.cpp(  78) Loading map data from test-files/cmd/slow/PoiPolygonConflateCombinedTest/output1.osm ...
+11:08:57.773 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 120) Conflating test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon1.osm with test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon2.osm and writing the output to test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm
+11:08:57.774 INFO  ...ore/io/OsmMapReaderFactory.cpp( 151) Loading map data from test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon1.osm ...
+11:08:57.881 INFO  ...ore/io/OsmMapReaderFactory.cpp( 151) Loading map data from test-files/cmd/slow/PoiPolygonConflateStandaloneTest/PoiPolygon2.osm ...
+11:08:57.886 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 163) Applying pre-conflation operations...
+11:08:57.886 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::BuildingOutlineRemoveOp
+11:08:57.886 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::MapCleaner
+11:08:57.886 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::ReprojectToPlanarOp
+Reprojecting 0 / 4760         Reprojecting 1000 / 4760         Reprojecting 2000 / 4760         Reprojecting 3000 / 4760         Reprojecting 4000 / 4760         
+11:08:57.918 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::DuplicateWayRemover
+11:08:57.920 INFO  ...hoot/core/schema/OsmSchema.cpp(1809) Loading translation files...
+11:08:57.985 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::SuperfluousWayRemover
+11:08:57.985 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::IntersectionSplitter
+11:08:57.987 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::UnlikelyIntersectionRemover
+11:08:57.993 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::DualWaySplitter
+11:08:57.997 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::ImpliedDividedMarker
+11:08:58.001 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::DuplicateNameRemover
+11:08:58.004 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::SmallWayMerger
+11:08:58.006 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  77) Applying visitor: hoot::RemoveEmptyAreasVisitor
+11:08:58.022 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  77) Applying visitor: hoot::RemoveDuplicateAreaVisitor
+11:08:58.084 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::NoInformationElementRemover
+11:08:58.131 INFO  ...conflate/UnifyingConflator.cpp( 124) Applying pre-unifying conflation operations...
+11:08:58.131 INFO  ...lygon/BuildingMatchCreator.cpp( 252) Creating matches with: hoot::BuildingMatchCreator...
+11:08:59.019 INFO  ...late/js/ScriptMatchCreator.cpp( 457) Creating matches with: hoot::ScriptMatchCreator; rules: PoiGeneric.js...
+11:09:01.587 INFO  ...ighway/HighwayMatchCreator.cpp( 274) Creating matches with: hoot::HighwayMatchCreator...
+11:09:01.993 INFO  .../hoot/rules/LinearWaterway.js"(  33) "Calculating search radius for waterway conflation..."
+11:09:02.008 INFO  ...ate/SearchRadiusCalculator.cpp( 149) Unable to automatically calculate search radius.  Not enough tie points.  Using default search radius value = 15
+11:09:02.010 INFO  ...late/js/ScriptMatchCreator.cpp( 457) Creating matches with: hoot::ScriptMatchCreator; rules: LinearWaterway.js...
+11:09:02.424 INFO  ...gon/PoiPolygonMatchCreator.cpp( 341) Creating matches with: hoot::PoiPolygonMatchCreator...
+11:09:19.392 INFO  ...conflate/UnifyingConflator.cpp( 229) Match count: 0
+11:09:19.392 INFO  ...conflate/UnifyingConflator.cpp( 246) Creating mergers...
+11:09:20.238 INFO  ...conflate/UnifyingConflator.cpp( 263) Applying 824 mergers...
+11:09:20.249 INFO  ...conflate/UnifyingConflator.cpp( 289) Applying post-unifying conflation operations...
+11:09:20.249 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::SuperfluousNodeRemover
+Reprojecting 0 / 4745         Reprojecting 1000 / 4745         Reprojecting 2000 / 4745         Reprojecting 3000 / 4745         Reprojecting 4000 / 4745         
+11:09:20.256 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::SmallWayMerger
+11:09:20.257 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 189) Applying post-conflation operations...
+11:09:20.257 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  77) Applying visitor: hoot::RemoveMissingElementsVisitor
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-4675 in Relation:-791.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-4736 in Relation:-764.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-664 in Relation:-552.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-665 in Relation:-551.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-682 in Relation:-547.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1288 in Relation:-286.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-268.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-267.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-266.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  53) Removing missing Node:-1290 in Relation:-265.
+11:09:20.258 WARN  ...portMissingElementsVisitor.cpp(  64) Reached maximum number of missing reports. No longer reporting.
+11:09:20.259 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  77) Applying visitor: hoot::RemoveInvalidReviewRelationsVisitor
+11:09:20.261 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::RemoveDuplicateReviewsOp
+11:09:20.275 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::BuildingOutlineUpdateOp
+11:09:20.292 INFO  .../cpp/hoot/core/ops/NamedOp.cpp(  57) Applying operation: hoot::AddHilbertReviewSortOrderOp
+Reprojecting 0 / 4735         Reprojecting 1000 / 4735         Reprojecting 2000 / 4735         Reprojecting 3000 / 4735         Reprojecting 4000 / 4735         
+11:09:20.297 INFO  ...ore/io/OsmMapWriterFactory.cpp( 134) Writing map to test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm
+11:09:20.413 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 248) Conflation job completed.
+11:09:20.560 INFO  ...ore/io/OsmMapReaderFactory.cpp( 151) Loading map data from test-output/cmd/PoiPolygonConflateCombinedTest/output1.osm ...
+11:09:20.713 INFO  ...ore/io/OsmMapReaderFactory.cpp( 151) Loading map data from test-files/cmd/slow/PoiPolygonConflateCombinedTest/output1.osm ...


### PR DESCRIPTION
1. refs #1388 - Change generic script init function to an optional calculateSearchRadius function, since thats all it was being used for anyway
2. refs #1388 - Cache the search radius calculated by generic scripts and set it on match candidate checkers if they are reset during merging