### PR TITLE
Core test stability issues found in Configure tests

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/ConflatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ConflatorTest.cpp
@@ -47,6 +47,7 @@ using namespace boost;
 
 // Qt
 #include <QDebug>
+#include <QDir>
 
 class ConflatorTest : public CppUnit::TestFixture
 {
@@ -60,6 +61,8 @@ public:
 
   void runPbfTest()
   {
+    QDir().mkpath("test-output");
+
     OsmPbfReader reader(true);
 
     OsmMapPtr map(new OsmMap());
@@ -82,6 +85,8 @@ public:
 
   void runTest()
   {
+    QDir().mkpath("test-output");
+
     OsmXmlReader reader;
 
     OsmMapPtr map(new OsmMap());
@@ -108,6 +113,8 @@ public:
   //Now the river/building never get mergeed together.
   void runMergeTest()
   {
+    QDir().mkpath("test-output");
+
     OsmXmlReader reader;
 
     OsmMapPtr map(new OsmMap());

--- a/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
@@ -174,6 +174,8 @@ public:
 
   void runAppendTest()
   {
+    QDir().mkpath("test-output");
+
     OsmXmlReader reader;
     reader.setUseDataSourceIds(true);
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/AlphaShapeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/AlphaShapeTest.cpp
@@ -102,7 +102,7 @@ public:
       map->addNode(n);
     }
 
-    QDir().mkdir("test-output/algorithms/");
+    QDir().mkpath("test-output/algorithms/");
     OsmXmlWriter writer;
     writer.write(map, "test-output/algorithms/AlphaDonut.osm");
 
@@ -132,7 +132,7 @@ public:
 
     uut.insert(points);
 
-    QDir().mkdir("test-output/algorithms/");
+    QDir().mkpath("test-output/algorithms/");
     OsmXmlWriter writer;
     writer.write(uut.toOsmMap(), "test-output/algorithms/AlphaMap.osm");
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayMatchStringMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayMatchStringMergerTest.cpp
@@ -129,7 +129,7 @@ public:
     vector< pair<ElementId, ElementId> > replaced;
     WayMatchStringMerger uut(map, mapping, replaced);
 
-    QDir().mkdir("test-output/algorithms/");
+    QDir().mkpath("test-output/algorithms/");
 
     WayMatchStringSplitter().applySplits(map, replaced, uut.getAllSublineMappings());
     uut.updateSublineMapping();
@@ -162,7 +162,7 @@ public:
     vector< pair<ElementId, ElementId> > replaced;
     WayMatchStringMerger uut(map, mapping, replaced);
 
-    QDir().mkdir("test-output/algorithms/");
+    QDir().mkpath("test-output/algorithms/");
 
     WayMatchStringSplitter().applySplits(map, replaced, uut.getAllSublineMappings());
     uut.updateSublineMapping();
@@ -193,7 +193,7 @@ public:
     WayMatchStringMerger uut(map, mapping, replaced);
     WayMatchStringSplitter().applySplits(map, replaced, uut.getAllSublineMappings());
 
-    QDir().mkdir("test-output/algorithms/");
+    QDir().mkpath("test-output/algorithms/");
 
     MapProjector::projectToWgs84(map);
     OsmMapWriterFactory::getInstance().write(map,

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateWayRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateWayRemoverTest.cpp
@@ -78,9 +78,10 @@ public:
 
   void runTest()
   {
-    OsmXmlReader reader;
-
+    QDir().mkpath("test-output/conflate");
     OsmMap::resetCounters();
+
+    OsmXmlReader reader;
     OsmMapPtr map(new OsmMap());
     reader.setDefaultStatus(Status::Unknown1);
     reader.read("test-files/algorithms/LongestCommonNodeStringTest.osm", map);
@@ -103,8 +104,9 @@ public:
    */
   void runStrictTagMatchingOnTest()
   {
-    QDir().mkdir("test-output/conflate");
+    QDir().mkpath("test-output/conflate");
     OsmMap::resetCounters();
+
     OsmMapPtr map(new OsmMap());
     OsmMapReaderFactory::read(map, "test-files/DcTigerRoads.osm", true, Status::Unknown1);
 
@@ -134,8 +136,9 @@ public:
    */
   void runStrictTagMatchingOffTest()
   {
-    QDir().mkdir("test-output/conflate");
+    QDir().mkpath("test-output/conflate");
     OsmMap::resetCounters();
+
     OsmMapPtr map(new OsmMap());
     OsmMapReaderFactory::read(map, "test-files/DcTigerRoads.osm", true, Status::Unknown1);
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/LargeWaySplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/LargeWaySplitterTest.cpp
@@ -76,7 +76,7 @@ public:
     LargeWaySplitter::splitWays(map, 20.0);
     MapProjector::projectToWgs84(map);
 
-    QDir().mkdir("test-output/conflate/");
+    QDir().mkpath("test-output/conflate/");
     OsmXmlWriter writer;
     writer.write(map, "test-output/conflate/LargeWaySplitterOutput1.osm");
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeReplacementsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeReplacementsTest.cpp
@@ -39,6 +39,7 @@ using namespace hoot;
 
 // Qt
 #include <QDebug>
+#include <QDir>
 
 class NodeReplacementsTest : public CppUnit::TestFixture
 {
@@ -51,6 +52,7 @@ public:
 
   void runIoTest()
   {
+    QDir().mkpath("test-output/conflate");
     NodeReplacements uut;
 
     HashMap<long, long>& m = uut.getReplacements();

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/RubberSheetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/RubberSheetTest.cpp
@@ -122,7 +122,7 @@ public:
 
       MapProjector::projectToWgs84(map);
 
-      QDir().mkdir("test-output/conflate/");
+      QDir().mkpath("test-output/conflate/");
       OsmXmlWriter writer;
       // for testing we don't need a high precision.
       writer.setPrecision(7);
@@ -154,7 +154,7 @@ public:
 
     MapProjector::projectToWgs84(map);
 
-    QDir().mkdir("test-output/conflate/");
+    QDir().mkpath("test-output/conflate/");
     OsmXmlWriter writer;
     writer.write(map, "test-output/conflate/RubberSheetSimple.osm");
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SmallWayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SmallWayMergerTest.cpp
@@ -68,7 +68,7 @@ public:
       SmallWayMerger::mergeWays(map, 15.0);
       MapProjector::projectToWgs84(map);
 
-      QDir().mkdir("test-output/conflate/");
+      QDir().mkpath("test-output/conflate/");
       OsmXmlWriter writer;
       writer.write(map, "test-output/conflate/SmallWayMergerOutput1.osm");
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.cpp
@@ -44,6 +44,7 @@ using namespace boost;
 
 // Qt
 #include <QDebug>
+#include <QDir>
 
 #include "../TestUtils.h"
 
@@ -118,6 +119,7 @@ public:
       }
     }
 
+    QDir().mkpath("test-output/conflate");
     OsmXmlWriter writer;
     writer.write(bounds, "test-output/conflate/TileBounds.osm");
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/TileConflatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/TileConflatorTest.cpp
@@ -75,6 +75,8 @@ public:
 
     FileUtils::removeDir("test-output/conflate/TileConflatorTest.osm-cache");
 
+    QDir().mkpath("test-output/conflate");
+
     boost::shared_ptr<TileWorker> worker(new LocalTileWorker());
     TileConflator uut(worker);
     // ~240m

--- a/hoot-core-test/src/test/cpp/hoot/core/fourpass/FourPassManagerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/fourpass/FourPassManagerTest.cpp
@@ -77,6 +77,8 @@ public:
 
     FileUtils::removeDir("test-output/fourpass/FourPassManagerTest.osm-cache");
 
+    QDir().mkpath("test-output/fourpass");
+
     boost::shared_ptr<TileWorker2> worker(new LocalTileWorker2());
     FourPassManager uut(worker);
     // ~240m

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
@@ -478,8 +478,6 @@ public:
   {
     OsmMapPtr map(new OsmMap());
     OsmPbfReader(true).read("test-files/index/hybrid/TinyGeoNamesOrg.osm.pbf", map);
-//    OsmPbfReader(true).read("/scratch/gis-data/geonames.org/tmp/GeoNamesOrgAfghanistan.osm.pbf",
-//                             map);
 
     MapProjector::projectToPlanar(map);
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -123,9 +123,10 @@ public:
 
   void runShpTest()
   {
+    FileUtils::removeDir("test-output/io/OgrWriterShpTest");
+    QDir().mkpath("test-output/io/");
     OgrWriter uut;
     uut.setScriptPath("test-files/io/SampleTranslation.js");
-    FileUtils::removeDir("test-output/io/OgrWriterShpTest");
     uut.open("test-output/io/OgrWriterShpTest.shp");
     uut.write(createTestMap());
     QStringList nameFilter;
@@ -138,9 +139,10 @@ public:
 
   void runGdbTest()
   {
+    FileUtils::removeDir("test-output/io/OgrWriterTest.gdb");
+    QDir().mkpath("test-output/io/");
     OgrWriter uut;
     uut.setScriptPath("test-files/io/SampleTranslation.js");
-    FileUtils::removeDir("test-output/io/OgrWriterTest.gdb");
     uut.open("test-output/io/OgrWriterTest.gdb");
     uut.write(createTestMap());
 
@@ -167,9 +169,10 @@ public:
 
     map->getRelation(1)->addElement("test", ElementId(ElementType::Relation, 2));
 
+    FileUtils::removeDir("test-output/io/OgrWriterRelationTest.gdb");
+    QDir().mkpath("test-output/io/");
     OgrWriter uut;
     uut.setScriptPath("test-files/io/SampleTranslation.js");
-    FileUtils::removeDir("test-output/io/OgrWriterRelationTest.gdb");
     uut.open("test-output/io/OgrWriterRelationTest.gdb");
     uut.write(map);
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfWriterTest.cpp
@@ -42,6 +42,9 @@
 using namespace hoot;
 using namespace hoot::pb;
 
+// Qt
+#include <QDir>
+
 // Standard
 #include <sstream>
 using namespace std;
@@ -69,6 +72,8 @@ public:
 
     OsmMapPtr map(new OsmMap());
     reader.read("test-files/ToyTestA.osm", map);
+
+    QDir().mkpath("test-output/io/");
 
     OsmPbfWriter writer;
     writer.write(map, "test-output/io/OsmPbfWriterTest.pbf");

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
@@ -64,9 +64,6 @@ public:
 
         CPPUNIT_ASSERT_EQUAL(36, (int)map->getNodes().size());
         CPPUNIT_ASSERT_EQUAL(4, (int)map->getWays().size());
-
-        OsmXmlWriter writer;
-        writer.write(map, "output.osm");
     }
 
     void runUseIdTest()
@@ -99,9 +96,6 @@ public:
         CPPUNIT_ASSERT(map->containsWay(-1669799));
         CPPUNIT_ASSERT(map->containsWay(-1669797));
         CPPUNIT_ASSERT(map->containsWay(-1669795));
-
-        OsmXmlWriter writer;
-        writer.write(map, "output.osm");
     }
 
     void runUseStatusTest()
@@ -134,14 +128,11 @@ public:
         HOOT_STR_EQUALS("Unknown2", map->getWay(-51)->getStatus().toString());
         HOOT_STR_EQUALS("Input003", map->getWay(-14)->getStatus().toString());
         HOOT_STR_EQUALS("Input004", map->getWay(-15)->getStatus().toString());
-
-        OsmXmlWriter writer;
-        writer.write(map, "output.osm");
     }
 
     void runUncompressTest()
     {
-      const std::string cmd("gzip -c test-files/ToyTestA.osm > test-files/ToyTestA_compressed.osm.gz");
+      const std::string cmd("gzip -c test-files/ToyTestA.osm > test-output/ToyTestA_compressed.osm.gz");
       LOG_DEBUG("Running compress command: " << cmd);
 
       int retVal;
@@ -158,18 +149,18 @@ public:
       uut.setUseDataSourceIds(true);
 
       // Excercise the code
-      uut.read("test-files/ToyTestA_compressed.osm.gz", map);
+      uut.read("test-output/ToyTestA_compressed.osm.gz", map);
 
       // Checka a few things
       CPPUNIT_ASSERT_EQUAL(36,(int)map->getNodes().size());
       CPPUNIT_ASSERT_EQUAL(4, (int)map->getWays().size());
 
-      QFile f("test-files/ToyTestA_compressed.osm.gz");
+      QFile f("test-output/ToyTestA_compressed.osm.gz");
       CPPUNIT_ASSERT(f.exists());
       CPPUNIT_ASSERT(f.remove());
     }
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(OsmXmlReaderTest);
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmXmlReaderTest, "quick");
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -124,7 +124,8 @@ public:
     actualMapWriter->open(actualOutputFile);
     actualMapWriter->write(actualMap);
 
-     HOOT_FILE_EQUALS(outputDir + "/psqlOffline.osm", actualOutputFile);
+    HOOT_FILE_EQUALS(
+      "test-files/io/ServiceHootApiDbBulkInserterTest/psqlOffline.osm", actualOutputFile);
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -94,7 +94,7 @@ public:
     QDir().mkpath(outputDir);
 
     HootApiDbBulkInserter writer;
-    const QString outFile = "test-output/io/ServiceHootApiDbBulkInserterTest/psql-offline-out.sql";
+    const QString outFile = outputDir + "/psql-offline-out.sql";
     writer.setOutputFilesCopyLocation(outFile);
     writer.setStatusUpdateInterval(1);
     writer.setChangesetUserId(1);
@@ -124,8 +124,7 @@ public:
     actualMapWriter->open(actualOutputFile);
     actualMapWriter->write(actualMap);
 
-     HOOT_FILE_EQUALS(
-       "test-files/io/ServiceHootApiDbBulkInserterTest/psqlOffline.osm", actualOutputFile);
+     HOOT_FILE_EQUALS(outputDir + "/psqlOffline.osm", actualOutputFile);
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayManipulationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayManipulationTest.cpp
@@ -106,7 +106,7 @@ public:
 
     MapProjector::projectToWgs84(after);
 
-    QDir().mkdir("test-output");
+    QDir().mkpath("test-output");
     OsmXmlWriter writer;
     writer.write(after, "test-output/DividedHighwayManipulationTest.osm");
   }

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayMergerTest.cpp
@@ -82,7 +82,7 @@ public:
     OsmMapPtr after(new OsmMap(conflator.getBestMap()));
     MapProjector::projectToWgs84(after);
 
-    QDir().mkdir("test-output");
+    QDir().mkpath("test-output");
     OsmXmlWriter writer;
     writer.write(after, "test-output/DividedHighwayMergerTest.osm");
     writer.write(map, "test-output/DividedHighwayMergerTestPre.osm");
@@ -108,7 +108,7 @@ public:
     OsmMapPtr after(new OsmMap(conflator.getBestMap()));
     MapProjector::projectToWgs84(after);
 
-    QDir().mkdir("test-output");
+    QDir().mkpath("test-output");
     OsmXmlWriter writer;
     writer.setIncludeIds(true);
     writer.write(after, "test-output/DividedHighwayMergerPreSplitTest.osm");

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MergeNearbyNodesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MergeNearbyNodesTest.cpp
@@ -77,12 +77,6 @@ public:
       MergeNearbyNodes::mergeNodes(map, 1.0);
 
       CPPUNIT_ASSERT_EQUAL(601, (int)map->getNodes().size());
-
-      MapProjector::projectToWgs84(map);
-
-      OsmXmlWriter writer;
-      writer.write(map, "output.osm");
-
     }
 
 };

--- a/hoot-test/hoot-test.pro
+++ b/hoot-test/hoot-test.pro
@@ -42,3 +42,6 @@ SOURCES += src/main/cpp/hoot/test/main.cpp \
     src/main/cpp/hoot/test/ScriptTest.cpp \
     src/main/cpp/hoot/test/ProcessPool.cpp
 
+OTHER_FILES = \
+    $$files(../test-files/cmd/*.sh, true) \
+    $$files(../scripts/core/*.sh, true) \

--- a/scripts/core/ServiceOsmApiDbHootApiDbConflate.sh
+++ b/scripts/core/ServiceOsmApiDbHootApiDbConflate.sh
@@ -63,7 +63,7 @@ fi
 
 REF_DIR=test-files/cmd/$TEST_CATEGORY/$TEST_NAME
 OUTPUT_DIR=test-output/cmd/$TEST_CATEGORY/$TEST_NAME
-rm -rf $OUTPUT_DIR
+rm -rf $OUTPUT_DIR/*
 mkdir -p $OUTPUT_DIR
 
 if [ "$SELECT_RANDOM_AOI" == "true" ]; then

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/cmd/glacial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest/AllDataTypesA-with-divided-highway.osm test-files/cmd/glacial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest/AllDataTypesB-with-divided-highway.osm -104.9132,38.8242,-104.6926,38.9181 unifying ServiceOsmApiDbHootApiDbAllDataTypesConflateTest glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest/AllDataTypesA-with-divided-highway.osm \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest/AllDataTypesB-with-divided-highway.osm \
+  -104.9132,38.8242,-104.6926,38.9181 unifying ServiceOsmApiDbHootApiDbAllDataTypesConflateTest glacial false -1

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbBuildingConflateTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbBuildingConflateTest.sh
@@ -8,4 +8,7 @@
 # the secondary building ID is kept by default.  This test activates preserve.unknown1.element.id.when.modifying.features,
 # which will force the ref ID to be preserved.
 
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/cmd/glacial/ServiceOsmApiDbHootApiDbBuildingConflateTest/BostonSubsetRoadBuilding_FromShp-cropped-4.osm test-files/cmd/glacial/ServiceOsmApiDbHootApiDbBuildingConflateTest/BostonSubsetRoadBuilding_FromOsm-cropped-4.osm -71.4771,42.4835,-71.4758,42.4841 unifying ServiceOsmApiDbHootApiDbBuildingConflateTest glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbBuildingConflateTest/BostonSubsetRoadBuilding_FromShp-cropped-4.osm \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbBuildingConflateTest/BostonSubsetRoadBuilding_FromOsm-cropped-4.osm \
+  -71.4771,42.4835,-71.4758,42.4841 unifying ServiceOsmApiDbHootApiDbBuildingConflateTest glacial false -1

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest2.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest2.sh
@@ -2,4 +2,7 @@
 
 # This test is similar to ServiceOsmApiDbHootApiDbDcStreetsConflateTest, but is specifically checking to see
 # that reference IDs are retained when the DualWaySplitter is used.
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/DcGisRoads.osm test-files/DcTigerRoads.osm -77.0535,38.8865,-77.0477,38.8913 unifying ServiceOsmApiDbHootApiDbDcStreetsConflateTest2 glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/DcGisRoads.osm \
+  test-files/DcTigerRoads.osm \
+  -77.0535,38.8865,-77.0477,38.8913 unifying ServiceOsmApiDbHootApiDbDcStreetsConflateTest2 glacial false -1

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbDcStreetsNetworkConflateTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbDcStreetsNetworkConflateTest.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/DcGisRoads.osm test-files/DcTigerRoads.osm -77.04,38.8916,-77.03324,38.8958 network ServiceOsmApiDbHootApiDbDcStreetsNetworkConflateTest glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/DcGisRoads.osm \
+  test-files/DcTigerRoads.osm \
+  -77.04,38.8916,-77.03324,38.8958 network ServiceOsmApiDbHootApiDbDcStreetsNetworkConflateTest glacial false -1

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbHaitiDrConflateTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbHaitiDrConflateTest.sh
@@ -4,4 +4,7 @@
 #hoot crop-map tmp/haiti-and-domrep-latest.osm test-files/cmd/slow/ServiceOsmApiDbHootApiDbHaitiDrConflateTest/haiti-and-domrep-latest-cropped.osm "-72.48643,18.52015,-72.46768,18.54206"
 #hoot crop-map tmp/PapMgcpClip.osm test-files/cmd/slow/ServiceOsmApiDbHootApiDbHaitiDrConflateTest/PapMgcpClip-cropped.osm "-72.48643,18.52015,-72.46768,18.54206"
 
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/cmd/glacial/ServiceOsmApiDbHootApiDbHaitiDrConflateTest/haiti-and-domrep-latest-cropped.osm test-files/cmd/glacial/ServiceOsmApiDbHootApiDbHaitiDrConflateTest/PapMgcpClip-cropped.osm -72.4822997917,18.5264918926,-72.4768066276,18.531700324028872 unifying ServiceOsmApiDbHootApiDbHaitiDrConflateTest glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbHaitiDrConflateTest/haiti-and-domrep-latest-cropped.osm \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbHaitiDrConflateTest/PapMgcpClip-cropped.osm \
+  -72.4822997917,18.5264918926,-72.4768066276,18.531700324028872 unifying ServiceOsmApiDbHootApiDbHaitiDrConflateTest glacial false -1

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbPoiPolygonConflateTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbPoiPolygonConflateTest.sh
@@ -6,4 +6,7 @@
 
 # by default the PoiPolygonMerger behaves as we expect w/o unknown1 ID preservation changes, so this test is here to ensure
 # that doesn't change
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/cmd/glacial/ServiceOsmApiDbHootApiDbPoiPolygonConflateTest/PoiPolygon1.osm test-files/cmd/glacial/ServiceOsmApiDbHootApiDbPoiPolygonConflateTest/PoiPolygon2.osm -122.4230,37.7620,-122.4204,37.7647 unifying ServiceOsmApiDbHootApiDbPoiPolygonConflateTest glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbPoiPolygonConflateTest/PoiPolygon1.osm \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbPoiPolygonConflateTest/PoiPolygon2.osm \
+  -122.4230,37.7620,-122.4204,37.7647 unifying ServiceOsmApiDbHootApiDbPoiPolygonConflateTest glacial false -1

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbRafahConflateTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbRafahConflateTest.sh
@@ -2,4 +2,7 @@
 
 #hoot crop-map tmp/rafah.osm tmp/rafah-cropped.osm "34.046,31.178,34.057,31.184"
 
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/cmd/glacial/ServiceOsmApiDbHootApiDbRafahConflateTest/rafah-cropped.osm test-files/cmd/glacial/ServiceOsmApiDbHootApiDbRafahConflateTest/secondary.osm 34.04725915004996,31.17907522629906,34.05654176863703,31.18329523832873 unifying ServiceOsmApiDbHootApiDbRafahConflateTest glacial false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbRafahConflateTest/rafah-cropped.osm \
+  test-files/cmd/glacial/ServiceOsmApiDbHootApiDbRafahConflateTest/secondary.osm \
+  34.04725915004996,31.17907522629906,34.05654176863703,31.18329523832873 unifying ServiceOsmApiDbHootApiDbRafahConflateTest glacial false -1

--- a/test-files/cmd/quick/BadJavaScriptTranslation.sh
+++ b/test-files/cmd/quick/BadJavaScriptTranslation.sh
@@ -1,10 +1,16 @@
+#!/bin/bash
 
+# Do not 'set -e' because these tests are suppsed to fail
+
+OUTPUT_DIR=$HOOT_HOME/test-output/cmd/quick
+
+mkdir -p $OUTPUT_DIR
 
 DATA_FILES=$HOOT_HOME/test-files/jakarta_raya_coastline.shp
 
-hoot ogr2osm test-files/cmd/slow/tSimple.js test-output/cmd/quick/BadJavaScriptTranslation.osm $DATA_FILES
+hoot ogr2osm test-files/cmd/slow/tSimple.js $OUTPUT_DIR/BadJavaScriptTranslation.osm $DATA_FILES
 
-hoot ogr2osm plugins/BadSyntaxTest.js test-output/cmd/quick/BadJavaScriptTranslation.osm $DATA_FILES
+hoot ogr2osm plugins/BadSyntaxTest.js $OUTPUT_DIR/BadJavaScriptTranslation.osm $DATA_FILES
 
-hoot ogr2osm test-files/cmd/slow/BadRequire.js test-output/cmd/quick/BadJavaScriptTranslation.osm $DATA_FILES
+hoot ogr2osm test-files/cmd/slow/BadRequire.js $OUTPUT_DIR/BadJavaScriptTranslation.osm $DATA_FILES
 

--- a/test-files/cmd/quick/ConvertGeoNames.sh
+++ b/test-files/cmd/quick/ConvertGeoNames.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+set -e
 
 hoot convert -D osm.map.writer.factory.writer=hoot::OsmXmlWriter -D convert.ops=hoot::TranslationOp -D translation.script=$HOOT_HOME/translations/GeoNames.js test-files/cmd/quick/ConvertGeoNames.geonames /dev/stdout

--- a/test-files/cmd/quick/HelloWorld.sh
+++ b/test-files/cmd/quick/HelloWorld.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo Hello World.
-echo This is an error. 1>&2

--- a/test-files/cmd/slow/RoadBridgeTest.sh
+++ b/test-files/cmd/slow/RoadBridgeTest.sh
@@ -4,15 +4,16 @@ set -e
 # Test translating one feature into two features.
 
 INPUT=test-files/RoadBridge.osm
-OUTPUT=test-output/RoadBridge
+OUTPUT=test-output/cmd/slow/RoadBridge
 
 rm -rf $OUTPUT
+mkdir -p test-output/cmd/slow
 
 # Make shapefiles
 hoot --osm2ogr -D ogr.thematic.structure=false $HOOT_HOME/translations/HootTest.js $INPUT $OUTPUT".shp"
 
-hoot stats --brief test-output/RoadBridge/BRIDGE_C.shp | grep Count
-hoot stats --brief test-output/RoadBridge/CART_TRACK_C.shp | grep Count
-hoot stats --brief test-output/RoadBridge/RAILWAY_C.shp | grep Count
-hoot stats --brief test-output/RoadBridge/ROAD_C.shp | grep Count
+hoot stats --brief $OUTPUT/BRIDGE_C.shp | grep Count
+hoot stats --brief $OUTPUT/CART_TRACK_C.shp | grep Count
+hoot stats --brief $OUTPUT/RAILWAY_C.shp | grep Count
+hoot stats --brief $OUTPUT/ROAD_C.shp | grep Count
 

--- a/test-files/cmd/slow/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest.sh
+++ b/test-files/cmd/slow/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-scripts/core/ServiceOsmApiDbHootApiDbConflate.sh test-files/DcGisRoads.osm test-files/DcTigerRoads.osm -77.04,38.8916,-77.03324,38.8958 unifying ServiceOsmApiDbHootApiDbDcStreetsConflateTest slow false -1
+scripts/core/ServiceOsmApiDbHootApiDbConflate.sh \
+  test-files/DcGisRoads.osm \
+  test-files/DcTigerRoads.osm \
+  -77.04,38.8916,-77.03324,38.8958 unifying ServiceOsmApiDbHootApiDbDcStreetsConflateTest slow false -1


### PR DESCRIPTION
Refs #2025 
Use `QDir().mkpath()` to make sure that directories are created before trying to write files inside of them.  Also added the scripts to the test project as non-compiled files to make them more accessible to developers.