### PR TITLE
glpk throws assert intermittently during nightly regression tests

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
@@ -79,13 +79,13 @@ void Hoot::_init()
   LOG_TRACE("Hoot instance init...");
 
 # ifdef TGS_HAVE_LIBSTXXL
-    // initialize the environment variable for loading STXXL configuration. If the environment
-    // variable has already been set then don't overwrite it (that is the 0 at the end).
-    QString stxxlConf = QString(getenv("HOOT_HOME")) + "/conf/core/stxxl.conf";
-    Tgs::Stxxl::getInstance().setConfig(stxxlConf);
+  // initialize the environment variable for loading STXXL configuration. If the environment
+  // variable has already been set then don't overwrite it (that is the 0 at the end).
+  QString stxxlConf = QString(getenv("HOOT_HOME")) + "/conf/core/stxxl.conf";
+  Tgs::Stxxl::getInstance().setConfig(stxxlConf);
 # endif
 
-  SignalCatcher::registerHandlers();
+  SignalCatcher::getInstance()->registerDefaultHandlers();
 
   Log::getInstance().setLevel(Log::Info);
 
@@ -110,19 +110,16 @@ void Hoot::_init()
 
   // force load hoot hadoop if it is available.
 # ifdef HOOT_HAVE_HADOOP
-    loadLibrary("HootHadoop");
+  loadLibrary("HootHadoop");
 # endif
 # ifdef HOOT_HAVE_RND
-    loadLibrary("HootRnd");
+  loadLibrary("HootRnd");
 # endif
 # ifdef HOOT_HAVE_NODEJS
-    // sometimes HootJs is loaded by node.js before we get to init.
-    if (Factory::getInstance().hasClass(QString("hoot::HootJsLoaded")) == false)
-    {
-      loadLibrary("HootJs");
-    }
+  // sometimes HootJs is loaded by node.js before we get to init.
+  if (Factory::getInstance().hasClass(QString("hoot::HootJsLoaded")) == false)
+    loadLibrary("HootJs");
 # endif
-
 }
 
 void Hoot::loadLibrary(QString name)
