### PR TITLE
Fix Log.h `using namespace std`

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
@@ -32,15 +32,16 @@
 #include <hoot/core/conflate/MatchFactory.h>
 #include <hoot/core/conflate/MergerFactory.h>
 #include <hoot/core/filters/TagCriterion.h>
-#include <hoot/core/schema/TagMergerFactory.h>
-#include <hoot/core/scoring/MapComparator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/schema/TagMergerFactory.h>
+#include <hoot/core/scoring/MapComparator.h>
+#include <hoot/core/schema/TagMergerFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/UuidHelper.h>
 #include <hoot/core/visitors/FilteredVisitor.h>
 #include <hoot/core/visitors/GetElementIdsVisitor.h>
-#include <hoot/core/util/FileUtils.h>
 
 //  tgs
 #include <tgs/Statistics/Random.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
@@ -32,10 +32,11 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/MaximalNearestSublineMatcher.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Qt
 #include <QDebug>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
@@ -29,14 +29,14 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/MaximalSublineStringMatcher.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 using namespace hoot;
-
 
 // Boost
 using namespace boost;

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
@@ -35,11 +35,12 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/MultiLineStringLocation.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
 #include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 #include "../../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
@@ -35,9 +35,10 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 #include "../../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
@@ -38,6 +38,7 @@
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/WaySublineMatchString.h>
 #include <hoot/core/ops/CopySubsetOp.h>
+#include <hoot/core/util/Log.h>
 
 #include "../../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
 #include "../../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
@@ -36,6 +36,7 @@
 
 // Hoot
 #include <hoot/core/algorithms/zindex/LongBox.h>
+#include <hoot/core/util/Log.h>
 
 #include "../../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
@@ -38,6 +38,7 @@
 #include <hoot/core/algorithms/zindex/ZCurveRanger.h>
 #include <hoot/core/algorithms/zindex/Range.h>
 #include <hoot/core/algorithms/zindex/BBox.h>
+#include <hoot/core/util/Log.h>
 
 #include "../../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateNameRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateNameRemoverTest.cpp
@@ -28,6 +28,7 @@
 // Hoot
 #include <hoot/core/conflate/DuplicateNameRemover.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/util/Log.h>
 using namespace hoot;
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NoInformationElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NoInformationElementRemoverTest.cpp
@@ -28,8 +28,8 @@
 // Hoot
 #include <hoot/core/conflate/NoInformationElementRemover.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/util/Log.h>
 using namespace hoot;
