### PR TITLE
Decompose multilinestring relations created during conflation with a post op

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -240,6 +240,7 @@ See also:
 ** `hoot::RemoveInvalidReviewRelationsVisitor` - Removes review relations whose members no longer exist after conflation.
 ** `hoot::RemoveDuplicateReviewsOp` - Removes any duplicate reviews
 ** `hoot::BuildingOutlineUpdateOp` - Updates any multi-part building outlines that may have changed during conflation.
+** `hoot::RemoveInvalidMultilineStringMembersVisitor` - Removes invalid multilinestring relations.
 ** `hoot::AddHilbertReviewSortOrderOp` - Adds a sorting value to all reviews.  By processing reviews in sorted order the results are a little more logically ordered.
 
 List of operations to run in the conflate command after data is conflated, after the ops in

--- a/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
@@ -46,6 +46,8 @@
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/ops/RemoveWayOp.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
+
+#include <hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h>
 using namespace hoot;
 
 // Qt
@@ -119,7 +121,7 @@ public:
 
     map->getWay(-1669801)->addNode(-1669723);
 
-    map->getRelation(-1)->addElement("outer", ElementId::way(-1669797));
+    map->getRelation(-1)->addElement(MetadataTags::RoleOuter(), ElementId::way(-1669797));
   }
 
   OsmMapPtr createMapForCopyTest()
@@ -130,8 +132,8 @@ public:
     reader.setDefaultStatus(Status::Unknown1);
     reader.read("test-files/ToyTestA.osm", map);
 
-    RelationPtr r(new Relation(Status::Unknown1, -1, 10, "multipolygon"));
-    r->addElement("outer", ElementId::way(-1669799));
+    RelationPtr r(new Relation(Status::Unknown1, -1, 10, MetadataTags::RelationMultiPolygon()));
+    r->addElement(MetadataTags::RoleOuter(), ElementId::way(-1669799));
     map->addRelation(r);
 
     return map;

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
@@ -207,7 +207,7 @@ public:
     WayPtr wg2b = createWay(map, Status::Unknown2, cg2b, 15.0, "g2");
 
     RelationPtr r(new Relation(Status::Unknown1, map->createNextRelationId(), 5,
-      "multilinestring"));
+      MetadataTags::RelationMultilineString()));
     r->getTags()["note"] = "rg2";
     r->addElement("", wg2a);
     r->addElement("", wg2b);
@@ -238,7 +238,7 @@ public:
     WayPtr wh2b = createWay(map, Status::Unknown2, ch2b, ce, "h2");
 
     RelationPtr rh2(new Relation(Status::Unknown1, map->createNextRelationId(), 3,
-      "multilinestring"));
+      MetadataTags::RelationMultilineString()));
     rh2->getTags()["note"] = "rh2";
     rh2->addElement("", wh2a);
     rh2->addElement("", wh2b);
@@ -269,7 +269,7 @@ public:
     WayPtr wi2b = createWay(map, Status::Unknown2, ci2b, ce, "i2");
 
     RelationPtr ri2(new Relation(Status::Unknown1, map->createNextRelationId(), 3,
-      "multilinestring"));
+      MetadataTags::RelationMultilineString()));
     ri2->getTags()["note"] = "ri2";
     ri2->addElement("", wi2a);
     ri2->addElement("", wi2b);
@@ -551,7 +551,7 @@ public:
     // test the simplest case
     {
       RelationPtr r(new Relation(Status::Unknown1, map->createNextRelationId(), 5,
-        "multilinestring"));
+        MetadataTags::RelationMultilineString()));
       r->addElement("", toWay(map, "a1"));
       map->addElement(r);
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
@@ -134,7 +134,7 @@ public:
     //LOG_VAR(way1->getElementId());
     //LOG_VAR(way1->getNodeIds());
     RelationPtr relation(new Relation(way1->getStatus(), map->createNextRelationId(),
-      way1->getCircularError(), Relation::MULTILINESTRING));
+      way1->getCircularError(), MetadataTags::RelationMultilineString()));
     //LOG_VAR(relation->getElementId());
     relation->addElement("", way1->getElementId());
     map->addElement(relation);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
@@ -74,7 +74,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTILINESTRING));
+      way->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way->getElementId());
     map->addElement(relation);
 
@@ -117,7 +117,7 @@ public:
     WayPtr way1 = TestUtils::createWay(map, Status::Unknown1, coords1, 1, "");
     WayPtr way2 = TestUtils::createWay(map, Status::Unknown1, coords2, 1, "");
     RelationPtr relation(new Relation(way1->getStatus(), map->createNextRelationId(),
-      way1->getCircularError(), Relation::MULTILINESTRING));
+      way1->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way1->getElementId());
     relation->addElement("", way2->getElementId());
     map->addElement(relation);
@@ -159,7 +159,7 @@ public:
     WayPtr way1 = TestUtils::createWay(map, Status::Unknown1, coords1, 1, "");
     WayPtr way2 = TestUtils::createWay(map, Status::Unknown1, coords2, 1, "");
     RelationPtr relation(new Relation(way1->getStatus(), map->createNextRelationId(),
-      way1->getCircularError(), Relation::MULTILINESTRING));
+      way1->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way1->getElementId());
     relation->addElement("", way2->getElementId());
     map->addElement(relation);
@@ -204,7 +204,7 @@ public:
     WayPtr way2 = TestUtils::createWay(map, Status::Unknown1, coords2, 1, "");
     WayPtr way3 = TestUtils::createWay(map, Status::Unknown1, coords3, 1, "");
     RelationPtr relation(new Relation(way1->getStatus(), map->createNextRelationId(),
-      way1->getCircularError(), Relation::MULTILINESTRING));
+      way1->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way1->getElementId());
     relation->addElement("", way2->getElementId());
     relation->addElement("", way3->getElementId());
@@ -245,7 +245,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTILINESTRING));
+      way->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way->getElementId());
     map->addElement(relation);
 
@@ -286,7 +286,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTILINESTRING));
+      way->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way->getElementId());
     map->addElement(relation);
 
@@ -327,7 +327,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTILINESTRING));
+      way->getCircularError(), MetadataTags::RelationMultilineString()));
     //relation->addElement("", way->getElementId());
     map->addElement(relation);
 
@@ -357,7 +357,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTIPOLYGON));
+      way->getCircularError(), MetadataTags::RelationMultiPolygon()));
     relation->addElement("", way->getElementId());
     map->addElement(relation);
 
@@ -386,7 +386,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTILINESTRING));
+      way->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", way->getElementId());
     map->addElement(relation);
 
@@ -415,7 +415,7 @@ public:
                             Coordinate::getNull() };
     WayPtr way = TestUtils::createWay(map, Status::Unknown1, coords, 1, "");
     RelationPtr relation(new Relation(way->getStatus(), map->createNextRelationId(),
-      way->getCircularError(), Relation::MULTILINESTRING));
+      way->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", map->getNode(way->getNodeId(0))->getElementId());
     relation->addElement("", way->getElementId());
     map->addElement(relation);
@@ -448,7 +448,7 @@ public:
     WayPtr way1 = TestUtils::createWay(map, Status::Unknown1, coords1, 1, "");
     WayPtr way2 = TestUtils::createWay(map, Status::Unknown1, coords2, 1, "");
     RelationPtr relation(new Relation(way1->getStatus(), map->createNextRelationId(),
-      way1->getCircularError(), Relation::MULTILINESTRING));
+      way1->getCircularError(), MetadataTags::RelationMultilineString()));
     relation->addElement("", map->getNode(way1->getNodeId(0))->getElementId());
     relation->addElement("", way1->getElementId());
     relation->addElement("", way2->getElementId());

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
@@ -296,7 +296,7 @@ public:
     w3->getTags()["highway"] = "path";
     w3->getTags()["uuid"] = "w3";
 
