### PR TITLE
Josm preset support

### DIFF
--- a/plugins/ElementMergeServer.js
+++ b/plugins/ElementMergeServer.js
@@ -5,6 +5,7 @@ var http = require('http');
 var url = require('url');
 var serverPort = 8096;
 var HOOT_HOME = process.env.HOOT_HOME;
+var hoot = require(HOOT_HOME + '/lib/HootJs');
 
 if (require.main === module) {
     //I'm a running server
@@ -127,7 +128,6 @@ var mergeElement = function(payload)
 // This is where all interesting things happen interfacing with hoot core lib directly
 var postHandler = function(data)
 {
-    var hoot = require(HOOT_HOME + '/lib/HootJs');
     var map = new hoot.OsmMap();
     map.setIdGenerator(new hoot.DefaultIdGenerator());
     hoot.loadMapFromString(map, data);

--- a/plugins/TranslationServer.js
+++ b/plugins/TranslationServer.js
@@ -259,6 +259,9 @@ function handleInputs(params) {
         case '/schema':
             result = getFilteredSchema(params);
             break;
+        case '/fcodes':
+            result = getFCodes(params);
+            break;
         case '/capabilities':
             result = getCapabilities(params);
             break;
@@ -457,6 +460,40 @@ var getTaginfoKeys = function(params)
     }
 }
 
+var getFCodes = function(params) {
+    if (params.method === 'POST') {
+        throw new Error('Unsupported method');
+    } else if (params.method === 'GET') {
+
+        // get query params
+        var geomType = params.geometry;
+        var translation = params.translation;
+
+        //Treat vertex geom type as point
+        if (geomType.toLowerCase() === 'vertex') geomType = 'point';
+
+        //Get valid FCODEs for this translation and geometry type
+        var schema = schemaMap[translation].getDbSchema();
+
+        console.log(geomType + ', ' + translation + ', ' + schema.length);
+        var fcodes = schema
+            .filter(function(d) {
+                return d.geom.toLowerCase() === geomType.toLowerCase();
+            })
+            .map(function(d) {
+                return {
+                    fcode: d.fcode,
+                    desc: d.desc
+                }
+            })
+            .sort(function(a, b) {
+                return a.fcode - b.fcode;
+            });
+
+        return fcodes;
+    }
+}
+
 var getFilteredSchema = function(params) {
     if (params.method === 'POST') {
         throw new Error('Unsupported method');
@@ -621,6 +658,7 @@ var schemaError = function(params) {
 }
 
 if (typeof exports !== 'undefined') {
+    exports.getFCodes = getFCodes;
     exports.searchSchema = searchSchema;
     exports.handleInputs = handleInputs;
     exports.TranslationServer = TranslationServer;

--- a/plugins/schema2josmpreset.js
+++ b/plugins/schema2josmpreset.js
@@ -1,0 +1,29 @@
+"use strict";
+require('./validation_mocks.js');
+var mgcp_schema = require('./mgcp_schema.js').getDbSchema();
+var ggdm30_schema = require('./ggdm30_full_schema.js').getDbSchema();
+var tds40_schema = require('./tds40_full_schema.js').getDbSchema();
+var tds61_schema = require('./tds61_full_schema.js').getDbSchema();
+var fs = require('fs');
+var stringify = require('json-stable-stringify');
+
+
+const output = 'tds40_schema.json';
+const objs = [tds40_schema];//, tds61_schema, mgcp_schema, ggdm30_schema];
+
+objs.forEach(f => {
+    // const one2one = f.one2one.reduce((tagmap, tag) => {
+    //     let temp = {};
+    //     temp[tag[1]] = tag[2] + '=' + tag[3];
+    //     tagmap[tag[0]] = Object.assign({}, tagmap[tag[0]], temp);
+    //     return tagmap;
+    // }, {});
+    // Object.assign(mapping, f.txtBiased, f.numBiased, one2one)
+
+    fs.writeFile(output, stringify(f, {space: 4}), (err) => {
+        if (err) throw err;
+        console.log(`${output} file has been saved.`);
+    });
+
+});
+

--- a/plugins/test/TranslationServer.js
+++ b/plugins/test/TranslationServer.js
@@ -11,6 +11,42 @@ var server = require('../TranslationServer.js');
 
 describe('TranslationServer', function () {
 
+    describe('fcodes', function() {
+
+        it('should return fcodes for MGCP Line', function(){
+            assert.equal(server.getFCodes({
+                method: 'GET',
+                translation: 'MGCP',
+                geometry: 'line'
+            }).length, 59);
+        });
+
+        it('should return fcodes for TDSv61 Point', function(){
+            assert.equal(server.getFCodes({
+                method: 'GET',
+                translation: 'TDSv61',
+                geometry: 'Point'
+            }).length, 193);
+        });
+
+        it('should return fcodes for GGDMv30 Area', function(){
+            assert.equal(server.getFCodes({
+                method: 'GET',
+                translation: 'GGDMv30',
+                geometry: 'Area'
+            }).length, 280);
+        });
+
+        it('should return fcodes for TDSv40 Vertex', function(){
+            assert.equal(server.getFCodes({
+                method: 'GET',
+                translation: 'TDSv40',
+                geometry: 'vertex'
+            }).length, 190);
+        });
+
+    });
+
     describe('searchSchema', function() {
 
         var defaults = {};

--- a/plugins/test/pass_thru_unknown.js
+++ b/plugins/test/pass_thru_unknown.js
@@ -1,0 +1,71 @@
+var assert = require('assert'),
+    http = require('http'),
+    xml2js = require('xml2js'),
+    fs = require('fs'),
+    httpMocks = require('node-mocks-http'),
+    osmtogeojson = require('osmtogeojson'),
+    DOMParser = new require('xmldom').DOMParser
+    parser = new DOMParser();
+
+var server = require('../TranslationServer.js');
+
+describe('TranslationServer', function () {
+
+    it('should pass thru unknown tags from tdsv61 -> osm -> tdsv61', function() {
+
+        var data = '<osm version="0.6" upload="true" generator="hootenanny">\
+                        <node id="-19" lon="9.304397440128325" lat="41.65083522130027" version="0">\
+                            <tag k="ZI001_SDP" v="DigitalGlobe"/>\
+                            <tag k="UFI" v="0d8b2563-81cf-44d4-8ef7-52c0e862651f"/>\
+                            <tag k="F_CODE" v="AL010"/>\
+                            <tag k="ZSAX_RS0" v="U"/>\
+                            <tag k="FOO" v="1"/>\
+                        </node>\
+                    </osm>';
+
+        var osm_xml = server.handleInputs({
+            osm: data,
+            method: 'POST',
+            translation: 'TDSv61',
+            path: '/translateFrom'
+        });
+
+        // console.log(osm_xml);
+
+        var xml = parser.parseFromString(osm_xml);
+        var gj = osmtogeojson(xml);
+
+        assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "OSM");
+
+        var tags = gj.features[0].properties;
+        assert.equal(tags["facility"], "yes");
+        assert.equal(tags["security:classification"], "UNCLASSIFIED");
+        assert.equal(tags["uuid"], "{0d8b2563-81cf-44d4-8ef7-52c0e862651f}");
+        assert.equal(tags["source"], "DigitalGlobe");
+        assert.equal(tags["FOO"], "1");
+
+        var tds_xml = server.handleInputs({
+            osm: osm_xml,
+            method: 'POST',
+            translation: 'TDSv61',
+            path: '/translateTo'
+        });
+
+        // console.log(tds_xml);
+        
+        xml = parser.parseFromString(tds_xml);
+        gj = osmtogeojson(xml);
+
+        assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "TDSv61");
+
+        var tags = gj.features[0].properties;
+        assert.equal(tags["F_CODE"], "AL010");
+        assert.equal(tags["ZI001_SDP"], "DigitalGlobe");
+        assert.equal(tags["ZSAX_RS0"], "U");
+        assert.equal(tags["UFI"], "0d8b2563-81cf-44d4-8ef7-52c0e862651f");
+        assert.equal(tags["ZI006_MEM"], "<OSM>{\"FOO\":\"1\"}</OSM>");
+
+    });
+
+});
+


### PR DESCRIPTION
- Adds a translation server endpoint to get valid fcodes by translation and geometry.
- Adds a placeholder node script for turning translation schemas into a JOSM preset xml file.
- Adds a hoot init performance fix for ElementMergeServer.
- Adds additional mocha test for unknown tags behavior.