@@ -134,10 +131,10 @@ void Hoot::loadLibrary(QString name)
     // if the file doesn't exist, then we aren't too concerned.
     if (lib.errorString().contains("No such file or directory"))
     {
-      // no biggie.
-      LOG_WARN(lib.errorString());
-    // if the file does exist.
-    } else {
+      LOG_WARN(lib.errorString());  // no biggie.
+    }
+    else
+    {
       throw HootException("Error loading libary: " + lib.errorString());
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "IntegerProgrammingSolver.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h
@@ -50,7 +50,6 @@
 
 namespace hoot
 {
-using namespace std;
 /**
  * A thin C++ style wrapper for a small subset of GLPK.
  * http://www.gnu.org/software/glpk/
@@ -67,29 +66,9 @@ public:
 
   void addRows(int rowCount) { glp_add_rows(_lp, rowCount); }
 
-  double getColumnPrimalValue(int j) const
-  {
-    if (isIntegerProblem())
-    {
-      return glp_mip_col_val(_lp, j);
-    }
-    else
-    {
-      return glp_get_col_prim(_lp, j);
-    }
-  }
+  double getColumnPrimalValue(int j) const;
 
-  double getObjectiveValue() const
-  {
-    if (isIntegerProblem())
-    {
-      return glp_mip_obj_val(_lp);
-    }
-    else
-    {
-      return glp_get_obj_val(_lp);
-    }
-  }
+  double getObjectiveValue() const;
 
   int getNumColumns() const { return glp_get_num_cols(_lp); }
 
@@ -105,7 +84,7 @@ public:
    * Just like GLPK the index starts at 1, not 0. This means that i.size() - 1 records will be
    * loaded.
    */
-  void loadMatrix(const vector<int>& i, const vector<int>& j, const vector<double>& r)
+  void loadMatrix(const std::vector<int>& i, const std::vector<int>& j, const std::vector<double>& r)
   {
     glp_load_matrix(_lp, i.size() - 1, &(i[0]), &(j[0]), &(r[0]));
   }
@@ -152,97 +131,11 @@ public:
   /**
    * Solves the problem using the default method.
    */
-  void solve()
-  {
-    if (isIntegerProblem())
-    {
-      solveBranchAndCut();
-    }
-    else
-    {
-      solveSimplex();
-    }
-  }
+  void solve();
 
-  void solveBranchAndCut()
-  {
-    glp_iocp iocp;
-    glp_init_iocp(&iocp);
-    iocp.presolve = GLP_ON;
-    iocp.binarize = GLP_ON;
-    if (_timeLimit > 0)
-    {
-      iocp.tm_lim = _timeLimit * 1000.0 + 0.5;
-    }
-    if (Log::getInstance().getLevel() <= Log::Debug)
-    {
-      iocp.msg_lev = GLP_MSG_ON;
-    }
-    else if (Log::getInstance().getLevel() <= Log::Warn)
-    {
-      iocp.msg_lev = GLP_MSG_ERR;
-    }
-    else
-    {
-      iocp.msg_lev = GLP_MSG_OFF;
-    }
+  void solveBranchAndCut();
 
-    int result = 0;
-    try
-    {
-      //  This function can intermittently throw an exception that is heretofore unhandled
-      result = glp_intopt(_lp, &iocp);
-    }
-    catch (...)
-    {
-      throw Exception(QString("Error solving integer programming problem in glp_intopt()."));
-    }
-
-    // if there was an error and the error was not a timeout or iteration limit error.
-    if (result != 0 && result != GLP_EITLIM && result != GLP_ETMLIM)
-    {
-      throw Exception(QString("Error solving integer programming problem. %1").arg(result));
-    }
-  }
-
-  void solveSimplex()
-  {
-    glp_smcp smcp;
-    glp_init_smcp(&smcp);
-    if (_timeLimit > 0)
-    {
-      smcp.tm_lim = _timeLimit * 1000.0 + 0.5;
-    }
-    if (Log::getInstance().getLevel() <= Log::Debug)
-    {
-      smcp.msg_lev = GLP_MSG_ON;
-    }
-    else if (Log::getInstance().getLevel() <= Log::Warn)
-    {
-      smcp.msg_lev = GLP_MSG_ERR;
-    }
-    else
-    {
-      smcp.msg_lev = GLP_MSG_OFF;
-    }
-
-    int result = 0;
-    try
-    {
-      //  This function can potentially throw an exception that is heretofore unhandled
-      result = glp_simplex(_lp, &smcp);
-    }
-    catch (...)
-    {
-      throw Exception(QString("Error solving integer programming problem in glp_simplex()."));
-    }
-
-    // if there was an error and the error was not a timeout or iteration limit error.
-    if (result != 0 && result != GLP_EITLIM && result != GLP_ETMLIM)
-    {
-      throw Exception(QString("Error solving integer programming problem. %1").arg(result));
-    }
-  }
+  void solveSimplex();
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.cpp
@@ -32,7 +32,6 @@
 
 // Standard
 #include <cxxabi.h>
-#include <signal.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -40,7 +39,72 @@
 namespace hoot
 {
 
-void SignalCatcher::handler(int sig)
+boost::shared_ptr<SignalCatcher> SignalCatcher::_instance;
+
+SignalCatcher::SignalCatcher()
+  : _defaultSet(false)
+{
+}
+
+boost::shared_ptr<SignalCatcher> SignalCatcher::getInstance()
+{
+  if (!SignalCatcher::_instance)
+    SignalCatcher::_instance.reset(new SignalCatcher());
+  return SignalCatcher::_instance;
+}
+
+void SignalCatcher::registerDefaultHandlers()
+{
+  // These _might_ work depending on the specific error.
+  std::set_terminate(terminateHandler);
+  registerHandler(SIGSEGV, default_handler);
+  registerHandler(SIGABRT, default_handler);
+  _defaultSet = true;
+}
+
+void SignalCatcher::registerHandler(unsigned int signal_id, __sighandler_t handler)
+{
+  if (signal_id < _NSIG)
+  {
+    if (_handlers.find(signal_id) == _handlers.end())
+      _handlers[signal_id] = std::stack<__sighandler_t>();
+    _handlers[signal_id].push(handler);
+    signal(signal_id, handler);
+  }
+}
+
+void SignalCatcher::unregisterHandler(unsigned int signal_id)
+{
+  if (signal_id >= _NSIG)
+    return;
+  __sighandler_t handler = SIG_DFL;
+  if (_handlers.find(signal_id) != _handlers.end())
+  {
+    switch (signal_id)
+    {
+    case SIGSEGV:
+    case SIGABRT:
+      //  These could possibly have a default handler already set
+      if ((_handlers[signal_id].size() > 1 && _defaultSet) || _handlers[signal_id].size() > 0)
+      {
+        _handlers[signal_id].pop();
+        handler = _handlers[signal_id].top();
+      }
+      break;
+    default:
+      //  No default other than SIG_DFL
+      if (_handlers[signal_id].size() > 0)
+      {
+        _handlers[signal_id].pop();
+        handler = _handlers[signal_id].top();
+      }
+      break;
+    }
+  }
+  signal(signal_id, handler);
+}
+
+void SignalCatcher::default_handler(int sig)
 {
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
@@ -131,14 +195,6 @@ void SignalCatcher::print_stacktrace(FILE *out, unsigned int max_frames)
 
     free(funcname);
     free(symbollist);
-}
-
-void SignalCatcher::registerHandlers()
-{
-  // These _might_ work depending on the specific error.
-  std::set_terminate(terminateHandler);
-  signal(SIGSEGV, handler);
-  signal(SIGABRT, handler);
 }
 
 void SignalCatcher::terminateHandler()

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
@@ -29,7 +29,14 @@
 #define SIGNALCATCHER_H
 
 #include <iostream>
+#include <csignal>
 #include <stdio.h>
+
+#include <map>
+#include <stack>
+
+// Tgs
+#include <tgs/SharedPtr.h>
 
 namespace hoot
 {
@@ -42,14 +49,27 @@ class SignalCatcher
 {
 public:
 
-  static void handler(int sig);
+  static boost::shared_ptr<SignalCatcher> getInstance();
 
-  /** Print a demangled stack backtrace of the caller function to FILE* out. */
+  void registerDefaultHandlers();
+
+  void registerHandler(unsigned int sig, __sighandler_t handler);
+
+  void unregisterHandler(unsigned int sig);
+
+private:
+
+  SignalCatcher();
+
+  static void default_handler(int sig);
   static void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63);
-
-  static void registerHandlers();
-
   static void terminateHandler();
+
+  static boost::shared_ptr<SignalCatcher> _instance;
+
+  std::map<unsigned int, std::stack<__sighandler_t> > _handlers;
+
+  bool _defaultSet;
 
 };
 


### PR DESCRIPTION
Updated SignalCatcher to allow for new handlers to be registered and unregistered on a stack and updated the IntegerProgrammingSolver to not crash.  :crosses_fingers: