### PR TITLE
Address possible mem leaks in CalculateStatsOp

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/MatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MatchCreator.cpp
@@ -101,25 +101,25 @@ MatchCreator::FeatureCalcType MatchCreator::getFeatureCalcType (BaseFeatureType 
   }
 }
 
-ElementCriterion* MatchCreator::getElementCriterion (BaseFeatureType t, ConstOsmMapPtr map)
+ElementCriterionPtr MatchCreator::getElementCriterion (BaseFeatureType t, ConstOsmMapPtr map)
 {
   switch (t)
   {
     case POI:
-      return new PoiCriterion();
+      return ElementCriterionPtr(new PoiCriterion());
     case Highway:
-      return new HighwayFilter(Filter::KeepMatches);
+      return ElementCriterionPtr(new HighwayFilter(Filter::KeepMatches));
     case Building:
-      return new BuildingCriterion(map);
+      return ElementCriterionPtr(new BuildingCriterion(map));
     case Waterway:
-      return new WaterwayCriterion();
+      return ElementCriterionPtr(new WaterwayCriterion());
     case PoiPolygonPOI:
-      return new PoiPolygonPoiCriterion();
+      return ElementCriterionPtr(new PoiPolygonPoiCriterion());
     case Polygon:
-      return new PoiPolygonPolyCriterion();
+      return ElementCriterionPtr(new PoiPolygonPolyCriterion());
     case Unknown:
     default:
-      return NULL;
+      return ElementCriterionPtr();
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MatchCreator.h
@@ -82,7 +82,7 @@ public:
    */
   static FeatureCalcType getFeatureCalcType(BaseFeatureType t);
 
-  static ElementCriterion* getElementCriterion(BaseFeatureType t, ConstOsmMapPtr map);
+  static boost::shared_ptr<ElementCriterion> getElementCriterion(BaseFeatureType t, ConstOsmMapPtr map);
 
   class Description
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterion.h
@@ -46,7 +46,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new PoiPolygonPoiCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PoiPolygonPoiCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterion.h
@@ -46,7 +46,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new PoiPolygonPolyCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PoiPolygonPolyCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -72,7 +72,7 @@ public:
     return result;
   }
 
-  virtual ElementCriterion* clone() { return new DeletableBuildingPart(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new DeletableBuildingPart()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/ArbitraryCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/ArbitraryCriterion.h
@@ -62,7 +62,7 @@ public:
     return _f(e);
   }
 
-  virtual ElementCriterion* clone() { return new ArbitraryCriterion(_f); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new ArbitraryCriterion(_f)); }
 
 private:
   boost::function<bool (const boost::shared_ptr<const Element> &e)> _f;

--- a/hoot-core/src/main/cpp/hoot/core/filters/AreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/AreaCriterion.h
@@ -46,7 +46,7 @@ public:
 
   bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new AreaCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new AreaCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/BuildingCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/BuildingCriterion.h
@@ -54,7 +54,7 @@ public:
 
   virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
 
-  virtual ElementCriterion* clone() { return new BuildingCriterion(_map); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new BuildingCriterion(_map)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/BuildingWayNodeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/filters/BuildingWayNodeCriterion.cpp
@@ -82,9 +82,9 @@ void BuildingWayNodeCriterion::setOsmMap(const OsmMap* map)
   _map = map->shared_from_this();
 }
 
-ElementCriterion* BuildingWayNodeCriterion::clone()
+ElementCriterionPtr BuildingWayNodeCriterion::clone()
 {
-  return new BuildingWayNodeCriterion(_map);
+  return ElementCriterionPtr(new BuildingWayNodeCriterion(_map));
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/filters/BuildingWayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/BuildingWayNodeCriterion.h
@@ -52,7 +52,7 @@ public:
 
   virtual void setOsmMap(const OsmMap* map);
 
-  virtual ElementCriterion* clone();
+  virtual ElementCriterionPtr clone();
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/ChainCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/ChainCriterion.h
@@ -52,7 +52,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone() { return new ChainCriterion(_filters); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new ChainCriterion(_filters)); }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/ContainsNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/ContainsNodeCriterion.h
@@ -52,7 +52,8 @@ public:
 
   bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  ContainsNodeCriterion* clone() { return new ContainsNodeCriterion(_nodeId); }
+  ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new ContainsNodeCriterion(_nodeId)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/DistanceNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/DistanceNodeCriterion.h
@@ -55,7 +55,8 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  DistanceNodeCriterion* clone() { return new DistanceNodeCriterion(_center, _distance); }
+  ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new DistanceNodeCriterion(_center, _distance)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/ElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/ElementCriterion.h
@@ -71,7 +71,7 @@ public:
   /**
    * Use the clone pattern for all classes based on the ElementCriterion class
    */
-  virtual ElementCriterion* clone() = 0;
+  virtual boost::shared_ptr<ElementCriterion> clone() = 0;
 };
 
 typedef boost::shared_ptr<ElementCriterion> ElementCriterionPtr;

