### PR TITLE
Remove w3m from provisioning

### DIFF
--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -66,7 +66,7 @@ sudo apt-get -q -y install texinfo g++ libicu-dev libqt4-dev git-core libboost-d
  automake protobuf-compiler libprotobuf-dev gdb libqt4-sql-psql libgeos++-dev swig lcov maven \
  libstxxl-dev nodejs-dev nodejs-legacy doxygen xsltproc asciidoc curl npm libxerces-c28 \
  libglpk-dev libboost-all-dev source-highlight texlive-lang-arabic texlive-lang-hebrew \
- texlive-lang-cyrillic graphviz w3m python-setuptools python python-pip git ccache distcc libogdi3.2-dev \
+ texlive-lang-cyrillic graphviz python-setuptools python python-pip git ccache distcc libogdi3.2-dev \
  gnuplot python-matplotlib libqt4-sql-sqlite ruby ruby-dev xvfb zlib1g-dev patch x11vnc openssh-server \
  htop unzip postgresql-9.5 postgresql-client-9.5 postgresql-9.5-postgis-scripts postgresql-9.5-postgis-2.3 \
  libpango-1.0-0 libappindicator1 >> Ubuntu_upgrade.txt 2>&1


### PR DESCRIPTION
Removed `w3m` from line 69 of `VagrantProvision.sh` after testing the effects of `make archive` on provisioning with and without `w3m`.