### PR TITLE
Fix hoot network conflicts test highway-025 when running with trace logging

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
@@ -72,13 +72,12 @@ ConflateCaseTest::ConflateCaseTest(QDir d, QStringList confs) :
 
 void ConflateCaseTest::runTest()
 {
+  TestUtils::resetEnvironment();
   LOG_DEBUG("Running conflate case test...");
 
   // configures and cleans up the conf() environment
   LOG_VART(_confs);
   SetupTest st(_confs);
-
-  bool failed = false;
 
   ConflateCmd cmd;
 
@@ -124,15 +123,10 @@ void ConflateCaseTest::runTest()
 
   if (result != 0)
   {
-    failed = true;
+    CPPUNIT_ASSERT_MESSAGE(QString("Conflate command had nonzero exit status").toStdString(), false);
   }
 
   if (!TestUtils::compareMaps(expected.absoluteFilePath(), testOutput))
-  {
-    failed = true;
-  }
-
-  if (failed)
   {
     CPPUNIT_ASSERT_MESSAGE(QString("Maps do not match").toStdString(), false);
   }

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeMatchSetFinder.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeMatchSetFinder.cpp
@@ -177,7 +177,10 @@ bool EdgeMatchSetFinder::_addEdgeNeighborsToEnd(ConstEdgeMatchPtr em,
   {
     LOG_VART(neighbor1);
     LOG_VART(em->contains(neighbor1));
-    LOG_VART(_details->getPartialEdgeMatchScore(neighbor1, em->getString2()->getLastEdge()));
+
+    // Calling this non-const function can alter the state of the map, and lead to different
+    // behaviors at different log levels! Beware!
+    //LOG_VART(_details->getPartialEdgeMatchScore(neighbor1, em->getString2()->getLastEdge()));
 
     // if the neighbor pair score is non-zero
     if (em->contains(neighbor1) == false &&
@@ -198,7 +201,10 @@ bool EdgeMatchSetFinder::_addEdgeNeighborsToEnd(ConstEdgeMatchPtr em,
     LOG_VART(neighbor2);
     LOG_VART(em->contains(neighbor2));
     LOG_VART(_details->isStringCandidate(em->getString2()->getLastEdge(), neighbor2));
-    LOG_VART(_details->getPartialEdgeMatchScore(neighbor2, em->getString1()->getLastEdge()));
+
+    // Calling this non-const function can alter the state of the map, and lead to different
+    // behaviors at different log levels! Beware!
+    //LOG_VART(_details->getPartialEdgeMatchScore(neighbor2, em->getString1()->getLastEdge()));
 
     // if the neighbor pair score is non-zero
     if (em->contains(neighbor2) == false &&
@@ -230,7 +236,10 @@ bool EdgeMatchSetFinder::_addEdgeNeighborsToStart(ConstEdgeMatchPtr em,
   {
     LOG_VART(neighbor1);
     LOG_VART(em->getString2()->getFirstEdge());
-    LOG_VART(_details->getPartialEdgeMatchScore(neighbor1, em->getString2()->getFirstEdge()));
+
+    // Calling this non-const function can alter the state of the map, and lead to different
+    // behaviors at different log levels! Beware!
+    //LOG_VART(_details->getPartialEdgeMatchScore(neighbor1, em->getString2()->getFirstEdge()));
 
     // if the neighbor pair score is non-zero
     if (em->contains(neighbor1) == false &&
@@ -250,7 +259,10 @@ bool EdgeMatchSetFinder::_addEdgeNeighborsToStart(ConstEdgeMatchPtr em,
   {
     LOG_VART(neighbor2);
     LOG_VART(em->getString1()->getFirstEdge());
-    LOG_VART(_details->getPartialEdgeMatchScore(neighbor2, em->getString1()->getFirstEdge()));
+
+    // Calling this non-const function can alter the state of the map, and lead to different
+    // behaviors at different log levels! Beware!
+    //LOG_VART(_details->getPartialEdgeMatchScore(neighbor2, em->getString1()->getFirstEdge()));
 
     // if the neighbor pair score is non-zero
     if (em->contains(neighbor2) == false &&


### PR DESCRIPTION
Ref #1566 

```
test-files/cases/hoot-rnd/network/conflicts/highway-025
```

Was failing when run with the --trace switch (maps do not match)
I tracked this down to invocation of a non-const function within a LOG_VART(...) statement. The function call was modifying the map, and producing different output, only when run in TRACE mode!

--

Fix error reporting in ConflateCaseTest.cpp (it was ambiguous before)
Comment out a few trace statements that were causing a test failure (and added appropriate warnings)
