### PR TITLE
Consistent ChromeDriver Version

### DIFF
--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -141,33 +141,9 @@ $HOOT_HOME/scripts/ruby/gem-install.sh
 # Make sure that we are in ~ before trying to wget & install stuff
 cd ~
 
-if  ! dpkg -l | grep --quiet google-chrome-stable; then
-    echo "### Installing Chrome..."
-    if [ ! -f google-chrome-stable_current_amd64.deb ]; then
-      wget --quiet https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    fi
-    sudo apt-get -q -y install gconf-service libgconf-2-4 gconf-service-backend gconf2-common
-    sudo dpkg -i google-chrome-stable_current_amd64.deb
-fi
-
-if [ ! -f bin/chromedriver ]; then
-    echo "### Installing Chromedriver..."
-    mkdir -p ~/bin
-    if [ ! -f chromedriver_linux64.zip ]; then
-      LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
-      wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    fi
-    unzip -d ~/bin chromedriver_linux64.zip
-else
-  LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
-  if [[ "$(chromedriver --version)" != "ChromeDriver $LATEST_RELEASE."* ]]; then
-    echo "### Updating Chromedriver"
-    rm ~/bin/chromedriver
-    rm ~/chromedriver_linux64.zip
-    wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    unzip -o -d ~/bin chromedriver_linux64.zip
-  fi
-fi
+# Install Google Chrome and ChromeDriver.
+$HOOT_HOME/scripts/chrome/chrome-install.sh
+$HOOT_HOME/scripts/chrome/driver-install.sh
 
 sudo apt-get autoremove -y
 

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -219,37 +219,9 @@ $HOOT_HOME/scripts/ruby/gem-install.sh
 # Make sure that we are in ~ before trying to wget & install stuff
 cd ~
 
-
-if  ! rpm -qa | grep google-chrome-stable; then
-    echo "### Installing Chrome..."
-    if [ ! -f google-chrome-stable_current_x86_64.rpm ]; then
-      wget --quiet https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
-    fi
-    sudo yum -y install ./google-chrome-stable_current_*.rpm
-fi
-
-if [ ! -f bin/chromedriver ]; then
-    echo "### Installing Chromedriver..."
-    mkdir -p ~/bin
-    if [ ! -f chromedriver_linux64.zip ]; then
-#       LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
-#       wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-
-# Errors with the latest release (2.31) wanting glibc v2.18 when only glibc v2.17 is available
-# https://bugs.chromium.org/p/chromedriver/issues/detail?id=1894#c2
-      wget --quiet http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip
-    fi
-    unzip -d ~/bin chromedriver_linux64.zip
-else
-  LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
-  if [[ "$(chromedriver --version)" != "ChromeDriver $LATEST_RELEASE."* ]]; then
-    echo "### Updating Chromedriver"
-    rm ~/bin/chromedriver
-    rm ~/chromedriver_linux64.zip
-    wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    unzip -o -d ~/bin chromedriver_linux64.zip
-  fi
-fi
+# Install Google Chrome and ChromeDriver.
+$HOOT_HOME/scripts/chrome/chrome-install.sh
+$HOOT_HOME/scripts/chrome/driver-install.sh
 
 if [ ! -f bin/osmosis ]; then
     echo "### Installing Osmosis"

--- a/VagrantProvisionUbuntu1604.sh
+++ b/VagrantProvisionUbuntu1604.sh
@@ -201,35 +201,9 @@ $HOOT_HOME/scripts/ruby/gem-install.sh
 # Make sure that we are in ~ before trying to wget & install stuff
 cd ~
 
