### PR TITLE
CentOS 6.7 o2sTranslationTest failure

### DIFF
--- a/test-files/cmd/slow/o2sTranslationTest.sh
+++ b/test-files/cmd/slow/o2sTranslationTest.sh
@@ -8,6 +8,8 @@ TRANS_MGCP=$HOOT_HOME/translations/MGCP_TRD4.js
 TRANS_GGDM=$HOOT_HOME/translations/GGDMv30.js
 
 inputFile=test-files/o2s_test.osm
+tds40File=test-files/o2s_tds40.osm
+ggdmFile=test-files/o2s_ggdm.osm
 
 outputDir=test-output/o2s
 mkdir -p $outputDir
@@ -25,22 +27,31 @@ HOOT_OPT="--info"
 # Export files
 echo "### TDSv40 ###"
 hoot osm2ogr $HOOT_OPT -D ogr.thematic.structure=false $TRANS_TDS40 $inputFile $outputDir/tds40.shp
-hoot ogr2osm $HOOT_OPT $TRANS_TDS40 $outputDir/tds40.osm  $outputDir/tds40/*.shp
+hoot ogr2osm $HOOT_OPT $TRANS_TDS40 $outputDir/tds40.osm \
+  $outputDir/tds40/HUT_P.shp \
+  $outputDir/tds40/o2s_*.shp \
+  $outputDir/tds40/ORCHARD_S.shp \
+  $outputDir/tds40/RIVER_C.shp
 
 # TDSv40 complains about the "source" tag. It maps to an attibute but it is not on each element
-#hoot is-match $outputDir/tds40.osm $inputFile || diff $outputDir/tds40.osm $inputFile
+hoot is-match $outputDir/tds40.osm $tds40File || diff $outputDir/tds40.osm $tds40File
 
 echo
 echo "### TDSv61 ###"
 hoot osm2ogr $HOOT_OPT -D ogr.thematic.structure=false $TRANS_TDS61 $inputFile $outputDir/tds61.shp
-hoot ogr2osm $HOOT_OPT $TRANS_TDS61 $outputDir/tds61.osm  $outputDir/tds61/*.shp
+hoot ogr2osm $HOOT_OPT $TRANS_TDS61 $outputDir/tds61.osm \
+  $outputDir/tds61/HUT_P.shp \
+  $outputDir/tds61/o2s_*.shp \
+  $outputDir/tds61/ORCHARD_S.shp \
+  $outputDir/tds61/RIVER_C.shp
+
 hoot is-match $outputDir/tds61.osm $inputFile || diff $outputDir/tds61.osm $inputFile
 
 echo
 echo "### MGCP ###"
 hoot osm2ogr $HOOT_OPT $TRANS_MGCP $inputFile $outputDir/mgcp.shp
 # hoot ogr2osm $HOOT_OPT $TRANS_MGCP $outputDir/mgcp.osm  $outputDir/mgcp/*.shp
-hoot ogr2osm $HOOT_OPT $TRANS_MGCP $outputDir/mgcp.osm  \
+hoot ogr2osm $HOOT_OPT $TRANS_MGCP $outputDir/mgcp.osm \
   $outputDir/mgcp/PAL099.shp \
   $outputDir/mgcp/o2s_*.shp \
   $outputDir/mgcp/AEA040.shp \
@@ -51,7 +62,11 @@ hoot is-match $outputDir/mgcp.osm $inputFile || diff $outputDir/mgcp.osm $inputF
 echo
 echo "### GGDM ###"
 hoot osm2ogr $HOOT_OPT -D ogr.thematic.structure=false $TRANS_GGDM $inputFile $outputDir/ggdm.shp
-hoot ogr2osm $HOOT_OPT $TRANS_GGDM $outputDir/ggdm.osm  $outputDir/ggdm/*.shp
+hoot ogr2osm $HOOT_OPT $TRANS_GGDM $outputDir/ggdm.osm \
+  $outputDir/ggdm/HUT_P.shp \
+  $outputDir/ggdm/o2s_*.shp \
+  $outputDir/ggdm/ORCHARD_S.shp \
+  $outputDir/ggdm/RIVER_C.shp
 
 # GGDMv30 complains about the "source" tag. It maps to an attibute but it is not on each element
-#hoot is-match $outputDir/ggdm.osm $inputFile || diff $outputDir/ggdm.osm $inputFile
+hoot is-match $outputDir/ggdm.osm $ggdmFile || diff $outputDir/ggdm.osm $ggdmFile

--- a/test-files/cmd/slow/o2sTranslationTest.sh
+++ b/test-files/cmd/slow/o2sTranslationTest.sh
@@ -33,7 +33,6 @@ hoot ogr2osm $HOOT_OPT $TRANS_TDS40 $outputDir/tds40.osm \
   $outputDir/tds40/ORCHARD_S.shp \
   $outputDir/tds40/RIVER_C.shp
 
-# TDSv40 complains about the "source" tag. It maps to an attibute but it is not on each element
 hoot is-match $outputDir/tds40.osm $tds40File || diff $outputDir/tds40.osm $tds40File
 
 echo
@@ -50,7 +49,6 @@ hoot is-match $outputDir/tds61.osm $inputFile || diff $outputDir/tds61.osm $inpu
 echo
 echo "### MGCP ###"
 hoot osm2ogr $HOOT_OPT $TRANS_MGCP $inputFile $outputDir/mgcp.shp
-# hoot ogr2osm $HOOT_OPT $TRANS_MGCP $outputDir/mgcp.osm  $outputDir/mgcp/*.shp
 hoot ogr2osm $HOOT_OPT $TRANS_MGCP $outputDir/mgcp.osm \
   $outputDir/mgcp/PAL099.shp \
   $outputDir/mgcp/o2s_*.shp \
@@ -68,5 +66,4 @@ hoot ogr2osm $HOOT_OPT $TRANS_GGDM $outputDir/ggdm.osm \
   $outputDir/ggdm/ORCHARD_S.shp \
   $outputDir/ggdm/RIVER_C.shp
 
-# GGDMv30 complains about the "source" tag. It maps to an attibute but it is not on each element
 hoot is-match $outputDir/ggdm.osm $ggdmFile || diff $outputDir/ggdm.osm $ggdmFile

--- a/test-files/o2s_ggdm.osm
+++ b/test-files/o2s_ggdm.osm
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326" schema="GGDMv30">
+    <bounds minlat="-25.42965211496126" minlon="153.16023944736" maxlat="-25.42494299723994" maxlon="153.16587208629"/>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4294534830511338" lon="153.1619614255399995"/>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4274477669206078" lon="153.1618434083399904"/>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4294583277411519" lon="153.1629753005499879"/>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4296521149612609" lon="153.1658720862899941"/>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4273460268105964" lon="153.1640374553199990"/>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4257084836401397" lon="153.1602394473599702">
+        <tag k="source:ingest:datetime" v="2017-12-18T20:47:56.969Z"/>
+        <tag k="papa" v="smurf"/>
+        <tag k="source" v="cartoon"/>
+        <tag k="uuid" v="{bfbf2946-4342-444c-9926-1477c7bcce05}"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4270165820404834" lon="153.1617843997499904"/>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4250108253499469" lon="153.1616663825500098"/>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4249429972399419" lon="153.1638657939400048"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4272491313805595" lon="153.1657004249099998"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4270553402905044" lon="153.1628036391699936"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4279564662007758" lon="153.1603145492099998">
+        <tag k="source:ingest:datetime" v="2017-12-18T20:47:56.965Z"/>
+        <tag k="building" v="hut"/>
+        <tag k="uuid" v="{1514e475-0a8b-450d-8138-af8623cbdd56}"/>
+        <tag k="source" v="ggdmv30:hut_p"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-12"/>
+        <nd ref="-13"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:47:56.974Z"/>
+        <tag k="waterway" v="river"/>
+        <tag k="uuid" v="{16006a93-ad6c-451e-b5ae-b530e6c5427a}"/>
+        <tag k="source" v="ggdmv30:river_c"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-9"/>
+        <nd ref="-10"/>
+        <nd ref="-11"/>
+        <nd ref="-9"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:47:56.971Z"/>
+        <tag k="uuid" v="{162abddf-bb8a-470a-8986-afdf5a171d45}"/>
+        <tag k="source" v="ggdmv30:orchard_s"/>
+        <tag k="landuse" v="orchard"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-6"/>
+        <nd ref="-7"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:47:56.967Z"/>
+        <tag k="papa" v="smurf"/>
+        <tag k="source" v="cartoon"/>
+        <tag k="uuid" v="{79cd86b0-882c-4d66-b7ec-60fed3cac8f7}"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="-3"/>
+        <nd ref="-4"/>
+        <nd ref="-5"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:47:56.967Z"/>
+        <tag k="papa" v="smurf"/>
+        <tag k="source" v="cartoon"/>
+        <tag k="uuid" v="{c0b66070-d3be-44bd-bb52-03d34716cd49}"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+</osm>

--- a/test-files/o2s_tds40.osm
+++ b/test-files/o2s_tds40.osm
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326" schema="TDSv40">
+    <bounds minlat="-25.42965211496126" minlon="153.16023944736" maxlat="-25.42494299723994" maxlon="153.16587208629"/>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4294534830511338" lon="153.1619614255399995"/>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4274477669206078" lon="153.1618434083399904"/>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4294583277411519" lon="153.1629753005499879"/>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4296521149612609" lon="153.1658720862899941"/>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4273460268105964" lon="153.1640374553199990"/>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4257084836401397" lon="153.1602394473599702">
+        <tag k="source:ingest:datetime" v="2017-12-18T20:34:25.112Z"/>
+        <tag k="papa" v="smurf"/>
+        <tag k="source" v="cartoon"/>
+        <tag k="uuid" v="{bfbf2946-4342-444c-9926-1477c7bcce05}"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4270165820404834" lon="153.1617843997499904"/>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4250108253499469" lon="153.1616663825500098"/>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4249429972399419" lon="153.1638657939400048"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4272491313805595" lon="153.1657004249099998"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4270553402905044" lon="153.1628036391699936"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="-25.4279564662007758" lon="153.1603145492099998">
+        <tag k="source:ingest:datetime" v="2017-12-18T20:34:25.107Z"/>
+        <tag k="building" v="hut"/>
+        <tag k="uuid" v="{1514e475-0a8b-450d-8138-af8623cbdd56}"/>
+        <tag k="source" v="tdsv40:hut_p"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-12"/>
+        <nd ref="-13"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:34:25.257Z"/>
+        <tag k="waterway" v="river"/>
+        <tag k="uuid" v="{16006a93-ad6c-451e-b5ae-b530e6c5427a}"/>
+        <tag k="source" v="tdsv40:river_c"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-9"/>
+        <nd ref="-10"/>
+        <nd ref="-11"/>
+        <nd ref="-9"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:34:25.114Z"/>
+        <tag k="uuid" v="{162abddf-bb8a-470a-8986-afdf5a171d45}"/>
+        <tag k="source" v="tdsv40:orchard_s"/>
+        <tag k="landuse" v="orchard"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-6"/>
+        <nd ref="-7"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:34:25.110Z"/>
+        <tag k="papa" v="smurf"/>
+        <tag k="source" v="cartoon"/>
+        <tag k="uuid" v="{79cd86b0-882c-4d66-b7ec-60fed3cac8f7}"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="-3"/>
+        <nd ref="-4"/>
+        <nd ref="-5"/>
+        <tag k="source:ingest:datetime" v="2017-12-18T20:34:25.110Z"/>
+        <tag k="papa" v="smurf"/>
+        <tag k="source" v="cartoon"/>
+        <tag k="uuid" v="{c0b66070-d3be-44bd-bb52-03d34716cd49}"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+</osm>


### PR DESCRIPTION
Refs #2021 
Fixed ordering problem and added GGDM and TDS 4.0 expected output test files that include the `source` tag.