### PR TITLE
Fix Ubuntu Provisioning Errors

### DIFF
--- a/VagrantProvision.sh
+++ b/VagrantProvision.sh
@@ -8,7 +8,7 @@ set -e
 # isn't the correct location for HOOT_HOME        #
 ###################################################
 if [ -z "$HOOT_HOME" ]; then
-    HOOT_HOME="~/hoot"
+    HOOT_HOME=~/hoot
 fi
 echo HOOT_HOME: $HOOT_HOME
 #################################################

--- a/VagrantProvisionUbuntu1604.sh
+++ b/VagrantProvisionUbuntu1604.sh
@@ -8,7 +8,7 @@ set -x
 # isn't the correct location for HOOT_HOME        #
 ###################################################
 if [ -z "$HOOT_HOME" ]; then
-    HOOT_HOME="~/hoot"
+    HOOT_HOME=~/hoot
 fi
 echo HOOT_HOME: $HOOT_HOME
 #################################################

--- a/scripts/tomcat/tomcat8/centos7/tomcat8_install.sh
+++ b/scripts/tomcat/tomcat8/centos7/tomcat8_install.sh
@@ -3,7 +3,7 @@
 # Set HOOT_HOME to another location prior to running this script
 # if ~/hoot isn't the correct location
 if [ -z "$HOOT_HOME" ]; then
-    HOOT_HOME="~/hoot"
+    HOOT_HOME=~/hoot
 fi
 TOMCAT_NAME=tomcat8
 TOMCAT_GROUP=tomcat8


### PR DESCRIPTION
As it says in the title, fix quoting of `~/hoot` so that it's possible to provision on Ubuntu again.