### PR TITLE
Fix potential buffer overflow vulnerability in PaintNodesDriver:177. …

### DIFF
--- a/hoot-hadoop/src/main/cpp/hoot/hadoop/paint-nodes/PaintNodesDriver.cpp
+++ b/hoot-hadoop/src/main/cpp/hoot/hadoop/paint-nodes/PaintNodesDriver.cpp
@@ -170,7 +170,7 @@ void PaintNodesDriver::_loadPartFile(const QString& partPath)
   s.resize(1024);
   PaintNodesReducer::Pixel pixel;
   int32_t sum;
-  while (reader.nextFixed<PaintNodesReducer::Pixel, int>(pixel, sum))
+  while (reader.nextFixed<PaintNodesReducer::Pixel, int32_t>(pixel, sum))
   {
     assert(pixel.x < _width);
     assert(pixel.y < _height);

--- a/pretty-pipes/pp-lib/src/main/cpp/pp/DataInputStream.h
+++ b/pretty-pipes/pp-lib/src/main/cpp/pp/DataInputStream.h
@@ -47,6 +47,9 @@ class DataInputStream
 public:
   DataInputStream(std::istream& in) : _in(in) {}
 
+  template<class ValueClass>
+  int read(ValueClass& value);
+
   int read(char* data, int length);
 
   char readByte();
@@ -98,6 +101,14 @@ inline int DataInputStream::read(char* data, int length)
 {
   _in.read(data, length);
   _checkEof(length);
+  return _in.gcount();
+}
+
+template<class ValueClass>
+inline int DataInputStream::read(ValueClass& value)
+{
+  _in.read((char*)&value, sizeof(value));
+  _checkEof(sizeof(value));
   return _in.gcount();
 }
 

--- a/pretty-pipes/pp-lib/src/main/cpp/pp/io/CppSeqFile.h
+++ b/pretty-pipes/pp-lib/src/main/cpp/pp/io/CppSeqFile.h
@@ -204,8 +204,8 @@ bool CppSeqFile::Reader::nextFixed(KeyClass& key, ValueClass& value)
     {
       throw Exception("Value data size does not match value class size.");
     }
-    _dis.read((char*)&key, sizeof(key));
-    _dis.read((char*)&value, sizeof(value));
+    _dis.read(key);
+    _dis.read(value);
 
     return true;
   }


### PR DESCRIPTION
…The function in question was depending upon data properties that were enforced outside the immediate scope of the code - which is not necessarily a good practice.

Refs #1908 