### PR TITLE
Use GDAL FGDB driver for read operations

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -358,7 +358,7 @@ shared_ptr<Envelope> OgrReader::getBoundingBoxFromConfig(const Settings& s,
 QStringList OgrReader::getLayerNames(QString path)
 {
   QStringList result;
-  shared_ptr<GDALDataset> ds = OgrUtilities::getInstance().openDataSource(path);
+  shared_ptr<GDALDataset> ds = OgrUtilities::getInstance().openDataSource(path, true);
   int count = ds->GetLayerCount();
   for (int i = 0; i < count; i++)
   {
@@ -515,7 +515,7 @@ OgrReaderInternal::~OgrReaderInternal()
 QStringList OgrReaderInternal::getLayersWithGeometry(QString path) const
 {
   QStringList result;
-  shared_ptr<GDALDataset> ds = OgrUtilities::getInstance().openDataSource(path);
+  shared_ptr<GDALDataset> ds = OgrUtilities::getInstance().openDataSource(path, true);
   int count = ds->GetLayerCount();
   for (int i = 0; i < count; i++)
   {
@@ -894,7 +894,7 @@ void OgrReaderInternal::open(QString path, QString layer)
   _initTranslate();
 
   _path = path;
-  _dataSource = OgrUtilities::getInstance().openDataSource(path);
+  _dataSource = OgrUtilities::getInstance().openDataSource(path, true);
   if (layer.isEmpty() == false)
   {
     _pendingLayers.append(layer);

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
@@ -47,38 +47,41 @@ shared_ptr<OgrUtilities> OgrUtilities::_theInstance;
 void OgrUtilities::loadDriverInfo()
 {
   //  Load the extension-based driver info
-  _drivers.push_back(OgrDriverInfo(".shp",      "ESRI Shapefile", true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".dbf",      "ESRI Shapefile", true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".sqlite",   "SQLite",         true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".db",       "SQLite",         true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".mif",      "MapInfo File",   true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".tab",      "MapInfo File",   true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".s57",      "S57",            true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".bna",      "BNA",            true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".csv",      "CSV",            true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gml",      "GML",            true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gpx",      "GPX",            true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".kml",      "KML/LIBKML",     true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".kmz",      "LIBKML",         true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".json",     "GeoJSON",        true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".geojson",  "GeoJSON",        true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".dxf",      "DXF",            true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gdb",      "FileGDB",        true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".pix",      "PCIDSK",         true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".sql",      "PGDump",         true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gtm",      "GPSTrackMaker",  true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gmt",      "GMT",            true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".vrt",      "VRT",            true,   GDAL_OF_ALL));
+  //                               EXT          DESCRIPTION       EXT/PRE   R/W     VECTOR/RASTER/BOTH
+  _drivers.push_back(OgrDriverInfo(".shp",      "ESRI Shapefile", true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".dbf",      "ESRI Shapefile", true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".sqlite",   "SQLite",         true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".db",       "SQLite",         true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".mif",      "MapInfo File",   true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".tab",      "MapInfo File",   true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".s57",      "S57",            true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".bna",      "BNA",            true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".csv",      "CSV",            true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".gml",      "GML",            true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".gpx",      "GPX",            true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".kml",      "KML/LIBKML",     true,     true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo(".kmz",      "LIBKML",         true,     true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo(".json",     "GeoJSON",        true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".geojson",  "GeoJSON",        true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".dxf",      "DXF",            true,     true,   GDAL_OF_VECTOR));
+  //  Order is important here for the two FileGDB drivers, grab the first for read ops and the second for write
+  _drivers.push_back(OgrDriverInfo(".gdb",      "OpenFileGDB",    true,     false,  GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".gdb",      "FileGDB",        true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".pix",      "PCIDSK",         true,     true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo(".sql",      "PGDump",         true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".gtm",      "GPSTrackMaker",  true,     true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo(".gmt",      "GMT",            true,     true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo(".vrt",      "VRT",            true,     true,   GDAL_OF_ALL));
   //  Load the prefix-based driver info
-  _drivers.push_back(OgrDriverInfo("PG:",       "PostgreSQL",     false,  GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("MySQL:",    "MySQL",          false,  GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo("CouchDB:",  "CouchDB",        false,  GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("GFT:",      "GFT",            false,  GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("MSSQL:",    "MSSQLSpatial",   false,  GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("ODBC:",     "ODBC",           false,  GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("OCI:",      "OCI",            false,  GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo("SDE:",      "SDE",            false,  GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo("WFS:",      "WFS",            false,  GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo("PG:",       "PostgreSQL",     false,    true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo("MySQL:",    "MySQL",          false,    true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo("CouchDB:",  "CouchDB",        false,    true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo("GFT:",      "GFT",            false,    true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo("MSSQL:",    "MSSQLSpatial",   false,    true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo("ODBC:",     "ODBC",           false,    true,   GDAL_OF_VECTOR));
+  _drivers.push_back(OgrDriverInfo("OCI:",      "OCI",            false,    true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo("SDE:",      "SDE",            false,    true,   GDAL_OF_ALL));
+  _drivers.push_back(OgrDriverInfo("WFS:",      "WFS",            false,    true,   GDAL_OF_ALL));
 }
 
 OgrUtilities::OgrUtilities()
@@ -94,21 +97,26 @@ OgrUtilities& OgrUtilities::getInstance()
   return *_theInstance;
 }
 
-OgrDriverInfo OgrUtilities::getDriverInfo(const QString& url)
+OgrDriverInfo OgrUtilities::getDriverInfo(const QString& url, bool read)
 {
   for (vector<OgrDriverInfo>::iterator it = _drivers.begin(); it != _drivers.end(); it++)
   {
-    if ((it->_is_ext && url.endsWith(it->_indicator)) || (!it->_is_ext && url.startsWith(it->_indicator)))
+    if (((it->_is_ext && url.endsWith(it->_indicator)) || (!it->_is_ext && url.startsWith(it->_indicator))) &&
+        (read || it->_is_rw))
+    {
+//      if (QString("FileGDB").compare(it->_driverName) == 0 || QString("OpenFileGDB").compare(it->_driverName) == 0)
+//        LOG_ERROR("OGR Driver Name: " << it->_driverName);
         return *it;
+    }
   }
   return OgrDriverInfo();
 }
 
 
-shared_ptr<GDALDataset> OgrUtilities::createDataSource(const QString& url)
+shared_ptr<GDALDataset> OgrUtilities::createDataSource(const QString& url, bool read)
 {
   QString source = url;
-  OgrDriverInfo driverInfo = getDriverInfo(url);
+  OgrDriverInfo driverInfo = getDriverInfo(url, read);
   if (driverInfo._driverName == NULL)
     throw HootException("Error getting driver info for: " + url);
   GDALDriver *driver = GetGDALDriverManager()->GetDriverByName(driverInfo._driverName);
@@ -131,16 +139,16 @@ shared_ptr<GDALDataset> OgrUtilities::createDataSource(const QString& url)
 
 bool OgrUtilities::isReasonableUrl(const QString& url)
 {
-  return getDriverInfo(url)._driverName != NULL;
+  return getDriverInfo(url, true)._driverName != NULL;
 }
 
-shared_ptr<GDALDataset> OgrUtilities::openDataSource(const QString& url)
+shared_ptr<GDALDataset> OgrUtilities::openDataSource(const QString& url, bool read)
 {
   /* Check for the correct driver name, if unknown try all drivers.
    * This can be an issue because drivers are tried in the order that they are
    * loaded which has been known to cause issues.
    */
-  OgrDriverInfo driverInfo = getDriverInfo(url);
+  OgrDriverInfo driverInfo = getDriverInfo(url, read);
   const char* drivers[2] = { driverInfo._driverName, NULL };
   shared_ptr<GDALDataset> result((GDALDataset*)GDALOpenEx(url.toUtf8().data(),
     driverInfo._driverType, (driverInfo._driverName != NULL ? drivers : NULL), NULL, NULL));

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
@@ -97,15 +97,13 @@ OgrUtilities& OgrUtilities::getInstance()
   return *_theInstance;
 }
 
-OgrDriverInfo OgrUtilities::getDriverInfo(const QString& url, bool read)
+OgrDriverInfo OgrUtilities::getDriverInfo(const QString& url, bool readonly)
 {
   for (vector<OgrDriverInfo>::iterator it = _drivers.begin(); it != _drivers.end(); it++)
   {
     if (((it->_is_ext && url.endsWith(it->_indicator)) || (!it->_is_ext && url.startsWith(it->_indicator))) &&
-        (read || it->_is_rw))
+        (readonly || it->_is_rw))
     {
-//      if (QString("FileGDB").compare(it->_driverName) == 0 || QString("OpenFileGDB").compare(it->_driverName) == 0)
-//        LOG_ERROR("OGR Driver Name: " << it->_driverName);
         return *it;
     }
   }
@@ -113,10 +111,10 @@ OgrDriverInfo OgrUtilities::getDriverInfo(const QString& url, bool read)
 }
 
 
-shared_ptr<GDALDataset> OgrUtilities::createDataSource(const QString& url, bool read)
+shared_ptr<GDALDataset> OgrUtilities::createDataSource(const QString& url)
 {
   QString source = url;
-  OgrDriverInfo driverInfo = getDriverInfo(url, read);
+  OgrDriverInfo driverInfo = getDriverInfo(url, false);
   if (driverInfo._driverName == NULL)
     throw HootException("Error getting driver info for: " + url);
   GDALDriver *driver = GetGDALDriverManager()->GetDriverByName(driverInfo._driverName);
@@ -142,13 +140,13 @@ bool OgrUtilities::isReasonableUrl(const QString& url)
   return getDriverInfo(url, true)._driverName != NULL;
 }
 
-shared_ptr<GDALDataset> OgrUtilities::openDataSource(const QString& url, bool read)
+shared_ptr<GDALDataset> OgrUtilities::openDataSource(const QString& url, bool readonly)
 {
   /* Check for the correct driver name, if unknown try all drivers.
    * This can be an issue because drivers are tried in the order that they are
    * loaded which has been known to cause issues.
    */
-  OgrDriverInfo driverInfo = getDriverInfo(url, read);
+  OgrDriverInfo driverInfo = getDriverInfo(url, readonly);
   const char* drivers[2] = { driverInfo._driverName, NULL };
   shared_ptr<GDALDataset> result((GDALDataset*)GDALOpenEx(url.toUtf8().data(),
     driverInfo._driverType, (driverInfo._driverName != NULL ? drivers : NULL), NULL, NULL));

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -52,14 +52,17 @@ public:
    *        (i.e. .shp for ESRI Shapefile)
    * @param driverName Text name of the driver
    * @param is_ext Value is true if the indcator is a file extension, false for prefix
+   * @param is_rw Value is true if the driver is able to read and write, false for readonly
    * @param driverType GDAL_OF_VECTOR or GDAL_OF_ALL open flags
    */
-  OgrDriverInfo(const char* indicator = NULL, const char* driverName = NULL, bool is_ext = false, unsigned int driverType = GDAL_OF_ALL)
-   : _indicator(indicator), _driverName(driverName), _is_ext(is_ext), _driverType(driverType)
+  OgrDriverInfo(const char* indicator = NULL, const char* driverName = NULL, bool is_ext = false,
+                bool is_rw = true, unsigned int driverType = GDAL_OF_ALL)
+   : _indicator(indicator), _driverName(driverName), _is_ext(is_ext), _is_rw(is_rw), _driverType(driverType)
   {}
   const char* _indicator;
   const char* _driverName;
   bool _is_ext;
+  bool _is_rw;
   unsigned int _driverType;
 };
 
@@ -68,7 +71,7 @@ class OgrUtilities
 public:
   OgrUtilities();
 
-  shared_ptr<GDALDataset> createDataSource(const QString& url);
+  shared_ptr<GDALDataset> createDataSource(const QString& url, bool read);
 
   static OgrUtilities& getInstance();
 
@@ -78,9 +81,9 @@ public:
    */
   bool isReasonableUrl(const QString& url);
 
-  shared_ptr<GDALDataset> openDataSource(const QString& url);
+  shared_ptr<GDALDataset> openDataSource(const QString& url, bool read);
 
-  OgrDriverInfo getDriverInfo(const QString& url);
+  OgrDriverInfo getDriverInfo(const QString& url, bool read);
 
 private:
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -71,8 +71,6 @@ class OgrUtilities
 public:
   OgrUtilities();
 
-  shared_ptr<GDALDataset> createDataSource(const QString& url, bool read);
-
   static OgrUtilities& getInstance();
 
   /**
@@ -81,9 +79,28 @@ public:
    */
   bool isReasonableUrl(const QString& url);
 
-  shared_ptr<GDALDataset> openDataSource(const QString& url, bool read);
+  /**
+   * @brief createDataSource - Create an OGR datasource from the url to write to
+   * @param url - Location of the datasource to create, pathname or API URL
+   * @return pointer to the datasource created
+   */
+  shared_ptr<GDALDataset> createDataSource(const QString& url);
 
-  OgrDriverInfo getDriverInfo(const QString& url, bool read);
+  /**
+   * @brief openDataSource - Open an OGR datasource from the url
+   * @param url - Location of the datasource to open, pathname or API URL
+   * @param readonly - Indicate if the datasource is read/write or read-only
+   * @return pointer to the datasource opened
+   */
+  shared_ptr<GDALDataset> openDataSource(const QString& url, bool readonly);
+
+  /**
+   * @brief getDriverInfo - Select the GDAL driver to use to open/create the datasource
+   * @param url - Location of the datasource to open/create, pathname or API URL
+   * @param readonly - Indicate if the datasource is read/write or read-only
+   * @return OGR driver information based on the URL and read-only flag
+   */
+  OgrDriverInfo getDriverInfo(const QString& url, bool readonly);
 
 private:
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -412,13 +412,13 @@ void OgrWriter::open(QString url)
 
   try
   {
-    _ds = OgrUtilities::getInstance().openDataSource(url);
+    _ds = OgrUtilities::getInstance().openDataSource(url, false);
   }
   catch(HootException& openException)
   {
     try
     {
-      _ds = OgrUtilities::getInstance().createDataSource(url);
+      _ds = OgrUtilities::getInstance().createDataSource(url, false);
     }
     catch(HootException& createException)
     {

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -418,7 +418,7 @@ void OgrWriter::open(QString url)
   {
     try
     {
-      _ds = OgrUtilities::getInstance().createDataSource(url, false);
+      _ds = OgrUtilities::getInstance().createDataSource(url);
     }
     catch(HootException& createException)
     {


### PR DESCRIPTION
Updated OgrReader/Writer to use the Open FGDB driver for reading and ESRI FGDB driver for writing for performance reasons.