-if  ! dpkg -l | grep --quiet google-chrome-stable; then
-    echo "### Installing Chrome..."
-    if [ ! -f google-chrome-stable_current_amd64.deb ]; then
-      wget --quiet https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    fi
-    sudo apt-get -f -y -q install || echo ignore failure
-    sudo dpkg -i google-chrome-stable_current_amd64.deb  || echo ignore failure
-    sudo apt-get -f -y -q install
-    sudo dpkg -i google-chrome-stable_current_amd64.deb
-fi
-
-if [ ! -f bin/chromedriver ]; then
-    echo "### Installing Chromedriver..."
-    mkdir -p ~/bin
-    if [ ! -f chromedriver_linux64.zip ]; then
-      LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
-      wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    fi
-    unzip -d ~/bin chromedriver_linux64.zip
-else
-  LATEST_RELEASE="`wget --quiet -O- http://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
-  if [[ "$(chromedriver --version)" != "ChromeDriver $LATEST_RELEASE."* ]]; then
-    echo "### Updating Chromedriver"
-    rm ~/bin/chromedriver
-    rm ~/chromedriver_linux64.zip
-    wget --quiet http://chromedriver.storage.googleapis.com/$LATEST_RELEASE/chromedriver_linux64.zip
-    unzip -o -d ~/bin chromedriver_linux64.zip
-  fi
-fi
+# Install Google Chrome and ChromeDriver.
+$HOOT_HOME/scripts/chrome/chrome-install.sh
+$HOOT_HOME/scripts/chrome/driver-install.sh
 
 sudo apt-get autoremove -y
 

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export CHROMEDRIVER_VERSION=2.33
+
 export JDK_VERSION=1.8.0_152
 export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jdk-8u152-linux-x64.tar.gz
 export JDK_TAR=jdk-8u152-linux-x64.tar.gz

--- a/scripts/chrome/chrome-install.sh
+++ b/scripts/chrome/chrome-install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+CHROME_BASE_URL=https://dl.google.com/linux/direct
+CHROME_DEB=google-chrome-stable_current_amd64.deb
+CHROME_DEB_URL=$CHROME_BASE_URL/$CHROME_DEB
+CHROME_RPM=google-chrome-stable_current_x86_64.rpm
+CHROME_RPM_URL=$CHROME_BASE_URL/$CHROME_RPM
+
+echo "### Installing Chrome..."
+if [ "$(lsb_release -i -s)" == "Ubuntu" ]; then
+    if  ! dpkg -l | grep --quiet google-chrome-stable; then
+        if [ ! -f $HOME/$CHROME_DEB ]; then
+            wget --quiet -O $HOME/$CHROME_DEB $CHROME_DEB_URL
+        fi
+        sudo apt-get -q -y install gconf-service libgconf-2-4 gconf-service-backend gconf2-common
+        sudo dpkg -i $HOME/$CHROME_DEB
+    fi
+else
+    if  ! rpm -qa | grep google-chrome-stable; then
+        if [ ! -f $HOME/$CHROME_RPM ]; then
+            wget --quiet -O $HOME/$CHROME_RPM $CHROME_RPM_URL
+        fi
+        sudo yum -y install $HOME/$CHROME_RPM
+    fi
+fi

--- a/scripts/chrome/driver-install.sh
+++ b/scripts/chrome/driver-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+# Embed version into ChromeDriver ZIP filename.
+CHROMEDRIVER_ZIP=chromedriver_linux64_v$CHROMEDRIVER_VERSION.zip
+CHROMEDRIVER_URL=https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
+
+if [ ! -f $HOME/$CHROMEDRIVER_ZIP ]; then
+    echo "### Downloading ChromeDriver v${CHROMEDRIVER_VERSION}..."
+    wget --quiet -O $HOME/$CHROMEDRIVER_ZIP $CHROMEDRIVER_URL
+fi
+
+if ! $HOME/bin/chromedriver --version | grep -q "^ChromeDriver ${CHROMEDRIVER_VERSION//\./\\.}"; then
+    echo "### Installing ChromeDriver v${CHROMEDRIVER_VERSION}..."
+    mkdir -p $HOME/bin
+    unzip -d $HOME/bin $HOME/$CHROMEDRIVER_ZIP
+fi


### PR DESCRIPTION
This PR resolves #1907 by locking the ChromeDriver version to 2.33 instead of attempting to download the latest version.  In addition:

* The installation of Chrome and ChromeDriver have been unified into common scripts: `scripts/chrome/{chrome,driver}-install.sh`. 
* Embed the version of ChromeDriver in the name of the downloaded file and check the output of `chromedriver --version` to ensure that proper version is downloaded and installed correctly.
* Use TLS when downloading ChromeDriver.