--- a/hoot-core/src/main/cpp/hoot/core/filters/ElementTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/ElementTypeCriterion.h
@@ -45,7 +45,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone() { return new ElementTypeCriterion(_elementType); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new ElementTypeCriterion(_elementType)); }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/HighwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/HighwayCriterion.h
@@ -44,7 +44,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone() { return new HighwayCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new HighwayCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/HighwayFilter.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/HighwayFilter.h
@@ -44,7 +44,7 @@ public:
 
   virtual bool isMatch(const Element& e) const;
 
-  virtual ElementCriterion* clone() { return new HighwayFilter(_type); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new HighwayFilter(_type)); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/IntersectionCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/IntersectionCriterion.h
@@ -52,7 +52,8 @@ public:
 
   IntersectionCriterion(ConstOsmMapPtr map);
 
-  virtual ElementCriterion* clone() { return new IntersectionCriterion(_map); }
+  virtual ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new IntersectionCriterion(_map)); }
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/IntersectionFilter.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/IntersectionFilter.h
@@ -44,7 +44,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone() { return new IntersectionFilter(_nids); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new IntersectionFilter(_nids)); }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/IsNodeFilter.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/IsNodeFilter.h
@@ -46,7 +46,7 @@ public:
 
   virtual bool isFiltered(const Element& e) const;
 
-  virtual ElementCriterion* clone() { return new IsNodeFilter(_type); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new IsNodeFilter(_type)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/LinearFilter.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/LinearFilter.h
@@ -41,7 +41,7 @@ public:
 
   virtual bool isMatch(const Element& e) const;
 
-  virtual ElementCriterion* clone() { return new LinearFilter(_type); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new LinearFilter(_type)); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/NeedsReviewCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/NeedsReviewCriterion.h
@@ -50,7 +50,8 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new NeedsReviewCriterion(_map); }
+  virtual ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new NeedsReviewCriterion(_map)); }
 
   virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/NoInformationCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/NoInformationCriterion.h
@@ -56,8 +56,8 @@ public:
 
   virtual void setConfiguration(const Settings& conf);
 
-  virtual ElementCriterion* clone()
-  { return new NoInformationCriterion(_treatReviewTagsAsMetadata); }
+  virtual ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new NoInformationCriterion(_treatReviewTagsAsMetadata)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/NonBuildingAreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/NonBuildingAreaCriterion.h
@@ -49,7 +49,8 @@ public:
 
   bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new NonBuildingAreaCriterion(); }
+  virtual ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new NonBuildingAreaCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/NotCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/NotCriterion.h
@@ -41,7 +41,7 @@ public:
 
   NotCriterion() {}
   NotCriterion(ElementCriterion* c) : _child(c) {}
-  NotCriterion(ElementCriterionPtr& c) : _child(c) {}
+  NotCriterion(ElementCriterionPtr c) : _child(c) {}
 
   virtual ~NotCriterion() {}
 
