### PR TITLE
add mapid attribute to osm xml responses

### DIFF
--- a/hoot-services/src/main/java/hoot/services/controllers/osm/MapResource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/osm/MapResource.java
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -116,7 +116,7 @@ public class MapResource extends JobControllerBase {
 
     /**
      * Returns a list of all map layers in the services database
-     * 
+     *
      * GET hoot-services/osm/api/0.6/map/layers
      *
      * @return a JSON object containing a list of map layers
@@ -188,7 +188,7 @@ public class MapResource extends JobControllerBase {
 
     /**
      * Returns a list of all folders in the services database
-     * 
+     *
      * GET hoot-services/osm/api/0.6/map/links
      *
      * @return a JSON object containing a list of folders
@@ -675,7 +675,7 @@ public class MapResource extends JobControllerBase {
 
     /**
      * Deletes a map
-     * 
+     *
      * POST hoot-services/osm/api/0.6/map/delete?mapId={Map ID}
      *
      * //TODO: should be an HTTP DELETE
@@ -719,7 +719,7 @@ public class MapResource extends JobControllerBase {
     }
 
     /**
-     * 
+     *
      * POST
      * hoot-services/osm/api/0.6/map/modify?mapId=123456&inputType='Dataset'&
      * modName='New Dataset'
@@ -771,10 +771,10 @@ public class MapResource extends JobControllerBase {
 
     /**
      * Adds new dataset folder
-     * 
+     *
      * POST hoot-services/osm/api/0.6/map/addfolder?folderName={foldername}&
      * parentId= {parentId}
-     * 
+     *
      * @param folderName
      *            Display name of folder
      * @param parentId
@@ -818,9 +818,9 @@ public class MapResource extends JobControllerBase {
 
     /**
      * Deletes a dataset folder.
-     * 
+     *
      * POST hoot-services/osm/api/0.6/map/deletefolder?folderId={folderId}
-     * 
+     *
      * //TODO: should be an HTTP DELETE
      *
      * @param folderId
@@ -866,7 +866,7 @@ public class MapResource extends JobControllerBase {
     }
 
     /**
-     * 
+     *
      * POST hoot-services/osm/api/0.6/map/updateParentId?folderId={folderId}
      *
      * //TODO: should be an HTTP PUT
@@ -906,7 +906,7 @@ public class MapResource extends JobControllerBase {
     /**
      * Adds or modifies record in folder_map_mappings if layer is created or
      * modified
-     * 
+     *
      * @param folderId
      *            ID of folder
      * @param mapId
@@ -1122,6 +1122,7 @@ public class MapResource extends JobControllerBase {
         }
 
         Element elementRootXml = OsmResponseHeaderGenerator.getOsmDataHeader(responseDoc);
+        elementRootXml.setAttribute("mapid", String.valueOf(mapId));
         responseDoc.appendChild(elementRootXml);
 
         if (!results.isEmpty()) {


### PR DESCRIPTION
This change is useful because now the ui code doesn't have to lookup what mapid each tile xml response belongs to and can just parse it out instead.