### PR TITLE
Update Oracle JDK to 8u152

### DIFF
--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -31,38 +31,31 @@ sudo service ntp stop
 sudo ntpd -gq
 sudo service ntp start
 
-
-JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
-JDK_TAR=jdk-8u144-linux-x64.tar.gz
-JDK_VERSION=1.8.0_144
+JDK_TAR=jdk-8u152-linux-x64.tar.gz
+JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/$JDK_TAR
+JDK_VERSION=1.8.0_152
 
 if ! java -version 2>&1 | grep --quiet $JDK_VERSION; then
     echo "### Installing Java 8..."
 
-    # jdk-8u144-linux-x64.tar.gz's official checksums:
-    # sha256: e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
-    # md5: 2d59a3add1f213cd249a67684d4aeb83
-
-    echo "2d59a3add1f213cd249a67684d4aeb83  ./${JDK_TAR} " > ./jdk.md5
+    # jdk-8u152-linux-x64.tar.gz's official checksums:
+    #    sha256: 218b3b340c3f6d05d940b817d0270dfe0cfd657a636bad074dcabe0c111961bf
+    #    md5: 20dddd28ced3179685a5f58d3fcbecd8
+    echo "20dddd28ced3179685a5f58d3fcbecd8  ${JDK_TAR} " > ./jdk.md5
 
 
     if [ ! -f ./${JDK_TAR} ] || ! md5sum -c ./jdk.md5; then
         echo "Downloading ${JDK_TAR} ...."
-        sudo wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDK_URL
+        wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDK_URL
         echo "Finished download of ${JDK_TAR}"
     fi
 
-    sudo tar -xvzf ./${JDK_TAR} >/dev/null
+    sudo tar -xvzf ./$JDK_TAR
+    sudo mkdir -p /usr/lib/jvm
+    sudo rm -rf /usr/lib/jvm/oracle_jdk8
 
-    if [[ ! -e /usr/lib/jvm ]]; then
-        sudo mkdir /usr/lib/jvm
-    else
-        if [[ -e /usr/lib/jvm/oracle_jdk8 ]]; then
-            sudo rm -rf /usr/lib/jvm/oracle_jdk8
-        fi
-    fi
-
-    sudo mv -f ./jdk1.8.0_144 /usr/lib/jvm/oracle_jdk8
+    sudo chown -R root:root ./jdk$JDK_VERSION
+    sudo mv -f ./jdk$JDK_VERSION /usr/lib/jvm/oracle_jdk8
     sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/oracle_jdk8/jre/bin/java 9999
     sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/oracle_jdk8/bin/javac 9999
     echo "### Done with Java 8 install..."

--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -50,10 +50,10 @@ if ! java -version 2>&1 | grep --quiet $JDK_VERSION; then
         echo "Finished download of ${JDK_TAR}"
     fi
 
-    sudo tar -xvzf ./$JDK_TAR
     sudo mkdir -p /usr/lib/jvm
     sudo rm -rf /usr/lib/jvm/oracle_jdk8
 
+    sudo tar -xzf ./$JDK_TAR
     sudo chown -R root:root ./jdk$JDK_VERSION
     sudo mv -f ./jdk$JDK_VERSION /usr/lib/jvm/oracle_jdk8
     sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/oracle_jdk8/jre/bin/java 9999
@@ -129,8 +129,8 @@ if ! grep --quiet "PATH=" ~/.profile; then
     source ~/.profile
 fi
 
-# Whether the client uses distcc or not, have distcc set up and ready to go.  To turn it on, 
-# enable it in LocalConfig.pri, configure the slaves in ~/.distcc/hosts, and launch distccd on 
+# Whether the client uses distcc or not, have distcc set up and ready to go.  To turn it on,
+# enable it in LocalConfig.pri, configure the slaves in ~/.distcc/hosts, and launch distccd on
 # the slaves.
 if [ ! -f ~/.distcc/hosts ]; then
     echo "Adding distcc hosts file..."
@@ -630,4 +630,3 @@ fi
 
 # Always start with a clean $HOOT_HOME/userfiles/tmp
 rm -rf $HOOT_HOME/userfiles/tmp
