### PR TITLE
HootTest '--exclude' multiplies the test count and doesn't exclude correctly

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.cpp
@@ -40,8 +40,9 @@
 namespace hoot
 {
 
-ConflateCaseTestSuite::ConflateCaseTestSuite(QString dir) :
-AbstractTestSuite(dir)
+ConflateCaseTestSuite::ConflateCaseTestSuite(QString dir, bool hideDisableTests)
+  : AbstractTestSuite(dir),
+    _hideDisableTests(hideDisableTests)
 {
   QStringList confs;
   loadDir(dir, confs);
@@ -66,13 +67,13 @@ void ConflateCaseTestSuite::loadDir(QString dir, QStringList confs)
   QStringList ignoreList;
 
 # ifndef HOOT_HAVE_RND
-    ignoreList << "hoot-rnd";
+  ignoreList << "hoot-rnd";
 # endif
 # ifndef HOOT_HAVE_SERVICES
-    ignoreList << "hoot-services";
+  ignoreList << "hoot-services";
 # endif
 # ifndef HOOT_HAVE_NODEJS
-    ignoreList << "hoot-js";
+  ignoreList << "hoot-js";
 # endif
 
   QStringList dirs = d.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
@@ -92,7 +93,8 @@ void ConflateCaseTestSuite::loadDir(QString dir, QStringList confs)
 
     if (ignore)
     {
-      LOG_WARN("Disabling: " + path);
+      if (!_hideDisableTests)
+        LOG_WARN("Disabling: " + path);
     }
     else
     {

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
@@ -40,7 +40,7 @@ class ConflateCaseTestSuite : public AbstractTestSuite
 
 public:
 
-  ConflateCaseTestSuite(QString dir);
+  ConflateCaseTestSuite(QString dir, bool hideDisableTests = false);
 
   /**
    * Attempts to load a conflate case test given a directory
@@ -49,6 +49,10 @@ public:
    * @param confs hoot configuration files to pass to the test
    */
   virtual void loadDir(QString dir, QStringList confs);
+
+private:
+
+  bool _hideDisableTests;
 };
 
 }

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/AbstractRegressionTestFitnessFunction.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/AbstractRegressionTestFitnessFunction.cpp
@@ -42,9 +42,9 @@ namespace hoot
 
 AbstractRegressionTestFitnessFunction::AbstractRegressionTestFitnessFunction(QString dir,
                                                                              QString configFile,
-                                                                             QString testDirExtension) :
-AbstractTestFitnessFunction(),
-_configFile(configFile)
+                                                                             QString testDirExtension)
+  : AbstractTestFitnessFunction(),
+    _configFile(configFile)
 {
   _testSuite.reset(new RegressionTestSuite(dir, testDirExtension));
   QStringList confs;

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/CaseTestFitnessFunction.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/CaseTestFitnessFunction.cpp
@@ -32,9 +32,9 @@
 namespace hoot
 {
 
-CaseTestFitnessFunction::CaseTestFitnessFunction(QString dir, QString configFile) :
-AbstractTestFitnessFunction(),
-_configFile(configFile)
+CaseTestFitnessFunction::CaseTestFitnessFunction(QString dir, QString configFile)
+  : AbstractTestFitnessFunction(),
+    _configFile(configFile)
 {
   _testSuite.reset(new ConflateCaseTestSuite(dir));
   QStringList confs;

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/RegressionTestSuite.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/RegressionTestSuite.cpp
@@ -38,9 +38,9 @@
 namespace hoot
 {
 
-RegressionTestSuite::RegressionTestSuite(QString dir, QString testDirExtension) :
-AbstractTestSuite(dir),
-_testDirExtension(testDirExtension)
+RegressionTestSuite::RegressionTestSuite(QString dir, QString testDirExtension)
+  : AbstractTestSuite(dir),
+    _testDirExtension(testDirExtension)
 {
   QDir dirInfo(dir);
   _topLevelDir = dirInfo.dirName();

--- a/hoot-test/src/main/cpp/hoot/test/main.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/main.cpp
@@ -155,43 +155,41 @@ private:
   double _slowTest;
 };
 
-void filterPattern(CppUnit::Test* from, std::vector<CppUnit::Test*> &to, QString pattern,
-  bool includeOnMatch)
+void getTestVector(CppUnit::Test* from, vector<CppUnit::Test*>& to)
 {
-  QRegExp regex(pattern);
-
   for (int i = 0; i < from->getChildTestCount(); i++)
   {
     CppUnit::Test* child = from->getChildTestAt(i);
-    QString name = QString::fromStdString(child->getName());
     if (dynamic_cast<CppUnit::TestComposite*>(child))
-    {
-      filterPattern(child, to, pattern, includeOnMatch);
-    }
-    else if (regex.exactMatch(name) == includeOnMatch)
-    {
+      getTestVector(child, to);
+    else
       to.push_back(child);
-    }
   }
 }
 
-void filterPattern(const std::vector<TestPtr> &from, std::vector<CppUnit::Test*> &to, QString pattern,
-  bool includeOnMatch)
+void getTestVector(const vector<TestPtr>& from, vector<CppUnit::Test*>& to)
+{
+  for (vector<TestPtr>::size_type i = 0; i < from.size(); ++i)
+  {
+    CppUnit::Test* child = from[i].get();
+    if (dynamic_cast<CppUnit::TestComposite*>(child))
+      getTestVector(child, to);
+    else
+      to.push_back(child);
+  }
+}
+
+void filterPattern(const std::vector<CppUnit::Test*> &from, std::vector<CppUnit::Test*> &to,
+                   QString pattern, bool includeOnMatch)
 {
   QRegExp regex(pattern);
 
   for (size_t i = 0; i < from.size(); i++)
   {
-    CppUnit::Test* child = from[i].get();
+    CppUnit::Test* child = from[i];
     QString name = QString::fromStdString(child->getName());
-    if (dynamic_cast<CppUnit::TestComposite*>(child))
-    {
-      filterPattern(child, to, pattern, includeOnMatch);
-    }
-    else if (regex.exactMatch(name) == includeOnMatch)
-    {
+    if (regex.exactMatch(name) == includeOnMatch)
       to.push_back(child);
-    }
   }
 }
 
@@ -363,7 +361,7 @@ void populateTests(_TestType t, std::vector<TestPtr> &vTests, bool printDiff, bo
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/quick/", printDiff, QUICK_WAIT, hideDisableTests)));
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/slow/", printDiff, SLOW_WAIT, hideDisableTests)));
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/slow/serial/", printDiff, SLOW_WAIT, hideDisableTests)));
-    vTests.push_back(TestPtr(new ConflateCaseTestSuite("test-files/cases")));
+    vTests.push_back(TestPtr(new ConflateCaseTestSuite("test-files/cases", hideDisableTests)));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("current").makeTest()));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("quick").makeTest()));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("TgsTest").makeTest()));
@@ -372,7 +370,7 @@ void populateTests(_TestType t, std::vector<TestPtr> &vTests, bool printDiff, bo
   case SLOW_ONLY:
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/slow/", printDiff, SLOW_WAIT, hideDisableTests)));
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/slow/serial/", printDiff, SLOW_WAIT, hideDisableTests)));
-    vTests.push_back(TestPtr(new ConflateCaseTestSuite("test-files/cases")));
+    vTests.push_back(TestPtr(new ConflateCaseTestSuite("test-files/cases", hideDisableTests)));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("slow").makeTest()));
     break;
   case GLACIAL:
