### PR TITLE
Fix hoot_ubuntu1404_nightly_develop_configure

### DIFF
--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapMapper.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapMapper.cpp
@@ -28,6 +28,8 @@
 #include <pp/Factory.h>
 #include <pp/Hdfs.h>
 
+#include <sstream>
+
 using namespace std;
 
 namespace hoot

--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapReducer.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/OsmMapReducer.cpp
@@ -26,6 +26,8 @@
 
 #include <pp/HadoopPipesUtils.h>
 
+#include <sstream>
+
 using namespace std;
 
 namespace hoot


### PR DESCRIPTION
Refs #1586 
Add missing includes when '--without-stxxl' is specified, side effect from previous issues of removing namespaces in headers and rearranging includes.