### PR TITLE
Hoot is "hard to install"

### DIFF
--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-HOOT_HOME=$HOME/hoot
+VMUSER=`id -u -n`
+echo USER: $VMUSER
+VMGROUP=`groups | grep -o $VMUSER`
+echo GROUP: $VMGROUP
+
+HOOT_HOME=~/hoot
 echo HOOT_HOME: $HOOT_HOME
 cd ~
 source ~/.profile
@@ -96,7 +101,7 @@ sudo /usr/bin/perl $HOOT_HOME/scripts/maven/SetMavenHttps.pl
 
 if ! grep --quiet "export HOOT_HOME" ~/.profile; then
     echo "Adding hoot home to profile..."
-    echo "export HOOT_HOME=\$HOME/hoot" >> ~/.profile
+    echo "export HOOT_HOME=~/hoot" >> ~/.profile
     echo "export PATH=\$PATH:\$HOOT_HOME/bin" >> ~/.profile
     source ~/.profile
 fi
@@ -111,14 +116,14 @@ fi
 
 if ! grep --quiet "export HADOOP_HOME" ~/.profile; then
     echo "Adding Hadoop home to profile..."
-    echo "export HADOOP_HOME=\$HOME/hadoop" >> ~/.profile
+    echo "export HADOOP_HOME=~/hadoop" >> ~/.profile
     echo "export PATH=\$PATH:\$HADOOP_HOME/bin" >> ~/.profile
     source ~/.profile
 fi
 
 if ! grep --quiet "PATH=" ~/.profile; then
     echo "Adding path vars to profile..."
-    echo "export PATH=\$PATH:\$JAVA_HOME/bin:\$HOME/bin:$HOOT_HOME/bin" >> ~/.profile
+    echo "export PATH=\$PATH:\$JAVA_HOME/bin:~/bin:$HOOT_HOME/bin" >> ~/.profile
     source ~/.profile
 fi
 
@@ -142,7 +147,7 @@ if ! ruby -v | grep --quiet 2.3.0; then
 
     curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
 
-    source /home/vagrant/.rvm/scripts/rvm
+    source ~/.rvm/scripts/rvm
 
     stdbuf -o L -e L rvm install ruby-2.3
     rvm --default use 2.3
@@ -206,20 +211,20 @@ fi
 
 if [ ! -f bin/chromedriver ]; then
     echo "### Installing Chromedriver..."
-    mkdir -p $HOME/bin
+    mkdir -p ~/bin
     if [ ! -f chromedriver_linux64.zip ]; then
       LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
       wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
     fi
-    unzip -d $HOME/bin chromedriver_linux64.zip
+    unzip -d ~/bin chromedriver_linux64.zip
 else
   LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
   if [[ "$(chromedriver --version)" != "ChromeDriver $LATEST_RELEASE."* ]]; then
     echo "### Updating Chromedriver"
-    rm $HOME/bin/chromedriver
-    rm $HOME/chromedriver_linux64.zip
+    rm ~/bin/chromedriver
+    rm ~/chromedriver_linux64.zip
     wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    unzip -o -d $HOME/bin chromedriver_linux64.zip
+    unzip -o -d ~/bin chromedriver_linux64.zip
   fi
 fi
 
@@ -227,13 +232,13 @@ sudo apt-get autoremove -y
 
 if [ ! -f bin/osmosis ]; then
     echo "### Installing Osmosis"
-    mkdir -p $HOME/bin
+    mkdir -p ~/bin
     if [ ! -f osmosis-latest.tgz ]; then
       wget --quiet http://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz
     fi
-    mkdir -p $HOME/bin/osmosis_src
-    tar -zxf osmosis-latest.tgz -C $HOME/bin/osmosis_src
-    ln -s $HOME/bin/osmosis_src/bin/osmosis $HOME/bin/osmosis
+    mkdir -p ~/bin/osmosis_src
+    tar -zxf osmosis-latest.tgz -C ~/bin/osmosis_src
+    ln -s ~/bin/osmosis_src/bin/osmosis ~/bin/osmosis
 fi
 
 
@@ -283,7 +288,7 @@ if ! mocha --version &>/dev/null; then
     echo "### Installing mocha for plugins test..."
     sudo npm install --silent -g mocha
     # Clean up after the npm install
-    sudo rm -rf $HOME/tmp
+    sudo rm -rf ~/tmp
 fi
 
 
@@ -380,7 +385,7 @@ fi
 TOMCAT_HOME=/usr/share/tomcat8
 
 # Install Tomcat 8
-sudo $HOOT_HOME/scripts/tomcat/tomcat8/ubuntu/tomcat8_install.sh
+$HOOT_HOME/scripts/tomcat/tomcat8/ubuntu/tomcat8_install.sh
 
 # Configure Tomcat
 if ! grep --quiet TOMCAT8_HOME ~/.profile; then