-

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -158,7 +158,7 @@ JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4
 JDK_VERSION=1.8.0_152
 if  ! rpm -qa | grep jdk$JDK_VERSION-$JDK_VERSION; then
     echo "### Installing Java8..."
-    if [ ! -f jdk-8u152-linux-x64.rpm ]; then
+    if [ ! -f $JDK_RPM ]; then
       wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDK_URL
     fi
     sudo yum -y install ./$JDK_RPM

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -154,18 +154,18 @@ sudo yum -y install \
 # http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 # JAVA JDK download URL
 JDK_RPM=jdk-8u152-linux-x64.rpm
-JDK_URL=JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/$JDK_RPM
+JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/$JDK_RPM
 JDK_VERSION=1.8.0_152
 if  ! rpm -qa | grep jdk$JDK_VERSION-$JDK_VERSION; then
     echo "### Installing Java8..."
     if [ ! -f jdk-8u152-linux-x64.rpm ]; then
-      wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDKURL
+      wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDK_URL
     fi
     sudo yum -y install ./$JDK_RPM
 fi
 
 # Trying the following instead of removing the OpenJDK
-# Setting /usr/java/jdk1.8.0_152/bin/java's priority to something really atrocious to guarantee that it will be
+# Setting /usr/java/jdk$JDK_VERSION/bin/java's priority to something really atrocious to guarantee that it will be
 # the one used when alternatives' auto mode is used.
 sudo alternatives --install /usr/bin/java java /usr/java/jdk$JDK_VERSION/bin/java 999999
 

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -153,29 +153,31 @@ sudo yum -y install \
 # Official download page:
 # http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 # JAVA JDK download URL
-JDKURL=http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm
-if  ! rpm -qa | grep jdk1.8.0_144-1.8.0_144; then
+JDK_RPM=jdk-8u152-linux-x64.rpm
+JDK_URL=JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/$JDK_RPM
+JDK_VERSION=1.8.0_152
+if  ! rpm -qa | grep jdk$JDK_VERSION-$JDK_VERSION; then
     echo "### Installing Java8..."
-    if [ ! -f jdk-8u144-linux-x64.rpm ]; then
+    if [ ! -f jdk-8u152-linux-x64.rpm ]; then
       wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDKURL
     fi
-    sudo yum -y install ./jdk-8u144-linux-x64.rpm
+    sudo yum -y install ./$JDK_RPM
 fi
 
 # Trying the following instead of removing the OpenJDK
-# Setting /usr/java/jdk1.8.0_144/bin/java's priority to something really atrocious to guarantee that it will be
+# Setting /usr/java/jdk1.8.0_152/bin/java's priority to something really atrocious to guarantee that it will be
 # the one used when alternatives' auto mode is used.
-sudo alternatives --install /usr/bin/java java /usr/java/jdk1.8.0_144/bin/java 999999
+sudo alternatives --install /usr/bin/java java /usr/java/jdk$JDK_VERSION/bin/java 999999
 
-# Setting /usr/java/jdk1.8.0_144/bin/javac's priority to something really atrocious to guarantee that it will be
+# Setting /usr/java/jdk$JDK_VERSION/bin/javac's priority to something really atrocious to guarantee that it will be
 # the one used when alternatives' auto mode is enabled.
-sudo alternatives --install /usr/bin/javac javac /usr/java/jdk1.8.0_144/bin/javac 9999999
+sudo alternatives --install /usr/bin/javac javac /usr/java/jdk$JDK_VERSION/bin/javac 9999999
 
 # switching to manual and forcing the desired version of java be configured
-sudo alternatives --set java /usr/java/jdk1.8.0_144/bin/java
+sudo alternatives --set java /usr/java/jdk$JDK_VERSION/bin/java
 
 # switching to manual and forcing the desired version of javac be configured
-sudo alternatives --set javac /usr/java/jdk1.8.0_144/bin/javac
+sudo alternatives --set javac /usr/java/jdk$JDK_VERSION/bin/javac
 
 # Now make sure that the version of Java we installed gets used.
 # maven installs java-1.8.0-openjdk
@@ -268,11 +270,11 @@ fi
 
 if ! grep --quiet "export JAVA_HOME" ~/.bash_profile; then
     echo "Adding Java home to profile..."