-
 
 // Boost
 using namespace boost;

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
@@ -26,11 +26,12 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/conflate/SearchRadiusCalculator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/core/conflate/MapCleaner.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
@@ -69,7 +70,7 @@ public:
   {
     OsmXmlReader reader;
     OsmMap::resetCounters();
-   OsmMapPtr map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
     reader.setDefaultStatus(Status::Unknown1);
     reader.read(
       "test-files/conflate/SearchRadiusCalculatorTest/Haiti_CNIGS_Rivers_REF1-cropped-2.osm", map);
@@ -135,7 +136,7 @@ public:
   {
     OsmXmlReader reader;
     OsmMap::resetCounters();
-   OsmMapPtr map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
     reader.setDefaultStatus(Status::Unknown1);
     reader.read(
       "test-files/conflate/SearchRadiusCalculatorTest/Haiti_CNIGS_Rivers_REF1-cropped-2.osm", map);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SmallWayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SmallWayMergerTest.cpp
@@ -59,7 +59,7 @@ public:
     {
       OsmXmlReader reader;
 
-     OsmMapPtr map(new OsmMap());
+      OsmMapPtr map(new OsmMap());
       reader.setDefaultStatus(Status::Unknown1);
       reader.read("test-files/conflate/SmallWayMergerInput1.osm", map);
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
@@ -26,6 +26,7 @@
  */
 
 #include <hoot/core/conflate/extractors/Histogram.h>
+#include <hoot/core/util/Log.h>
 
 #include "../../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
@@ -32,11 +32,12 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
 #include <hoot/core/conflate/MatchThreshold.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Qt
 #include <QDebug>

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
@@ -32,7 +32,6 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/MaximalNearestSublineMatcher.h>
 #include <hoot/core/algorithms/MaximalSublineStringMatcher.h>
@@ -42,6 +41,8 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Qt
 #include <QDebug>

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
@@ -35,7 +35,6 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/algorithms/MaximalSublineStringMatcher.h>
 #include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
@@ -46,6 +45,8 @@
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/util/ElementConverter.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 
 // Qt

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
@@ -30,8 +30,9 @@
 #include <hoot/core/conflate/Match.h>
 #include <hoot/core/conflate/MatchThreshold.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/io/OsmXmlReader.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 #include <hoot/core/visitors/FindNodesVisitor.h>
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchTest.cpp
@@ -26,8 +26,10 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatch.h>
+#include <hoot/core/util/Log.h>
+
+#include "../../TestUtils.h"
 
 using namespace geos::geom;
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -35,6 +35,7 @@
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMerger.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 
 using namespace geos::geom;
 using namespace std;

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 
 // Qt

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractor.h>
 #include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/util/Log.h>
 using namespace hoot;
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMergerTest.cpp
@@ -42,7 +42,6 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/conflate/polygon/BuildingMerger.h>
 #include <hoot/core/elements/ElementVisitor.h>
@@ -50,8 +49,10 @@
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmJsonWriter.h>
-#include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
@@ -38,6 +38,7 @@
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/util/Log.h>
 using namespace hoot;
 
 // Qt

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
@@ -29,8 +29,9 @@
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/io/OsmJsonWriter.h>
-#include <hoot/core/visitors/ElementCountVisitor.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
+#include <hoot/core/visitors/ElementCountVisitor.h>
 
 #include "../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
@@ -33,6 +33,7 @@
 
 // Hoot
 #include <hoot/core/elements/Tags.h>
+#include <hoot/core/util/Log.h>
 using namespace hoot;
 
 // Qt

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
@@ -33,6 +33,7 @@
 #include <hoot/core/io/ArffReader.h>
 #include <hoot/core/scoring/DataSamples.h>
 #include <hoot/core/scoring/MatchFeatureExtractor.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QDir>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/io/ChangesetDeriver.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/ChangesetProvider.h>
+#include <hoot/core/util/Log.h>
 
 #include "../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/ElementSorter.h>
+#include <hoot/core/util/Log.h>
 
 // Boost
 using namespace boost;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -35,6 +35,7 @@
 #include <hoot/core/io/OgrWriter.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/FileUtils.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QDir>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
@@ -31,6 +31,7 @@
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 
 using namespace hoot;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -32,6 +32,8 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/OsmMap.h>
+#include <hoot/core/elements/ElementAttributeType.h>
 #include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/io/HootApiDbReader.h>
 #include <hoot/core/io/HootApiDbWriter.h>
@@ -39,11 +41,10 @@
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
-#include <hoot/core/OsmMap.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/RemoveAttributeVisitor.h>
-#include <hoot/core/elements/ElementAttributeType.h>
 
 // Qt
 #include <QDir>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -34,6 +34,7 @@
 // Hoot
 #include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 
 #include "../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -34,9 +34,10 @@
 // Hoot
 #include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/io/HootApiDbWriter.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/util/OsmUtils.h>
+#include <hoot/core/util/Settings.h>
 
 // Standard
 #include <functional>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbChangesetSqlWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbChangesetSqlWriterTest.cpp
@@ -36,6 +36,7 @@
 #include <hoot/core/io/OsmApiDbChangesetSqlWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QDateTime>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -32,15 +32,16 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/OsmMap.h>
 #include <hoot/core/io/ApiDb.h>
 #include <hoot/core/io/OsmApiDb.h>
 #include <hoot/core/io/OsmApiDbReader.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/OsmMap.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Qt
 #include <QDir>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
@@ -34,6 +34,7 @@
 // Hoot
 #include <hoot/core/io/OsmApiDb.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QFile>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -33,10 +33,11 @@
 
 // Hoot
 #include <hoot/core/io/HootApiDb.h>
+#include <hoot/core/io/OsmApiDbReader.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/ConfPath.h>
-#include <hoot/core/io/OsmApiDbReader.h>
 #include <hoot/core/util/DbUtils.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QFile>

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/CalculateStatsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/CalculateStatsOpTest.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/ops/CalculateStatsOp.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 
 // CPP Unit
 #include <cppunit/extensions/TestFactoryRegistry.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyTestRunnerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyTestRunnerTest.cpp
@@ -26,12 +26,13 @@
  */
 
 // Hoot
+#include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/perty/PertyTestRunner.h>
 #include <hoot/core/perty/PertyMatchScorer.h>
 #include <hoot/core/perty/PertyTestRunResult.h>
-#include <hoot/core/io/OsmXmlReader.h>
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/Settings.h>
 
 // Qt
 #include <QString>

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWayGeneralizeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWayGeneralizeVisitorTest.cpp
@@ -32,11 +32,12 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/perty/PertyWayGeneralizeVisitor.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Qt
 #include <QString>

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWaySplitVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWaySplitVisitorTest.cpp
@@ -32,11 +32,12 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/perty/PertyWaySplitVisitor.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Qt
 #include <QString>

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
@@ -27,11 +27,12 @@
 
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/conflate/splitter/IntersectionSplitter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/scoring/GraphComparator.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/OpenCv.h>
 using namespace hoot;
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
@@ -26,12 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/conflate/UnifyingConflator.h>
 #include <hoot/core/filters/TagKeyCriterion.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/scoring/MatchComparator.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FilteredVisitor.h>
 #include <hoot/core/visitors/AddUuidVisitor.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
@@ -32,13 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/conflate/polygon/BuildingMatchCreator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/manipulators/WayMerger.h>
 #include <hoot/core/scoring/MatchFeatureExtractor.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // Tgs
 #include <tgs/Statistics/Random.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
@@ -31,6 +31,7 @@
 #include <hoot/core/conflate/MatchFactory.h>
 #include <hoot/core/conflate/MergerFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 
 #include "../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
@@ -32,6 +32,7 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/UuidHelper.h>
 
 #include "../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/MatchCandidateCountVisitor.h>
 using namespace hoot;
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/filters/PoiCriterion.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/RemoveRef2Visitor.h>
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
@@ -7,10 +7,11 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/visitors/SplitLongLinearWaysVisitor.h>
+#include <hoot/core/OsmMap.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Way.h>
-#include <hoot/core/OsmMap.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/visitors/SplitLongLinearWaysVisitor.h>
 
 #include "../TestUtils.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
@@ -28,6 +28,7 @@
 // hoot
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/io/OsmXmlReader.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/SplitNameVisitor.h>
 
 // Qt

--- a/hoot-core/src/main/cpp/hoot/core/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/OsmMap.h
@@ -37,12 +37,15 @@
 #include <geos/geom/Envelope.h>
 
 // Hoot
-#include <hoot/core/util/Units.h>
 #include <hoot/core/elements/ElementProvider.h>
 #include <hoot/core/elements/Node.h>
+#include <hoot/core/elements/NodeMap.h>
 #include <hoot/core/elements/Relation.h>
+#include <hoot/core/elements/RelationMap.h>
 #include <hoot/core/elements/Way.h>
-#include <hoot/core/util/Log.h>
+#include <hoot/core/elements/WayMap.h>
+#include <hoot/core/util/DefaultIdGenerator.h>
+#include <hoot/core/util/Units.h>
 namespace hoot
 {
     namespace elements
@@ -57,12 +60,6 @@ namespace hoot
 
 // TGS
 #include <tgs/RStarTree/HilbertRTree.h>
-
-#include <hoot/core/util/DefaultIdGenerator.h>
-#include <hoot/core/elements/RelationMap.h>
-#include <hoot/core/elements/WayMap.h>
-#include <hoot/core/elements/NodeMap.h>
-
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/BufferedLineSegmentIntersector.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/BufferedLineSegmentIntersector.cpp
@@ -35,6 +35,7 @@
 
 using namespace cv;
 using namespace geos::geom;
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/LevenshteinDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/LevenshteinDistance.cpp
@@ -38,6 +38,8 @@
 #include <iostream>
 #include <math.h>
 
+using namespace std;
+
 namespace hoot
 {
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.cpp
@@ -34,7 +34,11 @@
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/OsmUtils.h>
+
+using namespace std;
 
 namespace hoot
 {
@@ -157,6 +161,16 @@ QList<boost::shared_ptr<const Node> > RdpWayGeneralizer::getGeneralizedPoints(
     OsmUtils::printNodes("reducedLine", reducedLine);
     return reducedLine;
   }
+}
+
+void RdpWayGeneralizer::setEpsilon(double epsilon)
+{
+  if (epsilon <= 0.0)
+  {
+    throw HootException("Invalid epsilon value: " + QString::number(epsilon));
+  }
+  _epsilon = epsilon;
+  LOG_VART(_epsilon);
 }
 
 double RdpWayGeneralizer::_getPerpendicularDistanceBetweenSplitNodeAndImaginaryLine(

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -34,10 +34,6 @@
 // Qt
 #include <QString>
 
-// Hoot
-#include <hoot/core/util/HootException.h>
-#include <hoot/core/util/Log.h>
-
 namespace hoot
 {
 
@@ -102,15 +98,7 @@ public:
     Sets the distance parameter that determines to what degree the way is generalized; higher
     values result in more generalization (more nodes are removed)
     */
-  void setEpsilon(double epsilon)
-  {
-    if (epsilon <= 0.0)
-    {
-      throw HootException("Invalid epsilon value: " + QString::number(epsilon));
-    }
-    _epsilon = epsilon;
-    LOG_VART(_epsilon);
-  }
+  void setEpsilon(double epsilon);
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/Translator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/Translator.cpp
@@ -54,7 +54,6 @@ using namespace std;
 
 namespace hoot
 {
-using namespace std;
 
 /**
  * JSON Spirit isn't a very well behaved header file so I'm only using it within the CPP file.

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.h
@@ -31,6 +31,7 @@
 #include <hoot/core/OsmMap.h>
 #include <hoot/core/Hoot.h>
 #include <hoot/core/algorithms/linearreference/WaySubline.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QList>

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
@@ -26,6 +26,8 @@
  */
 #include "IntegerProgrammingSolver.h"
 
+#include <hoot/core/util/Exception.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/SignalCatcher.h>
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h
@@ -38,10 +38,6 @@
 # error "A valid glpk.h was not found during configure."
 #endif
 
-// Hoot
-#include <hoot/core/util/Exception.h>
-#include <hoot/core/util/Log.h>
-
 // Qt
 #include <QString>
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolver.h
@@ -30,9 +30,9 @@
 
 // hoot
 #include <hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h>
-#include <hoot/core/util/Log.h>
 
 // standard
+#include <set>
 #include <vector>
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MarkForReviewMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MarkForReviewMerger.h
@@ -58,8 +58,8 @@ public:
 
   virtual std::set<ElementId> getImpactedElementIds() const;
 
-  virtual set< pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const
-  { return set< pair<ElementId, ElementId> >(); }
+  virtual std::set< std::pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const
+  { return std::set< std::pair<ElementId, ElementId> >(); }
 
   virtual bool isValid(const ConstOsmMapPtr& map) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/Merger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/Merger.h
@@ -61,7 +61,7 @@ public:
    */
   virtual std::set<ElementId> getImpactedElementIds() const = 0;
 
-  virtual set< pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const = 0;
+  virtual std::set< std::pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const = 0;
 
   /**
    * Returns true if this merge can be applied to the specified map.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MergerBase.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MergerBase.h
@@ -45,8 +45,8 @@ public:
 
   virtual std::set<ElementId> getImpactedElementIds() const;
 
-  virtual set< pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const
-  {  return set< pair<ElementId, ElementId> >(); }
+  virtual std::set< std::pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const
+  {  return std::set< std::pair<ElementId, ElementId> >(); }
 
   virtual bool isValid(const ConstOsmMapPtr& map) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -78,7 +78,7 @@ public:
    * @param matchStatus If the element's status matches this status then it is checked for a match.
    */
   HighwayMatchVisitor(const ConstOsmMapPtr& map,
-    vector<const Match*>& result,boost::shared_ptr<HighwayClassifier> c,
+    vector<const Match*>& result, boost::shared_ptr<HighwayClassifier> c,
     boost::shared_ptr<SublineStringMatcher> sublineMatcher, Status matchStatus,
     ConstMatchThresholdPtr threshold,
     boost::shared_ptr<TagAncestorDifferencer> tagAncestorDiff):

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMerger.h
@@ -50,7 +50,7 @@ public:
 
   virtual QString toString() const;
 
-  virtual set< pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const;
+  virtual std::set< std::pair<ElementId, ElementId> > getImpactedUnknown1ElementIds() const;
 
 protected:
 
@@ -62,7 +62,7 @@ private:
   double _minSplitSize;
   std::set< std::pair<ElementId, ElementId> > _pairs;
   boost::shared_ptr<SublineStringMatcher> _sublineMatcher;
-  set< pair<ElementId, ElementId> > _unknown1Replacements;
+  std::set< std::pair<ElementId, ElementId> > _unknown1Replacements;
 
   /**
    * Returns true if the way directly connects the left and right ways. There is some tolerance

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonDistance.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "PoiPolygonDistance.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonDistance.cpp
@@ -29,6 +29,8 @@
 // Hoot
 #include <hoot/core/util/Log.h>
 
+using namespace std;
+
 namespace hoot
 {
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -29,17 +29,18 @@
 // hoot
 #include <hoot/core/conflate/ReviewMarker.h>
 #include <hoot/core/filters/BaseFilter.h>
+#include <hoot/core/filters/ElementTypeCriterion.h>
 #include <hoot/core/ops/BuildingPartMergeOp.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
 #include <hoot/core/ops/ReplaceElementOp.h>
+#include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/schema/OverwriteTagMerger.h>
 #include <hoot/core/schema/TagComparator.h>
 #include <hoot/core/schema/TagMergerFactory.h>
-#include <hoot/core/schema/OverwriteTagMerger.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
-#include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/visitors/FilteredVisitor.h>
 #include <hoot/core/visitors/ElementCountVisitor.h>
-#include <hoot/core/filters/ElementTypeCriterion.h>
 
 using namespace std;
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/NoInformationCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/NoInformationCriterion.h
@@ -28,12 +28,11 @@
 #define NOINFORMATIONCRITERION_H
 
 // hoot
+#include <hoot/core/elements/Tags.h>
+#include <hoot/core/elements/Element.h>
 #include <hoot/core/util/Configurable.h>
 #include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/elements/Tags.h>
 #include <hoot/core/util/MetadataTags.h>
-#include <hoot/core/util/Log.h>
-#include <hoot/core/elements/Element.h>
 
 #include "ElementCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/WayBufferCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/filters/WayBufferCriterion.cpp
@@ -41,6 +41,7 @@
 #include <QDebug>
 
 using namespace geos::geom;
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/FqTree.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/FqTree.h
@@ -27,9 +27,6 @@
 #ifndef FQTREE_H
 #define FQTREE_H
 
-// hoot
-#include <hoot/core/util/Log.h>
-
 // Standard
 #include <assert.h>
 #include <vector>

--- a/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/Node.h
@@ -30,6 +30,9 @@
 // Qt
 #include <QString>
 
+// hoot
+#include <hoot/core/util/Log.h>
+
 // Standard
 #include <sstream>
 

--- a/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/RTree.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/RTree.h
@@ -30,9 +30,6 @@
 // geos
 #include <geos/geom/Envelope.h>
 
-// hoot
-#include <hoot/core/util/Log.h>
-
 // Standard
 #include <assert.h>
 #include <math.h>

--- a/hoot-core/src/main/cpp/hoot/core/io/ObjectInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ObjectInputStream.h
@@ -31,8 +31,8 @@
 #include <boost/any.hpp>
 
 // Hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/io/Serializable.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
 
 // Qt

--- a/hoot-core/src/main/cpp/hoot/core/io/ObjectOutputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ObjectOutputStream.h
@@ -31,10 +31,10 @@
 #include <boost/any.hpp>
 
 // Hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/io/Serializable.h>
-#include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/NotImplementedException.h>
 
 // Qt
 #include <QDataStream>

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.cpp
@@ -34,6 +34,7 @@
 #include <QDateTime>
 
 using namespace geos::geom;
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.cpp
@@ -30,15 +30,17 @@
 #include <arpa/inet.h>
 
 // Hoot Includes
-#include <hoot/core/Version.h>
-#include <hoot/core/util/Factory.h>
+#include <hoot/core/OsmMap.h>
 #include <hoot/core/proto/FileFormat.pb.h>
 #include <hoot/core/proto/OsmFormat.pb.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
-#include <hoot/core/OsmMap.h>
+
+//  Version must be included last
+#include <hoot/core/Version.h>
 
 using namespace hoot::pb;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/PythonTranslator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/PythonTranslator.cpp
@@ -47,6 +47,8 @@
 typedef int Py_ssize_t;
 #endif
 
+using namespace std;
+
 namespace hoot
 {
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopySubsetOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopySubsetOp.cpp
@@ -27,6 +27,7 @@
 #include "CopySubsetOp.h"
 
 #include <hoot/core/elements/ElementVisitor.h>
+#include <hoot/core/util/Log.h>
 
 using namespace std;
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/SuperfluousNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SuperfluousNodeRemover.cpp
@@ -75,7 +75,7 @@ void SuperfluousNodeRemover::apply(boost::shared_ptr<OsmMap> &map)
     }
   }
 
- boost::shared_ptr<OsmMap> reprojected;
+  boost::shared_ptr<OsmMap> reprojected;
   const NodeMap* nodesWgs84 = &nodes;
   // if the map is not in WGS84
   if (MapProjector::isGeographic(map) == false)
@@ -121,7 +121,7 @@ void SuperfluousNodeRemover::readObject(QDataStream& is)
 
 boost::shared_ptr<OsmMap> SuperfluousNodeRemover::removeNodes(boost::shared_ptr<const OsmMap> map)
 {
- boost::shared_ptr<OsmMap> result(new OsmMap(map));
+  boost::shared_ptr<OsmMap> result(new OsmMap(map));
   SuperfluousNodeRemover().apply(result);
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/VisitorOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/VisitorOp.h
@@ -69,7 +69,7 @@ public:
   virtual void apply(boost::shared_ptr<OsmMap>& map);
 
 private:
- boost::shared_ptr<ElementVisitor> _visitor;
+  boost::shared_ptr<ElementVisitor> _visitor;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/perty/PertyMatchScorer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/perty/PertyMatchScorer.cpp
@@ -77,7 +77,7 @@ QString PertyMatchScorer::toString()
 }
 
 boost::shared_ptr<MatchComparator> PertyMatchScorer::scoreMatches(const QString referenceMapInputPath,
-                                                           const QString outputPath)
+                                                                  const QString outputPath)
 {
   LOG_INFO(toString());
 
@@ -95,9 +95,9 @@ boost::shared_ptr<MatchComparator> PertyMatchScorer::scoreMatches(const QString 
     outputPath + "/" + inputFileInfo.baseName() + "-conflated-out.osm";
   _conflatedMapOutput = conflatedMapOutputPath;
 
- OsmMapPtr referenceMap = _loadReferenceMap(referenceMapInputPath, referenceMapOutputPath);
+  OsmMapPtr referenceMap = _loadReferenceMap(referenceMapInputPath, referenceMapOutputPath);
   _loadPerturbedMap(referenceMapOutputPath, perturbedMapOutputPath);
- OsmMapPtr combinedMap =
+  OsmMapPtr combinedMap =
     _combineMapsAndPrepareForConflation(referenceMap, perturbedMapOutputPath);
 
   MapProjector::projectToWgs84(combinedMap);
@@ -107,18 +107,18 @@ boost::shared_ptr<MatchComparator> PertyMatchScorer::scoreMatches(const QString 
 }
 
 OsmMapPtr PertyMatchScorer::_loadReferenceMap(const QString referenceMapInputPath,
-                                                       const QString referenceMapOutputPath)
+                                              const QString referenceMapOutputPath)
 {
   LOG_DEBUG("Loading the reference data with status " << MetadataTags::Unknown1() << " and adding " << MetadataTags::Ref1() <<
             " tags to it; Saving a copy to " << referenceMapOutputPath << "...");
 
- OsmMapPtr referenceMap(new OsmMap());
+  OsmMapPtr referenceMap(new OsmMap());
   OsmUtils::loadMap(referenceMap, referenceMapInputPath, false, Status::Unknown1);
   MapCleaner().apply(referenceMap);
 
- boost::shared_ptr<AddRef1Visitor> addRef1Visitor(new AddRef1Visitor());
+  boost::shared_ptr<AddRef1Visitor> addRef1Visitor(new AddRef1Visitor());
   referenceMap->visitRw(*addRef1Visitor);
- boost::shared_ptr<SetTagVisitor> setAccuracyVisitor(
+  boost::shared_ptr<SetTagVisitor> setAccuracyVisitor(
     new SetTagVisitor(MetadataTags::ErrorCircular(), QString::number(_searchDistance)));
   referenceMap->visitRw(*setAccuracyVisitor);
   LOG_VARD(referenceMap->getNodes().size());
@@ -131,7 +131,7 @@ OsmMapPtr PertyMatchScorer::_loadReferenceMap(const QString referenceMapInputPat
     LOG_VARD(numTotalTags);
   }
 
- OsmMapPtr referenceMapCopy(referenceMap);
+  OsmMapPtr referenceMapCopy(referenceMap);
   MapProjector::projectToWgs84(referenceMapCopy);
   OsmUtils::saveMap(referenceMapCopy, referenceMapOutputPath);
 
@@ -146,15 +146,15 @@ void PertyMatchScorer::_loadPerturbedMap(const QString perturbedMapInputPath,
 
   //load from the modified reference data output to get the added ref1 tags; don't copy the map,
   //since updates to the names of the ref tags on this map will propagate to the map copied from
- OsmMapPtr perturbedMap(new OsmMap());
+  OsmMapPtr perturbedMap(new OsmMap());
   OsmUtils::loadMap(perturbedMap, perturbedMapInputPath, false, Status::Unknown2);
   MapCleaner().apply(perturbedMap);
 
- boost::shared_ptr<TagRenameKeyVisitor> tagRenameKeyVisitor(new TagRenameKeyVisitor(MetadataTags::Ref1(), MetadataTags::Ref2()));
+  boost::shared_ptr<TagRenameKeyVisitor> tagRenameKeyVisitor(new TagRenameKeyVisitor(MetadataTags::Ref1(), MetadataTags::Ref2()));
   perturbedMap->visitRw(*tagRenameKeyVisitor);
   // This could be replaced with a SetTagVisitor passed in from the command line
   // instead.
- boost::shared_ptr<SetTagVisitor> setAccuracyVisitor(
+  boost::shared_ptr<SetTagVisitor> setAccuracyVisitor(
     new SetTagVisitor(MetadataTags::ErrorCircular(), QString::number(_searchDistance)));
   perturbedMap->visitRw(*setAccuracyVisitor);
   LOG_VARD(perturbedMap->getNodes().size());
@@ -188,7 +188,7 @@ void PertyMatchScorer::_loadPerturbedMap(const QString perturbedMapInputPath,
 }
 
 OsmMapPtr PertyMatchScorer::_combineMapsAndPrepareForConflation(
- OsmMapPtr referenceMap, const QString perturbedMapInputPath)
+  OsmMapPtr referenceMap, const QString perturbedMapInputPath)
 {
   LOG_DEBUG("Combining the reference and perturbed data into a single file ...");
 
@@ -196,7 +196,7 @@ OsmMapPtr PertyMatchScorer::_combineMapsAndPrepareForConflation(
 //  QString combinedOutputPath = fileInfo.path() + "/ref-after-combination.osm";
 //  LOG_DEBUG("saving a debug copy to " << combinedOutputPath << " ...");
 
- OsmMapPtr combinedMap(referenceMap);
+  OsmMapPtr combinedMap(referenceMap);
   OsmUtils::loadMap(combinedMap, perturbedMapInputPath, false, Status::Unknown2);
   LOG_VARD(combinedMap->getNodes().size());
   LOG_VARD(combinedMap->getWays().size());
@@ -240,7 +240,7 @@ OsmMapPtr PertyMatchScorer::_combineMapsAndPrepareForConflation(
 
     //move Unknown2 toward Unknown1
     conf().set(RubberSheet::refKey(), true);
-   boost::shared_ptr<RubberSheet> rubberSheetOp(new RubberSheet());
+    boost::shared_ptr<RubberSheet> rubberSheetOp(new RubberSheet());
     rubberSheetOp->apply(combinedMap);
 
     LOG_VARD(combinedMap->getNodes().size());
@@ -262,12 +262,12 @@ OsmMapPtr PertyMatchScorer::_combineMapsAndPrepareForConflation(
 }
 
 boost::shared_ptr<MatchComparator> PertyMatchScorer::_conflateAndScoreMatches(
-   OsmMapPtr combinedDataToConflate, const QString conflatedMapOutputPath)
+  OsmMapPtr combinedDataToConflate, const QString conflatedMapOutputPath)
 {
   LOG_DEBUG("Conflating the reference data with the perturbed data, scoring the matches, and " <<
             "saving the conflated output to: " << conflatedMapOutputPath);
 
- boost::shared_ptr<MatchComparator> comparator(new MatchComparator());
+  boost::shared_ptr<MatchComparator> comparator(new MatchComparator());
   //shared_ptr<MatchThreshold> matchThreshold;
   OsmMapPtr conflationCopy(new OsmMap(combinedDataToConflate));
 

--- a/hoot-core/src/main/cpp/hoot/core/perty/PertyMatchScorer.h
+++ b/hoot-core/src/main/cpp/hoot/core/perty/PertyMatchScorer.h
@@ -54,7 +54,7 @@ public:
     @param outputPath output directory
     @returns a match comparator from which the PERTY score can be retrieved
     */
- boost::shared_ptr<MatchComparator> scoreMatches(const QString referenceMapInputPath,
+  boost::shared_ptr<MatchComparator> scoreMatches(const QString referenceMapInputPath,
                                            const QString outputPath);
 
   /**
@@ -105,13 +105,13 @@ private:
 
   Settings _settings;
 
- OsmMapPtr _loadReferenceMap(const QString referenceMapInputPath,
+  OsmMapPtr _loadReferenceMap(const QString referenceMapInputPath,
                                        const QString referenceMapOutputPath);
   void _loadPerturbedMap(const QString perturbedMapInputPath,
                          const QString perturbedMapOutputPath);
- OsmMapPtr _combineMapsAndPrepareForConflation(OsmMapPtr referenceMap,
+  OsmMapPtr _combineMapsAndPrepareForConflation(OsmMapPtr referenceMap,
                                                          const QString perturbedMapInputPath);
- boost::shared_ptr<MatchComparator> _conflateAndScoreMatches(OsmMapPtr combinedDataToConflate,
+  boost::shared_ptr<MatchComparator> _conflateAndScoreMatches(OsmMapPtr combinedDataToConflate,
                                                        const QString conflatedMapOutputPath);
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/perty/PertyOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/perty/PertyOp.cpp
@@ -244,7 +244,7 @@ Mat PertyOp::_calculatePermuteGrid(geos::geom::Envelope env, int& rows, int& col
 boost::shared_ptr<OsmMap> PertyOp::generateDebugMap(boost::shared_ptr<OsmMap>& map)
 {
   MapProjector::projectToPlanar(map);
- boost::shared_ptr<OsmMap> result(new OsmMap(map->getProjection()));
+  boost::shared_ptr<OsmMap> result(new OsmMap(map->getProjection()));
 
   LOG_INFO(toString());
 
@@ -271,12 +271,12 @@ boost::shared_ptr<OsmMap> PertyOp::generateDebugMap(boost::shared_ptr<OsmMap>& m
       double dy = EX.at<double>((i * cols + j) * 2 + 1, 0);
       dSum += sqrt(dx * dx + dy * dy);
 
-     NodePtr n1(new Node(Status::Unknown1, result->createNextNodeId(), x, y, 5));
-     NodePtr n2(new Node(Status::Unknown1, result->createNextNodeId(), x + dx, y + dy, 5));
+      NodePtr n1(new Node(Status::Unknown1, result->createNextNodeId(), x, y, 5));
+      NodePtr n2(new Node(Status::Unknown1, result->createNextNodeId(), x + dx, y + dy, 5));
       result->addNode(n1);
       result->addNode(n2);
 
-     WayPtr w(new Way(Status::Unknown1, result->createNextWayId(), 5.0));
+      WayPtr w(new Way(Status::Unknown1, result->createNextWayId(), 5.0));
       w->addNode(n1->getId());
       w->addNode(n2->getId());
       w->getTags().addNote(QString("r: %1 c: %2").arg(i).arg(j));

--- a/hoot-core/src/main/cpp/hoot/core/perty/PertyTestRunner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/perty/PertyTestRunner.cpp
@@ -42,6 +42,8 @@
 // Standard
 #include <cmath>
 
+using namespace std;
+
 namespace hoot
 {
 
@@ -129,7 +131,7 @@ QList<boost::shared_ptr<const PertyTestRunResult> > PertyTestRunner::runTest(con
       {
         const QString testRunOutputPath =
           outputPath + "/test-" + QString::number(i + 1) + "-" + QString::number(j + 1);
-       boost::shared_ptr<const MatchComparator> matchComparator =
+        boost::shared_ptr<const MatchComparator> matchComparator =
           _matchScorer->scoreMatches(referenceMapInputPath, testRunOutputPath);
         const double score = matchComparator->getPertyScore();
         simulationScores.append(score);
@@ -157,7 +159,7 @@ QList<boost::shared_ptr<const PertyTestRunResult> > PertyTestRunner::runTest(con
     const double scoreVariance = abs(_expectedScores[i] - avgScore);
     LOG_VARD(scoreVariance);
 
-   boost::shared_ptr<const PertyTestRunResult> testRunResult(
+    boost::shared_ptr<const PertyTestRunResult> testRunResult(
       new PertyTestRunResult(
          referenceMapInputPath, outputPath, i + 1, simulationScores, avgScore, _expectedScores[i],
           scoreVariance, _allowedScoreVariance, _failOnBetterScore, _dynamicVariables,
@@ -209,7 +211,7 @@ void PertyTestRunner::_writePlotFile(const QString outputPath,
   for (QList<boost::shared_ptr<const PertyTestRunResult> >::const_iterator it = testRunResults.begin();
        it != testRunResults.end(); ++it)
   {
-   boost::shared_ptr<const PertyTestRunResult> result = *it;
+    boost::shared_ptr<const PertyTestRunResult> result = *it;
     outStr += QString::number(dynamicVariableValue) + " " + QString::number(result->getScore()) + "\n";
     dynamicVariableValue += _dynamicVariableIncrement;
   }

--- a/hoot-core/src/main/cpp/hoot/core/perty/PertyTestRunner.h
+++ b/hoot-core/src/main/cpp/hoot/core/perty/PertyTestRunner.h
@@ -191,7 +191,7 @@ private:
 
   Settings _settings;
 
- boost::shared_ptr<PertyMatchScorer> _matchScorer;
+  boost::shared_ptr<PertyMatchScorer> _matchScorer;
 
   void _writeStatsForOutputFiles(const QString& inputMapPath, QString sep);
   void _writePlotFile(const QString outputPath,

--- a/hoot-core/src/main/cpp/hoot/core/perty/PertyWayGeneralizeVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/perty/PertyWayGeneralizeVisitor.h
@@ -107,7 +107,7 @@ private:
   double _wayGeneralizeProbability;
   double _epsilon;
 
- boost::shared_ptr<RdpWayGeneralizer> _generalizer;
+  boost::shared_ptr<RdpWayGeneralizer> _generalizer;
 
   void _generalize(const WayPtr& way);
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.cpp
@@ -55,7 +55,7 @@ boost::shared_ptr<OsmSchemaLoader> OsmSchemaLoaderFactory::createLoader(QString 
 
   for (size_t i = 0; i < names.size(); ++i)
   {
-   boost::shared_ptr<OsmSchemaLoader> l(Factory::getInstance().constructObject<OsmSchemaLoader>(
+    boost::shared_ptr<OsmSchemaLoader> l(Factory::getInstance().constructObject<OsmSchemaLoader>(
       names[i]));
 
     if (l->isSupported(url))

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.cpp
@@ -68,8 +68,8 @@ boost::shared_ptr<const TagMerger> TagMergerFactory::getDefaultPtr()
 
 boost::shared_ptr<const TagMerger> TagMergerFactory::getMergerPtr(const QString& name)
 {
- boost::shared_ptr<const TagMerger> result;
-  QHash<QString,boost::shared_ptr<const TagMerger> >::const_iterator it = _mergers.find(name);
+  boost::shared_ptr<const TagMerger> result;
+  QHash<QString, boost::shared_ptr<const TagMerger> >::const_iterator it = _mergers.find(name);
   if (it == _mergers.end())
   {
     result.reset(Factory::getInstance().constructObject<TagMerger>(name.toStdString()));

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
@@ -56,11 +56,11 @@ public:
    */
   const TagMerger& getDefault() { return *getDefaultPtr(); }
 
- boost::shared_ptr<const TagMerger> getDefaultPtr();
+  boost::shared_ptr<const TagMerger> getDefaultPtr();
 
   const TagMerger& getMerger(const QString& name) { return *getMergerPtr(name); }
 
- boost::shared_ptr<const TagMerger> getMergerPtr(const QString& name);
+  boost::shared_ptr<const TagMerger> getMergerPtr(const QString& name);
 
   /**
    * A convenience function for merging tags using the default mechanism. Equivalent to:
@@ -74,8 +74,8 @@ public:
   void reset();
 
 private:
-  QHash<QString,boost::shared_ptr<const TagMerger> > _mergers;
- boost::shared_ptr<const TagMerger> _default;
+  QHash<QString, boost::shared_ptr<const TagMerger> > _mergers;
+  boost::shared_ptr<const TagMerger> _default;
 
   static boost::shared_ptr<TagMergerFactory> _theInstance;
 };

--- a/hoot-core/src/main/cpp/hoot/core/schema/TranslatedTagDifferencer.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TranslatedTagDifferencer.h
@@ -94,7 +94,7 @@ private:
    * Does a lazy load of the translator to avoid initializing configuration options that aren't
    * being used.
    */
- boost::shared_ptr<ScriptToOgrTranslator> _getTranslator() const;
+  boost::shared_ptr<ScriptToOgrTranslator> _getTranslator() const;
 
   /**
    * Converts to tags if not-null otherwise returns an empty set of tags.

--- a/hoot-core/src/main/cpp/hoot/core/scoring/AttributeComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/AttributeComparator.cpp
@@ -101,11 +101,11 @@ double AttributeComparator::compareMaps()
     double bestScore = -1.0;
     for (size_t j = 0; j < wids1.size(); j++)
     {
-     WayPtr w1 = referenceMap->getWay(wids1[j]);
+      WayPtr w1 = referenceMap->getWay(wids1[j]);
 
       for (size_t k = 0; k < wids2.size(); k++)
       {
-       WayPtr w2 = otherMap->getWay(wids2[k]);
+        WayPtr w2 = otherMap->getWay(wids2[k]);
         double score = TagComparator::getInstance().compareTags(w1->getTags(), w2->getTags());
         if (score > bestScore)
         {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/AttributeComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/AttributeComparator.h
@@ -36,7 +36,7 @@ namespace hoot
 class AttributeComparator : public BaseComparator
 {
 public:
-  AttributeComparator(boost::shared_ptr<OsmMap> map1,boost::shared_ptr<OsmMap> map2);
+  AttributeComparator(boost::shared_ptr<OsmMap> map1, boost::shared_ptr<OsmMap> map2);
 
   virtual ~AttributeComparator() {}
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/AttributeCount.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/AttributeCount.cpp
@@ -72,11 +72,11 @@ QString AttributeCount::Count(QString input)
 
     LOG_DEBUG("Reading: " + input + " " + layers[i]);
 
-   boost::shared_ptr<ElementIterator> iterator(reader.createIterator(input, layers[i]));
+    boost::shared_ptr<ElementIterator> iterator(reader.createIterator(input, layers[i]));
 
     while(iterator->hasNext())
     {
-     boost::shared_ptr<Element> e = iterator->next();
+      boost::shared_ptr<Element> e = iterator->next();
 
       //        // Interesting problem: If there are no elements in the file, e == 0
       //        // Need to look at the ElementIterator.cpp file to fix this.

--- a/hoot-core/src/main/cpp/hoot/core/scoring/BaseComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/BaseComparator.cpp
@@ -53,7 +53,7 @@ using namespace geos::geom;
 namespace hoot
 {
 
-BaseComparator::BaseComparator(boost::shared_ptr<OsmMap> map1,boost::shared_ptr<OsmMap> map2)
+BaseComparator::BaseComparator(boost::shared_ptr<OsmMap> map1, boost::shared_ptr<OsmMap> map2)
 {
   _init(map1, map2);
 }
@@ -163,7 +163,7 @@ Coordinate BaseComparator::_findNearestPointOnFeature(boost::shared_ptr<OsmMap> 
   return result;
 }
 
-void BaseComparator::_init(boost::shared_ptr<OsmMap> map1,boost::shared_ptr<OsmMap> map2)
+void BaseComparator::_init(boost::shared_ptr<OsmMap> map1, boost::shared_ptr<OsmMap> map2)
 {
   _map1 = map1;
   _map2 = map2;

--- a/hoot-core/src/main/cpp/hoot/core/scoring/BaseComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/BaseComparator.h
@@ -61,7 +61,7 @@ public:
   /**
    * Takes two maps for comparison as input
    */
-  BaseComparator(boost::shared_ptr<OsmMap> map1,boost::shared_ptr<OsmMap> map2);
+  BaseComparator(boost::shared_ptr<OsmMap> map1, boost::shared_ptr<OsmMap> map2);
 
   virtual ~BaseComparator() {}
 
@@ -83,7 +83,7 @@ protected:
 
   geos::geom::Coordinate _findNearestPointOnFeature(boost::shared_ptr<OsmMap> map, geos::geom::Coordinate c);
 
-  virtual void _init(boost::shared_ptr<OsmMap> map1,boost::shared_ptr<OsmMap> map2);
+  virtual void _init(boost::shared_ptr<OsmMap> map1, boost::shared_ptr<OsmMap> map2);
 
   void _saveImage(cv::Mat& image, QString path, double max = 0.0, bool gradient = true);
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/DataSamples.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/DataSamples.cpp
@@ -66,7 +66,7 @@ vector<string> DataSamples::getUniqueLabels() const
 
 boost::shared_ptr<DataFrame> DataSamples::toDataFrame(double nullValue) const
 {
- boost::shared_ptr<DataFrame> result(new DataFrame);
+  boost::shared_ptr<DataFrame> result(new DataFrame);
   vector<string> labels = getUniqueLabels();
   result->setFactorLabels(labels);
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
@@ -66,7 +66,7 @@ using namespace Tgs;
 namespace hoot
 {
 
-GraphComparator::GraphComparator(OsmMapPtr map1,OsmMapPtr map2) :
+GraphComparator::GraphComparator(OsmMapPtr map1, OsmMapPtr map2) :
       BaseComparator(map1, map2)
 {
   _iterations = 100;
@@ -278,7 +278,7 @@ void GraphComparator::drawCostDistance(OsmMapPtr map, vector<Coordinate>& c,
   }
 
   // populate graph
- boost::shared_ptr<DirectedGraph> graph(new DirectedGraph());
+  boost::shared_ptr<DirectedGraph> graph(new DirectedGraph());
   graph->deriveEdges(map);
 
   LOG_DEBUG("Running cost");
@@ -415,7 +415,7 @@ cv::Mat GraphComparator::_paintGraph(OsmMapPtr map, DirectedGraph& graph, Shorte
 
   for (WayMap::const_iterator it = ways.begin(); it != ways.end(); ++it)
   {
-   WayPtr w = it->second;
+    WayPtr w = it->second;
     double cost = sp.getNodeCost(w->getNodeIds()[0]);
     if (cost >= 0)
     {
@@ -433,7 +433,7 @@ cv::Mat GraphComparator::_paintGraph(OsmMapPtr map, DirectedGraph& graph, Shorte
   return mat;
 }
 
-void GraphComparator::_paintWay(cv::Mat& mat, ConstOsmMapPtr map,WayPtr way, double friction,
+void GraphComparator::_paintWay(cv::Mat& mat, ConstOsmMapPtr map, WayPtr way, double friction,
                                 double startCost, double endCost)
 {
   LocationOfPoint lop(map, way);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.h
@@ -43,7 +43,7 @@ class Way;
 class GraphComparator : public BaseComparator
 {
 public:
-  GraphComparator(OsmMapPtr map1,OsmMapPtr map2);
+  GraphComparator(OsmMapPtr map1, OsmMapPtr map2);
 
   virtual ~GraphComparator() {}
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.h
@@ -47,7 +47,7 @@ public:
    * Returns true if the maps are essentially the same. Minor differences in node locations are
    * ignored.
    */
-  bool isMatch(boost::shared_ptr<OsmMap> ref,boost::shared_ptr<OsmMap> test);
+  bool isMatch(boost::shared_ptr<OsmMap> ref, boost::shared_ptr<OsmMap> test);
 
   void setIgnoreUUID() { _ignoreUUID = true; }
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.cpp
@@ -664,7 +664,7 @@ void MatchComparator::_tagError(const OsmMapPtr &map, const QString &uuid, const
   {
     if (it.key().contains(uuid))
     {
-     boost::shared_ptr<Element> eid = map->getElement(it.value());
+      boost::shared_ptr<Element> eid = map->getElement(it.value());
       stv.visit(eid);
     }
   }
@@ -678,7 +678,7 @@ void MatchComparator::_tagWrong(const OsmMapPtr &map, const QString &uuid)
   {
     if (it.key().contains(uuid))
     {
-     boost::shared_ptr<Element> eid = map->getElement(it.value());
+      boost::shared_ptr<Element> eid = map->getElement(it.value());
       stv.visit(eid);
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchScoringMapPreparer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchScoringMapPreparer.cpp
@@ -75,7 +75,7 @@ void MatchScoringMapPreparer::prepMap(OsmMapPtr map, const bool removeNodes)
   map->visitRw(convertUuidToRef);
 
   // #5891 if the feature is marked as todo then there is no need to conflate & evaluate it.
- boost::shared_ptr<TagCriterion> isTodo(new TagCriterion(MetadataTags::Ref2(), "todo"));
+  boost::shared_ptr<TagCriterion> isTodo(new TagCriterion(MetadataTags::Ref2(), "todo"));
   RemoveElementsVisitor remover(isTodo);
   remover.setRecursive(true);
   map->visitRw(remover);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/RasterComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/RasterComparator.h
@@ -47,7 +47,7 @@ public:
   /**
    * Takes two maps for comparison as input
    */
-  RasterComparator(boost::shared_ptr<OsmMap> map1,boost::shared_ptr<OsmMap> map2);
+  RasterComparator(boost::shared_ptr<OsmMap> map1, boost::shared_ptr<OsmMap> map2);
 
   virtual ~RasterComparator() {}
 

--- a/hoot-core/src/main/cpp/hoot/core/util/ConfPath.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/ConfPath.cpp
@@ -43,6 +43,8 @@
 
 #include <hoot/core/util/Log.h>
 
+using namespace std;
+
 namespace hoot
 {
 

--- a/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/ElementConverter.h
@@ -89,19 +89,19 @@ public:
    * Converts the given element to a geos geometry object. The tags are used with OsmSchema to
    * determine the geometry type.
    */
- boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const boost::shared_ptr<const Element>& e,
-                                                           bool throwError=true,
-                                                           const bool statsFlag=false) const;
- boost::shared_ptr<geos::geom::Point> convertToGeometry(const ConstNodePtr& n) const;
- boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const WayPtr& w) const;
- boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const ConstWayPtr& w, bool throwError,
-                                                           const bool statsFlag=false) const;
- boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const ConstRelationPtr& r,
-                                                           bool throwError,
-                                                           const bool statsFlag=false) const;
- boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const RelationPtr& r) const;
- boost::shared_ptr<geos::geom::LineString> convertToLineString(const ConstWayPtr& w) const;
- boost::shared_ptr<geos::geom::Polygon> convertToPolygon(const ConstWayPtr& w) const;
+  boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const boost::shared_ptr<const Element>& e,
+                                                            bool throwError=true,
+                                                            const bool statsFlag=false) const;
+  boost::shared_ptr<geos::geom::Point> convertToGeometry(const ConstNodePtr& n) const;
+  boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const WayPtr& w) const;
+  boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const ConstWayPtr& w, bool throwError,
+                                                            const bool statsFlag=false) const;
+  boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const ConstRelationPtr& r,
+                                                            bool throwError,
+                                                            const bool statsFlag=false) const;
+  boost::shared_ptr<geos::geom::Geometry> convertToGeometry(const RelationPtr& r) const;
+  boost::shared_ptr<geos::geom::LineString> convertToLineString(const ConstWayPtr& w) const;
+  boost::shared_ptr<geos::geom::Polygon> convertToPolygon(const ConstWayPtr& w) const;
 
   /**
    * Return the geometry type of the specific element.

--- a/hoot-core/src/main/cpp/hoot/core/util/GeometryConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/GeometryConverter.cpp
@@ -63,7 +63,7 @@ boost::shared_ptr<Element> GeometryConverter::convertGeometryCollection(const Ge
   if (gc->getNumGeometries() > 1)
   {
     LOG_INFO("Creating relation. convertGeometryCollection");
-   RelationPtr r(new Relation(s, _map->createNextRelationId(), circularError));
+    RelationPtr r(new Relation(s, _map->createNextRelationId(), circularError));
     int count = gc->getNumGeometries();
 
     for (int i = 0; i < count; i++)
@@ -120,7 +120,7 @@ boost::shared_ptr<Element> GeometryConverter::convertGeometryToElement(const Geo
 WayPtr GeometryConverter::convertLineStringToWay(const LineString* ls,
   const OsmMapPtr& map, Status s, double circularError)
 {
- WayPtr way;
+  WayPtr way;
   if (ls->getNumPoints() > 0)
   {
     Coordinate c = ls->getCoordinateN(0);
@@ -142,11 +142,11 @@ boost::shared_ptr<Element> GeometryConverter::convertMultiLineStringToElement(co
 {
   if (mls->getNumGeometries() > 1)
   {
-   RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
+    RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
       MetadataTags::RelationMultilineString()));
     for (size_t i = 0; i < mls->getNumGeometries(); i++)
     {
-     WayPtr w = convertLineStringToWay(
+      WayPtr w = convertLineStringToWay(
         dynamic_cast<const LineString*>(mls->getGeometryN(i)), map, s, circularError);
       r->addElement("", w);
     }
@@ -163,7 +163,7 @@ boost::shared_ptr<Element> GeometryConverter::convertMultiLineStringToElement(co
 RelationPtr GeometryConverter::convertMultiPolygonToRelation(const MultiPolygon* mp,
   const OsmMapPtr& map, Status s, double circularError)
 {
- RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
+  RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
     MetadataTags::RelationMultiPolygon()));
   for (size_t i = 0; i < mp->getNumGeometries(); i++)
   {
@@ -184,7 +184,7 @@ boost::shared_ptr<Element> GeometryConverter::convertPolygonToElement(const Poly
   }
   else if (polygon->getNumInteriorRing() == 0)
   {
-   WayPtr result = convertLineStringToWay(polygon->getExteriorRing(), map, s, circularError);
+    WayPtr result = convertLineStringToWay(polygon->getExteriorRing(), map, s, circularError);
     result->getTags()["area"] = "yes";
     return result;
   }
@@ -197,7 +197,7 @@ boost::shared_ptr<Element> GeometryConverter::convertPolygonToElement(const Poly
 RelationPtr GeometryConverter::convertPolygonToRelation(const Polygon* polygon,
   const OsmMapPtr& map, Status s, double circularError)
 {
- RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
+  RelationPtr r(new Relation(s, map->createNextRelationId(), circularError,
     MetadataTags::RelationMultiPolygon()));
   convertPolygonToRelation(polygon, map, r, s, circularError);
   map->addRelation(r);
@@ -208,13 +208,13 @@ RelationPtr GeometryConverter::convertPolygonToRelation(const Polygon* polygon,
 void GeometryConverter::convertPolygonToRelation(const Polygon* polygon,
   const OsmMapPtr& map, const RelationPtr& r, Status s, double circularError)
 {
- WayPtr outer = convertLineStringToWay(polygon->getExteriorRing(), map, s, circularError);
+  WayPtr outer = convertLineStringToWay(polygon->getExteriorRing(), map, s, circularError);
   if (outer != NULL)
   {
     r->addElement(MetadataTags::RoleOuter(), outer);
     for (size_t i = 0; i < polygon->getNumInteriorRing(); i++)
     {
-     WayPtr inner = convertLineStringToWay(polygon->getInteriorRingN(i), map, s, circularError);
+      WayPtr inner = convertLineStringToWay(polygon->getInteriorRingN(i), map, s, circularError);
       r->addElement(MetadataTags::RoleInner(), inner);
     }
   }
@@ -225,7 +225,7 @@ NodePtr GeometryConverter::_createNode(const OsmMapPtr& map, const Coordinate& c
 {
   if (_nf == 0)
   {
-   NodePtr n =NodePtr(new Node(s, map->createNextNodeId(), c, circularError));
+    NodePtr n =NodePtr(new Node(s, map->createNextNodeId(), c, circularError));
     map->addNode(n);
     return n;
   }

--- a/hoot-core/src/main/cpp/hoot/core/util/GeometryPainter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/GeometryPainter.cpp
@@ -332,7 +332,7 @@ void GeometryPainter::drawWay(QPainter& pt, const OsmMap* map, const Way* way, c
 
   for (int j = 0; j < size; j++)
   {
-   ConstNodePtr n = map->getNode(way->getNodeId(j));
+    ConstNodePtr n = map->getNode(way->getNodeId(j));
     a[j] = QPointF(m.map(QPointF(n->getX(), n->getY())) - QPointF(0.5, 0.5));
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -51,12 +51,6 @@
 
 namespace hoot
 {
-/**
- * The following 'using namespace std' is required to be here.  If it is removed, the software compiles
- * BUT it doesn't run correctly.  Removing it causes multiple unit tests fail.
- * See
- */
-using namespace std;
 
 /**
  * This class is here to abstract out the logging interface. I only have mild confidence in log4cxx

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.cpp
@@ -137,7 +137,7 @@ Radians MapProjector::_calculateAngle(Coordinate p1, Coordinate p2, Coordinate p
 
 boost::shared_ptr<OGRSpatialReference> MapProjector::createAeacProjection(const OGREnvelope& env)
 {
- boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
   double height = env.MaxY - env.MinY;
   double stdP1 = env.MinY + height * .25;
   double stdP2 = env.MinY + height * .75;
@@ -175,92 +175,92 @@ vector<boost::shared_ptr<OGRSpatialReference> > MapProjector::createAllPlanarPro
     try { result.push_back(createAeacProjection(env)); } catch (const HootException&) { }
     try { result.push_back(createSinusoidalProjection(env)); } catch (const HootException&) { }
 
-   boost::shared_ptr<OGRSpatialReference> mollweide(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> mollweide(new OGRSpatialReference());
     if (mollweide->importFromEPSG(54009) == OGRERR_NONE)
     {
       result.push_back(mollweide);
     }
 
-   boost::shared_ptr<OGRSpatialReference> eckertVI(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> eckertVI(new OGRSpatialReference());
     if (eckertVI->importFromEPSG(53010) == OGRERR_NONE)
     {
       result.push_back(eckertVI);
     }
 
-   boost::shared_ptr<OGRSpatialReference> sphereBonne(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> sphereBonne(new OGRSpatialReference());
     if (sphereBonne->importFromEPSG(53024) == OGRERR_NONE)
     {
       result.push_back(sphereBonne);
     }
 
-   boost::shared_ptr<OGRSpatialReference> customMercator(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customMercator(new OGRSpatialReference());
     if (customMercator->SetMercator(centerLat, centerLon, 1.0, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customMercator);
     }
 
-   boost::shared_ptr<OGRSpatialReference> customBonne(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customBonne(new OGRSpatialReference());
     if (customBonne->SetBonne(M_PI_2, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customBonne);
     }
 
     // Lambert azimuthal equal-area projection
-   boost::shared_ptr<OGRSpatialReference> customLaea(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customLaea(new OGRSpatialReference());
     if (customLaea->SetLAEA(centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customLaea);
     }
 
-   boost::shared_ptr<OGRSpatialReference> customLcc1sp(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customLcc1sp(new OGRSpatialReference());
     if (customLcc1sp->SetLCC1SP(centerLat, centerLon, 1.0, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customLcc1sp);
     }
 
-   boost::shared_ptr<OGRSpatialReference> customRobinson(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customRobinson(new OGRSpatialReference());
     if (customRobinson->SetRobinson(centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customRobinson);
     }
 
     // custom transverse mercator
-   boost::shared_ptr<OGRSpatialReference> customTm(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customTm(new OGRSpatialReference());
     if (customTm->SetTM(centerLat, centerLon, 1.0, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customTm);
     }
 
     // Polyconic
-   boost::shared_ptr<OGRSpatialReference> customPolyconic(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customPolyconic(new OGRSpatialReference());
     if (customPolyconic->SetPolyconic(centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customPolyconic);
     }
 
     // Two Point Equidistant
-   boost::shared_ptr<OGRSpatialReference> customTped(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customTped(new OGRSpatialReference());
     if (customTped->SetTPED(stdP1, centerLon, stdP2, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customTped);
     }
 
     // Equidistant Conic
-   boost::shared_ptr<OGRSpatialReference> customEc(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customEc(new OGRSpatialReference());
     if (customEc->SetEC(stdP1, stdP2, centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customEc);
     }
 
     // Azimuthal Equidistant
-   boost::shared_ptr<OGRSpatialReference> customAe(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customAe(new OGRSpatialReference());
     if (customAe->SetAE(centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customAe);
     }
 
     // Lambert Convformal Conic
-   boost::shared_ptr<OGRSpatialReference> customLcc(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> customLcc(new OGRSpatialReference());
     if (customLcc->SetLCC(stdP1, stdP2, centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
     {
       result.push_back(customLcc);
@@ -272,7 +272,7 @@ vector<boost::shared_ptr<OGRSpatialReference> > MapProjector::createAllPlanarPro
 
 boost::shared_ptr<OGRSpatialReference> MapProjector::createOrthographic(const OGREnvelope& env)
 {
- boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
   double x = (env.MinX + env.MaxX) / 2.0;
   double y = (env.MinY + env.MaxY) / 2.0;
   if (srs->SetOrthographic(y, x, 0, 0) != OGRERR_NONE)
@@ -375,7 +375,7 @@ boost::shared_ptr<OGRSpatialReference> MapProjector::createSinusoidalProjection(
 {
   double centerLon = (env.MaxX + env.MinX) / 2.0;
 
- boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
 
   if (srs->SetSinusoidal(centerLon, 0.0, 0.0) != OGRERR_NONE)
   {
@@ -387,7 +387,7 @@ boost::shared_ptr<OGRSpatialReference> MapProjector::createSinusoidalProjection(
 
 boost::shared_ptr<OGRSpatialReference> MapProjector::createWgs84Projection()
 {
- boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
 
   // EPSG 4326 = WGS84
   // if (srs->SetWellKnownGeogCS("WGS84") != OGRERR_NONE)
@@ -400,13 +400,13 @@ boost::shared_ptr<OGRSpatialReference> MapProjector::createWgs84Projection()
 }
 
 bool MapProjector::_evaluateProjection(const OGREnvelope& env,
- boost::shared_ptr<OGRSpatialReference> srs, Meters testDistance, Meters& maxDistanceError,
+  boost::shared_ptr<OGRSpatialReference> srs, Meters testDistance, Meters& maxDistanceError,
   Radians& maxAngleError)
 {
   // Disable CPL error messages. They will be re-enabled when the DisableCplErrors object is
   // destructed.
   DisableCplErrors disableErrors;
- boost::shared_ptr<OGRSpatialReference> wgs84 = MapProjector::createWgs84Projection();
+  boost::shared_ptr<OGRSpatialReference> wgs84 = MapProjector::createWgs84Projection();
 
   auto_ptr<OGRCoordinateTransformation> t(OGRCreateCoordinateTransformation(wgs84.get(),
                                                                             srs.get()));
@@ -515,8 +515,8 @@ bool MapProjector::isGeographic(const ConstElementProviderPtr& provider)
   return provider->getProjection()->IsGeographic();
 }
 
-Coordinate MapProjector::project(const Coordinate& c,boost::shared_ptr<OGRSpatialReference> srs1,
-                           boost::shared_ptr<OGRSpatialReference> srs2)
+Coordinate MapProjector::project(const Coordinate& c, boost::shared_ptr<OGRSpatialReference> srs1,
+                                 boost::shared_ptr<OGRSpatialReference> srs2)
 {
   OGRCoordinateTransformation* t(OGRCreateCoordinateTransformation(srs1.get(), srs2.get()));
 
@@ -537,9 +537,9 @@ Coordinate MapProjector::project(const Coordinate& c,boost::shared_ptr<OGRSpatia
 }
 
 
-void MapProjector::project(boost::shared_ptr<OsmMap> map,boost::shared_ptr<OGRSpatialReference> ref)
+void MapProjector::project(boost::shared_ptr<OsmMap> map, boost::shared_ptr<OGRSpatialReference> ref)
 {
- boost::shared_ptr<OGRSpatialReference> sourceSrs = map->getProjection();
+  boost::shared_ptr<OGRSpatialReference> sourceSrs = map->getProjection();
   OGRCoordinateTransformation* t(OGRCreateCoordinateTransformation(sourceSrs.get(), ref.get()));
 
   if (t == 0)
@@ -610,7 +610,7 @@ void MapProjector::project(const boost::shared_ptr<Geometry>& g,
 
 void MapProjector::projectToAeac(boost::shared_ptr<OsmMap> map)
 {
- boost::shared_ptr<OGRSpatialReference> srs = getInstance().createAeacProjection(
+  boost::shared_ptr<OGRSpatialReference> srs = getInstance().createAeacProjection(
     CalculateMapBoundsVisitor::getBounds(map));
   project(map, srs);
 }
@@ -624,7 +624,7 @@ void MapProjector::projectToOrthographic(boost::shared_ptr<OsmMap> map)
 void MapProjector::projectToOrthographic(boost::shared_ptr<OsmMap> map, const OGREnvelope& env)
 {
   MapProjector proj;
- boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
   double x = (env.MinX + env.MaxX) / 2.0;
   double y = (env.MinY + env.MaxY) / 2.0;
   if (srs->SetOrthographic(y, x, 0, 0) != OGRERR_NONE)
@@ -647,7 +647,7 @@ void MapProjector::projectToPlanar(boost::shared_ptr<OsmMap> map, const OGREnvel
 {
   if (map->getProjection()->IsProjected() == false)
   {
-   boost::shared_ptr<OGRSpatialReference> srs = getInstance().createPlanarProjection(env);
+    boost::shared_ptr<OGRSpatialReference> srs = getInstance().createPlanarProjection(env);
     project(map, srs);
   }
 }
@@ -657,7 +657,7 @@ void MapProjector::projectToWgs84(boost::shared_ptr<OsmMap> map)
   if (isGeographic(map) == false)
   {
     MapProjector proj;
-   boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+    boost::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
     //srs->importFromEPSG(4326);
     srs->SetWellKnownGeogCS("WGS84");
     proj.project(map, srs);
@@ -667,7 +667,7 @@ void MapProjector::projectToWgs84(boost::shared_ptr<OsmMap> map)
 Coordinate MapProjector::projectFromWgs84(const Coordinate& c,
                                     boost::shared_ptr<OGRSpatialReference> srs)
 {
- boost::shared_ptr<OGRSpatialReference> wgs84(new OGRSpatialReference());
+  boost::shared_ptr<OGRSpatialReference> wgs84(new OGRSpatialReference());
   wgs84->importFromEPSG(4326);
 
   return project(c, wgs84, srs);

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
@@ -175,7 +175,7 @@ private:
 
   static bool _distanceLessThan(const PlanarTestResult& p1, const PlanarTestResult& p2);
 
-  bool _evaluateProjection(const OGREnvelope& env,boost::shared_ptr<OGRSpatialReference> srs,
+  bool _evaluateProjection(const OGREnvelope& env, boost::shared_ptr<OGRSpatialReference> srs,
     Meters testDistance, Meters& maxDistanceError, Radians& maxAngleError);
 
   size_t _findBestResult(std::vector<PlanarTestResult>& results);

--- a/hoot-core/src/main/cpp/hoot/core/util/OsmUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/OsmUtils.cpp
@@ -43,6 +43,7 @@
 #include <QDateTime>
 
 using namespace geos::geom;
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CompletelyContainedByMapElementVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CompletelyContainedByMapElementVisitor.cpp
@@ -85,12 +85,12 @@ void CompletelyContainedByMapElementVisitor::visit(const ConstElementPtr& e)
 
   if (type == ElementType::Way)
   {
-   boost::shared_ptr<const Way> w = _map->getWay(id);
+    boost::shared_ptr<const Way> w = _map->getWay(id);
     _visit(w);
   }
   else if (type == ElementType::Relation)
   {
-   ConstRelationPtr r = _map->getRelation(id);
+    ConstRelationPtr r = _map->getRelation(id);
     _visit(r);
   }
   else if (type != ElementType::Node)

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
@@ -99,7 +99,7 @@ void DecomposeBuildingRelationsVisitor::_decomposeBuilding(const boost::shared_p
     }
 
     // ok, we've got a building part. Recompose it as a building.
-   boost::shared_ptr<Element> e = _map->getElement(members[i].getElementId());
+    boost::shared_ptr<Element> e = _map->getElement(members[i].getElementId());
 
     Tags t = baseTags;
     t.addTags(e->getTags());

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementOsmMapVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementOsmMapVisitor.cpp
@@ -35,7 +35,7 @@ namespace hoot
 
 void ElementOsmMapVisitor::visit(const ConstElementPtr& e)
 {
- boost::shared_ptr<Element> ee = _map->getElement(e->getElementId());
+  boost::shared_ptr<Element> ee = _map->getElement(e->getElementId());
   visit(ee);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -86,10 +86,10 @@ public:
 private:
 
   const ElementCriterion* _criterion;
- boost::shared_ptr<ElementCriterion> _criterionDelete;
+  boost::shared_ptr<ElementCriterion> _criterionDelete;
   const OsmMap* _map;
   ElementVisitor* _visitor;
- boost::shared_ptr<ElementVisitor> _visitDelete;
+  boost::shared_ptr<ElementVisitor> _visitDelete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.cpp
@@ -39,7 +39,7 @@ namespace hoot
 
 void FindIntersectionsVisitor::visit(const ConstElementPtr& e)
 {
- boost::shared_ptr<NodeToWayMap> n2w = _map->getIndex().getNodeToWayMap();
+  boost::shared_ptr<NodeToWayMap> n2w = _map->getIndex().getNodeToWayMap();
   long id = e->getId();
 
   const set<long>& wids = n2w->getWaysByNode(id);
@@ -48,7 +48,7 @@ void FindIntersectionsVisitor::visit(const ConstElementPtr& e)
   set<long> hwids;
   for (set<long>::const_iterator it = wids.begin(); it != wids.end(); ++it)
   {
-   WayPtr w = _map->getWay(*it);
+    WayPtr w = _map->getWay(*it);
 
     if (OsmSchema::getInstance().isLinearHighway(w->getTags(), w->getElementType()))
     {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MatchCandidateCountVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MatchCandidateCountVisitor.h
@@ -58,7 +58,7 @@ public:
 
 private:
 
-  QMap<QString,boost::shared_ptr<MatchCreator> > _matchCreatorsByName;
+  QMap<QString, boost::shared_ptr<MatchCreator> > _matchCreatorsByName;
   long _candidateCount;
   QMap<QString, long> _matchCandidateCountsByMatchCreator;
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ProjectToGeographicVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ProjectToGeographicVisitor.h
@@ -53,7 +53,7 @@ public:
 private:
 
   OGRCoordinateTransformation* _transform;
- boost::shared_ptr<ReprojectCoordinateFilter> _rcf;
+  boost::shared_ptr<ReprojectCoordinateFilter> _rcf;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitor.cpp
@@ -62,13 +62,13 @@ RemoveDuplicateAreaVisitor::RemoveDuplicateAreaVisitor()
 
 boost::shared_ptr<Geometry> RemoveDuplicateAreaVisitor::_convertToGeometry(const boost::shared_ptr<Element>& e1)
 {
-  QHash<ElementId,boost::shared_ptr<Geometry> >::const_iterator it = _geoms.find(e1->getElementId());
+  QHash<ElementId, boost::shared_ptr<Geometry> >::const_iterator it = _geoms.find(e1->getElementId());
   if (it != _geoms.end())
   {
     return it.value();
   }
   ElementConverter gc(_map->shared_from_this());
- boost::shared_ptr<Geometry> g = gc.convertToGeometry(e1);
+  boost::shared_ptr<Geometry> g = gc.convertToGeometry(e1);
   _geoms[e1->getElementId()] = g;
   return g;
 }
@@ -95,8 +95,8 @@ bool RemoveDuplicateAreaVisitor::_equals(const boost::shared_ptr<Element>& e1,
   }
 
   // convert to geometry and cache as relevant.
- boost::shared_ptr<Geometry> g1 = _convertToGeometry(e1);
- boost::shared_ptr<Geometry> g2 = _convertToGeometry(e2);
+  boost::shared_ptr<Geometry> g1 = _convertToGeometry(e1);
+  boost::shared_ptr<Geometry> g2 = _convertToGeometry(e2);
 
   double a1 = g1->getArea();
   double a2 = g2->getArea();
@@ -108,7 +108,7 @@ bool RemoveDuplicateAreaVisitor::_equals(const boost::shared_ptr<Element>& e1,
   }
 
   // calculate the overlap of the areas
- boost::shared_ptr<Geometry> overlap;
+  boost::shared_ptr<Geometry> overlap;
   try
   {
     overlap =boost::shared_ptr<Geometry>(g1->intersection(g2.get()));
@@ -130,7 +130,7 @@ bool RemoveDuplicateAreaVisitor::_equals(const boost::shared_ptr<Element>& e1,
   return true;
 }
 
-void RemoveDuplicateAreaVisitor::_removeOne(boost::shared_ptr<Element> e1,boost::shared_ptr<Element> e2)
+void RemoveDuplicateAreaVisitor::_removeOne(boost::shared_ptr<Element> e1, boost::shared_ptr<Element> e2)
 {
   if (e1->getTags().size() > e2->getTags().size())
   {
@@ -178,7 +178,7 @@ void RemoveDuplicateAreaVisitor::visit(const boost::shared_ptr<Element>& e1)
     ElementId eit = *it;
     if (e1->getElementId() < eit && eit.getType() != ElementType::Node)
     {
-     boost::shared_ptr<Element> e2 = _map->getElement(*it);
+      boost::shared_ptr<Element> e2 = _map->getElement(*it);
 
       // check to see if e2 is null, it is possible that we removed it w/ a previous call to remove
       // a parent.

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitor.h
@@ -70,10 +70,10 @@ private:
 
   bool _equals(const boost::shared_ptr<Element>& e1, const boost::shared_ptr<Element> &e2);
 
-  void _removeOne(boost::shared_ptr<Element> e1,boost::shared_ptr<Element> e2);
+  void _removeOne(boost::shared_ptr<Element> e1, boost::shared_ptr<Element> e2);
 
   std::auto_ptr<TagDifferencer> _diff;
-  QHash<ElementId,boost::shared_ptr<geos::geom::Geometry> > _geoms;
+  QHash<ElementId, boost::shared_ptr<geos::geom::Geometry> > _geoms;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
@@ -78,7 +78,7 @@ public:
 private:
 
   OsmMap* _map;
- boost::shared_ptr<ElementCriterion> _filter;
+  boost::shared_ptr<ElementCriterion> _filter;
   bool _recursive;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/TranslatedTagCountVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/TranslatedTagCountVisitor.h
@@ -69,8 +69,8 @@ public:
 private:
 
   const OsmMap* _map;
- boost::shared_ptr<const Schema> _schema;
- boost::shared_ptr<ScriptToOgrTranslator> _translator;
+  boost::shared_ptr<const Schema> _schema;
+  boost::shared_ptr<ScriptToOgrTranslator> _translator;
   long _populatedCount, _defaultCount, _nullCount;
 
   void _countTags(boost::shared_ptr<Feature>& f);

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/Debug.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/Debug.cpp
@@ -1,6 +1,7 @@
 #include "Debug.h"
 
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/util/Log.h>
 
 using namespace std;
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/Driver.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/Driver.cpp
@@ -52,7 +52,7 @@ Driver::Driver()
 void Driver::_addDefaultJobSettings(pp::Job& job)
 {
   QString schemaPath = ConfPath::search("schema.json");
- boost::shared_ptr<OsmSchemaLoader> l =
+  boost::shared_ptr<OsmSchemaLoader> l =
     OsmSchemaLoaderFactory::getInstance().createLoader(schemaPath);
   OsmSchema tmp;
   LOG_INFO("Loading translation files...");

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/HadoopTileWorker.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/HadoopTileWorker.cpp
@@ -122,7 +122,7 @@ MapStats HadoopTileWorker::_calculateStats(QString in)
   if (fs.getFileStatus(in.toStdString()).isDir())
   {
     // write the newly calculated stats out to the input directory.
-   boost::shared_ptr<ostream> out(fs.create((in + "/all.stats").toStdString()));
+    boost::shared_ptr<ostream> out(fs.create((in + "/all.stats").toStdString()));
     result.write(*out);
   }
   return result;

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/HadoopTileWorker2.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/HadoopTileWorker2.cpp
@@ -136,7 +136,7 @@ MapStats HadoopTileWorker2::_calculateStats(QString in)
   if (fs.getFileStatus(in.toStdString()).isDir())
   {
     // write the newly calculated stats out to the input directory.
-   boost::shared_ptr<ostream> out(fs.create((in + "/all.stats").toStdString()));
+    boost::shared_ptr<ostream> out(fs.create((in + "/all.stats").toStdString()));
     result.write(*out);
   }
   return result;

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapMapper.cpp
@@ -44,11 +44,34 @@ void OsmMapMapper::map(HadoopPipes::MapContext& context)
     throw HootException("Error parsing start value.");
   }
 
- OsmMapPtr m(new OsmMap());
+  OsmMapPtr m(new OsmMap());
 
   _loadMap(m);
 
   _map(m, context);
+}
+
+void OsmMapMapper::emitRecord(HadoopPipes::MapContext& context, const std::string& k,
+  const ConstOsmMapPtr& m)
+{
+  std::stringstream ss(std::stringstream::out);
+  _OsmPbfWriter.writePb(m, &ss);
+  context.emit(k, ss.str());
+}
+
+void OsmMapMapper::emitRecord(HadoopPipes::MapContext& context, const std::string& k, const ConstWayPtr& w)
+{
+  std::stringstream ss(std::stringstream::out);
+  _OsmPbfWriter.writePb(w, &ss);
+  context.emit(k, ss.str());
+}
+
+void OsmMapMapper::emitRecord(HadoopPipes::MapContext& context, const std::string& k,
+  const ConstNodePtr& n)
+{
+  std::stringstream ss(std::stringstream::out);
+  _OsmPbfWriter.writePb(n, &ss);
+  context.emit(k, ss.str());
 }
 
 void OsmMapMapper::_loadMap(OsmMapPtr& m)

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapMapper.h
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapMapper.h
@@ -40,27 +40,12 @@ public:
   void map(HadoopPipes::MapContext& context);
 
   void emitRecord(HadoopPipes::MapContext& context, const std::string& k,
-    const ConstOsmMapPtr& m)
-  {
-    std::stringstream ss(std::stringstream::out);
-    _OsmPbfWriter.writePb(m, &ss);
-    context.emit(k, ss.str());
-  }
+    const ConstOsmMapPtr& m);
 
-  void emitRecord(HadoopPipes::MapContext& context, const std::string& k, const ConstWayPtr& w)
-  {
-    std::stringstream ss(std::stringstream::out);
-    _OsmPbfWriter.writePb(w, &ss);
-    context.emit(k, ss.str());
-  }
+  void emitRecord(HadoopPipes::MapContext& context, const std::string& k, const ConstWayPtr& w);
 
   void emitRecord(HadoopPipes::MapContext& context, const std::string& k,
-    const ConstNodePtr& n)
-  {
-    std::stringstream ss(std::stringstream::out);
-    _OsmPbfWriter.writePb(n, &ss);
-    context.emit(k, ss.str());
-  }
+    const ConstNodePtr& n);
 
 protected:
   std::string _path;

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapReducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapReducer.cpp
@@ -35,7 +35,7 @@ class OsmMapIterator : public pp::Iterator<OsmMapPtr >
 {
 public:
 
-  OsmMapIterator(HadoopPipes::ReduceContext* context,OsmMapPtr& map,
+  OsmMapIterator(HadoopPipes::ReduceContext* context, OsmMapPtr& map,
                  OsmPbfReader& reader) :
     _context(context),
     _map(map),

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapReducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapReducer.cpp
@@ -59,7 +59,7 @@ public:
 private:
   HadoopPipes::ReduceContext* _context;
   bool _hasNext;
- OsmMapPtr& _map;
+  OsmMapPtr& _map;
   OsmPbfReader& _reader;
 };
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/cmd/BigConflateCmd.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/cmd/BigConflateCmd.cpp
@@ -87,7 +87,7 @@ public:
       pp::Job::setDefaultJobTracker("local");
     }
 
-   boost::shared_ptr<TileWorker> worker(new HadoopTileWorker());
+    boost::shared_ptr<TileWorker> worker(new HadoopTileWorker());
     TileConflator uut(worker);
     // ~240m
     uut.setBuffer(pixelSize);

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/cmd/BigMergeNodesCmd.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/cmd/BigMergeNodesCmd.cpp
@@ -63,13 +63,13 @@ public:
       pp::Job::setDefaultJobTracker("local");
     }
 
-   boost::shared_ptr<TileWorker2> worker(new HadoopTileWorker2());
+    boost::shared_ptr<TileWorker2> worker(new HadoopTileWorker2());
     FourPassManager driver(worker);
     driver.setBuffer(pixelSize);
     driver.setMaxNodesPerBox(maxNodeCount);
     driver.setSource(in);
 
-   boost::shared_ptr<OpList> op(new OpList());
+    boost::shared_ptr<OpList> op(new OpList());
     // this will automatically reproject to planar as needed.
     op->addOp(boost::shared_ptr<OsmMapOperation>(new MergeNearbyNodes()));
     // after the op is done the reducer will automatically reproject to WGS84 as needed.

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateDriver.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateDriver.cpp
@@ -17,9 +17,10 @@
 #include "ConflateDriver.h"
 
 // Hoot
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/Settings.h>
 #include <hoot/hadoop/stats/MapStats.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateMapper.cpp
@@ -23,9 +23,10 @@
 #include <pp/conf/Configuration.h>
 
 // Hoot
-#include <hoot/core/util/GeometryUtils.h>
-#include <hoot/hadoop/Debug.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/hadoop/Debug.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -123,7 +124,7 @@ void ConflateMapper::_flush()
   key.resize(sizeof(int64_t));
   int64_t* k = (int64_t*)key.data();
   // emit all maps
-  for (QHash< int,boost::shared_ptr<OsmPbfWriter> >::iterator it = _writers.begin();
+  for (QHash< int, boost::shared_ptr<OsmPbfWriter> >::iterator it = _writers.begin();
     it != _writers.end(); ++it)
   {
     *k = it.key();
@@ -144,7 +145,7 @@ void ConflateMapper::_init(HadoopPipes::MapContext& context)
   // read the envelopes
   _envelopes = parseEnvelopes(context.getJobConf()->get(envelopesKey()));
 
- boost::shared_ptr<pp::Configuration> c(pp::HadoopPipesUtils::toConfiguration(context.getJobConf()));
+  boost::shared_ptr<pp::Configuration> c(pp::HadoopPipesUtils::toConfiguration(context.getJobConf()));
   _tileBufferSize = c->getDouble(bufferKey());
 
   // read the node replacements

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateMapper.h
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateMapper.h
@@ -52,8 +52,8 @@ public:
 
 protected:
 
-  QHash< int,boost::shared_ptr<OsmPbfWriter> > _writers;
-  QHash< int,boost::shared_ptr<std::stringstream> > _buffers;
+  QHash< int, boost::shared_ptr<OsmPbfWriter> > _writers;
+  QHash< int, boost::shared_ptr<std::stringstream> > _buffers;
   double _tileBufferSize;
 
   std::vector<geos::geom::Envelope> _envelopes;

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateReducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/conflate/ConflateReducer.cpp
@@ -17,10 +17,10 @@
 #include "ConflateReducer.h"
 
 // Hoot
-#include <hoot/core/conflate/Conflator.h>
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/OsmMap.h>
 #include <hoot/core/OsmMapListener.h>
 #include <hoot/core/algorithms/WaySplitter.h>
+#include <hoot/core/conflate/Conflator.h>
 #include <hoot/core/conflate/DuplicateNameRemover.h>
 #include <hoot/core/conflate/DuplicateWayRemover.h>
 #include <hoot/core/conflate/ImpliedDividedMarker.h>
@@ -36,9 +36,10 @@
 #include <hoot/core/ops/MergeNearbyNodes.h>
 #include <hoot/core/ops/SuperfluousNodeRemover.h>
 #include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 #include <hoot/hadoop/Debug.h>
-#include <hoot/core/OsmMap.h>
 #include <hoot/hadoop/HadoopIdGenerator.h>
 #include <hoot/hadoop/pbf/PbfRecordWriter.h>
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/convert/WriteOsmSqlStatementsDriver.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/convert/WriteOsmSqlStatementsDriver.cpp
@@ -15,14 +15,15 @@
  */
 
 // Hoot
-#include <hoot/core/util/ConfPath.h>
-#include <hoot/hadoop/pbf/PbfInputFormat.h>
-#include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/core/io/ApiDb.h>
-#include <hoot/core/util/UuidHelper.h>
 #include <hoot/core/io/OsmApiDbSqlStatementFormatter.h>
+#include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/DbUtils.h>
 #include <hoot/core/util/FileUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/UuidHelper.h>
+#include <hoot/hadoop/pbf/PbfInputFormat.h>
+#include <hoot/hadoop/pbf/PbfRecordReader.h>
 
 // Pretty Pipes
 #include <pp/mapreduce/Job.h>

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/convert/WriteOsmSqlStatementsMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/convert/WriteOsmSqlStatementsMapper.cpp
@@ -26,8 +26,9 @@
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/elements/Relation.h>
-#include <hoot/core/io/OsmApiDbSqlStatementFormatter.h>
 #include <hoot/core/elements/Tags.h>
+#include <hoot/core/io/OsmApiDbSqlStatementFormatter.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QStringBuilder>

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/fourpass/TileOpMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/fourpass/TileOpMapper.cpp
@@ -23,10 +23,11 @@
 #include <pp/conf/Configuration.h>
 
 // Hoot
-#include <hoot/hadoop/Debug.h>
-#include <hoot/core/util/GeometryUtils.h>
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/Settings.h>
+#include <hoot/hadoop/Debug.h>
 
 #include "TileOpDriver.h"
 
@@ -126,7 +127,7 @@ void TileOpMapper::_flush()
   key.resize(sizeof(int64_t));
   int64_t* k = (int64_t*)key.data();
   // emit all maps
-  for (QHash< int,boost::shared_ptr<OsmPbfWriter> >::iterator it = _writers.begin();
+  for (QHash< int, boost::shared_ptr<OsmPbfWriter> >::iterator it = _writers.begin();
     it != _writers.end(); ++it)
   {
     *k = it.key();
@@ -144,7 +145,7 @@ void TileOpMapper::_flush()
 void TileOpMapper::_init(HadoopPipes::MapContext& context)
 {
   LOG_INFO("Initializing.");
- boost::shared_ptr<pp::Configuration> c(pp::HadoopPipesUtils::toConfiguration(context.getJobConf()));
+  boost::shared_ptr<pp::Configuration> c(pp::HadoopPipesUtils::toConfiguration(context.getJobConf()));
   _tileBufferSize = c->getDouble(bufferKey());
 
   LOG_DEBUG("Serialized settings: " << c->get(TileOpDriver::settingsConfKey().toStdString(), "{}"));

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/fourpass/TileOpMapper.h
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/fourpass/TileOpMapper.h
@@ -52,8 +52,8 @@ public:
 
 protected:
 
-  QHash< int,boost::shared_ptr<OsmPbfWriter> > _writers;
-  QHash< int,boost::shared_ptr<std::stringstream> > _buffers;
+  QHash< int, boost::shared_ptr<OsmPbfWriter> > _writers;
+  QHash< int, boost::shared_ptr<std::stringstream> > _buffers;
   Degrees _tileBufferSize;
 
   std::vector<geos::geom::Envelope> _envelopes;

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/paint-nodes/PaintNodesDriver.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/paint-nodes/PaintNodesDriver.cpp
@@ -17,9 +17,10 @@
 #include "PaintNodesDriver.h"
 
 // hoot
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/Settings.h>
 #include <hoot/core/util/UuidHelper.h>
 #include <hoot/hadoop/stats/MapStats.h>
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/paint-nodes/PaintNodesMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/paint-nodes/PaintNodesMapper.cpp
@@ -17,8 +17,9 @@
 #include "PaintNodesMapper.h"
 
 // Hoot
-#include <hoot/core/util/HootException.h>
 #include <hoot/core/io/OsmPbfReader.h>
+#include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
 
 // Pretty Pipes
 #include <pp/Factory.h>

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/pbf/PbfRecordWriter.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/pbf/PbfRecordWriter.cpp
@@ -24,6 +24,9 @@
 #include <pp/Hdfs.h>
 using namespace pp;
 
+// Hoot
+#include <hoot/core/util/Log.h>
+
 // Standard
 #include <map>
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/stats/MapStats.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/stats/MapStats.cpp
@@ -224,7 +224,7 @@ void MapStats::readDir(QString dir)
       if (fn.endsWith(".stats"))
       {
         MapStats s;
-       boost::shared_ptr<istream> is(fs.open(fn.toStdString()));
+        boost::shared_ptr<istream> is(fs.open(fn.toStdString()));
         s.read(*is);
         combine(s);
         is.reset();

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/stats/MapStatsMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/stats/MapStatsMapper.cpp
@@ -17,9 +17,10 @@
 #include "MapStatsMapper.h"
 
 // Hoot
-#include <hoot/core/util/HootException.h>
-#include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/io/OsmPbfReader.h>
+#include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
 
 // Pretty Pipes
 #include <pp/Factory.h>
@@ -82,7 +83,7 @@ void MapStatsMapper::_writeStats(HadoopPipes::MapContext& context, const MapStat
         arg(partition, 5, 10, QChar('0'));
 
     LOG_INFO("Writing to: " << path);
-   boost::shared_ptr<ostream> osStats(fs.create(path.toStdString()));
+    boost::shared_ptr<ostream> osStats(fs.create(path.toStdString()));
 
     stats.write(*osStats);
   }

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin1Mapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin1Mapper.cpp
@@ -17,11 +17,12 @@
 #include "WayJoin1Mapper.h"
 
 // Hoot
-#include <hoot/core/filters/TagCriterion.h>
-#include <hoot/core/visitors/RemoveElementsVisitor.h>
-#include <hoot/hadoop/pbf/PbfRecordWriter.h>
-#include <hoot/hadoop/Debug.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/filters/TagCriterion.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/visitors/RemoveElementsVisitor.h>
+#include <hoot/hadoop/Debug.h>
+#include <hoot/hadoop/pbf/PbfRecordWriter.h>
 
 // Pretty Pipes
 #include <pp/Factory.h>
@@ -51,7 +52,7 @@ void WayJoin1Mapper::_map(OsmMapPtr& m, HadoopPipes::MapContext& context)
   int64_t* key = (int64_t*)keyStr.data();
 
   // Remove all non-roads.
- boost::shared_ptr<TagCriterion> pCrit(new TagCriterion("highway", ""));
+  boost::shared_ptr<TagCriterion> pCrit(new TagCriterion("highway", ""));
   RemoveElementsVisitor::removeWays(m, pCrit);
 
   Debug::printTroubled(m);

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin1Reducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin1Reducer.cpp
@@ -18,6 +18,7 @@
 
 // Hoot
 #include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/Debug.h>
 
 // Pretty Pipes

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2InputFormat.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2InputFormat.cpp
@@ -63,7 +63,7 @@ void WayJoin2InputFormat::_addCsqSplits(const QString& p)
     fif.setPath(p.toStdString());
     for (int i = 0; i < fif.getSplitCount(); i++)
     {
-     boost::shared_ptr<pp::InputSplit> split(fif.getSplit(i).copy());
+      boost::shared_ptr<pp::InputSplit> split(fif.getSplit(i).copy());
 
       // create a parent split and add it to the list.
       WayJoin2InputSplit parentSplit;
@@ -79,7 +79,7 @@ void WayJoin2InputFormat::_addPbfSplits(const QString& p)
   pif.setPath(p.toStdString());
   for (int i = 0; i < pif.getSplitCount(); i++)
   {
-   boost::shared_ptr<pp::InputSplit> split(pif.getSplit(i).copy());
+    boost::shared_ptr<pp::InputSplit> split(pif.getSplit(i).copy());
 
     // create a parent split and add it to the list.
     WayJoin2InputSplit parentSplit;

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2Mapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2Mapper.cpp
@@ -20,6 +20,7 @@
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmPbfWriter.h>
 #include <hoot/core/filters/TagCriterion.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/RemoveElementsVisitor.h>
 
 // Pretty Pipes

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2RecordReader.h
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2RecordReader.h
@@ -46,7 +46,7 @@ public:
 
   char getRecordType();
 
- boost::shared_ptr<OsmMap> getMap();
+  boost::shared_ptr<OsmMap> getMap();
 
   bool next(int64_t& key, WayJoin1Reducer::Value& value);
 
@@ -61,13 +61,13 @@ public:
   virtual void initialize(pp::InputSplit* split, HadoopPipes::MapContext& context);
 
 private:
- boost::shared_ptr<WayJoin2InputSplit> _split;
- boost::shared_ptr<RecordReader> _reader;
+  boost::shared_ptr<WayJoin2InputSplit> _split;
+  boost::shared_ptr<RecordReader> _reader;
 
   const pp::FileInputSplit* _csqSplit;
   const PbfInputSplit* _pbfSplit;
- boost::shared_ptr<pp::CppSeqFileRecordReader> _csqReader;
- boost::shared_ptr<PbfRecordReader> _OsmPbfReader;
+  boost::shared_ptr<pp::CppSeqFileRecordReader> _csqReader;
+  boost::shared_ptr<PbfRecordReader> _OsmPbfReader;
 };
 
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2Reducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoin2Reducer.cpp
@@ -21,13 +21,13 @@
 
 // Hoot
 #include <hoot/core/algorithms/WaySplitter.h>
+#include <hoot/core/elements/Element.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/ops/RemoveNodeOp.h>
-#include <hoot/core/util/HootException.h>
 #include <hoot/core/util/GeometryUtils.h>
-#include <hoot/hadoop/HadoopIdGenerator.h>
+#include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/Debug.h>
-#include <hoot/core/elements/Element.h>
 #include <hoot/hadoop/HadoopIdGenerator.h>
 #include <hoot/hadoop/pbf/PbfRecordWriter.h>
 

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoinDriver.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/way-join/WayJoinDriver.cpp
@@ -17,13 +17,14 @@
 #include "WayJoinDriver.h"
 
 // Hoot
+#include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/Settings.h>
+#include <hoot/core/util/UuidHelper.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/pbf/PbfRecordWriter.h>
-#include <hoot/core/util/ConfPath.h>
-#include <hoot/core/util/Settings.h>
-#include <hoot/core/util/UuidHelper.h>
 
 // Pretty Pipes
 #include <pp/Hdfs.h>

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/HadoopTileWorker2Test.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/HadoopTileWorker2Test.cpp
@@ -37,6 +37,7 @@ using namespace pp;
 #include <hoot/core/ops/MapCropper.h>
 #include <hoot/core/ops/MergeNearbyNodes.h>
 #include <hoot/core/ops/SuperfluousNodeRemover.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/conflate/ConflateDriver.h>
@@ -96,7 +97,7 @@ public:
       LOG_INFO(path);
       if (QString::fromStdString(path).endsWith(".pbf"))
       {
-       boost::shared_ptr<istream> is(fs.open(path));
+        boost::shared_ptr<istream> is(fs.open(path));
         reader.parse(is.get(), map);
       }
     }

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/HadoopTileWorkerTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/HadoopTileWorkerTest.cpp
@@ -32,6 +32,7 @@ using namespace pp;
 #include <hoot/core/conflate/TileConflator.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/conflate/ConflateDriver.h>
@@ -72,7 +73,7 @@ public:
     fs.copyFromLocal("test-files/DcTigerRoads.pbf", outDir + "in1.pbf/DcTigerRoads.pbf");
     fs.copyFromLocal("test-files/DcGisRoads.pbf", outDir + "in2.pbf/DcGisRoads.pbf");
 
-   boost::shared_ptr<TileWorker> worker(new HadoopTileWorker());
+    boost::shared_ptr<TileWorker> worker(new HadoopTileWorker());
     TileConflator uut(worker);
     // ~240m
     uut.setBuffer(8.0 / 3600.0);
@@ -83,7 +84,7 @@ public:
 
     uut.conflate(QString::fromStdString(outDir) + "HadoopTileWorkerTest.pbf");
 
-   OsmMapPtr map(new OsmMap);
+    OsmMapPtr map(new OsmMap);
     OsmPbfReader reader(true);
     reader.setUseFileStatus(true);
     std::vector<FileStatus> status = fs.listStatus(outDir + "HadoopTileWorkerTest.pbf", true);
@@ -93,7 +94,7 @@ public:
       LOG_INFO(path);
       if (QString::fromStdString(path).endsWith(".pbf"))
       {
-       boost::shared_ptr<istream> is(fs.open(path));
+        boost::shared_ptr<istream> is(fs.open(path));
         reader.parse(is.get(), map);
       }
     }

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/conflate/ConflateDriverTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/conflate/ConflateDriverTest.cpp
@@ -27,9 +27,10 @@ using namespace pp;
 #include <iostream>
 #include <stdlib.h>
 
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
-#include <hoot/core/TestUtils.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/conflate/ConflateDriver.h>
@@ -92,7 +93,7 @@ public:
     uut.conflate(QString::fromStdString(outDir) + "step2.pbf", e, 0.002,
                  QString::fromStdString(outDir) + "result.pbf");
 
-   OsmMapPtr map(new OsmMap);
+    OsmMapPtr map(new OsmMap);
     OsmPbfReader reader(true);
     reader.setUseFileStatus(true);
     std::vector<FileStatus> status = fs.listStatus(outDir + "result.pbf");
@@ -102,7 +103,7 @@ public:
       LOG_INFO(path);
       if (QString::fromStdString(path).endsWith(".pbf"))
       {
-       boost::shared_ptr<istream> is(fs.open(path));
+        boost::shared_ptr<istream> is(fs.open(path));
         reader.parse(is.get(), map);
       }
     }

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/paint-nodes/PaintNodesDriverTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/paint-nodes/PaintNodesDriverTest.cpp
@@ -27,9 +27,10 @@ using namespace pp;
 #include <iostream>
 #include <stdlib.h>
 
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
-#include <hoot/core/TestUtils.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/paint-nodes/PaintNodesDriver.h>

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/pbf/PbfInputFormatTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/pbf/PbfInputFormatTest.cpp
@@ -26,6 +26,7 @@ using namespace pp;
 #include <iostream>
 #include <stdlib.h>
 
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/paint-nodes/PaintNodesMapper.h>

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/stats/MapStatsTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/stats/MapStatsTest.cpp
@@ -21,9 +21,10 @@
 #include <cppunit/TestFixture.h>
 
 // hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
-#include <hoot/core/TestUtils.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/stats/MapStats.h>
 
 using namespace geos::geom;

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/way-join/WayJoin1Test.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/way-join/WayJoin1Test.cpp
@@ -24,6 +24,7 @@ using namespace pp;
 #include <iostream>
 #include <stdlib.h>
 
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/way-join/WayJoin1Mapper.h>

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/way-join/WayJoin2InputFormatTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/way-join/WayJoin2InputFormatTest.cpp
@@ -63,7 +63,7 @@ public:
     WayJoin1Reducer::Value v;
     int64_t wid;
 
-   boost::shared_ptr<ostream> sample(fs.create(csqIn));
+    boost::shared_ptr<ostream> sample(fs.create(csqIn));
 
     pp::CppSeqFile::Writer writer(*sample);
 

--- a/hoot-hadoop/src/test/cpp/hoot/hadoop/way-join/WayJoinDriverTest.cpp
+++ b/hoot-hadoop/src/test/cpp/hoot/hadoop/way-join/WayJoinDriverTest.cpp
@@ -27,10 +27,11 @@ using namespace pp;
 #include <iostream>
 #include <stdlib.h>
 
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Element.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
-#include <hoot/core/TestUtils.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/hadoop/pbf/PbfInputFormat.h>
 #include <hoot/hadoop/pbf/PbfRecordReader.h>
 #include <hoot/hadoop/way-join/WayJoinDriver.h>
@@ -67,7 +68,7 @@ public:
     uut.calculateWayBounds(QString::fromStdString(outDir) + "/input.pbf",
       QString::fromStdString(outDir) +  "result.pbf");
 
-   OsmMapPtr map(new OsmMap);
+    OsmMapPtr map(new OsmMap);
     OsmPbfReader reader(true);
     reader.setUseDataSourceIds(true);
     reader.setUseFileStatus(true);
@@ -78,7 +79,7 @@ public:
       LOG_INFO(path);
       if (QString::fromStdString(path).endsWith(".pbf"))
       {
-       boost::shared_ptr<istream> is(fs.open(path));
+        boost::shared_ptr<istream> is(fs.open(path));
         reader.parse(is.get(), map);
       }
     }

--- a/hoot-js/src/main/cpp/hoot/js/JavaScriptTranslator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/JavaScriptTranslator.cpp
@@ -129,11 +129,11 @@ boost::shared_ptr<Feature> JavaScriptTranslator::_createFeature(QVariantMap vm, 
   tableName = vm["tableName"].toString();
 
   // figure out which layer this feature belongs in.
- boost::shared_ptr<const Layer> layer;
+  boost::shared_ptr<const Layer> layer;
 
   for (size_t i = 0; i < _schema->getLayerCount(); ++i)
   {
-   boost::shared_ptr<const Layer> l = _schema->getLayer(i);
+    boost::shared_ptr<const Layer> l = _schema->getLayer(i);
 
     if (l->getName() == tableName)
     {
@@ -154,7 +154,7 @@ boost::shared_ptr<Feature> JavaScriptTranslator::_createFeature(QVariantMap vm, 
 
   QVariantMap attrs = vm["attrs"].toMap();
 
- boost::shared_ptr<Feature> result(new Feature(layer->getFeatureDefinition()));
+  boost::shared_ptr<Feature> result(new Feature(layer->getFeatureDefinition()));
 
 
   for (QVariantMap::const_iterator it = attrs.begin(); it != attrs.end(); ++it)
@@ -396,7 +396,7 @@ boost::shared_ptr<const Schema> JavaScriptTranslator::getOgrOutputSchema()
     if (schemaJs->IsArray())
     {
 
-     boost::shared_ptr<Schema> schema(new Schema());
+      boost::shared_ptr<Schema> schema(new Schema());
       QVariantList schemaV = toCpp<QVariant>(schemaJs).toList();
 
       for (int i = 0; i < schemaV.size(); ++i)
@@ -543,7 +543,7 @@ void JavaScriptTranslator::_parseEnumerations(LongIntegerFieldDefinition* fd, QV
 
 boost::shared_ptr<FieldDefinition> JavaScriptTranslator::_parseFieldDefinition(QVariant fieldV) const
 {
- boost::shared_ptr<FieldDefinition> result;
+  boost::shared_ptr<FieldDefinition> result;
 
   if (fieldV.canConvert(QVariant::Map) == false)
   {
@@ -700,7 +700,7 @@ boost::shared_ptr<FieldDefinition> JavaScriptTranslator::_parseFieldDefinition(Q
 
 boost::shared_ptr<Layer> JavaScriptTranslator::_parseLayer(QVariant layer) const
 {
- boost::shared_ptr<Layer> newLayer(new Layer());
+  boost::shared_ptr<Layer> newLayer(new Layer());
 
   if (layer.canConvert(QVariant::Map) == false)
   {
@@ -754,10 +754,10 @@ boost::shared_ptr<Layer> JavaScriptTranslator::_parseLayer(QVariant layer) const
   }
   set<QString> names;
   QVariantList columns = columnsV.toList();
- boost::shared_ptr<FeatureDefinition> dfd(new FeatureDefinition());
+  boost::shared_ptr<FeatureDefinition> dfd(new FeatureDefinition());
   for (int i = 0; i < columns.size(); i++)
   {
-   boost::shared_ptr<FieldDefinition> fd = _parseFieldDefinition(columns[i]);
+    boost::shared_ptr<FieldDefinition> fd = _parseFieldDefinition(columns[i]);
     if (names.find(fd->getName()) != names.end())
     {
       throw HootException("Found multiple fields with the same name. (" + fd->getName() + ")");

--- a/hoot-js/src/main/cpp/hoot/js/OsmMapJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/OsmMapJs.cpp
@@ -109,7 +109,7 @@ Handle<Value> OsmMapJs::setIdGenerator(const Arguments& args)
 
   OsmMapJs* obj = ObjectWrap::Unwrap<OsmMapJs>(args.This());
 
- boost::shared_ptr<IdGenerator> idGen =  toCpp<boost::shared_ptr<IdGenerator> >(args[0]);
+  boost::shared_ptr<IdGenerator> idGen =  toCpp<boost::shared_ptr<IdGenerator> >(args[0]);
 
   if (obj->getMap()) {
     obj->getMap()->setIdGenerator(idGen);
@@ -248,7 +248,7 @@ Handle<Value> OsmMapJs::visit(const Arguments& args)
     }
     else
     {
-     boost::shared_ptr<ElementVisitor> v =
+      boost::shared_ptr<ElementVisitor> v =
           ObjectWrap::Unwrap<ElementVisitorJs>(args[0]->ToObject())->getVisitor();
 
       map->getMap()->visitRw(*v);

--- a/hoot-js/src/main/cpp/hoot/js/OsmMapJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/OsmMapJs.h
@@ -40,20 +40,20 @@ namespace hoot
 class OsmMapJs : public node::ObjectWrap
 {
 public:
- static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Handle<v8::Object> target);
 
- static v8::Handle<v8::Object> create(ConstOsmMapPtr map);
- static v8::Handle<v8::Object> create(OsmMapPtr map);
+  static v8::Handle<v8::Object> create(ConstOsmMapPtr map);
+  static v8::Handle<v8::Object> create(OsmMapPtr map);
 
- OsmMapPtr& getMap();
- ConstOsmMapPtr& getConstMap() { return _constMap; }
+  OsmMapPtr& getMap();
+  ConstOsmMapPtr& getConstMap() { return _constMap; }
 
- bool isConst() const { return !_map.get() && _constMap.get(); }
+  bool isConst() const { return !_map.get() && _constMap.get(); }
 
 private:
- OsmMapJs();
- OsmMapJs(OsmMapPtr map);
- ~OsmMapJs();
+  OsmMapJs();
+  OsmMapJs(OsmMapPtr map);
+  ~OsmMapJs();
 
   static v8::Handle<v8::Value> clone(const v8::Arguments& args);
   static v8::Handle<v8::Value> New(const v8::Arguments& args);

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptMatchCreator.cpp
@@ -83,7 +83,7 @@ class ScriptMatchVisitor : public ElementVisitor
 public:
 
   ScriptMatchVisitor(const ConstOsmMapPtr& map, vector<const Match*>& result,
-    ConstMatchThresholdPtr mt,boost::shared_ptr<PluginContext> script) :
+    ConstMatchThresholdPtr mt, boost::shared_ptr<PluginContext> script) :
     _map(map),
     _result(result),
     _mt(mt),
@@ -300,21 +300,21 @@ public:
     LOG_DEBUG("Search radius calculation complete for " << scriptFileInfo.fileName());
   }
 
- boost::shared_ptr<HilbertRTree>& getIndex()
+  boost::shared_ptr<HilbertRTree>& getIndex()
   {
     if (!_index)
     {
       // No tuning was done, I just copied these settings from OsmMapIndex.
       // 10 children - 368
-     boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(728));
+      boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(728));
       _index.reset(new HilbertRTree(mps, 2));
 
       // Only index elements that have Status::Unknown2 and
-     boost::shared_ptr<StatusCriterion> pC1(new StatusCriterion(Status::Unknown2));
+      boost::shared_ptr<StatusCriterion> pC1(new StatusCriterion(Status::Unknown2));
       boost::function<bool (ConstElementPtr e)> f =
         boost::bind(&ScriptMatchVisitor::isMatchCandidate, this, _1);
-     boost::shared_ptr<ArbitraryCriterion> pC2(new ArbitraryCriterion(f));
-     boost::shared_ptr<ChainCriterion> pCC(new ChainCriterion());
+      boost::shared_ptr<ArbitraryCriterion> pC2(new ArbitraryCriterion(f));
+      boost::shared_ptr<ChainCriterion> pCC(new ChainCriterion());
       pCC->addCriterion(pC1);
       pCC->addCriterion(pC2);
 
@@ -386,11 +386,11 @@ private:
   size_t _maxGroupSize;
   ConstMatchThresholdPtr _mt;
   Meters _worstCircularError;
- boost::shared_ptr<PluginContext> _script;
+  boost::shared_ptr<PluginContext> _script;
   Persistent<v8::Function> _getSearchRadius;
 
   // Used for finding neighbors
- boost::shared_ptr<HilbertRTree> _index;
+  boost::shared_ptr<HilbertRTree> _index;
   deque<ElementId> _indexToEid;
 
   double _candidateDistanceSigma;
@@ -504,7 +504,7 @@ MatchCreator::Description ScriptMatchCreator::_getScriptDescription(QString path
   MatchCreator::Description result;
   result.experimental = true;
 
- boost::shared_ptr<PluginContext> script(new PluginContext());
+  boost::shared_ptr<PluginContext> script(new PluginContext());
   HandleScope handleScope;
   Context::Scope context_scope(script->getContext());
   script->loadScript(path, "plugin");

--- a/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptStatsComposer.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/js/ScriptStatsComposer.h
@@ -54,7 +54,7 @@ public:
   virtual QString compose(QList<QList<SingleStat> >& stats, const QStringList& names);
 
 private:
- boost::shared_ptr<PluginContext> _script;
+  boost::shared_ptr<PluginContext> _script;
   QString _format;
   QString _outputPath;
   QString _path;

--- a/hoot-js/src/main/cpp/hoot/js/filter/JsFunctionCriterion.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/filter/JsFunctionCriterion.cpp
@@ -67,7 +67,7 @@ bool JsFunctionCriterion::isSatisfied(const boost::shared_ptr<const Element> &e)
     Local<Value> exception = trycatch.Exception();
     if (HootExceptionJs::isHootException(exception))
     {
-     boost::shared_ptr<HootException> e = toCpp<boost::shared_ptr<HootException> >(exception);
+      boost::shared_ptr<HootException> e = toCpp<boost::shared_ptr<HootException> >(exception);
       HootExceptionThrower::getInstance().rethrowPointer(e);
     }
     else

--- a/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
@@ -128,7 +128,7 @@ void HootExceptionJs::throwAsHootException(TryCatch& tc)
 
   if (isHootException(exception))
   {
-   boost::shared_ptr<HootException> e = toCpp<boost::shared_ptr<HootException> >(exception);
+    boost::shared_ptr<HootException> e = toCpp<boost::shared_ptr<HootException> >(exception);
     HootExceptionThrower::getInstance().rethrowPointer(e);
   }
   else
@@ -178,7 +178,7 @@ v8::Handle<v8::Value> HootExceptionJs::toJSON(const v8::Arguments& args)
 {
   HandleScope scope;
 
- boost::shared_ptr<HootException> e = ObjectWrap::Unwrap<HootExceptionJs>(args.This())->getException();
+  boost::shared_ptr<HootException> e = ObjectWrap::Unwrap<HootExceptionJs>(args.This())->getException();
 
   QVariantMap m;
   m["message"] = e->getWhat();
@@ -191,7 +191,7 @@ v8::Handle<v8::Value> HootExceptionJs::toString(const v8::Arguments& args)
 {
   HandleScope scope;
 
- boost::shared_ptr<HootException> e = ObjectWrap::Unwrap<HootExceptionJs>(args.This())->getException();
+  boost::shared_ptr<HootException> e = ObjectWrap::Unwrap<HootExceptionJs>(args.This())->getException();
 
   return scope.Close(toV8(e->getWhat()));
 }

--- a/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.h
@@ -87,7 +87,7 @@ private:
 
 };
 
-inline void toCpp(v8::Handle<v8::Value> v,boost::shared_ptr<HootException>& e)
+inline void toCpp(v8::Handle<v8::Value> v, boost::shared_ptr<HootException>& e)
 {
   if (HootExceptionJs::isHootException(v))
   {

--- a/hoot-js/src/main/cpp/hoot/js/util/PopulateConsumersJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/PopulateConsumersJs.h
@@ -205,7 +205,7 @@ public:
     }
     else if (ecc != 0)
     {
-     boost::shared_ptr<JsFunctionCriterion> ecp(new JsFunctionCriterion());
+      boost::shared_ptr<JsFunctionCriterion> ecp(new JsFunctionCriterion());
       ecp->addFunction(func);
       ecc->addCriterion(ecp);
     }

--- a/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.h
@@ -47,7 +47,7 @@ class ElementVisitorJs : public node::ObjectWrap
 public:
   static void Init(v8::Handle<v8::Object> target);
 
- boost::shared_ptr<ElementVisitor> getVisitor() { return _v; }
+  boost::shared_ptr<ElementVisitor> getVisitor() { return _v; }
 
 private:
   ElementVisitorJs(ElementVisitor* v) : _v(v) {}

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
@@ -73,7 +73,7 @@ void JsFunctionVisitor::visit(const ConstElementPtr& e)
     Local<Value> exception = trycatch.Exception();
     if (HootExceptionJs::isHootException(exception))
     {
-     boost::shared_ptr<HootException> e = toCpp<boost::shared_ptr<HootException> >(exception);
+      boost::shared_ptr<HootException> e = toCpp<boost::shared_ptr<HootException> >(exception);
       HootExceptionThrower::getInstance().rethrowPointer(e);
     }
     else

--- a/hoot-js/src/test/cpp/hoot/js/JavaScriptTranslatorTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/JavaScriptTranslatorTest.cpp
@@ -42,6 +42,7 @@
 #include <hoot/core/io/schema/FeatureDefinition.h>
 #include <hoot/core/io/schema/FieldDefinition.h>
 #include <hoot/core/io/schema/Schema.h>
+#include <hoot/core/util/Log.h>
 
 #include <hoot/core/TestUtils.h>
 
@@ -189,7 +190,7 @@ public:
       boost::shared_ptr<const FeatureDefinition> fd = l->getFeatureDefinition();
       for (size_t j = 0; j < fd->getFieldCount(); j++)
       {
-       boost::shared_ptr<const FieldDefinition> f = fd->getFieldDefinition(j);
+        boost::shared_ptr<const FieldDefinition> f = fd->getFieldDefinition(j);
         result += sep1 + "  " + f->toString() + sep2 + "\n";
       }
     }

--- a/hoot-js/src/test/cpp/hoot/js/PluginContextTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/PluginContextTest.cpp
@@ -50,7 +50,7 @@ public:
 
   void basicTest()
   {
-   boost::shared_ptr<PluginContext> _pc(new PluginContext());
+    boost::shared_ptr<PluginContext> _pc(new PluginContext());
     HandleScope handleScope;
     Context::Scope context_scope(_pc->getContext());
 

--- a/hoot-js/src/test/cpp/hoot/js/conflate/js/ScriptMatchTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/js/ScriptMatchTest.cpp
@@ -69,7 +69,7 @@ public:
     // create the test scenario in ScriptMatchTest
     // call ScriptMatch is consistent repeatedly.
 
-   boost::shared_ptr<const MatchThreshold> mt(new MatchThreshold(0.6, 0.6, 0.6));
+    boost::shared_ptr<const MatchThreshold> mt(new MatchThreshold(0.6, 0.6, 0.6));
 
     ScriptMatchCreator smc;
     smc.setArguments(QStringList() << "LineStringGenericTest.js");

--- a/hoot-js/src/test/cpp/hoot/js/util/UuidHelperJsTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/util/UuidHelperJsTest.cpp
@@ -90,7 +90,7 @@ public:
 
   void uuidHashTest()
   {
-   boost::shared_ptr<PluginContext> _pc(new PluginContext());
+    boost::shared_ptr<PluginContext> _pc(new PluginContext());
     HandleScope handleScope;
     Context::Scope context_scope(_pc->getContext());
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/CumulativeConflator.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/CumulativeConflator.cpp
@@ -29,15 +29,16 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/visitors/SetTagVisitor.h>
-#include <hoot/core/util/MetadataTags.h>
-#include <hoot/rnd/visitors/KeepReviewsVisitor.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/ops/NamedOp.h>
 #include <hoot/core/conflate/UnifyingConflator.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/ops/NamedOp.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/util/MetadataTags.h>
+#include <hoot/core/visitors/SetTagVisitor.h>
+#include <hoot/rnd/visitors/KeepReviewsVisitor.h>
 
 namespace hoot
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/frechet/FrechetSublineMatcher.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/frechet/FrechetSublineMatcher.cpp
@@ -81,8 +81,8 @@ WaySublineMatchString FrechetSublineMatcher::findMatch(const ConstOsmMapPtr& map
     //  Calculate the score (max length of both sublines)
     if (sub1->getNodeCount() > 1 && sub2->getNodeCount() > 1)
     {
-     boost::shared_ptr<LineString> ls1 = ElementConverter(mapCopy).convertToLineString(sub1);
-     boost::shared_ptr<LineString> ls2 = ElementConverter(mapCopy).convertToLineString(sub2);
+      boost::shared_ptr<LineString> ls1 = ElementConverter(mapCopy).convertToLineString(sub1);
+      boost::shared_ptr<LineString> ls2 = ElementConverter(mapCopy).convertToLineString(sub2);
       if (ls1->isValid() && ls2->isValid())
       {
         score = min(ls1->getLength(), ls2->getLength());

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeLocation.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeLocation.cpp
@@ -27,6 +27,7 @@
 #include "EdgeLocation.h"
 
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
+#include <hoot/core/util/Log.h>
 
 using namespace std;
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeLocation.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeLocation.h
@@ -77,7 +77,7 @@ public:
 
   bool isValid() const { return _portion >= 0.0 && _portion <= 1.0; }
 
- boost::shared_ptr<EdgeLocation> move(const ConstElementProviderPtr& provider, Meters distance) const;
+  boost::shared_ptr<EdgeLocation> move(const ConstElementProviderPtr& provider, Meters distance) const;
 
   QString toString() const;
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeMatch.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeMatch.h
@@ -49,7 +49,7 @@ public:
 
   EdgeMatch(ConstEdgeStringPtr es1, ConstEdgeStringPtr es2);
 
- boost::shared_ptr<EdgeMatch> clone() const;
+  boost::shared_ptr<EdgeMatch> clone() const;
 
   /**
    * Returns true if the specified edge is in either the first or second edge string.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeString.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeString.h
@@ -108,7 +108,7 @@ public:
    */
   ConstEdgeLocationPtr calculateNearestLocation(ConstEdgeLocationPtr el) const;
 
- boost::shared_ptr<EdgeString> clone() const;
+  boost::shared_ptr<EdgeString> clone() const;
 
   /**
    * Returns true if the entire string in other is contained by this.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeSubline.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/EdgeSubline.h
@@ -48,7 +48,7 @@ public:
 
   Meters calculateLength(const ConstElementProviderPtr& provider) const;
 
- boost::shared_ptr<EdgeSubline> clone() const;
+  boost::shared_ptr<EdgeSubline> clone() const;
 
   bool contains(ConstNetworkVertexPtr v) const;
 
@@ -111,7 +111,7 @@ public:
    * Returns a new subline that combines this and other. This and other must touch. If they are
    * going in different directions then the direction of this will be maintained.
    */
- boost::shared_ptr<EdgeSubline> unionSubline(boost::shared_ptr<const EdgeSubline> other) const;
+  boost::shared_ptr<EdgeSubline> unionSubline(boost::shared_ptr<const EdgeSubline> other) const;
 
 private:
   ConstEdgeLocationPtr _start, _end;

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IndexedEdgeMatchSet.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IndexedEdgeMatchSet.cpp
@@ -82,7 +82,7 @@ void IndexedEdgeMatchSet::_addVertexToMatchMapping(ConstEdgeStringPtr str,
 
 boost::shared_ptr<IndexedEdgeLinks> IndexedEdgeMatchSet::calculateEdgeLinks()
 {
- boost::shared_ptr<IndexedEdgeLinks> result(new IndexedEdgeLinks());
+  boost::shared_ptr<IndexedEdgeLinks> result(new IndexedEdgeLinks());
   for (QHash<ConstEdgeMatchPtr, double>::const_iterator it = getAllMatches().begin();
        it != getAllMatches().end(); ++it)
   {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IndexedEdgeMatchSet.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IndexedEdgeMatchSet.h
@@ -50,9 +50,9 @@ public:
    */
   void addEdgeMatch(const ConstEdgeMatchPtr& em, double score);
 
- boost::shared_ptr<IndexedEdgeLinks> calculateEdgeLinks();
+  boost::shared_ptr<IndexedEdgeLinks> calculateEdgeLinks();
 
- boost::shared_ptr<IndexedEdgeMatchSet> clone() const;
+  boost::shared_ptr<IndexedEdgeMatchSet> clone() const;
 
   /**
    * Returns true if the specified element (or the reversed equivalent) is contained in this set.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/LegacyVertexMatcher.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/LegacyVertexMatcher.cpp
@@ -29,6 +29,7 @@
 // hoot
 #include <hoot/core/conflate/NodeMatcher.h>
 #include <hoot/core/conflate/polygon/extractors/EuclideanDistanceExtractor.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/rnd/conflate/network/SearchRadiusProvider.h>
 
 // tgs
@@ -109,7 +110,7 @@ void LegacyVertexMatcher::_createVertexIndex(const OsmNetwork::VertexMap& vm,
 {
   // No tuning was done, I just copied these settings from OsmMapIndex.
   // 10 children = 368 bytes
- boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(728));
+  boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(728));
   _vertex2Index.reset(new HilbertRTree(mps, 2));
 
   std::vector<Box> boxes;

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkDetails.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkDetails.h
@@ -179,10 +179,10 @@ public:
   virtual void setConfiguration(const Settings& conf);
 
 private:
- boost::shared_ptr<HighwayClassifier> _classifier;
+  boost::shared_ptr<HighwayClassifier> _classifier;
   ConstOsmMapPtr _map;
   ConstOsmNetworkPtr _n1, _n2;
- boost::shared_ptr<SublineStringMatcher> _sublineMatcher;
+  boost::shared_ptr<SublineStringMatcher> _sublineMatcher;
   LegacyVertexMatcherPtr _vertexMatcher;
 
   class SublineCache

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkEdge.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkEdge.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "NetworkEdge.h"
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkEdge.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/NetworkEdge.cpp
@@ -26,6 +26,7 @@
  */
 #include "NetworkEdge.h"
 
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/ElementConverter.h>
 
 namespace hoot

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/OsmNetworkExtractor.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/OsmNetworkExtractor.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/elements/ElementVisitor.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/util/Log.h>
 
 using namespace std;
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/frechet/FrechetSublineMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/frechet/FrechetSublineMatcherTest.cpp
@@ -34,13 +34,13 @@
 // GEOS
 #include <geos/geom/LineString.h>
 // Hoot
-#include <hoot/rnd/conflate/frechet/FrechetSublineMatcher.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/core/visitors/FindWaysVisitor.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-
-#include <hoot-core-test/src/test/cpp/hoot/core/TestUtils.h>
+#include <hoot/core/visitors/FindWaysVisitor.h>
+#include <hoot/rnd/conflate/frechet/FrechetSublineMatcher.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -127,7 +127,7 @@ public:
   void runCircleTest()
   {
     Settings s;
-   OsmMapPtr map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
     OsmMap::resetCounters();
     OsmXmlReader reader;
     reader.read("test-files/algorithms/MaximalSublineCircleTestIn.osm", map);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeSublineMatchTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeSublineMatchTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeSublineMatchTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeSublineMatchTest.cpp
@@ -26,8 +26,9 @@
  */
 
 // Hoot
-#include <hoot/rnd/conflate/network/EdgeSublineMatch.h>
 #include <hoot/core/TestUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/rnd/conflate/network/EdgeSublineMatch.h>
 
 namespace hoot
 {

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/NetworkEdgeTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/NetworkEdgeTest.cpp
@@ -27,9 +27,10 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/rnd/conflate/network/NetworkEdge.h>
 #include <hoot/core/elements/Node.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/conflate/network/NetworkEdge.h>
 
 using namespace geos::geom;
 
@@ -66,7 +67,7 @@ public:
     OGREnvelope env;
     env.MinX = env.MinY = 0.0;
     env.MaxX = env.MaxY = 2.0;
-   boost::shared_ptr<OGRSpatialReference> sref = MapProjector::getInstance().
+    boost::shared_ptr<OGRSpatialReference> sref = MapProjector::getInstance().
         createPlanarProjection(env);
     OsmMapPtr pMap(new OsmMap(sref));
     pMap->addElement(pN1);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/NetworkVertexTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/NetworkVertexTest.cpp
@@ -27,8 +27,9 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/rnd/conflate/network/NetworkVertex.h>
 #include <hoot/core/elements/Node.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/rnd/conflate/network/NetworkVertex.h>
 
 using namespace geos::geom;
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/OsmNetworkExtractorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/OsmNetworkExtractorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/OsmNetworkExtractorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/OsmNetworkExtractorTest.cpp
@@ -29,6 +29,7 @@
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/filters/HighwayCriterion.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
 namespace hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/OsmNetworkTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/OsmNetworkTest.cpp
@@ -27,8 +27,9 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/rnd/conflate/network/OsmNetwork.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/conflate/network/OsmNetwork.h>
 
 using namespace geos::geom;
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/visitors/MatchCandidateCountVisitorRndTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/visitors/MatchCandidateCountVisitorRndTest.cpp
@@ -69,7 +69,7 @@ public:
   void runMatchCandidateCountTest()
   {
     OsmXmlReader reader;
-   OsmMapPtr map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
     OsmMap::resetCounters();
     reader.setDefaultStatus(Status::Unknown1);
     reader.read("test-files/conflate/unified/AllDataTypesA.osm", map);

--- a/pretty-pipes/pp-lib/src/main/cpp/pp/mapreduce/LocalJobRunner.cpp
+++ b/pretty-pipes/pp-lib/src/main/cpp/pp/mapreduce/LocalJobRunner.cpp
@@ -60,7 +60,7 @@ namespace pp
 class LocalMapContext : public HadoopPipes::MapContext, public RecordReaderProvider
 {
 public:
-  LocalMapContext(Configuration* conf,boost::shared_ptr<HadoopPipes::RecordReader> reader,
+  LocalMapContext(Configuration* conf, boost::shared_ptr<HadoopPipes::RecordReader> reader,
     LocalJobRunner::ShuffleMap& shuffle, const InputSplit& is) :
     _conf(conf),
     _is(is),
@@ -114,7 +114,7 @@ private:
   string _empty;
   string _isStr;
   string _key;
- boost::shared_ptr<HadoopPipes::RecordReader> _reader;
+  boost::shared_ptr<HadoopPipes::RecordReader> _reader;
   LocalJobRunner::ShuffleMap& _shuffle;
   string _value;
 
@@ -139,7 +139,7 @@ private:
 class LocalReduceContext : public HadoopPipes::ReduceContext, public RecordWriterProvider
 {
 public:
-  LocalReduceContext(Configuration* conf,boost::shared_ptr<HadoopPipes::RecordWriter> writer) :
+  LocalReduceContext(Configuration* conf, boost::shared_ptr<HadoopPipes::RecordWriter> writer) :
     _conf(conf),
     _writer(writer)
   {
@@ -201,7 +201,7 @@ private:
   Configuration* _conf;
   string _empty;
   string _key;
- boost::shared_ptr<HadoopPipes::RecordWriter> _writer;
+  boost::shared_ptr<HadoopPipes::RecordWriter> _writer;
   vector<QByteArray>::const_iterator _it;
   string _value;
   const vector<QByteArray>* _values;
@@ -248,7 +248,7 @@ void LocalJobRunner::run()
   {
     // if there are no reducers then just write the output.
     ShuffleMap::iterator it = _shuffle.begin();
-   boost::shared_ptr<pp::RecordWriter> writer;
+    boost::shared_ptr<pp::RecordWriter> writer;
 
     writer.reset(Factory::getInstance().constructObject<pp::RecordWriter>(
       _conf.get(PP_RECORD_WRITER, LineRecordWriter::className())));
@@ -279,7 +279,7 @@ void LocalJobRunner::run()
 
 void LocalJobRunner::_runMapper()
 {
- boost::shared_ptr<pp::InputFormat> inputFormat(Factory::getInstance().
+  boost::shared_ptr<pp::InputFormat> inputFormat(Factory::getInstance().
     constructObject<pp::InputFormat>(_conf.get(PP_INPUT_FORMAT, FileInputFormat::className())));
   inputFormat->setConfiguration(_conf);
 
@@ -293,10 +293,10 @@ void LocalJobRunner::_runMapper()
     }
 
     // create a new mapper for each split
-   boost::shared_ptr<pp::Mapper> mapper(Factory::getInstance().
+    boost::shared_ptr<pp::Mapper> mapper(Factory::getInstance().
       constructObject<pp::Mapper>(conf.get(PP_MAPPER, NullMapper::className())));
 
-   boost::shared_ptr<pp::RecordReader> reader(
+    boost::shared_ptr<pp::RecordReader> reader(
       Factory::getInstance().constructObject<pp::RecordReader>(
       conf.get(PP_RECORD_READER, LineRecordReader::className())));
 
@@ -339,8 +339,8 @@ void LocalJobRunner::_runReducer()
   int reduceSize = _shuffle.size() / _reducerCount + 1;
   for (int i = 0; i < _reducerCount; i++)
   {
-   boost::shared_ptr<pp::Reducer> reducer;
-   boost::shared_ptr<pp::RecordWriter> writer;
+    boost::shared_ptr<pp::Reducer> reducer;
+    boost::shared_ptr<pp::RecordWriter> writer;
 
     reducer.reset(Factory::getInstance().
       constructObject<pp::Reducer>(_conf.get(PP_REDUCER, NullReducer::className())));

--- a/pretty-pipes/pp-lib/src/test/cpp/pp/io/LineRecordReaderTest.cpp
+++ b/pretty-pipes/pp-lib/src/test/cpp/pp/io/LineRecordReaderTest.cpp
@@ -70,7 +70,7 @@ public:
       hdfs.remove(fn);
     }
 
-   boost::shared_ptr<ostream> osPtr(hdfs.create(fn));
+    boost::shared_ptr<ostream> osPtr(hdfs.create(fn));
     ostream& os = *osPtr;
 
     int count = 5000;

--- a/pretty-pipes/pp-lib/src/test/cpp/pp/io/LineRecordWriterTest.cpp
+++ b/pretty-pipes/pp-lib/src/test/cpp/pp/io/LineRecordWriterTest.cpp
@@ -79,7 +79,7 @@ public:
       uut.emitRecord(key.data(), key.size(), value.data(), value.size());
     }
 
-   boost::shared_ptr<istream> is(fs.open("test-output/LineRecordWriterTest/output/part-00000.txt"));
+    boost::shared_ptr<istream> is(fs.open("test-output/LineRecordWriterTest/output/part-00000.txt"));
     char buffer[1000] = { '\0' };
     is->read(buffer, 1000);
     string output(buffer);

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/BasicMathCalculatorNode.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/BasicMathCalculatorNode.cpp
@@ -43,8 +43,8 @@ namespace Tgs
 
   double BinaryCalculatorNode::getOutput(const int uid) const
   {
-   boost::shared_ptr<CalculatorGenomeNode> v1 = getInput(V1());
-   boost::shared_ptr<CalculatorGenomeNode> v2 = getInput(V2());
+    boost::shared_ptr<CalculatorGenomeNode> v1 = getInput(V1());
+    boost::shared_ptr<CalculatorGenomeNode> v2 = getInput(V2());
     return _calculate(v1->getOutput(uid), v2->getOutput(uid));
   }
   
@@ -61,7 +61,7 @@ namespace Tgs
 
   double UnaryCalculatorNode::getOutput(const int uid) const
   {
-   boost::shared_ptr<CalculatorGenomeNode> v1 = getInput(V1());
+    boost::shared_ptr<CalculatorGenomeNode> v1 = getInput(V1());
     return _calculate(v1->getOutput(uid));
   }
 

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/CalculatorGenome.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/CalculatorGenome.cpp
@@ -215,7 +215,7 @@ namespace Tgs
   }
 
   void CalculatorGenome::crossoverSexually(const Genome& father, const Genome& mother, 
-    boost::shared_ptr<Genome>& brother,boost::shared_ptr<Genome>& sister)
+    boost::shared_ptr<Genome>& brother, boost::shared_ptr<Genome>& sister)
   {
     boost::shared_ptr<CalculatorGenome> bro = boost::dynamic_pointer_cast<CalculatorGenome>(father.clone());
     boost::shared_ptr<CalculatorGenome> sis = boost::dynamic_pointer_cast<CalculatorGenome>(mother.clone());
@@ -262,7 +262,7 @@ namespace Tgs
   }
 
   boost::shared_ptr<CalculatorGenomeNode> CalculatorGenome::_findParent(
-    boost::shared_ptr<CalculatorGenomeNode> node,boost::shared_ptr<CalculatorGenomeNode> current) const
+    boost::shared_ptr<CalculatorGenomeNode> node, boost::shared_ptr<CalculatorGenomeNode> current) const
   {
     if (current == NULL)
     {
@@ -371,7 +371,7 @@ namespace Tgs
     setInvalidScore();
   }
 
-  void CalculatorGenome::_mutate(double p,boost::shared_ptr<CalculatorGenomeNode> node)
+  void CalculatorGenome::_mutate(double p, boost::shared_ptr<CalculatorGenomeNode> node)
   {
     double r = Tgs::Random::instance()->generateUniform();
 

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/CfsFitnessFunction.h
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/CfsFitnessFunction.h
@@ -64,9 +64,9 @@ namespace Tgs
   private:
 
     double _baseScore;
-   boost::shared_ptr<DataFrame> _baseCopy;
+    boost::shared_ptr<DataFrame> _baseCopy;
     std::vector<int> _baseUids;
-   boost::shared_ptr<DataFrame> _workingCopy;
+    boost::shared_ptr<DataFrame> _workingCopy;
     std::vector<int> _workingUids;
     std::vector<boost::shared_ptr<CalculatorGenome> > _features;
     int _workingFactor;
@@ -74,7 +74,7 @@ namespace Tgs
     /**
      * Add one empty factor to the specified data frame.
      */
-   boost::shared_ptr<DataFrame> _addOneFactor(boost::shared_ptr<DataFrame> df);
+    boost::shared_ptr<DataFrame> _addOneFactor(boost::shared_ptr<DataFrame> df);
 
     void _loadGenome(const CalculatorGenome& genome);
   };

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/FeatureScoreFitnessFunction.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/FeatureScoreFitnessFunction.cpp
@@ -41,7 +41,7 @@ using namespace std;
 namespace Tgs
 {
   FeatureScoreFitnessFunction::FeatureScoreFitnessFunction(boost::shared_ptr<DataFrame> df, 
-   boost::shared_ptr<FeatureScoreCalculator> fsc)
+    boost::shared_ptr<FeatureScoreCalculator> fsc)
   {
     _workingCopy.reset(new DataFrame());
     std::vector<std::string> factorLabels;

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/FeatureScoreFitnessFunction.h
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/FeatureScoreFitnessFunction.h
@@ -43,7 +43,7 @@ namespace Tgs
   {
   public:
 
-    FeatureScoreFitnessFunction(boost::shared_ptr<DataFrame> df,boost::shared_ptr<FeatureScoreCalculator> fsc);
+    FeatureScoreFitnessFunction(boost::shared_ptr<DataFrame> df, boost::shared_ptr<FeatureScoreCalculator> fsc);
 
     virtual ~FeatureScoreFitnessFunction();
 
@@ -51,8 +51,8 @@ namespace Tgs
   
   private:
 
-   boost::shared_ptr<DataFrame> _workingCopy;
-   boost::shared_ptr<FeatureScoreCalculator> _fsc;
+    boost::shared_ptr<DataFrame> _workingCopy;
+    boost::shared_ptr<FeatureScoreCalculator> _fsc;
   };
 }
 

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/GeneticAlgorithm.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/GeneticAlgorithm.cpp
@@ -44,7 +44,7 @@ using namespace std;
 
 namespace Tgs
 {
-  GeneticAlgorithm::GeneticAlgorithm(boost::shared_ptr<Genome> seed,boost::shared_ptr<FitnessFunction> fitness)
+  GeneticAlgorithm::GeneticAlgorithm(boost::shared_ptr<Genome> seed, boost::shared_ptr<FitnessFunction> fitness)
   {
     _seed = seed;
     _fitness = fitness;

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/GeneticAlgorithm.h
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/GeneticAlgorithm.h
@@ -81,7 +81,7 @@ namespace Tgs
   {
   public:
 
-    GeneticAlgorithm(boost::shared_ptr<Genome> seed,boost::shared_ptr<FitnessFunction> fitness);
+    GeneticAlgorithm(boost::shared_ptr<Genome> seed, boost::shared_ptr<FitnessFunction> fitness);
 
     virtual ~GeneticAlgorithm();
 
@@ -92,7 +92,7 @@ namespace Tgs
 
     void enableScoreCaching() { _scoreCaching = true; }
 
-   boost::shared_ptr<Genome> getBestGenome() const { return _best; }
+    boost::shared_ptr<Genome> getBestGenome() const { return _best; }
 
     const std::vector<boost::shared_ptr<Genome> >& getPopulation() const { return _population; }
 
@@ -138,12 +138,12 @@ namespace Tgs
 
   private:
     /// the very first genome
-   boost::shared_ptr<Genome> _seed;
+    boost::shared_ptr<Genome> _seed;
     /// the best genome
-   boost::shared_ptr<Genome> _best;
+    boost::shared_ptr<Genome> _best;
     /// number of new genomes to create at each iteration
     int _freshMeat;
-   boost::shared_ptr<FitnessFunction> _fitness;
+    boost::shared_ptr<FitnessFunction> _fitness;
     bool _initialized;
 
     int _populationSize;

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/MimicGa.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/MimicGa.cpp
@@ -41,7 +41,7 @@ using namespace std;
 
 namespace Tgs
 {
-  MimicGa::MimicGa(boost::shared_ptr<Genome> seed,boost::shared_ptr<FitnessFunction> fitness) :
+  MimicGa::MimicGa(boost::shared_ptr<Genome> seed, boost::shared_ptr<FitnessFunction> fitness) :
     GeneticAlgorithm(seed, fitness)
   {
     _thetaPercentile = .5;

--- a/tgs/src/main/cpp/tgs/FeatureExtraction/MimicGa.h
+++ b/tgs/src/main/cpp/tgs/FeatureExtraction/MimicGa.h
@@ -51,7 +51,7 @@ namespace Tgs
   {
   public:
 
-    MimicGa(boost::shared_ptr<Genome> seed,boost::shared_ptr<FitnessFunction> fitness);
+    MimicGa(boost::shared_ptr<Genome> seed, boost::shared_ptr<FitnessFunction> fitness);
 
     virtual ~MimicGa();
 

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
@@ -75,7 +75,7 @@ HilbertRTree* BaseInterpolator::_getIndex() const
   {
     const DataFrame& df = *_df;
     // 8 children was picked experimentally with two dimensions.
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(
       BoxInternalData::size(_indColumns.size()) * 8 + sizeof(int) * 4));
     _index.reset(new HilbertRTree(mps, _indColumns.size()));
 
@@ -139,7 +139,7 @@ void BaseInterpolator::readInterpolator(QIODevice& is)
   ds >> qb;
   string str = QString::fromUtf8(qb.constData()).toStdString();
   stringstream ss(str);
- boost::shared_ptr<DataFrame> df(new DataFrame());
+  boost::shared_ptr<DataFrame> df(new DataFrame());
   df->import(ss);
   _df = df;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.cpp
@@ -40,15 +40,15 @@ namespace Tgs
   {
   }
 
- boost::shared_ptr<Page> MemoryPageStore::createPage()
+  boost::shared_ptr<Page> MemoryPageStore::createPage()
   {
     char* data = Page::allocateAligned(_pageSize);
-   boost::shared_ptr<Page> newPage(_createPage(this, (int)_pages.size(), data, _pageSize));
+    boost::shared_ptr<Page> newPage(_createPage(this, (int)_pages.size(), data, _pageSize));
     _pages.push_back(newPage);
     return newPage;
   }
 
- boost::shared_ptr<Page> MemoryPageStore::getPage(int id)
+  boost::shared_ptr<Page> MemoryPageStore::getPage(int id)
   {
     assert(id >= 0 && id <= (int)_pages.size());
     return _pages[id];

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
@@ -239,7 +239,7 @@ namespace Tgs
     double _p;
     RTreeNodeStore _store;
     Header* _headerStruct;
-   boost::shared_ptr<Page> _header;
+    boost::shared_ptr<Page> _header;
     /// Levels that have been treated for overflow during this insert.
     std::set<int> _overflowedLevels;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
@@ -255,7 +255,7 @@ namespace Tgs
       char* getBox() { return ((char*)&id) + 4; }
     };
 
-    RTreeNode(int dimensions,boost::shared_ptr<Page> page);
+    RTreeNode(int dimensions, boost::shared_ptr<Page> page);
     /**
      * Return the start of the child's data. This includes the box (BoxInternalData) and the 
      * index.

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNodeStore.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNodeStore.cpp
@@ -34,7 +34,7 @@ namespace Tgs
 {
   const int MAX_NODE_COUNT = 100000;
 
-  RTreeNodeStore::RTreeNodeStore(int dimensions,boost::shared_ptr<PageStore> ps)
+  RTreeNodeStore::RTreeNodeStore(int dimensions, boost::shared_ptr<PageStore> ps)
   {
     _dimensions = dimensions;
     _storeSp = ps;
@@ -60,7 +60,7 @@ namespace Tgs
 
   RTreeNode* RTreeNodeStore::createNode()
   {
-   boost::shared_ptr<Page> page = _store->createPage();
+    boost::shared_ptr<Page> page = _store->createPage();
     page->setDirty();
     RTreeNode* node = new RTreeNode(_dimensions, page);
     node->clear();
@@ -83,7 +83,7 @@ namespace Tgs
     if (it == _availableNodes.end())
     {
       RTreeNodeStore* me = const_cast<RTreeNodeStore*>(this);
-     boost::shared_ptr<Page> page = me->_store->getPage(id);
+      boost::shared_ptr<Page> page = me->_store->getPage(id);
       node = new RTreeNode(_dimensions, page);
       RecItem * item = new RecItem();
       item->pNode = node;
@@ -115,7 +115,7 @@ namespace Tgs
     }
     else
     {
-     boost::shared_ptr<Page> page = _store->getPage(id);
+      boost::shared_ptr<Page> page = _store->getPage(id);
       node = new RTreeNode(_dimensions, page);
       RecItem * item = new RecItem();
       item->pNode = node;

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNodeStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNodeStore.h
@@ -47,7 +47,7 @@ namespace Tgs
   {
   public:
 
-    RTreeNodeStore(int dimensions,boost::shared_ptr<PageStore> ps);
+    RTreeNodeStore(int dimensions, boost::shared_ptr<PageStore> ps);
 
     ~RTreeNodeStore();
     
@@ -88,7 +88,7 @@ namespace Tgs
     // mutable cache
     NodeMap _availableNodes;
     int _dimensions;
-   boost::shared_ptr<PageStore> _storeSp;
+    boost::shared_ptr<PageStore> _storeSp;
     /// pointer to the same thing as above, only faster. Zoom zoom!
     PageStore* _store;
 

--- a/tgs/src/test/cpp/tgs/FeatureExtraction/CalculatorGenomeTest.cpp
+++ b/tgs/src/test/cpp/tgs/FeatureExtraction/CalculatorGenomeTest.cpp
@@ -136,18 +136,18 @@ namespace Tgs
 
       for (unsigned int i = 0; i < 10; i++)
       {
-       boost::shared_ptr<CalculatorGenome> father(new CalculatorGenome());
+        boost::shared_ptr<CalculatorGenome> father(new CalculatorGenome());
         father->addBasicMathNodeTypes();
         father->addNodeType(new VectorCalculatorNodeSource(v), "VectorCalculatorNodeSource", 1.0);
         father->initialize();
         cout << "dad: " << father->toString() << endl;
 
-       boost::shared_ptr<CalculatorGenome> mother =
+        boost::shared_ptr<CalculatorGenome> mother =
           boost::dynamic_pointer_cast<CalculatorGenome>(father->clone());
         mother->initialize();
         cout << "mom: " << mother->toString() << endl;
 
-       boost::shared_ptr<Genome> brother, sister;
+        boost::shared_ptr<Genome> brother, sister;
         father->crossoverSexually(*father, *mother, brother, sister);
 
         cout << "bro: " << brother->toString() << endl;
@@ -285,9 +285,9 @@ namespace Tgs
 
       double vweight = 1.0 / (VARIABLE_SIZE + 2) * (params.find("variableWeight")->second.value);
 
-     boost::shared_ptr<SimpleFitness> fitness(new SimpleFitness(v1, v2));
+      boost::shared_ptr<SimpleFitness> fitness(new SimpleFitness(v1, v2));
 
-     boost::shared_ptr<CalculatorGenome> genome(new CalculatorGenome());
+      boost::shared_ptr<CalculatorGenome> genome(new CalculatorGenome());
       genome->addBasicMathNodeTypes();
       VectorCalculatorNodeSource* good1 = new VectorCalculatorNodeSource(v1);
       good1->setLabel("v1[]");
@@ -309,7 +309,7 @@ namespace Tgs
         {
           bad.push_back(Tgs::Random::instance()->generateInt());
         }
-       boost::shared_ptr<VectorCalculatorNodeSource> src(new VectorCalculatorNodeSource(bad));
+        boost::shared_ptr<VectorCalculatorNodeSource> src(new VectorCalculatorNodeSource(bad));
         src->setLabel(strm.str() + "[]");
         genome->addNodeType(src, strm.str(), vweight);
         badGenome.push_back(src);
@@ -347,7 +347,7 @@ namespace Tgs
 
         ga.step();
         c+= ga.getPopulation().size();
-       boost::shared_ptr<CalculatorGenome> best =
+        boost::shared_ptr<CalculatorGenome> best =
           boost::dynamic_pointer_cast<CalculatorGenome>(ga.getBestGenome());
         score = best->getScore();
         //cout << "individuals: " << c << "\r";
@@ -388,14 +388,14 @@ namespace Tgs
     {
       for (unsigned int i = 0; i < 10; i++)
       {
-       boost::shared_ptr<CalculatorGenome> father(new CalculatorGenome());
+        boost::shared_ptr<CalculatorGenome> father(new CalculatorGenome());
         father->addBasicMathNodeTypes();
         father->initialize();
 
         stringstream strm;
         father->save(strm);
 
-       boost::shared_ptr<CalculatorGenome> loader(new CalculatorGenome());
+        boost::shared_ptr<CalculatorGenome> loader(new CalculatorGenome());
         //stringstream strm2(strm.str());
         loader->addBasicMathNodeTypes();
         loader->load(strm);

--- a/tgs/src/test/cpp/tgs/FeatureExtraction/GeneticAlgorithmTest.cpp
+++ b/tgs/src/test/cpp/tgs/FeatureExtraction/GeneticAlgorithmTest.cpp
@@ -71,7 +71,7 @@ namespace Tgs
     {
       // load data frame
       cout << "Importing data frame... ";
-     boost::shared_ptr<DataFrame> df(new DataFrame);
+      boost::shared_ptr<DataFrame> df(new DataFrame);
       fstream fs("OttawaCars.xml", ios_base::in);
       if (fs.is_open() == false)
       {
@@ -80,14 +80,14 @@ namespace Tgs
       df->import(fs);
       cout << "done." << endl;
 
-     boost::shared_ptr<CalculatorGenome> genome(new CalculatorGenome());
+      boost::shared_ptr<CalculatorGenome> genome(new CalculatorGenome());
       genome->setInitializationDepth(4);
       genome->addBasicMathNodeTypes();
 
       // create source node for each factor
       for (unsigned int i = 0; i < df->getNumFactors(); i++)
       {
-       boost::shared_ptr<DataFrameCalculatorNodeSource> src(new DataFrameCalculatorNodeSource(df, i));
+        boost::shared_ptr<DataFrameCalculatorNodeSource> src(new DataFrameCalculatorNodeSource(df, i));
         string label = df->getFactorLabelFromIndex(i);
         if (label != "MAX_Z_GROUND" && label != "MIN_Z_GROUND" && 
           label != "MAX_Z_AERIAL" && label != "MIN_Z_AERIAL")
@@ -97,8 +97,8 @@ namespace Tgs
       }
 
       // create a fitness function using symmetric uncertainty
-     boost::shared_ptr<FeatureScoreCalculator> fsc(new SymmetricUncertaintyCalculator());
-     boost::shared_ptr<FeatureScoreFitnessFunction> fitness(new FeatureScoreFitnessFunction(df, fsc));
+      boost::shared_ptr<FeatureScoreCalculator> fsc(new SymmetricUncertaintyCalculator());
+      boost::shared_ptr<FeatureScoreFitnessFunction> fitness(new FeatureScoreFitnessFunction(df, fsc));
 
       GeneticAlgorithm ga(genome, fitness);
       ga.setPopulationSize(500);
@@ -116,7 +116,7 @@ namespace Tgs
       {
         ga.step();
         c+= ga.getPopulation().size();
-       boost::shared_ptr<CalculatorGenome> best = 
+        boost::shared_ptr<CalculatorGenome> best =
           boost::dynamic_pointer_cast<CalculatorGenome>(ga.getBestGenome());
         cout << c << "\t" << best->getScore() << "\t" << best->toString() << endl;
 //         if (1 / best->getScore() < 1.0)

--- a/tgs/src/test/cpp/tgs/FeatureSelection/CfsSubsetEvaluatorTest.cpp
+++ b/tgs/src/test/cpp/tgs/FeatureSelection/CfsSubsetEvaluatorTest.cpp
@@ -130,7 +130,7 @@ namespace Tgs
       generatedData20(df);
 
       GreedyStepwiseSearch uut;
-     boost::shared_ptr<CfsSubsetEvaluator> evaluator(new CfsSubsetEvaluator());
+      boost::shared_ptr<CfsSubsetEvaluator> evaluator(new CfsSubsetEvaluator());
       uut.setEvaluator(evaluator);
 
       // this has been validated against weka
@@ -151,7 +151,7 @@ namespace Tgs
       generatedData1000(df);
 
       GreedyStepwiseSearch uut;
-     boost::shared_ptr<CfsSubsetEvaluator> evaluator(new CfsSubsetEvaluator());
+      boost::shared_ptr<CfsSubsetEvaluator> evaluator(new CfsSubsetEvaluator());
       uut.setEvaluator(evaluator);
 
       // this has been validated against weka

--- a/tgs/src/test/cpp/tgs/FeatureSelection/GreedyStepwiseSearchTest.cpp
+++ b/tgs/src/test/cpp/tgs/FeatureSelection/GreedyStepwiseSearchTest.cpp
@@ -60,7 +60,7 @@ namespace Tgs
       generatedData20(df);
 
       GreedyStepwiseSearch uut;
-     boost::shared_ptr<ConsistencySubsetEvaluator> evaluator(new ConsistencySubsetEvaluator());
+      boost::shared_ptr<ConsistencySubsetEvaluator> evaluator(new ConsistencySubsetEvaluator());
       uut.setEvaluator(evaluator);
 
       // this has been validated against weka

--- a/tgs/src/test/cpp/tgs/Interpolation/DelaunayInterpolatorTest.cpp
+++ b/tgs/src/test/cpp/tgs/Interpolation/DelaunayInterpolatorTest.cpp
@@ -59,12 +59,12 @@ class DelaunayInterpolatorTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 public:
 
- boost::shared_ptr<DelaunayInterpolator> buildRandom()
+  boost::shared_ptr<DelaunayInterpolator> buildRandom()
   {
-   boost::shared_ptr<DelaunayInterpolator> result(new DelaunayInterpolator);
+    boost::shared_ptr<DelaunayInterpolator> result(new DelaunayInterpolator);
     DelaunayInterpolator& uut = *result;
 
-   boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
+    boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
     DataFrame& df = *dfPtr;
     vector<string> labels;
     labels.push_back("x");
@@ -103,7 +103,7 @@ public:
   {
     Tgs::Random::instance()->seed(0);
 
-   boost::shared_ptr<DelaunayInterpolator> di = buildRandom();
+    boost::shared_ptr<DelaunayInterpolator> di = buildRandom();
     DelaunayInterpolator& uut = *di;
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.025, uut.estimateError(), 0.001);
@@ -162,7 +162,7 @@ public:
   {
     Tgs::Random::instance()->seed(0);
 
-   boost::shared_ptr<DelaunayInterpolator> di = buildRandom();
+    boost::shared_ptr<DelaunayInterpolator> di = buildRandom();
     DelaunayInterpolator& uut = *di;
 
     Tgs::Random::instance()->seed(0);
@@ -187,7 +187,7 @@ public:
     Tgs::Random::instance()->seed(0);
     DelaunayInterpolator uut;
 
-   boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
+    boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
     DataFrame& df = *dfPtr;
     vector<string> labels;
     labels.push_back("x");

--- a/tgs/src/test/cpp/tgs/Interpolation/KernelEstimationInterpolatorTest.cpp
+++ b/tgs/src/test/cpp/tgs/Interpolation/KernelEstimationInterpolatorTest.cpp
@@ -58,12 +58,12 @@ class KernelEstimationInterpolatorTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 public:
 
- boost::shared_ptr<KernelEstimationInterpolator> buildRandom()
+  boost::shared_ptr<KernelEstimationInterpolator> buildRandom()
   {
-   boost::shared_ptr<KernelEstimationInterpolator> result(new KernelEstimationInterpolator());
+    boost::shared_ptr<KernelEstimationInterpolator> result(new KernelEstimationInterpolator());
     KernelEstimationInterpolator& uut = *result;
 
-   boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
+    boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
     DataFrame& df = *dfPtr;
     vector<string> labels;
     labels.push_back("x");
@@ -102,7 +102,7 @@ public:
   {
     Tgs::Random::instance()->seed(0);
 
-   boost::shared_ptr<KernelEstimationInterpolator> di = buildRandom();
+    boost::shared_ptr<KernelEstimationInterpolator> di = buildRandom();
     KernelEstimationInterpolator& uut = *di;
     uut.setStopDelta(0.0001);
     uut.setSigma(-1);
@@ -148,7 +148,7 @@ public:
   {
     Tgs::Random::instance()->seed(0);
 
-   boost::shared_ptr<KernelEstimationInterpolator> di = buildRandom();
+    boost::shared_ptr<KernelEstimationInterpolator> di = buildRandom();
     KernelEstimationInterpolator& uut = *di;
     uut.setStopDelta(0.0001);
     uut.setSigma(0.3);
@@ -177,7 +177,7 @@ public:
     Tgs::Random::instance()->seed(0);
     KernelEstimationInterpolator uut(.1);
 
-   boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
+    boost::shared_ptr<DataFrame> dfPtr(new DataFrame());
     DataFrame& df = *dfPtr;
     vector<string> labels;
     labels.push_back("x");

--- a/tgs/src/test/cpp/tgs/RStarTree/HilbertRTreeTest.cpp
+++ b/tgs/src/test/cpp/tgs/RStarTree/HilbertRTreeTest.cpp
@@ -124,7 +124,7 @@ public:
 
   void test1()
   {
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(2048));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(2048));
     // @todo fix me.
     RStarTree uut(mps, 2);
     int maxChildCount = uut.getRoot()->getMaxChildCount();
@@ -185,7 +185,7 @@ public:
   {
     int testSize = 1000;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
     HilbertRTree uut(mps, 2);
 
     std::vector<Box> boxes;
@@ -201,7 +201,7 @@ public:
   {
     int testSize = 1000;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
     HilbertRTree uut(mps, 2);
     
     std::vector<Box> boxes;
@@ -221,7 +221,7 @@ public:
   {
     int testSize = 1000;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
     HilbertRTree uut(mps, 2);
 
     std::vector<Box> boxes;
@@ -237,8 +237,8 @@ public:
     int testSize = 300;
     int sampleSize = 40;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
-   boost::shared_ptr<HilbertRTree> uut(new HilbertRTree(mps, 2));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<HilbertRTree> uut(new HilbertRTree(mps, 2));
     _testTreeDistance(uut, testSize, sampleSize, false);
   }
 
@@ -247,8 +247,8 @@ public:
     int testSize = 500;
     int sampleSize = 50;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
-   boost::shared_ptr<HilbertRTree> uut(new HilbertRTree(mps, 2));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<HilbertRTree> uut(new HilbertRTree(mps, 2));
     _testTreeDistance(uut, testSize, sampleSize, true);
   }
 
@@ -260,8 +260,8 @@ public:
     std::vector<int> fids;
     _createRandomTestData(testSize, boxes, fids);
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
-   boost::shared_ptr<HilbertRTree> uut(new HilbertRTree(mps, 2));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<HilbertRTree> uut(new HilbertRTree(mps, 2));
     std::vector<Box> firstBoxes = boxes;
     std::vector<int> firstFids = fids;
     firstBoxes.resize(testSize / 2);
@@ -279,7 +279,7 @@ public:
   {
     int testSize = 1000;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(128));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(128));
     HilbertRTree uut(mps, 2);
 
     std::vector<Box> boxes;
@@ -326,8 +326,8 @@ public:
     int testSize = 300;
     int sampleSize = 40;
 
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
-   boost::shared_ptr<RStarTree> uut(new RStarTree(mps, 2));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<RStarTree> uut(new RStarTree(mps, 2));
     _testTreeDistance(uut, testSize, sampleSize, false);
   }
 
@@ -338,7 +338,7 @@ public:
     _createRandomTestData(testSize, boxes, fids);
     if (bulkLoad)
     {
-     boost::shared_ptr<HilbertRTree> hrt = boost::dynamic_pointer_cast<HilbertRTree>(uut);
+      boost::shared_ptr<HilbertRTree> hrt = boost::dynamic_pointer_cast<HilbertRTree>(uut);
       hrt->bulkInsert(boxes, fids);
     }
     else
@@ -400,7 +400,7 @@ public:
     
     if (bulkLoad == true)
     {
-     boost::shared_ptr<HilbertRTree> hrt = boost::dynamic_pointer_cast<HilbertRTree>(rst);
+      boost::shared_ptr<HilbertRTree> hrt = boost::dynamic_pointer_cast<HilbertRTree>(rst);
       hrt->bulkInsert(boxes, fids);
     }
     else
@@ -431,21 +431,21 @@ public:
     {
       printf("%d\t%d\t", testSize, pageSize);
       {
-       boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(pageSize));
-       boost::shared_ptr<HilbertRTree> hrt(new HilbertRTree(mps, 2));
+        boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(pageSize));
+        boost::shared_ptr<HilbertRTree> hrt(new HilbertRTree(mps, 2));
         printf("%d\t", hrt->getRoot()->getMaxChildCount());
         benchmarkTree(hrt, testSize, sampleSize, false);
       }
 
       {
-       boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(pageSize));
-       boost::shared_ptr<HilbertRTree> hrt(new HilbertRTree(mps, 2));
+        boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(pageSize));
+        boost::shared_ptr<HilbertRTree> hrt(new HilbertRTree(mps, 2));
         benchmarkTree(hrt, testSize, sampleSize, true);
       }
 
       {
-       boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(pageSize));
-       boost::shared_ptr<RStarTree> rst(new RStarTree(mps, 2));
+        boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(pageSize));
+        boost::shared_ptr<RStarTree> rst(new RStarTree(mps, 2));
         benchmarkTree(rst, testSize, sampleSize, false);
       }
       printf("\n");

--- a/tgs/src/test/cpp/tgs/RStarTree/KnnIteratorNdTest.cpp
+++ b/tgs/src/test/cpp/tgs/RStarTree/KnnIteratorNdTest.cpp
@@ -118,8 +118,8 @@ public:
 
   void test1()
   {
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
-   boost::shared_ptr<HilbertRTree> tree(new HilbertRTree(mps, 3));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(256));
+    boost::shared_ptr<HilbertRTree> tree(new HilbertRTree(mps, 3));
 
     createTestData(3, 4);
     tree->bulkInsert(testData, testId);

--- a/tgs/src/test/cpp/tgs/RStarTree/PageStoreTest.cpp
+++ b/tgs/src/test/cpp/tgs/RStarTree/PageStoreTest.cpp
@@ -71,7 +71,7 @@ public:
 
       for (int i = 0; i < 100; i++)
       {
-       boost::shared_ptr<Page> p = uut.getPage(_ids[i]);
+        boost::shared_ptr<Page> p = uut.getPage(_ids[i]);
         verifyPage(p);
       }
     }
@@ -101,7 +101,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(0, uut.getPageCount());
     int pageSize = uut.getPageSize();
 
-   boost::shared_ptr<Page> p = uut.createPage();
+    boost::shared_ptr<Page> p = uut.createPage();
     CPPUNIT_ASSERT_EQUAL(pageSize, p->getDataSize());
 
     populatePage(p);

--- a/tgs/src/test/cpp/tgs/RStarTree/RTreeNodeStoreTest.cpp
+++ b/tgs/src/test/cpp/tgs/RStarTree/RTreeNodeStoreTest.cpp
@@ -46,7 +46,7 @@ class RTreeNodeStoreTest : public CppUnit::TestFixture
 public:
   void test1()
   {
-   boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(100));
+    boost::shared_ptr<MemoryPageStore> mps(new MemoryPageStore(100));
     RTreeNodeStore uut(2, mps);
 
     RTreeNode* n1 = uut.createNode();

--- a/tgs/src/test/cpp/tgs/RStarTree/RTreeNodeTest.cpp
+++ b/tgs/src/test/cpp/tgs/RStarTree/RTreeNodeTest.cpp
@@ -48,8 +48,8 @@ namespace Tgs
   public:
     void test1()
     {
-     boost::shared_ptr<PageStore>mps(new MemoryPageStore(100));
-     boost::shared_ptr<RTreeNodeStore>store(new RTreeNodeStore(2, mps));
+      boost::shared_ptr<PageStore>mps(new MemoryPageStore(100));
+      boost::shared_ptr<RTreeNodeStore>store(new RTreeNodeStore(2, mps));
 
       {
         Tgs::RTreeNode rtn(2, mps->createPage());
@@ -76,8 +76,8 @@ namespace Tgs
 
     void test2()
     {
-     boost::shared_ptr<PageStore>mps(new MemoryPageStore(368));
-     boost::shared_ptr<RTreeNodeStore>store(new RTreeNodeStore(2, mps));
+      boost::shared_ptr<PageStore>mps(new MemoryPageStore(368));
+      boost::shared_ptr<RTreeNodeStore>store(new RTreeNodeStore(2, mps));
 
       RTreeNode rtn(2, mps->createPage());
       rtn.clear();

--- a/tgs/src/test/cpp/tgs/SpinImage/SpinImageGeneratorTest.cpp
+++ b/tgs/src/test/cpp/tgs/SpinImage/SpinImageGeneratorTest.cpp
@@ -246,7 +246,7 @@ for (unsigned int si = 0; si < s.size(); si++)
       for (unsigned int i = 0; i < training.size(); i++)
       {
         cout << "Training " << training[i] << endl;
-       boost::shared_ptr<SpinImageStack> stack(new SpinImageStack());
+        boost::shared_ptr<SpinImageStack> stack(new SpinImageStack());
         stacks.push_back(stack);
         PointCloud pc;
         pc.load(training[i]);


### PR DESCRIPTION
Refs #1562

Found where math functions such as `abs()`, `min()`, `max()`, etc. were being called with `double` and without the `using namespace std` from `Log.h` it was using the `int` versions which would round or truncate.  Also found a bunch of rogue missing spaces before `boost::shared_ptr`.  Oh yeah, and I reordered some `#include` statements.