### PR TITLE
Remove build warnings 'no mocha'

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -131,7 +131,7 @@ ifneq ($(HADOOP_HOME),)
 endif
 
 plugins-test:
-ifneq ($(shell which mocha),)
+ifneq ($(shell hash mocha >/dev/null 2>&1),)
 	cd plugins; npm install && npm test
 else
 	@echo Skipping mocha tests

--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -380,7 +380,7 @@ fi
 cd ~
 # hoot has only been tested successfully with hadoop 0.20.2, which is not available from public repos,
 # so purposefully not installing hoot from the repos.
-if ! which hadoop > /dev/null ; then
+if ! hash hadoop >/dev/null 2>&1 ; then
   echo "Installing Hadoop..."
   if [ ! -f hadoop-0.20.2.tar.gz ]; then
     wget --quiet https://archive.apache.org/dist/hadoop/core/hadoop-0.20.2/hadoop-0.20.2.tar.gz


### PR DESCRIPTION
Updated instances of 'which mocha' to 'hash mocha' to remove the warning for both CentOS and Ubuntu builds