### PR TITLE
Tame TeX Packages

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -121,7 +121,10 @@ sudo yum -y install \
     qtwebkit \
     qtwebkit-devel \
     swig \
-    tex* \
+    tex-fonts-hebrew \
+    texlive \
+    texlive-collection-fontsrecommended \
+    texlive-collection-langcyrillic \
     unzip \
     v8-devel \
     vim \


### PR DESCRIPTION
This PR streamlines the install process on CentOS 7 by no longer installing every TeX package (`tex*`), and replaced with what is necessary to successfully run `make docs`:

* `texlive`
* `texlive-collection-fontsrecommended`
* `texlive-collection-langcyrillic`
* `tex-fonts-hebrew`

This prevents 400+ unnecessary packages from being installed on CentOS 7.