@@ -52,7 +52,8 @@ public:
    */
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone() { return new NotCriterion(_child->clone()); }
+  virtual ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new NotCriterion(_child->clone())); }
 
 private:
   ElementCriterionPtr _child;

--- a/hoot-core/src/main/cpp/hoot/core/filters/OneWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/OneWayCriterion.h
@@ -47,7 +47,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  OneWayCriterion* clone() { return new OneWayCriterion(); }
+  ElementCriterionPtr clone() { return ElementCriterionPtr(new OneWayCriterion()); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/OrCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/OrCriterion.h
@@ -46,11 +46,15 @@ public:
     ChainCriterion(child1, child2)
   {
   }
+  OrCriterion(ElementCriterionPtr child1, ElementCriterionPtr child2) :
+    ChainCriterion(child1, child2)
+  {
+  }
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone()
-  { return new OrCriterion(_filters[0]->clone(), _filters[1]->clone()); }
+  virtual ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new OrCriterion(_filters[0]->clone(), _filters[1]->clone())); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/ParallelWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/ParallelWayCriterion.h
@@ -60,7 +60,8 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  ParallelWayCriterion* clone() { return new ParallelWayCriterion(_map, _baseWay, _isParallel); }
+  ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new ParallelWayCriterion(_map, _baseWay, _isParallel)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/PoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/PoiCriterion.h
@@ -45,7 +45,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element>& e) const;
 
-  virtual ElementCriterion* clone() { return new PoiCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PoiCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/StatsAreaFilter.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/StatsAreaFilter.h
@@ -43,7 +43,7 @@ public:
 
   virtual bool isMatch(const Element& e) const;
 
-  virtual ElementCriterion* clone() { return new StatsAreaFilter(_type); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new StatsAreaFilter(_type)); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/StatusCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/StatusCriterion.h
@@ -52,7 +52,7 @@ public:
 
   virtual void setConfiguration(const Settings& conf);
 
-  virtual ElementCriterion* clone() { return new StatusCriterion(_status); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new StatusCriterion(_status)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/TagContainsFilter.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/TagContainsFilter.h
@@ -47,7 +47,7 @@ public:
    */
   void addPair(QString key, QString valueSubstring);
 
-  virtual ElementCriterion* clone() { return new TagContainsFilter(_type, _key, _valueSubstring); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagContainsFilter(_type, _key, _valueSubstring)); }
 
 protected:
   virtual bool isFiltered(const Element& e) const;

--- a/hoot-core/src/main/cpp/hoot/core/filters/TagCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/TagCriterion.h
@@ -53,7 +53,7 @@ public:
 
   void setConfiguration(const Settings& s);
 
-  virtual ElementCriterion* clone() { return new TagCriterion(_k, _v); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagCriterion(_k, _v)); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/TagKeyCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/TagKeyCriterion.h
@@ -54,7 +54,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new TagKeyCriterion(_keys); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagKeyCriterion(_keys)); }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/UnknownCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/UnknownCriterion.h
@@ -47,7 +47,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  UnknownCriterion* clone() { return new UnknownCriterion(); }
+  ElementCriterionPtr clone() { return ElementCriterionPtr(new UnknownCriterion()); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/filters/UselessElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/UselessElementCriterion.h
@@ -54,7 +54,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new UselessElementCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new UselessElementCriterion()); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/WaterwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/WaterwayCriterion.h
@@ -44,7 +44,7 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new WaterwayCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new WaterwayCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/WayBufferCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/WayBufferCriterion.h
@@ -68,7 +68,8 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  WayBufferCriterion* clone() { return new WayBufferCriterion(_map, _baseLs, _buffer, 0, _matchPercent); }
+  ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new WayBufferCriterion(_map, _baseLs, _buffer, 0, _matchPercent)); }
 
 private:
   Meters _buffer;