-    RelationPtr r(new Relation(Status::Unknown1, 0, 15, Relation::MULTILINESTRING));
+    RelationPtr r(new Relation(Status::Unknown1, 0, 15, MetadataTags::RelationMultilineString()));
     r->addElement("", w1);
     r->addElement("", w2);
     r->setTag("uuid", "r");
@@ -436,7 +436,7 @@ public:
     Coordinate w2c[] = { Coordinate(0, 0), Coordinate(100, 0), Coordinate::getNull() };
     WayPtr w2 = createWay(map, w2c, Status::Unknown2);
 
-    RelationPtr r(new Relation(Status::Unknown2, 0, 15, Relation::MULTILINESTRING));
+    RelationPtr r(new Relation(Status::Unknown2, 0, 15, MetadataTags::RelationMultilineString()));
     r->addElement("", w2);
     r->setTag("uuid", "r");
     r->setTag("highway", "footway");

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -110,11 +110,11 @@ public:
     w5->addNode(w5->getNodeId(0));
     map->addWay(w5);
 
-    RelationPtr r1(new Relation(Status::Unknown1, 1, 15.0, "multipolygon"));
+    RelationPtr r1(new Relation(Status::Unknown1, 1, 15.0, MetadataTags::RelationMultiPolygon()));
     r1->setTag("building", "yes");
     r1->setTag("name", "r1");
-    r1->addElement("outer", w4->getElementId());
-    r1->addElement("inner", w5->getElementId());
+    r1->addElement(MetadataTags::RoleOuter(), w4->getElementId());
+    r1->addElement(MetadataTags::RoleInner(), w5->getElementId());
     map->addRelation(r1);
 
     return map;
@@ -157,11 +157,11 @@ public:
   {
     OsmMapPtr map = createTestMap();
 
-    RelationPtr r2(new Relation(Status::Unknown1, 2, 15.0, "multipolygon"));
+    RelationPtr r2(new Relation(Status::Unknown1, 2, 15.0, MetadataTags::RelationMultiPolygon()));
     r2->setTag("building", "yes");
     r2->setTag("name", "r2");
-    r2->addElement("outer", ElementId(ElementType::Way, 1));
-    r2->addElement("inner", ElementId(ElementType::Way, 2));
+    r2->addElement(MetadataTags::RoleOuter(), ElementId(ElementType::Way, 1));
+    r2->addElement(MetadataTags::RoleInner(), ElementId(ElementType::Way, 2));
     map->addRelation(r2);
 
     map->getRelation(1)->addElement("test", ElementId(ElementType::Relation, 2));

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -131,7 +131,7 @@ public:
     w3->addNode(2);
     map->addWay(w3);
 
-    RelationPtr r1(new Relation(Status::Unknown1, 1, 18.1, "collection"));
+    RelationPtr r1(new Relation(Status::Unknown1, 1, 18.1, MetadataTags::RelationCollection()));
     r1->addElement("n1", n1->getElementId());
     r1->addElement("w1", w1->getElementId());
     r1->setTag("note", "r1");
@@ -364,7 +364,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(Status::Unknown1, relation->getStatus().getEnum());
     CPPUNIT_ASSERT_EQUAL((long)1, relation->getId());
     CPPUNIT_ASSERT_EQUAL(18.1, relation->getCircularError());
-    HOOT_STR_EQUALS("collection", relation->getType());
+    HOOT_STR_EQUALS(MetadataTags::RelationCollection(), relation->getType());
     vector<RelationData::Entry> relationMembers = relation->getMembers();
     CPPUNIT_ASSERT_EQUAL(size_t(2), relationMembers.size());
     CPPUNIT_ASSERT(relation->contains(ElementId::node(1)));
@@ -580,7 +580,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(Status::Unknown1, relation->getStatus().getEnum());
     CPPUNIT_ASSERT_EQUAL((long)1, relation->getId());
     CPPUNIT_ASSERT_EQUAL(18.1, relation->getCircularError());
-    HOOT_STR_EQUALS("collection", relation->getType());
+    HOOT_STR_EQUALS(MetadataTags::RelationCollection(), relation->getType());
     CPPUNIT_ASSERT_EQUAL(size_t(2), relation->getMembers().size());
     CPPUNIT_ASSERT(relation->contains(ElementId::node(1)));
     CPPUNIT_ASSERT(relation->contains(ElementId::way(1)));

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -158,7 +158,7 @@ public:
     map->addWay(w1);
     map->addWay(w2);
 
-    RelationPtr r1(new Relation(Status::Unknown1, 1, 15.0, "collection"));
+    RelationPtr r1(new Relation(Status::Unknown1, 1, 15.0, MetadataTags::RelationCollection()));
     r1->addElement("n1", n1->getElementId());
     r1->addElement("w1", w1->getElementId());
     r1->setTag("note", "r1");
@@ -263,13 +263,13 @@ public:
     map->addWay(w1);
     map->addWay(w2);
 
-    RelationPtr r1(new Relation(Status::Unknown1, -1, 15.0, "collection"));
+    RelationPtr r1(new Relation(Status::Unknown1, -1, 15.0, MetadataTags::RelationCollection()));
     r1->addElement("n1", n1->getElementId());
     r1->addElement("w1", w1->getElementId());
     r1->setTag("note", "r1");
     map->addRelation(r1);
 
-    RelationPtr r2(new Relation(Status::Unknown1, -2, 15.0, "collection"));
+    RelationPtr r2(new Relation(Status::Unknown1, -2, 15.0, MetadataTags::RelationCollection()));
     r2->addElement("r1", r1->getElementId());
     r2->setTag("note", "r2");
     map->addRelation(r2);

--- a/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
@@ -78,7 +78,7 @@ public:
   void runBadOuterRingsTest()
   {
     OsmMapPtr map(new OsmMap());
-    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, Relation::MULTIPOLYGON));
+    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, MetadataTags::RelationMultiPolygon()));
     WayPtr w;
     // way #1
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
@@ -86,7 +86,7 @@ public:
     addPoint(map, w, 5, 6);
     addPoint(map, w, 8, 11);
     addPoint(map, w, 12, 9);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     // way #2
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
@@ -94,7 +94,7 @@ public:
     addPoint(map, w, 5, 6);
     addPoint(map, w, 8, 2);
     addPoint(map, w, 13, 5);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     boost::shared_ptr<Geometry> g = MultiPolygonCreator(map, uut).createMultipolygon();
 
@@ -109,7 +109,7 @@ public:
   void runMultiPolygonExample1Test()
   {
     OsmMapPtr map(new OsmMap());
-    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, Relation::MULTIPOLYGON));
+    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, MetadataTags::RelationMultiPolygon()));
     WayPtr w;
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
     map->addWay(w);
@@ -119,7 +119,7 @@ public:
     addPoint(map, w, 12, 9);
     addPoint(map, w, 13, 5);
     closeWay(w);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
     map->addWay(w);
@@ -128,7 +128,7 @@ public:
     addPoint(map, w, 8, 8);
     addPoint(map, w, 10, 7);
     closeWay(w);
