### PR TITLE
Add Implicit Dependencies

### DIFF
--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -68,15 +68,15 @@ if [ ! -f /etc/apt/sources.list.d/pgdg.list ]; then
 fi
 
 echo "### Installing dependencies from repos..."
-sudo apt-get -q -y install texinfo g++ libicu-dev libqt4-dev git-core libboost-dev libcppunit-dev \
+sudo apt-get -q -y install texinfo g++ libicu-dev libqt4-dev libqtwebkit-dev git-core libboost-dev libcppunit-dev \
  libcv-dev libopencv-dev liblog4cxx10-dev libnewmat10-dev libproj-dev python-dev libjson-spirit-dev \
  automake protobuf-compiler libprotobuf-dev gdb libqt4-sql-psql libgeos++-dev swig lcov maven \
  libstxxl-dev nodejs-dev nodejs-legacy doxygen xsltproc asciidoc curl npm libxerces-c28 \
  libglpk-dev libboost-all-dev source-highlight texlive-lang-arabic texlive-lang-hebrew \
  w3m texlive-lang-cyrillic graphviz python-setuptools python python-pip git ccache distcc libogdi3.2-dev \
  gnuplot python-matplotlib libqt4-sql-sqlite ruby ruby-dev xvfb zlib1g-dev patch x11vnc openssh-server \
- htop unzip postgresql-9.5 postgresql-client-9.5 postgresql-9.5-postgis-scripts postgresql-9.5-postgis-2.3 \
- libpango-1.0-0 libappindicator1 valgrind dos2unix bc mlocate vim >> Ubuntu_upgrade.txt 2>&1
+ htop unzip postgresql-9.5 postgresql-client-9.5 postgresql-contrib-9.5 postgresql-9.5-postgis-scripts postgresql-9.5-postgis-2.3 \
+ libpango-1.0-0 libappindicator1 valgrind dos2unix bc mlocate vim docbook-xml dblatex >> Ubuntu_upgrade.txt 2>&1
 
 if ! dpkg -l | grep --quiet dictionaries-common; then
     # See /usr/share/doc/dictionaries-common/README.problems for details

--- a/VagrantProvisionUbuntu1604.sh
+++ b/VagrantProvisionUbuntu1604.sh
@@ -83,6 +83,8 @@ sudo apt-get -q -y install \
  automake \
  ccache \
  curl \
+ dblatex \
+ docbook-xml \
  doxygen \
  g++ \
  gdb \
@@ -109,6 +111,7 @@ sudo apt-get -q -y install \
  libqt4-dev \
  libqt4-sql-psql \
  libqt4-sql-sqlite \
+ libqtwebkit-dev \
  libstxxl-dev \
  maven \
  npm \
@@ -116,6 +119,8 @@ sudo apt-get -q -y install \
  patch \
  pgadmin3 \
  postgresql-9.5 \
+ postgresql-client-9.5 \
+ postgresql-contrib-9.5 \
  postgresql-9.5-postgis-2.3 \
  postgresql-9.5-postgis-scripts \
  postgresql-client-9.5 \


### PR DESCRIPTION
This PR adds in packages that were implicitly installed by `apt-get` only because they're recommended by the maintainer, in particular:

* `libqtwebkit-dev` (required to build `capybara-webkit` gem)
* `postgresql-contrib-9.5` (required for the hstore extension)
* `docbook-xml` and `dblatex` (used for docs)

This resolves the issue that if `apt-get` is configured to ignore recommended packages, provisioning will fail due to unmet dependencies.