### PR TITLE
Hoot crashes on NULL shared_ptr in MultiPolygonCreator

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/MultiPolygonCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/MultiPolygonCreator.cpp
@@ -200,8 +200,8 @@ boost::shared_ptr<Geometry> MultiPolygonCreator::createMultipolygon() const
         (e.role == MetadataTags::RoleOuter() || e.role == MetadataTags::RolePart()))
     {
       ConstRelationPtr r = _provider->getRelation(e.getElementId().getId());
-      if (r->isMultiPolygon() ||
-        OsmSchema::getInstance().isArea(r->getTags(), ElementType::Relation))
+      if (r && (r->isMultiPolygon() ||
+        OsmSchema::getInstance().isArea(r->getTags(), ElementType::Relation)))
       {
         boost::shared_ptr<Geometry> child(MultiPolygonCreator(_provider, r).createMultipolygon());
         try

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -573,7 +573,7 @@ void OgrWriter::_writePartial(ElementProviderPtr& provider, const ConstElementPt
 
     try
     {
-      g = ElementConverter(provider).convertToGeometry(e);
+      g = ElementConverter(provider).convertToGeometry(e, false);
     }
     catch (const IllegalArgumentException& err)
     {


### PR DESCRIPTION
Refs #1988
Don't fail on unknown relation types and check NULL pointer in MultiPolygonCreator