@@ -384,7 +382,7 @@ void populateTests(_TestType t, std::vector<TestPtr> &vTests, bool printDiff, bo
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/slow/serial/", printDiff, SLOW_WAIT, hideDisableTests)));
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/glacial/", printDiff, GLACIAL_WAIT, hideDisableTests)));
     vTests.push_back(TestPtr(new ScriptTestSuite("test-files/cmd/glacial/serial/", printDiff, GLACIAL_WAIT, hideDisableTests)));
-    vTests.push_back(TestPtr(new ConflateCaseTestSuite("test-files/cases")));
+    vTests.push_back(TestPtr(new ConflateCaseTestSuite("test-files/cases", hideDisableTests)));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("current").makeTest()));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("quick").makeTest()));
     vTests.push_back(TestPtr(CppUnit::TestFactoryRegistry::getRegistry("TgsTest").makeTest()));
@@ -564,15 +562,24 @@ int main(int argc, char *argv[])
         populateTests(GLACIAL_ONLY, vAllTests, printDiff);
       }
 
+      vector<CppUnit::Test*> vTests;
+      getTestVector(vAllTests, vTests);
       bool filtered = false;
+
       for (int i = 0; i < args.size(); i++)
       {
         if (args[i].startsWith("--exclude="))
         {
+          if (vTestsToRun.size() > 0)
+          {
+            //  On the second (or more) time around exclude from the excluded list
+            vTests.swap(vTestsToRun);
+            vTestsToRun.clear();
+          }
           int equalsPos = args[i].indexOf('=');
           QString regex = args[i].mid(equalsPos + 1);
           LOG_WARN("Excluding pattern: " << regex);
-          filterPattern(vAllTests, vTestsToRun, regex, false);
+          filterPattern(vTests, vTestsToRun, regex, false);
           filtered = true;
         }
         else if (args[i].startsWith("--include="))
@@ -580,15 +587,13 @@ int main(int argc, char *argv[])
           int equalsPos = args[i].indexOf('=');
           QString regex = args[i].mid(equalsPos + 1);
           LOG_WARN("Including only tests that match: " << regex);
-          filterPattern(vAllTests, vTestsToRun, regex, true);
+          filterPattern(vTests, vTestsToRun, regex, true);
           filtered = true;
         }
       }
 
       if (!filtered) // Do all tests
-      {
-        filterPattern(vAllTests, vTestsToRun, ".*", true);
-      }
+        vTestsToRun.swap(vTests);
       cout << "Running core tests.  Test count: " << vTestsToRun.size() << endl;
     }
 


### PR DESCRIPTION
Fixed --exclude duplication issue, Conflate case ignore warning in parallel, and minor cleanup