--- a/hoot-core/src/main/cpp/hoot/core/filters/WayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/WayCriterion.h
@@ -46,7 +46,7 @@ public:
 
   bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new WayCriterion(); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new WayCriterion()); }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/filters/WayDirectionCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/filters/WayDirectionCriterion.h
@@ -46,7 +46,8 @@ public:
 
   virtual bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  WayDirectionCriterion* clone() { return new WayDirectionCriterion(_map, _baseWay, _similarDirection); }
+  ElementCriterionPtr clone()
+  { return ElementCriterionPtr(new WayDirectionCriterion(_map, _baseWay, _similarDirection)); }
 
 private:
   ConstOsmMapPtr _map;

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
@@ -544,12 +544,11 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
   LOG_VARD(poisMergedIntoPolys);
   const QString description = MatchCreator::BaseFeatureTypeToString(featureType);
   LOG_VARD(description);
-  boost::shared_ptr<ElementCriterion> e_criterion(criterion);
 
   double totalFeatures = 0.0;
   totalFeatures =
     _applyVisitor(
-      map, FilteredVisitor(*(e_criterion->clone()), *(_getElementVisitorForFeatureType(featureType))));
+      map, FilteredVisitor(criterion->clone(), _getElementVisitorForFeatureType(featureType)));
   LOG_VARD(totalFeatures);
   _stats.append(SingleStat(QString("%1 Count").arg(description), totalFeatures));
   _stats.append(SingleStat(QString("Conflatable %1s").arg(description), conflatableCount));
@@ -559,7 +558,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
       map,
       FilteredVisitor(
         ChainCriterion(
-          new StatusCriterion(Status::Conflated), e_criterion->clone()),
+          new StatusCriterion(Status::Conflated), criterion->clone()),
       _getElementVisitorForFeatureType(featureType)));
   LOG_VARD(conflatedFeatureCount);
   if (featureType == MatchCreator::PoiPolygonPOI)
@@ -576,7 +575,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
       FilteredVisitor(
         ChainCriterion(
           new NeedsReviewCriterion(map),
-          e_criterion->clone()),
+          criterion->clone()),
       _getElementVisitorForFeatureType(featureType)));
   _stats.append(
     SingleStat(QString("Conflated %1s").arg(description), conflatedFeatureCount));
@@ -586,7 +585,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
     _applyVisitor(
       map,
        FilteredVisitor(
-         e_criterion->clone(),
+         criterion->clone(),
          ConstElementVisitorPtr(new CountUniqueReviewsVisitor())));
   _stats.append(
     SingleStat(
@@ -598,7 +597,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
       FilteredVisitor(
         ChainCriterion(
           new NotCriterion(new StatusCriterion(Status::Conflated)),
-          e_criterion->clone()),
+          criterion->clone()),
       _getElementVisitorForFeatureType(featureType)));
   LOG_VARD(unconflatedFeatureCount);
   if (featureType == MatchCreator::PoiPolygonPOI)
