### PR TITLE
EdgeMatchSetFinderTest tests fail on clean Ubuntu VM in quick tests

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
@@ -62,6 +62,11 @@ class FindIntersectionsOpTest : public CppUnit::TestFixture
 
 public:
 
+  void setUp()
+  {
+    TestUtils::resetEnvironment();
+  }
+
   void runToyTest()
   {
     OsmXmlReader reader;

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
@@ -59,6 +59,11 @@ class ReprojectToPlanarOpTest : public CppUnit::TestFixture
 
 public:
 
+  void setUp()
+  {
+    TestUtils::resetEnvironment();
+  }
+
   void runTest()
   {
     QString inputPath  = "test-files/ops/ReprojectToPlanarOp/";

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
@@ -59,6 +59,11 @@ class WaySplitterOpTest : public CppUnit::TestFixture
 
 public:
 
+  void setUp()
+  {
+    TestUtils::resetEnvironment();
+  }
+
   void runTest()
   {
     QString inputPath  = "test-files/ops/WaySplitterOp/";

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeMatchSetFinderTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeMatchSetFinderTest.cpp
@@ -35,6 +35,9 @@
 #include <hoot/rnd/conflate/network/EdgeMatchSetFinder.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -54,6 +57,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
 
     MapProjector::projectToWgs84(copy);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
@@ -38,6 +38,9 @@
 #include <hoot/rnd/conflate/network/IterativeNetworkMatcher.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -53,6 +56,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, IterativeNetworkMatcher& uut, int index)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
@@ -38,6 +38,9 @@
 #include <hoot/rnd/conflate/network/SingleSidedNetworkMatcher.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -51,6 +54,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, SingleSidedNetworkMatcher& uut, int index)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
@@ -38,6 +38,9 @@
 #include <hoot/rnd/conflate/network/VagabondNetworkMatcher.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -51,6 +54,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, VagabondNetworkMatcher& uut, int index)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());


### PR DESCRIPTION
Refs #1610 
In certain circumstances that we weren't testing for some of the unit tests were failing.  The fixes were simple, just reset the environment before some of the tests and create the `tmp` directory if it doesn't exist for the others.