### PR TITLE
glpk throws assert intermittently during nightly regression tests

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h
@@ -169,6 +169,7 @@ public:
     glp_iocp iocp;
     glp_init_iocp(&iocp);
     iocp.presolve = GLP_ON;
+    iocp.binarize = GLP_ON;
     if (_timeLimit > 0)
     {
       iocp.tm_lim = _timeLimit * 1000.0 + 0.5;


### PR DESCRIPTION
Updated `IntegerProgrammingSolver` to eliminate race condition that causes unify to fail on regressions tests intermittently.  Turn on the `binarize` option in the `glp_iocp` options class to accomplish this.  In testing I was able to reproduce the failure consistently, and adding this option caused the calculations to complete before accessing the vector data.