@@ -614,13 +613,13 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
   {
     _stats.append(SingleStat(QString("Meters of %1 Processed by Conflation").arg(description),
       _applyVisitor(map, FilteredVisitor(ChainCriterion(ElementCriterionPtr(new StatusCriterion(Status::Conflated)),
-        e_criterion->clone()), ConstElementVisitorPtr(new LengthOfWaysVisitor())))));
+        criterion->clone()), ConstElementVisitorPtr(new LengthOfWaysVisitor())))));
   }
   else if (type == MatchCreator::CalcTypeArea)
   {
     _stats.append(SingleStat(QString("Meters Squared of %1s Processed by Conflation").arg(description),
       _applyVisitor(map, FilteredVisitor(ChainCriterion(ElementCriterionPtr(new StatusCriterion(Status::Conflated)),
-        e_criterion->clone()), ConstElementVisitorPtr(new CalculateAreaVisitor())))));
+        criterion->clone()), ConstElementVisitorPtr(new CalculateAreaVisitor())))));
   }
 
   double percentageOfTotalFeaturesConflated = 0.0;

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
@@ -133,31 +133,31 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
 
   _stats.append(SingleStat("Node Count",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Node),
-      new ElementCountVisitor()))));
+      ConstElementVisitorPtr(new ElementCountVisitor())))));
   _stats.append(SingleStat("Way Count",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Way),
-      new ElementCountVisitor()))));
+      ConstElementVisitorPtr(new ElementCountVisitor())))));
   _stats.append(SingleStat("Relation Count",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Relation),
-      new ElementCountVisitor()))));
+      ConstElementVisitorPtr(new ElementCountVisitor())))));
   _stats.append(SingleStat("Minimum Node ID",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Node),
-      new MinIdVisitor()))));
+      ConstElementVisitorPtr(new MinIdVisitor())))));
   _stats.append(SingleStat("Maximum Node ID",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Node),
-      new MaxIdVisitor()))));
+      ConstElementVisitorPtr(new MaxIdVisitor())))));
   _stats.append(SingleStat("Minimum Way ID",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Way),
-      new MinIdVisitor()))));
+      ConstElementVisitorPtr(new MinIdVisitor())))));
   _stats.append(SingleStat("Maximum Way ID",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Way),
-      new MaxIdVisitor()))));
+      ConstElementVisitorPtr(new MaxIdVisitor())))));
   _stats.append(SingleStat("Minimum Relation ID",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Relation),
-      new MinIdVisitor()))));
+      ConstElementVisitorPtr(new MinIdVisitor())))));
   _stats.append(SingleStat("Maximum Relation ID",
     _applyVisitor(constMap, FilteredVisitor(ElementTypeCriterion(ElementType::Relation),
-      new MaxIdVisitor()))));
+      ConstElementVisitorPtr(new MaxIdVisitor())))));
 
   if (!_quick)
   {
@@ -173,17 +173,17 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
     _applyVisitor(constMap, &v);
     _stats.append(SingleStat("Unique Names", v.getStat()));
     _stats.append(SingleStat("Meters of Linear Features",
-      _applyVisitor(constMap, FilteredVisitor(LinearFilter(keep), new LengthOfWaysVisitor()))));
+      _applyVisitor(constMap, FilteredVisitor(LinearFilter(keep), ConstElementVisitorPtr(new LengthOfWaysVisitor())))));
     _stats.append(SingleStat("Meters Squared of Area Features",
-      _applyVisitor(constMap, FilteredVisitor(StatsAreaFilter(keep), new CalculateAreaForStatsVisitor()))));
+      _applyVisitor(constMap, FilteredVisitor(StatsAreaFilter(keep), ConstElementVisitorPtr(new CalculateAreaForStatsVisitor())))));
     _stats.append(SingleStat("Meters of Highway",
-      _applyVisitor(constMap, FilteredVisitor(HighwayFilter(keep), new LengthOfWaysVisitor()))));
+      _applyVisitor(constMap, FilteredVisitor(HighwayFilter(keep), ConstElementVisitorPtr(new LengthOfWaysVisitor())))));
     _stats.append(SingleStat("Highway Unique Name Count",
-      _applyVisitor(constMap, FilteredVisitor(HighwayFilter(keep), new UniqueNamesVisitor()))));
+      _applyVisitor(constMap, FilteredVisitor(HighwayFilter(keep), ConstElementVisitorPtr(new UniqueNamesVisitor())))));
     _stats.append(SingleStat("Meters Squared of Buildings",
-      _applyVisitor(constMap, FilteredVisitor(BuildingCriterion(map), new CalculateAreaVisitor()))));
+      _applyVisitor(constMap, FilteredVisitor(BuildingCriterion(map), ConstElementVisitorPtr(new CalculateAreaVisitor())))));
     _stats.append(SingleStat("Building Unique Name Count",
-      _applyVisitor(constMap, FilteredVisitor(BuildingCriterion(map), new UniqueNamesVisitor()))));
+      _applyVisitor(constMap, FilteredVisitor(BuildingCriterion(map), ConstElementVisitorPtr(new UniqueNamesVisitor())))));
 
     FeatureCountVisitor featureCountVisitor;
     _applyVisitor(constMap, &featureCountVisitor);