@@ -408,27 +413,26 @@ if ! hash hadoop >/dev/null 2>&1 ; then
     wget --quiet https://archive.apache.org/dist/hadoop/core/hadoop-0.20.2/hadoop-0.20.2.tar.gz
   fi
 
-  if [ ! -f $HOME/.ssh/id_rsa ]; then
-    ssh-keygen -t rsa -N "" -f $HOME/.ssh/id_rsa
-    cat ~/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
-    ssh-keyscan -H localhost >> $HOME/.ssh/known_hosts
+  if [ ! -f ~/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+    cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+    ssh-keyscan -H localhost >> ~/.ssh/known_hosts
   fi
-  chmod 600 $HOME/.ssh/authorized_keys
+  chmod 600 ~/.ssh/authorized_keys
 
   #cd /usr/local
   cd ~
-  sudo tar -zxf $HOME/hadoop-0.20.2.tar.gz
-  sudo chown -R vagrant:vagrant hadoop-0.20.2
+  sudo tar -zxf ~/hadoop-0.20.2.tar.gz
+  sudo chown -R $VMUSER:$VMGROUP hadoop-0.20.2
   sudo ln -s hadoop-0.20.2 hadoop
-  sudo chown -R vagrant:vagrant hadoop
+  sudo chown -R $VMUSER:$VMGROUP hadoop
   cd hadoop
   sudo find . -type d -exec chmod a+rwx {} \;
   sudo find . -type f -exec chmod a+rw {} \;
   cd ~
 
-#TODO: remove these home dir hardcodes
 sudo rm -f $HADOOP_HOME/conf/core-site.xml
-sudo bash -c "cat >> /home/vagrant/hadoop/conf/core-site.xml" <<EOT
+sudo bash -c "cat >> $HADOOP_HOME/conf/core-site.xml" <<EOT
 
 <configuration>
   <property>
@@ -438,7 +442,7 @@ sudo bash -c "cat >> /home/vagrant/hadoop/conf/core-site.xml" <<EOT
 </configuration>
 EOT
 sudo rm -f $HADOOP_HOME/conf/mapred-site.xml
-sudo bash -c "cat >> /home/vagrant/hadoop/conf/mapred-site.xml" <<EOT
+sudo bash -c "cat >> $HADOOP_HOME/conf/mapred-site.xml" <<EOT
 
 <configuration>
   <property>
@@ -476,7 +480,7 @@ sudo bash -c "cat >> /home/vagrant/hadoop/conf/mapred-site.xml" <<EOT
 </configuration>
 EOT
 sudo rm -f $HADOOP_HOME/conf/hdfs-site.xml
-sudo bash -c "cat >> /home/vagrant/hadoop/conf/hdfs-site.xml" <<EOT
+sudo bash -c "cat >> $HADOOP_HOME/conf/hdfs-site.xml" <<EOT
 
 <configuration>
   <property>
@@ -517,15 +521,15 @@ sudo bash -c "cat >> /home/vagrant/hadoop/conf/hdfs-site.xml" <<EOT
   </property>
   <property>
     <name>fs.checkpoint.dir</name>
-    <value>/home/vagrant/hadoop/dfs/namesecondary</value>
+    <value>$HADOOP_HOME/dfs/namesecondary</value>
   </property>
   <property>
     <name>dfs.name.dir</name>
-    <value>/home/vagrant/hadoop/dfs/name</value>
+    <value>$HADOOP_HOME/dfs/name</value>
   </property>
   <property>
     <name>dfs.data.dir</name>
-    <value>/home/vagrant/hadoop/dfs/data</value>
+    <value>$HADOOP_HOME/dfs/data</value>
   </property>
 </configuration>
 EOT
@@ -533,10 +537,10 @@ EOT
   sudo sed -i.bak 's/# export JAVA_HOME=\/usr\/lib\/j2sdk1.5-sun/export JAVA_HOME=\/usr\/lib\/jvm\/oracle_jdk8/g' $HADOOP_HOME/conf/hadoop-env.sh
   sudo sed -i.bak 's/#include <pthread.h>/#include <pthread.h>\n#include <unistd.h>/g' $HADOOP_HOME/src/c++/pipes/impl/HadoopPipes.cc
 
-  sudo mkdir -p $HOME/hadoop/dfs/name/current
+  sudo mkdir -p $HADOOP_HOME/dfs/name/current
   # this could perhaps be more strict
-  sudo chmod -R 777 $HOME/hadoop
-  sudo chmod go-w $HOME/hadoop/bin $HOME/hadoop
+  sudo chmod -R 777 $HADOOP_HOME
+  sudo chmod go-w $HADOOP_HOME/bin $HADOOP_HOME
   echo 'Y' | hadoop namenode -format
 
   cd /lib
@@ -561,7 +565,7 @@ sudo chmod a+x /etc/init.d/node-mapnik-server
 cd $HOOT_HOME/node-mapnik-server
 npm install --silent
 # Clean up after the npm install
-rm -rf $HOME/tmp
+rm -rf ~/tmp
 
 echo "### Installing node-export-server..."
 sudo cp $HOOT_HOME/node-export-server/init.d/node-export-server /etc/init.d
@@ -570,7 +574,7 @@ sudo chmod a+x /etc/init.d/node-export-server
 cd $HOOT_HOME/node-export-server
 npm install --silent
 # Clean up after the npm install
-rm -rf $HOME/tmp
+rm -rf ~/tmp
 
 cd $HOOT_HOME
 

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-#TODO: Fix HOOT_HOME
-HOOT_HOME=$HOME/hoot
+HOOT_HOME=~/hoot
 echo HOOT_HOME: $HOOT_HOME
 cd ~
 source ~/.bash_profile
@@ -9,16 +8,7 @@ source ~/.bash_profile
 # Keep VagrantBuild.sh happy
 #ln -s ~/.bash_profile ~/.profile
 
-# Find out what user we have: vagrant or ubuntu
-# This comes from a user difference in one of the Vagrant boxes
-if [ "$(getent passwd vagrant)" ]; then
-  VMUSER=vagrant
-else
-  if [ "$(getent passwd ubuntu)" ]; then
-    VMUSER=ubuntu
-  fi
-fi
-
+VMUSER=`id -u -n`
 
 # add EPEL repo for extra packages
 echo "### Add epel repo ###" > CentOS_upgrade.txt
@@ -158,7 +148,7 @@ sudo /usr/bin/perl $HOOT_HOME/scripts/maven/SetMavenHttps.pl
 
 if ! grep --quiet "export HOOT_HOME" ~/.bash_profile; then
     echo "Adding hoot home to profile..."
-    echo "export HOOT_HOME=\$HOME/hoot" >> ~/.bash_profile
+    echo "export HOOT_HOME=~/hoot" >> ~/.bash_profile
     echo "export PATH=\$PATH:\$HOOT_HOME/bin" >> ~/.bash_profile
     source ~/.bash_profile
 fi
@@ -174,7 +164,7 @@ fi
 
 if ! grep --quiet "export HADOOP_HOME" ~/.bash_profile; then
     echo "Adding Hadoop home to profile..."
-    echo "export HADOOP_HOME=\$HOME/hadoop" >> ~/.bash_profile
+    echo "export HADOOP_HOME=~/hadoop" >> ~/.bash_profile
     echo "export PATH=\$PATH:\$HADOOP_HOME/bin" >> ~/.bash_profile
     source ~/.bash_profile
 fi
@@ -250,32 +240,32 @@ cd ~
 
 if [ ! -f bin/chromedriver ]; then
     echo "### Installing Chromedriver..."
-    mkdir -p $HOME/bin
+    mkdir -p ~/bin
     if [ ! -f chromedriver_linux64.zip ]; then
       LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
       wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
     fi
-    unzip -d $HOME/bin chromedriver_linux64.zip
+    unzip -d ~/bin chromedriver_linux64.zip
 else
   LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
   if [[ "$(chromedriver --version)" != "ChromeDriver $LATEST_RELEASE."* ]]; then
     echo "### Updating Chromedriver"
-    rm $HOME/bin/chromedriver
-    rm $HOME/chromedriver_linux64.zip
+    rm ~/bin/chromedriver
+    rm ~/chromedriver_linux64.zip
     wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    unzip -o -d $HOME/bin chromedriver_linux64.zip
+    unzip -o -d ~/bin chromedriver_linux64.zip
   fi
 fi
 
 if [ ! -f bin/osmosis ]; then
     echo "### Installing Osmosis"
-    mkdir -p $HOME/bin
+    mkdir -p ~/bin
     if [ ! -f osmosis-latest.tgz ]; then
       wget --quiet http://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz
     fi
-    mkdir -p $HOME/bin/osmosis_src
-    tar -zxf osmosis-latest.tgz -C $HOME/bin/osmosis_src
-    ln -s $HOME/bin/osmosis_src/bin/osmosis $HOME/bin/osmosis
+    mkdir -p ~/bin/osmosis_src
+    tar -zxf osmosis-latest.tgz -C ~/bin/osmosis_src
+    ln -s ~/bin/osmosis_src/bin/osmosis ~/bin/osmosis
 fi
 
 # Need to figure out a way to do this automagically
@@ -344,7 +334,7 @@ if ! mocha --version &>/dev/null; then
     echo "### Installing mocha for plugins test..."
     sudo npm install --silent -g mocha
     # Clean up after the npm install
-    sudo rm -rf $HOME/tmp
+    sudo rm -rf ~/tmp
 fi
 
 
@@ -556,7 +546,7 @@ sudo chmod a+x /etc/init.d/node-mapnik-server
 cd $HOOT_HOME/node-mapnik-server
 npm install --silent
 # Clean up after the npm install
-rm -rf $HOME/tmp
+rm -rf ~/tmp
 
 echo "### Installing node-export-server..."
 sudo cp $HOOT_HOME/node-export-server/init.d/node-export-server /etc/init.d
@@ -565,7 +555,7 @@ sudo chmod a+x /etc/init.d/node-export-server
 cd $HOOT_HOME/node-export-server
 npm install --silent
 # Clean up after the npm install
-rm -rf $HOME/tmp
+rm -rf ~/tmp
 
 cd $HOOT_HOME
 

--- a/VagrantProvisionUbuntu1604.sh
+++ b/VagrantProvisionUbuntu1604.sh
@@ -4,7 +4,12 @@
 # Initial basic provisioning script for Ubuntu1604
 #
 
-HOOT_HOME=$HOME/hoot
+VMUSER=`id -u -n`
+echo USER: $VMUSER
+VMGROUP=`groups | grep -o $VMUSER`
+echo GROUP: $VMGROUP
+
+HOOT_HOME=~/hoot
 echo HOOT_HOME: $HOOT_HOME
 cd ~
 source ~/.profile
@@ -162,7 +167,7 @@ echo "### Configuring environment..."
 
 if ! grep --quiet "export HOOT_HOME" ~/.profile; then
     echo "Adding hoot home to profile..."
-    echo "export HOOT_HOME=\$HOME/hoot" >> ~/.profile
+    echo "export HOOT_HOME=~/hoot" >> ~/.profile
     echo "export PATH=\$PATH:\$HOOT_HOME/bin" >> ~/.profile
     source ~/.profile
 fi
@@ -177,14 +182,14 @@ fi
 
 if ! grep --quiet "export HADOOP_HOME" ~/.profile; then
     echo "Adding Hadoop home to profile..."
-    echo "export HADOOP_HOME=\$HOME/hadoop" >> ~/.profile
+    echo "export HADOOP_HOME=~/hadoop" >> ~/.profile
     echo "export PATH=\$PATH:\$HADOOP_HOME/bin" >> ~/.profile
     source ~/.profile
 fi
 
 if ! grep --quiet "PATH=" ~/.profile; then
     echo "Adding path vars to profile..."
-    echo "export PATH=\$PATH:\$JAVA_HOME/bin:\$HOME/bin:$HOOT_HOME/bin" >> ~/.profile
+    echo "export PATH=\$PATH:\$JAVA_HOME/bin:~/bin:$HOOT_HOME/bin" >> ~/.profile
     source ~/.profile
 fi
 
@@ -194,7 +199,6 @@ if ! ruby -v | grep --quiet 2.3.0; then
 
     curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
 
-    #source /home/vagrant/.rvm/scripts/rvm
     source ~/.rvm/scripts/rvm
 
     stdbuf -o L -e L rvm install ruby-2.3
@@ -259,20 +263,20 @@ fi
 
 if [ ! -f bin/chromedriver ]; then
     echo "### Installing Chromedriver..."
-    mkdir -p $HOME/bin
+    mkdir -p ~/bin
     if [ ! -f chromedriver_linux64.zip ]; then
       LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
       wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
     fi
-    unzip -d $HOME/bin chromedriver_linux64.zip
+    unzip -d ~/bin chromedriver_linux64.zip
 else
   LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
   if [[ "$(chromedriver --version)" != "ChromeDriver $LATEST_RELEASE."* ]]; then
     echo "### Updating Chromedriver"
-    rm $HOME/bin/chromedriver
-    rm $HOME/chromedriver_linux64.zip
+    rm ~/bin/chromedriver
+    rm ~/chromedriver_linux64.zip
     wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    unzip -o -d $HOME/bin chromedriver_linux64.zip
+    unzip -o -d ~/bin chromedriver_linux64.zip
   fi
 fi
 
@@ -280,13 +284,13 @@ sudo apt-get autoremove -y
 
 if [ ! -f bin/osmosis ]; then
     echo "### Installing Osmosis"
-    mkdir -p $HOME/bin
+    mkdir -p ~/bin
     if [ ! -f osmosis-latest.tgz ]; then
       wget --quiet http://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz
     fi
-    mkdir -p $HOME/bin/osmosis_src
-    tar -zxf osmosis-latest.tgz -C $HOME/bin/osmosis_src
-    ln -s $HOME/bin/osmosis_src/bin/osmosis $HOME/bin/osmosis
+    mkdir -p ~/bin/osmosis_src
+    tar -zxf osmosis-latest.tgz -C ~/bin/osmosis_src
+    ln -s ~/bin/osmosis_src/bin/osmosis ~/bin/osmosis
 fi
 
 
@@ -336,7 +340,7 @@ if ! mocha --version &>/dev/null; then
     echo "### Installing mocha for plugins test..."
     sudo npm install --silent -g mocha
     # Clean up after the npm install
-    sudo rm -rf $HOME/tmp
+    sudo rm -rf ~/tmp
 fi
 
 # NOTE: These have been changed to pg9.5
@@ -413,7 +417,7 @@ fi
 TOMCAT_HOME=/usr/share/tomcat8
 
 # Install Tomcat 8
-sudo $HOOT_HOME/scripts/tomcat8/ubuntu/tomcat8_install.sh
+$HOOT_HOME/scripts/tomcat8/ubuntu/tomcat8_install.sh
 
 # Configure Tomcat
 if ! grep --quiet TOMCAT8_HOME ~/.profile; then
@@ -445,7 +449,7 @@ sudo chmod a+x /etc/init.d/node-mapnik-server
 cd $HOOT_HOME/node-mapnik-server
 npm install --silent
 # Clean up after the npm install
-rm -rf $HOME/tmp
+rm -rf ~/tmp
 
 echo "### Installing node-export-server..."
 sudo cp $HOOT_HOME/node-export-server/init.d/node-export-server /etc/init.d
@@ -454,7 +458,7 @@ sudo chmod a+x /etc/init.d/node-export-server
 cd $HOOT_HOME/node-export-server
 npm install --silent
 # Clean up after the npm install
-rm -rf $HOME/tmp
+rm -rf ~/tmp
 
 cd $HOOT_HOME
 

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
@@ -62,6 +62,11 @@ class FindIntersectionsOpTest : public CppUnit::TestFixture
 
 public:
 
+  void setUp()
+  {
+    TestUtils::resetEnvironment();
+  }
+
   void runToyTest()
   {
     OsmXmlReader reader;

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
@@ -59,6 +59,11 @@ class ReprojectToPlanarOpTest : public CppUnit::TestFixture
 
 public:
 
+  void setUp()
+  {
+    TestUtils::resetEnvironment();
+  }
+
   void runTest()
   {
     QString inputPath  = "test-files/ops/ReprojectToPlanarOp/";

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
@@ -59,6 +59,11 @@ class WaySplitterOpTest : public CppUnit::TestFixture
 
 public:
 
+  void setUp()
+  {
+    TestUtils::resetEnvironment();
+  }
+
   void runTest()
   {
     QString inputPath  = "test-files/ops/WaySplitterOp/";

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeMatchSetFinderTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/EdgeMatchSetFinderTest.cpp
@@ -35,6 +35,9 @@
 #include <hoot/rnd/conflate/network/EdgeMatchSetFinder.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -54,6 +57,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
 
     MapProjector::projectToWgs84(copy);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
@@ -38,6 +38,9 @@
 #include <hoot/rnd/conflate/network/IterativeNetworkMatcher.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -53,6 +56,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, IterativeNetworkMatcher& uut, int index)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
@@ -38,6 +38,9 @@
 #include <hoot/rnd/conflate/network/SingleSidedNetworkMatcher.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -51,6 +54,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, SingleSidedNetworkMatcher& uut, int index)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
@@ -38,6 +38,9 @@
 #include <hoot/rnd/conflate/network/VagabondNetworkMatcher.h>
 #include <hoot/rnd/conflate/network/OsmNetworkExtractor.h>
 
+// Qt
+#include <QDir>
+
 namespace hoot
 {
 
@@ -51,6 +54,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, VagabondNetworkMatcher& uut, int index)
   {
+    QDir().mkpath("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/scripts/tomcat/tomcat8/ubuntu/tomcat8_install.sh
+++ b/scripts/tomcat/tomcat8/ubuntu/tomcat8_install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-HOOT_HOME=$HOME/hoot
+HOOT_HOME=~/hoot
 TOMCAT_NAME=tomcat8
 TOMCAT_GROUP=tomcat8
 TOMCAT_USER=tomcat8
@@ -22,114 +22,103 @@ TOMCAT_TAR_FILE=${SCRIPT_HOME}/../apache-tomcat-8.5.8.tar.gz
 
 # Find out what user we have: vagrant or ubuntu
 # This comes from a user difference in one of the Vagrant boxes
-if [ "$(getent passwd vagrant)" ]; then
-  VMUSER=vagrant
-else
-  if [ "$(getent passwd ubuntu)" ]; then
-    VMUSER=ubuntu
-  fi
-fi
-
-if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root"
-   exit 1
-fi
+VMUSER=`id -u -n`
 
 echo "######## Begin $TOMCAT_NAME installation ########"
 echo "SCRIPT_HOME=$SCRIPT_HOME"
 
 # Stop tomcat service if it already exists
-if service --status-all 2>&1 | grep -q ${TOMCAT_NAME}; then
-  service ${TOMCAT_NAME} stop
+if sudo service --status-all 2>&1 | grep -q ${TOMCAT_NAME}; then
+  sudo service ${TOMCAT_NAME} stop
 fi
 
 # Create tomcat group if not already created
-getent group ${TOMCAT_GROUP} >/dev/null || groupadd -r ${TOMCAT_GROUP}
+sudo getent group ${TOMCAT_GROUP} >/dev/null || sudo groupadd -r ${TOMCAT_GROUP}
 
 # Create tomcat user if not already created
-getent passwd ${TOMCAT_USER} >/dev/null || useradd --comment "$TOMCAT_NAME daemon user" --shell /bin/bash -M -r -g ${TOMCAT_GROUP} --home ${TOMCAT_HOME} ${TOMCAT_USER}
+sudo getent passwd ${TOMCAT_USER} >/dev/null || sudo useradd --comment "$TOMCAT_NAME daemon user" --shell /bin/bash -M -r -g ${TOMCAT_GROUP} --home ${TOMCAT_HOME} ${TOMCAT_USER}
 
 # Add tomcat and ubuntu to each other's groups so we can get the group write working with nfs
-if ! groups $VMUSER | grep --quiet "\b$TOMCAT_GROUP\b"; then
+if ! sudo groups $VMUSER | grep --quiet "\b$TOMCAT_GROUP\b"; then
     echo "### Adding $VMUSER user to $TOMCAT_GROUP user group..."
-    usermod -a -G ${TOMCAT_GROUP} ${VMUSER}
+    sudo usermod -a -G ${TOMCAT_GROUP} ${VMUSER}
 fi
 
 # Add tomcat and ubuntu to each other's groups so we can get the group write working with nfs
-if ! groups ${TOMCAT_GROUP} | grep --quiet "\b$VMUSER\b"; then
+if ! sudo groups ${TOMCAT_GROUP} | grep --quiet "\b$VMUSER\b"; then
     echo "### Adding $TOMCAT_GROUP user to $VMUSER user group..."
-    usermod -a -G ${VMUSER}${TOMCAT_GROUP}
+    sudo usermod -a -G ${VMUSER} ${TOMCAT_GROUP}
 fi
 
 
-mkdir -p ${TOMCAT_HOME}
-tar -zxf ${TOMCAT_TAR_FILE} -C ${TOMCAT_HOME} --strip-components 1
-chmod -R ${TOMCAT_HOME_PERMISSIONS} ${TOMCAT_HOME}
+sudo mkdir -p ${TOMCAT_HOME}
+sudo tar -zxf ${TOMCAT_TAR_FILE} -C ${TOMCAT_HOME} --strip-components 1
+sudo chmod -R ${TOMCAT_HOME_PERMISSIONS} ${TOMCAT_HOME}
 
-rm -rf ${TOMCAT_HOME}/webapps
-mkdir -p ${TOMCAT_USER_HOME}/webapps
+sudo rm -rf ${TOMCAT_HOME}/webapps
+sudo mkdir -p ${TOMCAT_USER_HOME}/webapps
 
-ln -sf ${TOMCAT_USER_HOME}/webapps ${TOMCAT_HOME}/webapps
-chmod ${TOMCAT_USER_HOME_PERMISSIONS} ${TOMCAT_USER_HOME}
-chown ${TOMCAT_GROUP}:${TOMCAT_USER} ${TOMCAT_USER_HOME}/webapps
+sudo ln -sf ${TOMCAT_USER_HOME}/webapps ${TOMCAT_HOME}/webapps
+sudo chmod ${TOMCAT_USER_HOME_PERMISSIONS} ${TOMCAT_USER_HOME}
+sudo chown ${TOMCAT_GROUP}:${TOMCAT_USER} ${TOMCAT_USER_HOME}/webapps
 
 #We don't need .bat files lying around
-rm -f ${TOMCAT_HOME}/bin/*.bat
+sudo rm -f ${TOMCAT_HOME}/bin/*.bat
 
 echo "### Setting up Tomcat logs"
 # Put logging in /var/log and link back.
-rm -rf ${TOMCAT_HOME}/logs
-mkdir -p ${TOMCAT_LOGS_HOME}
-chmod -R ${TOMCAT_LOGS_HOME_PERMISSIONS} ${TOMCAT_LOGS_HOME}
-chown ${TOMCAT_GROUP}:adm ${TOMCAT_LOGS_HOME}
-ln -sf ${TOMCAT_LOGS_HOME} ${TOMCAT_HOME}/logs
+sudo rm -rf ${TOMCAT_HOME}/logs
+sudo mkdir -p ${TOMCAT_LOGS_HOME}
+sudo chmod -R ${TOMCAT_LOGS_HOME_PERMISSIONS} ${TOMCAT_LOGS_HOME}
+sudo chown ${TOMCAT_GROUP}:adm ${TOMCAT_LOGS_HOME}
+sudo ln -sf ${TOMCAT_LOGS_HOME} ${TOMCAT_HOME}/logs
 
 echo "### Done setting up Tomcat logs"
 
 if [ -d "$TOMCAT_CONFIG_HOME" ]; then
-    rm -rf ${TOMCAT_CONFIG_HOME}
+    sudo rm -rf ${TOMCAT_CONFIG_HOME}
 fi
 
-mkdir -p ${TOMCAT_CONFIG_HOME}
+sudo mkdir -p ${TOMCAT_CONFIG_HOME}
 
 # Put conf in /etc/ and link back.
 echo "### Setting up config"
-mkdir -p ${TOMCAT_HOME}/conf/policy.d
-cp ${SCRIPT_HOME}/../policy.d/* ${TOMCAT_HOME}/conf/policy.d
-mv ${TOMCAT_HOME}/conf/* ${TOMCAT_CONFIG_HOME}
-rm -rf ${TOMCAT_HOME}/conf
-ln -sf ${TOMCAT_CONFIG_HOME} ${TOMCAT_HOME}/conf
-mkdir -p ${TOMCAT_CONFIG_HOME}/Catalina
-chgrp -R ${TOMCAT_GROUP} ${TOMCAT_CONFIG_HOME}/*
-chmod -R g+w ${TOMCAT_CONFIG_HOME}/*
+sudo mkdir -p ${TOMCAT_HOME}/conf/policy.d
+sudo cp ${SCRIPT_HOME}/../policy.d/* ${TOMCAT_HOME}/conf/policy.d
+sudo mv ${TOMCAT_HOME}/conf/* ${TOMCAT_CONFIG_HOME}
+sudo rm -rf ${TOMCAT_HOME}/conf
+sudo ln -sf ${TOMCAT_CONFIG_HOME} ${TOMCAT_HOME}/conf
+sudo mkdir -p ${TOMCAT_CONFIG_HOME}/Catalina
+sudo chgrp -R ${TOMCAT_GROUP} ${TOMCAT_CONFIG_HOME}/*
+sudo chmod -R g+w ${TOMCAT_CONFIG_HOME}/*
 echo "### Finished setting up config"
 
-mkdir -p ${TOMCAT_HOME}/.deegree
-chown ${TOMCAT_GROUP}:${TOMCAT_USER} ${TOMCAT_HOME}/.deegree
+sudo mkdir -p ${TOMCAT_HOME}/.deegree
+sudo chown ${TOMCAT_GROUP}:${TOMCAT_USER} ${TOMCAT_HOME}/.deegree
 
 # Put temp and work to /var/cache and link back.
-mkdir -p ${TOMCAT_CACHE_HOME}
+sudo mkdir -p ${TOMCAT_CACHE_HOME}
 
 if [ -d "$TOMCAT_CACHE_HOME/temp" ]; then
-    rm -rf ${TOMCAT_CACHE_HOME}/temp
+    sudo rm -rf ${TOMCAT_CACHE_HOME}/temp
 fi
 
-mv ${TOMCAT_HOME}/temp ${TOMCAT_CACHE_HOME}
-ln -sf ${TOMCAT_CACHE_HOME}/temp ${TOMCAT_HOME}/temp
-chmod ${TOMCAT_CACHE_HOME_PERMISSIONS} ${TOMCAT_CACHE_HOME}/temp
-chgrp -R ${TOMCAT_GROUP} ${TOMCAT_CACHE_HOME}/temp
+sudo mv ${TOMCAT_HOME}/temp ${TOMCAT_CACHE_HOME}
+sudo ln -sf ${TOMCAT_CACHE_HOME}/temp ${TOMCAT_HOME}/temp
+sudo chmod ${TOMCAT_CACHE_HOME_PERMISSIONS} ${TOMCAT_CACHE_HOME}/temp
+sudo chgrp -R ${TOMCAT_GROUP} ${TOMCAT_CACHE_HOME}/temp
 
 if [ -d "$TOMCAT_CACHE_HOME/work" ]; then
-    rm -rf ${TOMCAT_CACHE_HOME}/work
+    sudo rm -rf ${TOMCAT_CACHE_HOME}/work
 fi
 
-mv ${TOMCAT_HOME}/work ${TOMCAT_CACHE_HOME}
-ln -sf ${TOMCAT_CACHE_HOME}/work ${TOMCAT_HOME}/work
-chmod ${TOMCAT_CACHE_HOME_PERMISSIONS} ${TOMCAT_CACHE_HOME}/work
-chgrp -R ${TOMCAT_GROUP} ${TOMCAT_CACHE_HOME}/work
+sudo mv ${TOMCAT_HOME}/work ${TOMCAT_CACHE_HOME}
+sudo ln -sf ${TOMCAT_CACHE_HOME}/work ${TOMCAT_HOME}/work
+sudo chmod ${TOMCAT_CACHE_HOME_PERMISSIONS} ${TOMCAT_CACHE_HOME}/work
+sudo chgrp -R ${TOMCAT_GROUP} ${TOMCAT_CACHE_HOME}/work
 
-cp ${SCRIPT_HOME}/etc/init.d/${TOMCAT_NAME} /etc/init.d
-cp ${SCRIPT_HOME}/etc/default/${TOMCAT_NAME} /etc/default
+sudo cp ${SCRIPT_HOME}/etc/init.d/${TOMCAT_NAME} /etc/init.d
+sudo cp ${SCRIPT_HOME}/etc/default/${TOMCAT_NAME} /etc/default
 
 if ! grep -i --quiet 'ingest/processed' ${TOMCAT_CONFIG_HOME}/server.xml; then
     echo "Adding Tomcat context path for tile images..."
@@ -142,9 +131,9 @@ if ! grep -i --quiet '<Resources allowLinking="true" />' ${TOMCAT_CONFIG_HOME}/c
 fi
 
 # Clean out tomcat logfile. We restart tomcat after provisioning.
-service ${TOMCAT_NAME} stop
-rm -f ${TOMCAT_LOGS_HOME}/catalina.out
+sudo service ${TOMCAT_NAME} stop
+sudo rm -f ${TOMCAT_LOGS_HOME}/catalina.out
 
-update-rc.d ${TOMCAT_NAME} defaults
+sudo update-rc.d ${TOMCAT_NAME} defaults
 
 echo "######## End $TOMCAT_NAME installation ########"

--- a/scripts/tomcat/tomcat8/ubuntu/tomcat8_uninstall.sh
+++ b/scripts/tomcat/tomcat8/ubuntu/tomcat8_uninstall.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 
-if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root"
-   exit 1
-fi
+sudo service tomcat8 stop
 
-service tomcat8 stop
+sudo rm -rf /usr/share/tomcat8
+sudo rm -rf /var/lib/tomcat8
+sudo rm -rf /var/cache/tomcat8
+sudo rm -rf /var/log/tomcat8
+sudo rm -rf /etc/tomcat8
 
-rm -rf /usr/share/tomcat8
-rm -rf /var/lib/tomcat8
-rm -rf /var/cache/tomcat8
-rm -rf /var/log/tomcat8
-rm -rf /etc/tomcat8
+sudo update-rc.d -f tomcat8 remove
 
-update-rc.d -f tomcat8 remove

--- a/test-files/ui/features/support/env.rb
+++ b/test-files/ui/features/support/env.rb
@@ -9,7 +9,7 @@ require 'selenium-webdriver'
 # Chrome instance with timeout is set to 100 seconds
 Capybara.register_driver :selenium do |app|
   client = Selenium::WebDriver::Remote::Http::Default.new
-  client.timeout = 100
+  client.timeout = 150
   Capybara::Selenium::Driver.new(app, :browser => :chrome, :http_client => client)
 end
 


### PR DESCRIPTION
Refs #1605 
While helping a user install Hootenanny on a bare metal Ubuntu 14.04 it suggested:
> f you want to install it without a VM, I would suggest the using the commands from the VagrantProvision.sh script.
> https://github.com/ngageoint/hootenanny/blob/master/VagrantProvision.sh
> 
> A simple search for the vagrant user and group and replace with your user/group and then executing that script will setup your Ubuntu machine to be able to build and run Hootenanny.

Which is all true but a pain.  So I changed the Vagrant provision scripts to use the current user as the user to install it as.  This works great with both base boxes as one logs in as `vagrant` and the other `ubuntu` so the Vagrant provisioning works great.  It also works on a VM where I installed a clean copy of Ubuntu 14.04 and used my own user/group.

In short I updated provision scripts to use the current user/group instead of hard coded user/group (i.e. `vagrant` vs `ubuntu` users). Also updated the call to `tomcat8_install.sh` to not use `sudo` but for the script to call `sudo` on each line that is needed. This allows for the use of other users not `root` and not having to hard code the user.