-    uut->addElement(Relation::INNER, w);
+    uut->addElement(MetadataTags::RoleInner(), w);
 
     boost::shared_ptr<Geometry> g = MultiPolygonCreator(map, uut).createMultipolygon();
 
@@ -143,7 +143,7 @@ public:
   void runMultiPolygonExample7Test()
   {
     OsmMapPtr map(new OsmMap());
-    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, Relation::MULTIPOLYGON));
+    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, MetadataTags::RelationMultiPolygon()));
     WayPtr w;
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
     map->addWay(w);
@@ -153,7 +153,7 @@ public:
     addPoint(map, w, 13, 11);
     addPoint(map, w, 14, 4);
     closeWay(w);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
     map->addWay(w);
@@ -162,7 +162,7 @@ public:
     addPoint(map, w, 8, 11);
     addPoint(map, w, 12, 7);
     closeWay(w);
-    uut->addElement(Relation::INNER, w);
+    uut->addElement(MetadataTags::RoleInner(), w);
 
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
     map->addWay(w);
@@ -171,7 +171,7 @@ public:
     addPoint(map, w, 8, 7);
     addPoint(map, w, 10, 7);
     closeWay(w);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     boost::shared_ptr<Geometry> g = MultiPolygonCreator(map, uut).createMultipolygon();
 
@@ -186,7 +186,7 @@ public:
   void runMultipleWaysFormingARing()
   {
     OsmMapPtr map(new OsmMap());
-    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, Relation::MULTIPOLYGON));
+    RelationPtr uut(new Relation(Status::Unknown1, 1, 10, MetadataTags::RelationMultiPolygon()));
     WayPtr w;
     // way #1
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
@@ -194,7 +194,7 @@ public:
     addPoint(map, w, 5, 6);
     addPoint(map, w, 8, 11);
     addPoint(map, w, 12, 9);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     // way #2
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
@@ -203,7 +203,7 @@ public:
     addPoint(map, w, 8, 2);
     addPoint(map, w, 13, 5);
     addPoint(map, w, 12, 9);
-    uut->addElement(Relation::OUTER, w);
+    uut->addElement(MetadataTags::RoleOuter(), w);
 
     // way #3
     w.reset(new Way(Status::Unknown1, map->createNextWayId(), 10));
@@ -213,7 +213,7 @@ public:
     addPoint(map, w, 10, 7);
     addPoint(map, w, 9, 5);
     closeWay(w);
-    uut->addElement(Relation::INNER, w);
+    uut->addElement(MetadataTags::RoleInner(), w);
 
     boost::shared_ptr<Geometry> g = MultiPolygonCreator(map, uut).createMultipolygon();
 

--- a/hoot-core/hoot-core.pro
+++ b/hoot-core/hoot-core.pro
@@ -541,7 +541,8 @@ SOURCES += \
     src/main/cpp/hoot/core/visitors/CompletelyContainedByMapElementVisitor.cpp \
     src/main/cpp/hoot/core/visitors/CalculateMapBoundsVisitor.cpp \
     src/main/cpp/hoot/core/util/DbUtils.cpp \
-    src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.cpp
+    src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.cpp \
+    src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.cpp
 
 HEADERS += \
     src/main/cpp/hoot/core/util/Progress.h \
@@ -1069,5 +1070,6 @@ HEADERS += \
     src/main/cpp/hoot/core/visitors/CalculateMapBoundsVisitor.h \
     src/main/cpp/hoot/core/util/DbUtils.h \
     src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.h \