@@ -196,7 +196,7 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
     double conflatedFeatureCount =
       _applyVisitor(
         constMap,
-        FilteredVisitor(StatusCriterion(Status::Conflated), new FeatureCountVisitor()));
+        FilteredVisitor(StatusCriterion(Status::Conflated), ConstElementVisitorPtr(new FeatureCountVisitor())));
 
     //We're tailoring the stats to whether the map being examined is the input to a conflation job
     //or the output from a conflation job.  When the stats option is called from the conflate
@@ -217,9 +217,9 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
         constMap,
         FilteredVisitor(
           ChainCriterion(
-            new NotCriterion(new StatusCriterion(Status::Conflated)),
-            new NotCriterion(new NeedsReviewCriterion(constMap))),
-          new MatchCandidateCountVisitor(matchCreators)),
+            ElementCriterionPtr(new NotCriterion(ElementCriterionPtr(new StatusCriterion(Status::Conflated)))),
+            ElementCriterionPtr(new NotCriterion(ElementCriterionPtr(new NeedsReviewCriterion(constMap))))),
+          ConstElementVisitorPtr(new MatchCandidateCountVisitor(matchCreators))),
         matchCandidateCountsData);
     LOG_VARD(matchCreators.size());
     SumNumericTagsVisitor tagSumVis(MetadataTags::HootPoiPolygonPoisMerged());
@@ -311,7 +311,7 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
               constMap,
               //see comment in _generateFeatureStats as to why ElementCountVisitor is used here
               //instead of FeatureCountVisitor
-              FilteredVisitor(PoiPolygonPolyCriterion(), new ElementCountVisitor()));
+              FilteredVisitor(PoiPolygonPolyCriterion(), ConstElementVisitorPtr(new ElementCountVisitor())));
         }
         _stats.append(
           SingleStat(
@@ -326,7 +326,7 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
               constMap,
               //see comment in _generateFeatureStats as to why ElementCountVisitor is used here
               //instead of FeatureCountVisitor
-              FilteredVisitor(PoiPolygonPoiCriterion(), new ElementCountVisitor()));
+              FilteredVisitor(PoiPolygonPoiCriterion(), ConstElementVisitorPtr(new ElementCountVisitor())));
         }
         _stats.append(
           SingleStat(
@@ -393,22 +393,22 @@ void CalculateStatsOp::apply(const OsmMapPtr& map)
 
       _stats.append(SingleStat("Building Translated Populated Tag Percent",
         _applyVisitor(constMap, FilteredVisitor(BuildingCriterion(map),
-          new TranslatedTagCountVisitor(st)))));
+          ConstElementVisitorPtr(new TranslatedTagCountVisitor(st))))));
       _stats.append(SingleStat("Highway Translated Populated Tag Percent",
         _applyVisitor(constMap, FilteredVisitor(HighwayFilter(keep),
-          new TranslatedTagCountVisitor(st)))));
+          ConstElementVisitorPtr(new TranslatedTagCountVisitor(st))))));
       _stats.append(SingleStat("POI Translated Populated Tag Percent",
         _applyVisitor(constMap, FilteredVisitor(PoiCriterion(),
-          new TranslatedTagCountVisitor(st)))));
+          ConstElementVisitorPtr(new TranslatedTagCountVisitor(st))))));
       _stats.append(SingleStat("Waterway Translated Populated Tag Percent",
-        _applyVisitor(constMap, FilteredVisitor(new WaterwayCriterion(),
-          new TranslatedTagCountVisitor(st)))));
+        _applyVisitor(constMap, FilteredVisitor(WaterwayCriterion(),
+          ConstElementVisitorPtr(new TranslatedTagCountVisitor(st))))));
       _stats.append(SingleStat("Polygon Conflatable POI Translated Populated Tag Percent",
-        _applyVisitor(constMap, FilteredVisitor(new PoiPolygonPoiCriterion(),
-          new TranslatedTagCountVisitor(st)))));
+        _applyVisitor(constMap, FilteredVisitor(PoiPolygonPoiCriterion(),
+          ConstElementVisitorPtr(new TranslatedTagCountVisitor(st))))));
       _stats.append(SingleStat("Polygon Translated Populated Tag Percent",
-        _applyVisitor(constMap, FilteredVisitor(new PoiPolygonPolyCriterion(),
-          new TranslatedTagCountVisitor(st)))));
+        _applyVisitor(constMap, FilteredVisitor(PoiPolygonPolyCriterion(),
+          ConstElementVisitorPtr(new TranslatedTagCountVisitor(st))))));
     }
     else
     {
@@ -519,21 +519,18 @@ void CalculateStatsOp::printStats()
   }
 }
 
