### PR TITLE
Fix project dependencies and UI tests on CentOS 7

### DIFF
--- a/hoot-core/hoot-core.pro
+++ b/hoot-core/hoot-core.pro
@@ -40,6 +40,7 @@ OTHER_FILES = \
 include(../Configure.pri)
 
 LIBS += -L../lib/ -lTgs -ltbs
+LIBS -= -lhdfs
 
 UI_DIR = tmp/ui
 MOC_DIR = tmp/moc

--- a/hoot-js/hoot-js.pro
+++ b/hoot-js/hoot-js.pro
@@ -42,6 +42,7 @@ QMAKE_CXXFLAGS = -I/usr/include/nodejs $$QMAKE_CXXFLAGS
 QMAKE_POST_LINK = cp -l ../lib/libHootJs.so.1.0.0 ../lib/HootJs.node 2>/dev/null || cp ../lib/libHootJs.so.1.0.0 ../lib/HootJs.node
 
 LIBS += -L../lib/ -lTgs -ltbs -lHootCore -lv8
+LIBS -= -lhdfs
 
 UI_DIR = tmp/ui
 MOC_DIR = tmp/moc

--- a/hoot-rnd/hoot-rnd.pro
+++ b/hoot-rnd/hoot-rnd.pro
@@ -36,6 +36,7 @@ include(../Configure.pri)
 QMAKE_CXXFLAGS = -I/usr/include/nodejs $$QMAKE_CXXFLAGS
 
 LIBS += -L../lib/ -lTgs -ltbs -lHootCore -lHootCoreTest
+LIBS -= -lhdfs
 
 UI_DIR = tmp/ui
 MOC_DIR = tmp/moc

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         booleanParam(name: 'Core_tests', defaultValue: true)
         booleanParam(name: 'Services_tests', defaultValue: true)
         booleanParam(name: 'UI_tests', defaultValue: true)
-        string(name: 'Box', defaultValue: 'default', description: 'Vagrant Box')
+        string(name: 'Box', defaultValue: 'hoot_centos7', description: 'Vagrant Box')
     }
     stages {
         stage("Setup") {

--- a/scripts/tomcat/tomcat8/centos7/tomcat8_install.sh
+++ b/scripts/tomcat/tomcat8/centos7/tomcat8_install.sh
@@ -131,6 +131,11 @@ then
   sudo sed -i "s/User=tomcat8/User=${TOMCAT_USER}/g" /etc/systemd/system/${TOMCAT_NAME}.service
   sudo sed -i "s/Group=tomcat8/Group=${TOMCAT_GROUP}/g" /etc/systemd/system/${TOMCAT_NAME}.service
 fi
+if [ "$HADOOP_HOME" != "" ]
+then
+  # add hadoop library path to the LD_LIBRARY_PATH for tomcat
+  sudo sed -i 's|$LD_LIBRARY_PATH|$LD_LIBRARY_PATH:$HADOOP_HOME/c++/Linux-amd64-64/lib|g' ${TOMCAT_HOME}/bin/tomcat8_start.sh
+fi
 sudo systemctl daemon-reload
 sudo systemctl enable ${TOMCAT_NAME}
 

--- a/tbs/tbs.pro
+++ b/tbs/tbs.pro
@@ -15,6 +15,8 @@ exists ("../Configure.pri") {
     include("../Configure.pri")
 }
 
+LIBS -= -lhdfs
+
 unix:QMAKE_CXXFLAGS += -Wno-deprecated
 unix:QT -= gui
 UI_DIR = tmp/ui

--- a/test-files/ui/features/hide_map_features.feature
+++ b/test-files/ui/features/hide_map_features.feature
@@ -18,6 +18,7 @@ Feature: Toggle/hide map features of conflated layer in review mode
     And I scroll element into view and press "conflate2"
     Then I wait 30 "seconds" to see "Conflating …"
     Then I wait 3 "minutes" to see "HideMapFeaturesCucumber"
+    Then I wait 30 "seconds" to see "Complete Review"
     Then I context click "HideMapFeaturesCucumber"
     And I click the "div" with text "Zoom to Layer"
     Then I should see land use areas on the map

--- a/tgs/tgs.pro
+++ b/tgs/tgs.pro
@@ -15,6 +15,8 @@ CONFIG += rtti \
 
 DESTDIR = ../lib/
 
+LIBS -= -lhdfs
+
 # allow the <algorithm> std::min
 win32:QMAKE_CXXFLAGS += /EHsc
 unix:QMAKE_CXXFLAGS += -Wno-deprecated


### PR DESCRIPTION
Refs #1960 
Updated LD_LIBRARY_PATH for Tomcat, updated project dependencies so that only `HootHadoop` has `libhdfs` as a dependency, and fixed broken UI test.