-    src/main/cpp/hoot/core/io/schema/LongIntegerFieldDefinition.h
+    src/main/cpp/hoot/core/io/schema/LongIntegerFieldDefinition.h \
+    src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/MultiLineStringSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/MultiLineStringSplitter.cpp
@@ -109,7 +109,7 @@ ElementPtr MultiLineStringSplitter::createSublines(const OsmMapPtr& map,
   {
     LOG_TRACE("multilinestring: multiple matches get relation");
     RelationPtr r(new Relation(matches[0]->getStatus(), map->createNextRelationId(),
-      matches[0]->getCircularError(), Relation::MULTILINESTRING));
+      matches[0]->getCircularError(), MetadataTags::RelationMultilineString()));
 
     for (size_t i = 0; i < matches.size(); i++)
     {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocation.cpp
@@ -47,7 +47,7 @@ MultiLineStringLocation::MultiLineStringLocation(ConstOsmMapPtr map,
     throw HootException(
       "Feature splitting for multi-line string relations requires that the relation has way members.");
   }
-  if (relation->getType() != Relation::MULTILINESTRING)
+  if (relation->getType() != MetadataTags::RelationMultilineString())
   {
     throw HootException(
       "Invalid relation type: " + relation->getType() + " expected multiline string.");

--- a/hoot-core/src/main/cpp/hoot/core/conflate/ReviewMarker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/ReviewMarker.cpp
@@ -37,7 +37,6 @@ namespace hoot
 {
 
 QString ReviewMarker::_complexGeometryType = "Bad Geometry";
-QString ReviewMarker::_revieweeKey = "reviewee";
 
 ReviewMarker::ReviewMarker()
 {
@@ -71,7 +70,7 @@ set<ElementId> ReviewMarker::_getReviewRelations(const ConstOsmMapPtr &map, Elem
     set<ElementId>::iterator current = it++;
     ElementId p = *current;
     if (p.getType() != ElementType::Relation ||
-        map->getRelation(p.getId())->getType() != Relation::REVIEW)
+        map->getRelation(p.getId())->getType() != MetadataTags::RelationReview())
     {
       result.erase(current);
     }
@@ -97,7 +96,7 @@ set<ReviewMarker::ReviewUid> ReviewMarker::getReviewUids(const ConstOsmMapPtr &m
   for (RelationMap::const_iterator it = relations.begin(); it != relations.end(); ++it)
   {
     RelationPtr relation = it->second;
-    if (relation->getElementType() == ElementType::Relation || relation->getType() == Relation::REVIEW)
+    if (relation->getElementType() == ElementType::Relation || relation->getType() == MetadataTags::RelationReview())
     {
       result.insert(relation->getElementId());
     }
@@ -166,7 +165,7 @@ void ReviewMarker::mark(const OsmMapPtr &map, const ElementPtr& e1, const Elemen
     throw IllegalArgumentException("You must specify a review note.");
   }
 
-  RelationPtr r(new Relation(Status::Conflated, map->createNextRelationId(), 0, Relation::REVIEW));
+  RelationPtr r(new Relation(Status::Conflated, map->createNextRelationId(), 0, MetadataTags::RelationReview()));
   r->getTags().set(MetadataTags::HootReviewNeeds(), true);
   r->getTags().appendValueIfUnique(MetadataTags::HootReviewType(), reviewType);
   if (ConfigOptions().getWriterIncludeConflateReviewDetailTags())
@@ -174,8 +173,8 @@ void ReviewMarker::mark(const OsmMapPtr &map, const ElementPtr& e1, const Elemen
     r->getTags().appendValueIfUnique(MetadataTags::HootReviewNote(), note);
     r->getTags().set(MetadataTags::HootReviewScore(), score);
   }
-  r->addElement(_revieweeKey, e1->getElementId());
-  r->addElement(_revieweeKey, e2->getElementId());
+  r->addElement(MetadataTags::RoleReviewee(), e1->getElementId());
+  r->addElement(MetadataTags::RoleReviewee(), e2->getElementId());
   r->getTags().set(MetadataTags::HootReviewMembers(), (int)r->getMembers().size());
   r->setCircularError(-1);
 
@@ -201,7 +200,7 @@ void ReviewMarker::mark(const OsmMapPtr &map, set<ElementId> ids, const QString&
     throw IllegalArgumentException("You must specify a review note.");
   }
 
-  RelationPtr r(new Relation(Status::Conflated, map->createNextRelationId(), 0, Relation::REVIEW));
+  RelationPtr r(new Relation(Status::Conflated, map->createNextRelationId(), 0, MetadataTags::RelationReview()));
   r->getTags().set(MetadataTags::HootReviewNeeds(), true);
   r->getTags().appendValueIfUnique(MetadataTags::HootReviewType(), reviewType);
   if (ConfigOptions().getWriterIncludeConflateReviewDetailTags())
@@ -213,7 +212,7 @@ void ReviewMarker::mark(const OsmMapPtr &map, set<ElementId> ids, const QString&
   while (it != ids.end())
   {
     ElementId id = *it;
-    r->addElement(_revieweeKey, id);
+    r->addElement(MetadataTags::RoleReviewee(), id);
     it++;
   }
   r->getTags().set(MetadataTags::HootReviewMembers(), (int)r->getMembers().size());
@@ -241,7 +240,7 @@ void ReviewMarker::mark(const OsmMapPtr& map, const ElementPtr& e, const QString
     throw IllegalArgumentException("You must specify a review note.");
   }
 
-  RelationPtr r(new Relation(Status::Conflated, map->createNextRelationId(), 0, Relation::REVIEW));
+  RelationPtr r(new Relation(Status::Conflated, map->createNextRelationId(), 0, MetadataTags::RelationReview()));
   r->getTags().set(MetadataTags::HootReviewNeeds(), true);
   r->getTags().appendValueIfUnique(MetadataTags::HootReviewType(), reviewType);
   if (ConfigOptions().getWriterIncludeConflateReviewDetailTags())
@@ -249,7 +248,7 @@ void ReviewMarker::mark(const OsmMapPtr& map, const ElementPtr& e, const QString
     r->getTags().appendValueIfUnique(MetadataTags::HootReviewNote(), note);
     r->getTags().set(MetadataTags::HootReviewScore(), score);
   }
-  r->addElement(_revieweeKey, e->getElementId());
+  r->addElement(MetadataTags::RoleReviewee(), e->getElementId());
   r->getTags().set(MetadataTags::HootReviewMembers(), (int)r->getMembers().size());
   r->setCircularError(-1);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/ReviewMarker.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/ReviewMarker.h
@@ -117,7 +117,6 @@ public:
 private:
   // don't use these keys directly, instead call the helper functions above.
   static QString _complexGeometryType;
-  static QString _revieweeKey;
 
   /**
    * Returns a hilbert value that represents the center of the bounds that covers e1 and e2.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/extractors/WayFeatureExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/extractors/WayFeatureExtractor.cpp
@@ -62,8 +62,8 @@ double WayFeatureExtractor::extract(const OsmMap& map,
     ConstRelationPtr r1 = dynamic_pointer_cast<const Relation>(target);
     ConstRelationPtr r2 = dynamic_pointer_cast<const Relation>(candidate);
 
-    if (r1->getType() == Relation::MULTILINESTRING &&
-        r2->getType() == Relation::MULTILINESTRING &&
+    if (r1->getType() == MetadataTags::RelationMultilineString() &&
+        r2->getType() == MetadataTags::RelationMultilineString() &&
         r1->getMembers().size() == r2->getMembers().size())
     {
       for (size_t i = 0; i < r1->getMembers().size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMerger.cpp
@@ -486,7 +486,7 @@ void HighwaySnapMerger::_splitElement(const OsmMapPtr& map, const WaySublineColl
     {
       LOG_TRACE("multilinestring: scrap relation");
       r.reset(new Relation(splitee->getStatus(), map->createNextRelationId(),
-                           splitee->getCircularError(), Relation::MULTILINESTRING));
+                           splitee->getCircularError(), MetadataTags::RelationMultilineString()));
       if (scrap)
       {
         r->addElement("", scrap);
@@ -538,7 +538,7 @@ void HighwaySnapMerger::_splitElement(const OsmMapPtr& map, const WaySublineColl
       // create a new relation to contain this single way (footway relation)
       LOG_TRACE("multilinestring: footway relation");
       RelationPtr r(new Relation(splitee->getStatus(), map->createNextRelationId(),
-        splitee->getCircularError(), Relation::MULTILINESTRING));
+        splitee->getCircularError(), MetadataTags::RelationMultilineString()));
       r->addElement("", scrap->getElementId());
       scrap = r;
       map->addElement(r);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/Building.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/Building.cpp
@@ -56,7 +56,7 @@ boost::shared_ptr<Geometry> Building::buildOutline() const
     const vector<RelationData::Entry> entries = r->getMembers();
     for (size_t i = 0; i < entries.size(); i++)
     {
-      if (entries[i].role == "part")
+      if (entries[i].role == MetadataTags::RolePart())
       {
         boost::shared_ptr<Geometry> g = ec.convertToGeometry(_map.getElement(entries[i].getElementId()));
         result.reset(result->Union(g.get()));

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -197,7 +197,7 @@ boost::shared_ptr<Element> BuildingMerger::buildBuilding(const OsmMapPtr& map, c
       if (e && e->getElementType() == ElementType::Relation)
       {
         RelationPtr r = dynamic_pointer_cast<Relation>(e);
-        if (r->getType() == "building")
+        if (r->getType() == MetadataTags::RelationBuilding())
         {
           isBuilding = true;
 
@@ -208,7 +208,7 @@ boost::shared_ptr<Element> BuildingMerger::buildBuilding(const OsmMapPtr& map, c
           vector<RelationData::Entry> m = r->getMembers();
           for (size_t i = 0; i < m.size(); ++i)
           {
-            if (m[i].getRole() == "part")
+            if (m[i].getRole() == MetadataTags::RolePart())
             {
               boost::shared_ptr<Element> em = map->getElement(m[i].getElementId());
               // push any non-conflicing tags in the parent relation down into the building part.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/MultiPolygonCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/MultiPolygonCreator.cpp
@@ -181,11 +181,11 @@ void MultiPolygonCreator::_addWayToSequence(ConstWayPtr w, CoordinateSequence& c
 boost::shared_ptr<Geometry> MultiPolygonCreator::createMultipolygon() const
 {
   vector<LinearRing*> outers;
-  _createRings("outer", outers);
-  _createRings("part", outers);
+  _createRings(MetadataTags::RoleOuter(), outers);
+  _createRings(MetadataTags::RolePart(), outers);
 
   vector<LinearRing*> inners;
-  _createRings("inner", inners);
+  _createRings(MetadataTags::RoleInner(), inners);
 
   boost::shared_ptr<Geometry> result(_addHoles(outers, inners));
 
@@ -194,7 +194,7 @@ boost::shared_ptr<Geometry> MultiPolygonCreator::createMultipolygon() const
   {
     const RelationData::Entry& e = _r->getMembers()[i];
     if (e.getElementId().getType() == ElementType::Relation &&
-        (e.role == "outer" || e.role == "part"))
+        (e.role == MetadataTags::RoleOuter() || e.role == MetadataTags::RolePart()))
     {
       ConstRelationPtr r = _provider->getRelation(e.getElementId().getId());
       if (r->isMultiPolygon() ||

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
@@ -49,12 +49,6 @@ namespace hoot
 
 unsigned int Relation::logWarnCount = 0;
 
-QString Relation::INNER = "inner";
-QString Relation::MULTILINESTRING = "multilinestring";
-QString Relation::MULTIPOLYGON = "multipolygon";
-QString Relation::OUTER = "outer";
-QString Relation::REVIEW = "review";
-
 /**
  * This is a convenience class to handle cases when exceptions are thrown.
  */

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -59,12 +59,6 @@ class Relation : public Element
 {
 public:
 
-  static QString INNER;
-  static QString MULTILINESTRING;
-  static QString MULTIPOLYGON;
-  static QString OUTER;
-  static QString REVIEW;
-
   static string className() { return "hoot::Relation"; }
 
   static unsigned int logWarnCount;
@@ -109,12 +103,12 @@ public:
    * Returns true if this is a multipolygon type. No checking is done to determine if the geometry
    * is valid.
    */
-  bool isMultiPolygon() const { return _relationData->getType() == MULTIPOLYGON; }
+  bool isMultiPolygon() const { return _relationData->getType() == MetadataTags::RelationMultiPolygon(); }
 
   /**
    * Returns true if this is a review.
    */
-  bool isReview() const { return _relationData->getType() == REVIEW; }
+  bool isReview() const { return _relationData->getType() == MetadataTags::RelationReview(); }
 
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
@@ -383,7 +383,7 @@ RelationPtr HootApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, 
       _status,
       newRelationId,
       -1,
-      "",/*"collection"*/ //services db doesn't support relation "type" yet
+      "",/*MetadataTags::RelationCollection()*/ //services db doesn't support relation "type" yet
       resultIterator.value(ApiDb::RELATIONS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::RELATIONS_VERSION).toLongLong(),
       OsmUtils::fromTimeString(

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -677,7 +677,7 @@ void OgrReaderInternal::_addMultiPolygon(OGRMultiPolygon* mp, Tags& t)
   else
   {
     RelationPtr r(new Relation(_status, _map->createNextRelationId(), circularError,
-      Relation::MULTIPOLYGON));
+      MetadataTags::RelationMultiPolygon()));
     r->setTags(t);
 
     for (int i = 0; i < nParts; i++)
@@ -720,7 +720,7 @@ void OgrReaderInternal::_addPolygon(OGRPolygon* p, Tags& t)
   else
   {
     RelationPtr r(new Relation(_status, _map->createNextRelationId(), circularError,
-      Relation::MULTIPOLYGON));
+      MetadataTags::RelationMultiPolygon()));
     if (OsmSchema::getInstance().isArea(t, ElementType::Relation) == false)
     {
       t.setArea(true);
@@ -735,13 +735,13 @@ void OgrReaderInternal::_addPolygon(OGRPolygon* p, RelationPtr r, Meters circula
 {
   WayPtr outer = _createWay(p->getExteriorRing(), circularError);
   _map->addWay(outer);
-  r->addElement(Relation::OUTER, outer);
+  r->addElement(MetadataTags::RoleOuter(), outer);
 
   for (int i = 0; i < p->getNumInteriorRings(); i++)
   {
     WayPtr inner = _createWay(p->getInteriorRing(i), circularError);
     _map->addWay(inner);
-    r->addElement(Relation::INNER, inner);
+    r->addElement(MetadataTags::RoleInner(), inner);
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineRemoveOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineRemoveOp.cpp
@@ -59,7 +59,7 @@ void BuildingOutlineRemoveOp::apply(boost::shared_ptr<OsmMap>& map)
   {
     const boost::shared_ptr<Relation>& r = it->second;
     // add the relation to a building group if appropriate
-    if (r->getType() == "building")
+    if (r->getType() == MetadataTags::RelationBuilding())
     {
       _removeOutline(r);
     }
@@ -71,7 +71,7 @@ void BuildingOutlineRemoveOp::_removeOutline(const boost::shared_ptr<Relation> &
   const vector<RelationData::Entry> entries = building->getMembers();
   for (size_t i = 0; i < entries.size(); i++)
   {
-    if (entries[i].role == "outline")
+    if (entries[i].role == MetadataTags::RoleOutline())
     {
       building->removeElement(entries[i].role, entries[i].getElementId());
       RecursiveElementRemover(entries[i].getElementId()).apply(_map);

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.cpp
@@ -181,12 +181,12 @@ void BuildingOutlineUpdateOp::_createOutline(const RelationPtr& building)
   const vector<RelationData::Entry> entries = building->getMembers();
   for (size_t i = 0; i < entries.size(); i++)
   {
-    if (entries[i].role == "outline")
+    if (entries[i].role == MetadataTags::RoleOutline())
     {
       LOG_TRACE("Removing outline from building: " << entries[i].getElementId() << "...");
       building->removeElement(entries[i].role, entries[i].getElementId());
     }
-    else if (entries[i].role == "part")
+    else if (entries[i].role == MetadataTags::RolePart())
     {
       LOG_TRACE("Processing building part: " << entries[i].getElementId() << "...");
       if (entries[i].getElementId().getType() == ElementType::Way)
@@ -315,7 +315,7 @@ void BuildingOutlineUpdateOp::_createOutline(const RelationPtr& building)
     outlineElement->setTags(building->getTags());
     // we don't need the relation "type" tag.
     outlineElement->getTags().remove("type");
-    building->addElement("outline", outlineElement);
+    building->addElement(MetadataTags::RoleOutline(), outlineElement);
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingPartMergeOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingPartMergeOp.cpp
@@ -286,14 +286,14 @@ RelationPtr BuildingPartMergeOp::combineParts(const OsmMapPtr& map,
       parts[0]->getStatus(),
       map->createNextRelationId(),
       -1,
-      "building"));
+      MetadataTags::RelationBuilding()));
 
   OsmSchema& schema = OsmSchema::getInstance();
   Tags& t = building->getTags();
 
   for (size_t i = 0; i < parts.size(); i++)
   {
-    building->addElement("part", parts[i]);
+    building->addElement(MetadataTags::RolePart(), parts[i]);
 
     Tags pt = parts[i]->getTags();
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -1670,11 +1670,11 @@ bool OsmSchema::isCollection(const Element& e) const
     const Relation& r = dynamic_cast<const Relation&>(e);
 
     // This list could get HUGE.
-    if (r.getType() == "waterway" ||
-        r.getType() == "network" ||
-        r.getType() == "route_master" ||
-        r.getType() == "superroute" ||
-        r.getType() == "route")
+    if (r.getType() == MetadataTags::RelationWaterway() ||
+        r.getType() == MetadataTags::RelationNetwork() ||
+        r.getType() == MetadataTags::RelationRouteMaster() ||
+        r.getType() == MetadataTags::RelationSuperRoute() ||
+        r.getType() == MetadataTags::RelationRoute())
     {
       result = true;
     }
@@ -1735,8 +1735,8 @@ bool OsmSchema::isLinear(const Element &e)
   if (e.getElementType() == ElementType::Relation)
   {
     const Relation& r = dynamic_cast<const Relation&>(e);
-    result |= r.getType() == "multilinestring";
-    result |= r.getType() == "route";
+    result |= r.getType() == MetadataTags::RelationMultilineString();
+    result |= r.getType() == MetadataTags::RelationRoute();
   }
 
   for (Tags::const_iterator it = t.constBegin(); it != t.constEnd(); ++it)
@@ -1789,7 +1789,7 @@ bool OsmSchema::isMetaData(const QString& key, const QString& /*value*/)
 
 bool OsmSchema::isMultiLineString(const Relation& r) const
 {
-  return r.getType() == "multilinestring";
+  return r.getType() == MetadataTags::RelationMultilineString();
 }
 
 bool OsmSchema::isOneWay(const Element& e) const

--- a/hoot-core/src/main/cpp/hoot/core/util/GeometryConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/GeometryConverter.cpp
@@ -141,7 +141,7 @@ boost::shared_ptr<Element> GeometryConverter::convertMultiLineStringToElement(co
   if (mls->getNumGeometries() > 1)
   {
    RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
-      Relation::MULTILINESTRING));
+      MetadataTags::RelationMultilineString()));
     for (size_t i = 0; i < mls->getNumGeometries(); i++)
     {
      WayPtr w = convertLineStringToWay(
@@ -162,7 +162,7 @@ RelationPtr GeometryConverter::convertMultiPolygonToRelation(const MultiPolygon*
   const OsmMapPtr& map, Status s, double circularError)
 {
  RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
-    Relation::MULTIPOLYGON));
+    MetadataTags::RelationMultiPolygon()));
   for (size_t i = 0; i < mp->getNumGeometries(); i++)
   {
     convertPolygonToRelation(dynamic_cast<const Polygon*>(mp->getGeometryN(i)), map, r, s,
@@ -196,7 +196,7 @@ RelationPtr GeometryConverter::convertPolygonToRelation(const Polygon* polygon,
   const OsmMapPtr& map, Status s, double circularError)
 {
  RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
-    Relation::MULTIPOLYGON));
+    MetadataTags::RelationMultiPolygon()));
   convertPolygonToRelation(polygon, map, r, s, circularError);
   map->addRelation(r);
 
@@ -209,11 +209,11 @@ void GeometryConverter::convertPolygonToRelation(const Polygon* polygon,
  WayPtr outer = convertLineStringToWay(polygon->getExteriorRing(), map, s, circularError);
   if (outer != NULL)
   {
-    r->addElement(Relation::OUTER, outer);
+    r->addElement(MetadataTags::RoleOuter(), outer);
     for (size_t i = 0; i < polygon->getNumInteriorRing(); i++)
     {
      WayPtr inner = convertLineStringToWay(polygon->getInteriorRingN(i), map, s, circularError);
-      r->addElement(Relation::INNER, inner);
+      r->addElement(MetadataTags::RoleInner(), inner);
     }
   }
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/MetadataTags.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MetadataTags.h
@@ -40,64 +40,85 @@ public:
   /** Metadata tag names that are used throughout the code.  This class centralizes them
    *  into one place in the code base.  This class also includes a couple of key values too.
    */
-  inline static const QString HootTagPrefix()         { return "hoot:"; }
+  inline static const QString HootTagPrefix()           { return "hoot:"; }
 
-  inline static const QString Accuracy()              { return "accuracy"; }
-  inline static const QString ErrorCircular()         { return "error:circular"; }
+  inline static const QString Accuracy()                { return "accuracy"; }
+  inline static const QString ErrorCircular()           { return "error:circular"; }
 
-  inline static const QString HootBuildingMatch()     { return "hoot:building:match"; }
+  inline static const QString HootBuildingMatch()       { return "hoot:building:match"; }
 
-  inline static const QString HootActual()            { return "hoot:actual"; }
-  inline static const QString HootExpected()          { return "hoot:expected"; }
-  inline static const QString HootMismatch()          { return "hoot:mismatch"; }
-  inline static const QString HootWrong()             { return "hoot:wrong"; }
+  inline static const QString HootActual()              { return "hoot:actual"; }
+  inline static const QString HootExpected()            { return "hoot:expected"; }
+  inline static const QString HootMismatch()            { return "hoot:mismatch"; }
+  inline static const QString HootWrong()               { return "hoot:wrong"; }
 
-  inline static const QString HootEdge()              { return "hoot:edge"; }
-  inline static const QString HootEdgeId()            { return "hoot:edge:id"; }
-  inline static const QString HootEdgeScore()         { return "hoot:edge:score"; }
-  inline static const QString HootEdgeScore12()       { return "hoot:edge:score12"; }
-  inline static const QString HootEdgeScore21()       { return "hoot:edge:score21"; }
+  inline static const QString HootEdge()                { return "hoot:edge"; }
+  inline static const QString HootEdgeId()              { return "hoot:edge:id"; }
+  inline static const QString HootEdgeScore()           { return "hoot:edge:score"; }
+  inline static const QString HootEdgeScore12()         { return "hoot:edge:score12"; }
+  inline static const QString HootEdgeScore21()         { return "hoot:edge:score21"; }
 
-  inline static const QString HootVertex()            { return "hoot:vertex"; }
-  inline static const QString HootVertexScore()       { return "hoot:vertex:score"; }
-  inline static const QString HootVertexScore12()     { return "hoot:vertex:score12"; }
-  inline static const QString HootVertexScore21()     { return "hoot:vertex:score21"; }
+  inline static const QString HootVertex()              { return "hoot:vertex"; }
+  inline static const QString HootVertexScore()         { return "hoot:vertex:score"; }
+  inline static const QString HootVertexScore12()       { return "hoot:vertex:score12"; }
+  inline static const QString HootVertexScore21()       { return "hoot:vertex:score21"; }
 
-  inline static const QString HootId()                { return "hoot:id"; }
+  inline static const QString HootId()                  { return "hoot:id"; }
 
-  inline static const QString HootLayername()         { return "hoot:layername"; }
+  inline static const QString HootLayername()           { return "hoot:layername"; }
 
-  inline static const QString HootMatchOrder()        { return "hoot:match:order"; }
-  inline static const QString HootMatchP()            { return "hoot:match:p"; }
-  inline static const QString HootMatchScore()        { return "hoot:match:score"; }
+  inline static const QString HootMatchOrder()          { return "hoot:match:order"; }
+  inline static const QString HootMatchP()              { return "hoot:match:p"; }
+  inline static const QString HootMatchScore()          { return "hoot:match:score"; }
 
-  inline static const QString HootPertied()           { return "hoot:pertied"; }
+  inline static const QString HootPertied()             { return "hoot:pertied"; }
 
-  inline static const QString HootReviewTagPrefix()   { return "hoot:review:"; }
-  inline static const QString HootReviewChoices()     { return "hoot:review:choices"; }
-  inline static const QString HootReviewMembers()     { return "hoot:review:members"; }
-  inline static const QString HootReviewNeeds()       { return "hoot:review:needs"; }
-  inline static const QString HootReviewNote()        { return "hoot:review:note"; }
-  inline static const QString HootReviewScore()       { return "hoot:review:score"; }
-  inline static const QString HootReviewSortOrder()   { return "hoot:review:sort_order"; }
-  inline static const QString HootReviewType()        { return "hoot:review:type"; }
-  inline static const QString HootReviewUuid()        { return "hoot:review:uuid"; }
+  inline static const QString HootReviewTagPrefix()     { return "hoot:review:"; }
+  inline static const QString HootReviewChoices()       { return "hoot:review:choices"; }
+  inline static const QString HootReviewMembers()       { return "hoot:review:members"; }
+  inline static const QString HootReviewNeeds()         { return "hoot:review:needs"; }
+  inline static const QString HootReviewNote()          { return "hoot:review:note"; }
+  inline static const QString HootReviewScore()         { return "hoot:review:score"; }
+  inline static const QString HootReviewSortOrder()     { return "hoot:review:sort_order"; }
+  inline static const QString HootReviewType()          { return "hoot:review:type"; }
+  inline static const QString HootReviewUuid()          { return "hoot:review:uuid"; }
 
-  inline static const QString HootScoreMatch()        { return "hoot:score:match"; }
-  inline static const QString HootScoreMiss()         { return "hoot:score:miss"; }
-  inline static const QString HootScoreReview()       { return "hoot:score:review"; }
-  inline static const QString HootScoreUuid()         { return "hoot:score:uuid"; }
+  inline static const QString HootScoreMatch()          { return "hoot:score:match"; }
+  inline static const QString HootScoreMiss()           { return "hoot:score:miss"; }
+  inline static const QString HootScoreReview()         { return "hoot:score:review"; }
+  inline static const QString HootScoreUuid()           { return "hoot:score:uuid"; }
 
-  inline static const QString HootStatus()            { return "hoot:status"; }
-  inline static const QString HootSource()            { return "hoot:source"; }
+  inline static const QString HootStatus()              { return "hoot:status"; }
+  inline static const QString HootSource()              { return "hoot:source"; }
 
-  inline static const QString HootStub()              { return "hoot:stub"; }
+  inline static const QString HootStub()                { return "hoot:stub"; }
 
-  inline static const QString Ref1()                  { return "REF1"; }
-  inline static const QString Ref2()                  { return "REF2"; }
+  inline static const QString Ref1()                    { return "REF1"; }
+  inline static const QString Ref2()                    { return "REF2"; }
 
-  inline static const QString Unknown1()              { return "Unknown1"; }
-  inline static const QString Unknown2()              { return "Unknown2"; }
+  inline static const QString Unknown1()                { return "Unknown1"; }
+  inline static const QString Unknown2()                { return "Unknown2"; }
+
+  inline static const QString BuildingPart()            { return "building:part"; }
+
+  inline static const QString RelationBuilding()        { return "building"; }
+  inline static const QString RelationCollection()      { return "collection"; }
+  inline static const QString RelationInner()           { return "inner"; }
+  inline static const QString RelationMultilineString() { return "multilinestring"; }
+  inline static const QString RelationMultiPolygon()    { return "multipolygon"; }
+  inline static const QString RelationNetwork()         { return "network"; }
+  inline static const QString RelationOuter()           { return "outer"; }
+  inline static const QString RelationReview()          { return "review"; }
+  inline static const QString RelationRoute()           { return "route"; }
+  inline static const QString RelationRouteMaster()     { return "route_master"; }
+  inline static const QString RelationSuperRoute()      { return "superroute"; }
+  inline static const QString RelationWaterway()        { return "waterway"; }
+
+  inline static const QString RoleInner()               { return RelationInner(); }
+  inline static const QString RoleOuter()               { return RelationOuter(); }
+  inline static const QString RoleOutline()             { return "outline"; }
+  inline static const QString RolePart()                { return "part"; }
+  inline static const QString RoleReviewee()            { return "reviewee"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
@@ -48,7 +48,7 @@ void DecomposeBuildingRelationsVisitor::visit(const ConstElementPtr& e)
   if (e->getElementType() == ElementType::Relation)
   {
     const boost::shared_ptr<Relation>& r = _map->getRelation(e->getId());
-    if (r->getType() == "building")
+    if (r->getType() == MetadataTags::RelationBuilding())
     {
       _decomposeBuilding(r);
     }
@@ -79,11 +79,11 @@ void DecomposeBuildingRelationsVisitor::_decomposeBuilding(const boost::shared_p
       continue;
     }
     // we're dropping the outline. We only care about the parts.
-    else if (members[i].getRole() == "outline")
+    else if (members[i].getRole() == MetadataTags::RoleOutline())
     {
       continue;
     }
-    else if (members[i].getRole() != "part")
+    else if (members[i].getRole() != MetadataTags::RolePart())
     {
       if (logWarnCount < ConfigOptions().getLogWarnMessageLimit())
       {
@@ -102,7 +102,7 @@ void DecomposeBuildingRelationsVisitor::_decomposeBuilding(const boost::shared_p
     Tags t = baseTags;
     t.addTags(e->getTags());
     // don't need the building:part tag anymore.
-    t.remove("building:part");
+    t.remove(MetadataTags::BuildingPart());
 
     if (!t.contains("building"))
     {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.cpp
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ */

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#ifndef REMOVEINVALIDMULTILINESTRINGMEMBERSVISITOR_H
+#define REMOVEINVALIDMULTILINESTRINGMEMBERSVISITOR_H
+
+//  hoot
+#include <hoot/core/visitors/ElementOsmMapVisitor.h>
+
+// tgs
+#include <tgs/SharedPtr.h>
+
+
+namespace hoot
+{
+
+class RemoveInvalidMultilineStringMembersVisitor : public ElementOsmMapVisitor
+{
+public:
+
+  static string className() { return "hoot::RemoveInvalidReviewRelationsVisitor"; }
+
+  RemoveInvalidReviewRelationsVisitor();
+
+  virtual void visit(const ElementPtr& e);
+
+};
+
+}
+
+#endif  //  REMOVEINVALIDMULTILINESTRINGMEMBERSVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h
@@ -41,9 +41,9 @@ class RemoveInvalidMultilineStringMembersVisitor : public ElementOsmMapVisitor
 {
 public:
 
-  static string className() { return "hoot::RemoveInvalidReviewRelationsVisitor"; }
+  static string className() { return "hoot::RemoveInvalidMultilineStringMembersVisitor"; }
 
-  RemoveInvalidReviewRelationsVisitor();
+  RemoveInvalidMultilineStringMembersVisitor();
 
   virtual void visit(const ElementPtr& e);
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitor.cpp
@@ -52,7 +52,7 @@ void RemoveInvalidReviewRelationsVisitor::visit(const ElementPtr& e)
 
     LOG_VART(r->getId());
     bool invalidRelation = false;
-    if (r->getType() == Relation::REVIEW)
+    if (r->getType() == MetadataTags::RelationReview())
     {
       const bool hasMemberCountTag = r->getTags().contains(MetadataTags::HootReviewMembers());
       if (hasMemberCountTag &&

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkDetails.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkDetails.cpp
@@ -644,9 +644,9 @@ double NetworkDetails::getEdgeStringMatchScore(ConstEdgeStringPtr e1, ConstEdgeS
     else
     {
       RelationPtr r1(new Relation(Status::Unknown1, _map->createNextRelationId(), 15));
-      r1->setType("multilinestring");
+      r1->setType(MetadataTags::RelationMultilineString());
       RelationPtr r2(new Relation(Status::Unknown1, _map->createNextRelationId(), 15));
-      r2->setType("multilinestring");
+      r2->setType(MetadataTags::RelationMultilineString());
 
       // create a set of all the way IDs
       set<long> widSet;

--- a/test-files/cases/unifying/highway-search-radius-1/Expected.osm
+++ b/test-files/cases/unifying/highway-search-radius-1/Expected.osm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0033548285096528" lon="0.0059647944607357"/>
     <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0051235458882351" lon="0.0005717796483473"/>
     <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0060751017000000" lon="-0.0000762576100000">
@@ -102,11 +102,13 @@
     <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-12"/>
         <nd ref="-21"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24"/>
         <nd ref="-23"/>
         <nd ref="-32"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-32"/>
@@ -127,6 +129,7 @@
         <nd ref="-18"/>
         <nd ref="-17"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-8"/>
@@ -134,12 +137,6 @@
         <nd ref="-6"/>
         <nd ref="-5"/>
         <tag k="highway" v="road"/>
-    </way>
-    <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-21" role=""/>
-        <member type="way" ref="-22" role=""/>
-        <tag k="highway" v="road"/>
-        <tag k="type" v="multilinestring"/>
         <tag k="error:circular" v="15"/>
-    </relation>
+    </way>
 </osm>

--- a/test-files/cmd/glacial/NonContiguousRoadReviewsTest/output.osm
+++ b/test-files/cmd/glacial/NonContiguousRoadReviewsTest/output.osm
@@ -26368,7 +26368,20 @@
         <nd ref="-3704"/>
         <nd ref="-3703"/>
         <nd ref="-21"/>
-        <tag k="source:datetime" v="2016-04-11T14:26:36Z"/>
+        <tag k="source:ingest:datetime" v="2016-04-11T17:50:37.775Z"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="width:minimum_traveled_way" v="2"/>
+        <tag k="source:accuracy:horizontal:evaluation" v="emc_product_specification"/>
+        <tag k="seasonal" v="fair"/>
+        <tag k="source:copyright" v="Copyright 2013 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
+        <tag k="source:commercial_distribution_restriction" v="Unrestricted.  For Public Release."/>
+        <tag k="uuid" v="{340B01E5-488E-4365-87B4-5685B9ADFC49}"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
+        <tag k="source:accuracy:horizontal" v="25"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2016-04-11T14:26:36Z;2010-01-01T00:00:00Z"/>
+        <tag k="highway" v="track"/>
         <tag k="error:circular" v="28.65"/>
     </way>
     <way visible="true" id="-51" timestamp="2016-04-11T14:26:36Z" version="1" changeset="10">
@@ -26506,7 +26519,20 @@
         <nd ref="-3572"/>
         <nd ref="-3571"/>
         <nd ref="-1631"/>
-        <tag k="source:datetime" v="2016-04-11T14:26:36Z"/>
+        <tag k="source:ingest:datetime" v="2016-04-11T17:50:37.775Z"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="width:minimum_traveled_way" v="2"/>
+        <tag k="source:accuracy:horizontal:evaluation" v="emc_product_specification"/>
+        <tag k="seasonal" v="fair"/>
+        <tag k="source:copyright" v="Copyright 2013 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
+        <tag k="source:commercial_distribution_restriction" v="Unrestricted.  For Public Release."/>
+        <tag k="uuid" v="{340B01E5-488E-4365-87B4-5685B9ADFC49}"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
+        <tag k="source:accuracy:horizontal" v="25"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2016-04-11T14:26:36Z;2010-01-01T00:00:00Z"/>
+        <tag k="highway" v="track"/>
         <tag k="error:circular" v="28.65"/>
     </way>
     <way visible="true" id="-50" timestamp="2016-04-11T14:26:36Z" version="1" changeset="10">
@@ -28845,25 +28871,5 @@
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="3"/>
         <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-1" timestamp="2016-04-11T14:26:36Z" version="1" changeset="10">
-        <member type="way" ref="-52" role=""/>
-        <member type="way" ref="-51" role=""/>
-        <tag k="source:ingest:datetime" v="2016-04-11T17:50:37.775Z"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="2"/>
-        <tag k="source:accuracy:horizontal:evaluation" v="emc_product_specification"/>
-        <tag k="seasonal" v="fair"/>
-        <tag k="source:copyright" v="Copyright 2013 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
-        <tag k="source:commercial_distribution_restriction" v="Unrestricted.  For Public Release."/>
-        <tag k="uuid" v="{340B01E5-488E-4365-87B4-5685B9ADFC49}"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
-        <tag k="source:accuracy:horizontal" v="25"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2010-01-01T00:00:00Z"/>
-        <tag k="highway" v="track"/>
-        <tag k="type" v="multilinestring"/>
-        <tag k="error:circular" v="28.65"/>
     </relation>
 </osm>

--- a/test-files/cmd/slow/ConflateCmdStatsGenericRiversTest.sh.stdout
+++ b/test-files/cmd/slow/ConflateCmdStatsGenericRiversTest.sh.stdout
@@ -1,8 +1,8 @@
 stats = (stat) OR (input map 1 stat) (input map 2 stat) (output map stat)
 Node Count	338	176	410	
 Way Count	14	15	110	
-Relation Count	0	0	23	
-Total Feature Count	14	15	79	
+Relation Count	0	0	8	
+Total Feature Count	14	15	118	
 Total Conflatable Features	14	15	0	
 Percentage of Total Features Conflatable	100	100	0	
 Untagged Feature Count	0	0	0	
@@ -11,12 +11,12 @@ Percentage of Total Features Unconflatable	0	0	0
 Number of Match Creators	1	1	1	
 Features Conflatable by: hoot::ScriptMatchCreator,LinearWaterway.js	14	15	0	
 Total Conflated Features	0	0	23	
-Percentage of Total Features Conflated	0	0	29.11392405063291	
+Percentage of Total Features Conflated	0	0	19.49152542372881	
 Total Features Marked for Review	0	0	0	
 Percentage of Total Features Marked for Review	0	0	0	
 Total Number of Reviews to be Made	0	0	0	
-Total Unmatched Features	14	15	56	
-Percentage of Total Features Unmatched	100	100	70.88607594936708	
+Total Unmatched Features	14	15	95	
+Percentage of Total Features Unmatched	100	100	80.50847457627118	
 POI Count	0	0	0	
 Conflatable POIs	0	0	0	
 Conflated POIs	0	0	0	
@@ -44,16 +44,17 @@ Unmatched Buildings	0	0	0
 Percentage of Buildings Conflated	0	0	0	
 Percentage of Buildings Marked for Review	0	0	0	
 Percentage of Unmatched Buildings	0	0	0	
-Waterway Count	14	15	79	
+Waterway Count	14	15	118	
 Conflatable Waterways	14	15	0	
 Conflated Waterways	0	0	23	
 Waterways Marked for Review	0	0	0	
 Number of Waterway Reviews to be Made	0	0	0	
-Unmatched Waterways	14	15	56	
+Unmatched Waterways	14	15	95	
 Meters of Waterway Processed by Conflation	0	0	7533.441935619483	
-Percentage of Waterways Conflated	0	0	29.11392405063291	
+Percentage of Waterways Conflated	0	0	19.49152542372881	
 Percentage of Waterways Marked for Review	0	0	0	
-Percentage of Unmatched Waterways	100	100	70.88607594936708	
-Difference Between Total Features in Output and Total Features in Inputs			50	
-Percentage Difference Between Total Features in Output and Total Features in Inputs			172.4137931034483	
+Percentage of Unmatched Waterways	100	100	80.50847457627118	
+Difference Between Total Features in Output and Total Features in Inputs			89	
+Percentage Difference Between Total Features in Output and Total Features in Inputs			306.896551724138	
 
+12:02:44.779 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 248) Conflation job completed.


### PR DESCRIPTION
Created `RemoveInvalidMultilineStringMembersVisitor` to eliminate `multilinestring` relations created by Hootenanny in the conflation process and push the relation's tags down to the ways.  Also replaces the any `multilinestring` relation that is part of a `review` relation with any way from the `multilinestring` relation that is "near" any of the ways in the `review` relation.

Also while I was at it, I added more string values to the `MetadataTags` class and removed the string copies from all over the code.