-ConstElementVisitor* CalculateStatsOp::_getElementVisitorForFeatureType(
+ConstElementVisitorPtr CalculateStatsOp::_getElementVisitorForFeatureType(
   const MatchCreator::BaseFeatureType& featureType)
 {
-  //only pass the output of this to methods which will take ownership of the visitor
-  //(criterion, etc.)
-
   if (featureType == MatchCreator::PoiPolygonPOI || featureType == MatchCreator::Polygon)
   {
     //Poi/poly doesn't have the restriction that an element have a tag information count > 0 to
     //be considered for conflation.
-    return new ElementCountVisitor();
+    return ConstElementVisitorPtr(new ElementCountVisitor());
   }
   else
   {
-    return new FeatureCountVisitor();
+    return ConstElementVisitorPtr(new FeatureCountVisitor());
   }
 }
 
@@ -541,7 +538,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
                                              const MatchCreator::BaseFeatureType& featureType,
                                              const float conflatableCount,
                                              const MatchCreator::FeatureCalcType& type,
-                                             ElementCriterion* criterion,
+                                             ElementCriterionPtr criterion,
                                              const long poisMergedIntoPolys)
 {
   LOG_VARD(poisMergedIntoPolys);
@@ -552,7 +549,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
   double totalFeatures = 0.0;
   totalFeatures =
     _applyVisitor(
-      map, FilteredVisitor(e_criterion->clone(), _getElementVisitorForFeatureType(featureType)));
+      map, FilteredVisitor(*(e_criterion->clone()), *(_getElementVisitorForFeatureType(featureType))));
   LOG_VARD(totalFeatures);
   _stats.append(SingleStat(QString("%1 Count").arg(description), totalFeatures));
   _stats.append(SingleStat(QString("Conflatable %1s").arg(description), conflatableCount));
@@ -590,7 +587,7 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
       map,
        FilteredVisitor(
          e_criterion->clone(),
-         new CountUniqueReviewsVisitor()));
+         ConstElementVisitorPtr(new CountUniqueReviewsVisitor())));
   _stats.append(
     SingleStat(
       QString("Number of %1 Reviews to be Made").arg(description), numFeatureReviewsToBeMade));
