### PR TITLE
Fix Locale for CentOS Docker Images

### DIFF
--- a/docker/centos7.2/Dockerfile
+++ b/docker/centos7.2/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:centos7.2.1511
 ENV container docker
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 #RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 #systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 #rm -f /lib/systemd/system/multi-user.target.wants/*;\

--- a/docker/centos7.4/Dockerfile
+++ b/docker/centos7.4/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:centos7.4.1708
 ENV container docker
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 #RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 #systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 #rm -f /lib/systemd/system/multi-user.target.wants/*;\


### PR DESCRIPTION
This PR fixes #1900 by adding `ENV` directives that properly specify the locale in the CentOS 7 `Dockerfile`s.  This eliminates the need for the `localedef` command, which was previously used to ensure the PostgreSQL database was initialized properly using the UTF-8 for its database encoding.

### Testing

I built the CentOS 7.4 image using this branch:
```
docker build --rm -t local/centos7.4vagrant ./docker/centos7.4/
```

I brought up the CentOS 7.4 image, provisioning only with `VagrantProvisionCentOS7.sh`:
```
vagrant up dockercentos7.4 --provider docker --provision-with hoot
```

The provision script worked successfully; I finally confirmed PostgreSQL was using the right encoding:

```
vagrant ssh dockercentos7.4 -c 'sudo -u postgres -g postgres psql -c "SELECT datname,datcollate,datctype FROM pg_database;"'

   datname   | datcollate  |  datctype   
-------------+-------------+-------------
 template1   | en_US.UTF-8 | en_US.UTF-8
 template0   | en_US.UTF-8 | en_US.UTF-8
 postgres    | en_US.UTF-8 | en_US.UTF-8
 hoot        | en_US.UTF-8 | en_US.UTF-8
 wfsstoredb  | en_US.UTF-8 | en_US.UTF-8
 osmapi_test | en_US.UTF-8 | en_US.UTF-8
(6 rows)
```