-    echo "export JAVA_HOME=/usr/java/jdk1.8.0_144" >> ~/.bash_profile
+    echo "export JAVA_HOME=/usr/java/jdk$JDK_VERSION" >> ~/.bash_profile
     echo "export PATH=\$PATH:\$JAVA_HOME/bin" >> ~/.bash_profile
     source ~/.bash_profile
 else
-    sed -i '/^export JAVA_HOME=.*/c\export JAVA_HOME=\/usr\/java\/jdk1.8.0_144' ~/.bash_profile
+    sed -i '/^export JAVA_HOME=.*/c\export JAVA_HOME=\/usr\/java\/jdk$JDK_VERSION' ~/.bash_profile
 fi
 
 if ! grep --quiet "export HADOOP_HOME" ~/.bash_profile; then
@@ -680,7 +682,7 @@ sudo bash -c "cat >> $HADOOP_HOME/conf/hdfs-site.xml" <<EOT
 </configuration>
 EOT
 
-  sudo sed -i.bak 's/# export JAVA_HOME=\/usr\/lib\/j2sdk1.5-sun/export JAVA_HOME=\/usr\/java\/jdk1.8.0_144/g' $HADOOP_HOME/conf/hadoop-env.sh
+  sudo sed -i.bak "s/# export JAVA_HOME=\/usr\/lib\/j2sdk1.5-sun/export JAVA_HOME=\/usr\/java\/jdk${JDK_VERSION}/g" $HADOOP_HOME/conf/hadoop-env.sh
   sudo sed -i.bak 's/#include <pthread.h>/#include <pthread.h>\n#include <unistd.h>/g' $HADOOP_HOME/src/c++/pipes/impl/HadoopPipes.cc
 
   sudo mkdir -p $HADOOP_HOME/dfs/name/current

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -156,7 +156,7 @@ sudo yum -y install \
 JDK_RPM=jdk-8u152-linux-x64.rpm
 JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/$JDK_RPM
 JDK_VERSION=1.8.0_152
-if  ! rpm -qa | grep jdk$JDK_VERSION-$JDK_VERSION; then
+if  ! rpm -qa | grep "^jdk${JDK_VERSION:0:3}-${JDK_VERSION}"; then
     echo "### Installing Java8..."
     if [ ! -f $JDK_RPM ]; then
       wget --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" $JDK_URL

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -270,11 +270,11 @@ fi
 
 if ! grep --quiet "export JAVA_HOME" ~/.bash_profile; then
     echo "Adding Java home to profile..."
-    echo "export JAVA_HOME=/usr/java/jdk$JDK_VERSION" >> ~/.bash_profile
+    echo "export JAVA_HOME=/usr/java/jdk${JDK_VERSION}" >> ~/.bash_profile
     echo "export PATH=\$PATH:\$JAVA_HOME/bin" >> ~/.bash_profile
     source ~/.bash_profile
 else
-    sed -i '/^export JAVA_HOME=.*/c\export JAVA_HOME=\/usr\/java\/jdk$JDK_VERSION' ~/.bash_profile
+    sed -i "/^export JAVA_HOME=.*/c\export JAVA_HOME=\/usr\/java\/jdk${JDK_VERSION}" ~/.bash_profile
 fi
 
 if ! grep --quiet "export HADOOP_HOME" ~/.bash_profile; then

--- a/scripts/tomcat/tomcat8/centos7/etc/systemd/system/tomcat8.service
+++ b/scripts/tomcat/tomcat8/centos7/etc/systemd/system/tomcat8.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 [Service]
 Type=forking
 
-Environment=JAVA_HOME=/usr/java/jdk1.8.0_144
+Environment=JAVA_HOME=/usr/java/jdk1.8.0_152
 Environment=CATALINA_PID=/usr/share/tomcat8/temp/tomcat8.pid
 Environment=CATALINA_HOME=/usr/share/tomcat8
 Environment=CATALINA_BASE=/usr/share/tomcat8


### PR DESCRIPTION
The wonderful folks at Oracle pulled all the public downloads for the 8u144 JDK.  This PR switches us to the 8u152 JDK along with some minor tweaks to provision scripts.

Note: this is a temporary solution.  Oracle will pull this release again in January 2018 and will pull all Java 8 downloads from public distribution in September 2018.