@@ -616,14 +613,14 @@ void CalculateStatsOp::_generateFeatureStats(boost::shared_ptr<const OsmMap>& ma
   if (type == MatchCreator::CalcTypeLength)
   {
     _stats.append(SingleStat(QString("Meters of %1 Processed by Conflation").arg(description),
-      _applyVisitor(map, FilteredVisitor(ChainCriterion(new StatusCriterion(Status::Conflated),
-        e_criterion->clone()), new LengthOfWaysVisitor()))));
+      _applyVisitor(map, FilteredVisitor(ChainCriterion(ElementCriterionPtr(new StatusCriterion(Status::Conflated)),
+        e_criterion->clone()), ConstElementVisitorPtr(new LengthOfWaysVisitor())))));
   }
   else if (type == MatchCreator::CalcTypeArea)
   {
     _stats.append(SingleStat(QString("Meters Squared of %1s Processed by Conflation").arg(description),
-      _applyVisitor(map, FilteredVisitor(ChainCriterion(new StatusCriterion(Status::Conflated),
-        e_criterion->clone()), new CalculateAreaVisitor()))));
+      _applyVisitor(map, FilteredVisitor(ChainCriterion(ElementCriterionPtr(new StatusCriterion(Status::Conflated)),
+        e_criterion->clone()), ConstElementVisitorPtr(new CalculateAreaVisitor())))));
   }
 
   double percentageOfTotalFeaturesConflated = 0.0;

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.h
@@ -110,9 +110,10 @@ private:
                              const MatchCreator::BaseFeatureType& featureType,
                              const float conflatableCount,
                              const MatchCreator::FeatureCalcType& type,
-                             ElementCriterion* criterion, const long poisMergedIntoPolys);
+                             ElementCriterionPtr criterion,
+                             const long poisMergedIntoPolys);
 
-  ConstElementVisitor* _getElementVisitorForFeatureType(
+  ConstElementVisitorPtr _getElementVisitorForFeatureType(
       const MatchCreator::BaseFeatureType& featureType);
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
@@ -44,11 +44,16 @@ FilteredVisitor::FilteredVisitor(const ElementCriterion& criterion, ConstElement
 {
 }
 
-FilteredVisitor::FilteredVisitor(const ElementCriterion& criterion, ConstElementVisitor* visitor) :
+FilteredVisitor::FilteredVisitor(const ElementCriterion& criterion, ConstElementVisitorPtr visitor) :
   _criterion(&criterion),
-  _visitor(visitor)
+  _visitor(visitor.get())
 {
-  _visitDelete.reset(visitor);
+}
+
+FilteredVisitor::FilteredVisitor(ElementCriterionPtr criterion, ConstElementVisitorPtr visitor) :
+  _criterion(criterion.get()),
+  _visitor(visitor.get())
+{
 }
 
 FilteredVisitor::FilteredVisitor(ElementCriterion* criterion, ConstElementVisitor* visitor) :

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -60,6 +60,9 @@ public:
    */
   FilteredVisitor(const ElementCriterion& criterion, ConstElementVisitorPtr visitor);
 
+  /**
+   * Similar to the first, but takes smart pointer params.
+   */
   FilteredVisitor(ElementCriterionPtr criterion, ConstElementVisitorPtr visitor);
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -58,7 +58,9 @@ public:
    * Similar to above but this is convenient if you want to pass in a temporary visitor. In this
    * case FilteredVisitor will take ownership of the visitor and delete it when destructed.
    */
-  FilteredVisitor(const ElementCriterion& criterion, ConstElementVisitor* visitor);
+  FilteredVisitor(const ElementCriterion& criterion, ConstElementVisitorPtr visitor);
+
+  FilteredVisitor(ElementCriterionPtr criterion, ConstElementVisitorPtr visitor);
 
   /**
    * Similar to above but this is convenient if you want to pass in a temporary criterion and

--- a/hoot-js/src/main/cpp/hoot/js/filter/JsFunctionCriterion.h
+++ b/hoot-js/src/main/cpp/hoot/js/filter/JsFunctionCriterion.h
@@ -51,7 +51,7 @@ public:
 
   bool isSatisfied(const boost::shared_ptr<const Element> &e) const;
 
-  virtual ElementCriterion* clone() { return new JsFunctionCriterion(_func); }
+  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new JsFunctionCriterion(_func)); }
 
 private:
   JsFunctionCriterion(v8::Persistent<v8::Function> func) { _func = func; }


### PR DESCRIPTION
Refs #1915

Implemented a bunch of RAII stuff, adding smart pointers. This is to address possible memory leaks in CalculateStatsOp, but the changes involved a LOT of other files.