### PR TITLE
Add tag overrides as hoot export option

### DIFF
--- a/node-export-server/config.json
+++ b/node-export-server/config.json
@@ -29,7 +29,7 @@
     "security:dissemination:control:ic":"",
     "security:dissemination:control:non_ic":"",
     "security:releasability":"",
-    "source:":"",
+    "source":"",
     "source:non_spatial_source:type":"",
     "source:copywrite":""
   },

--- a/node-export-server/config.json
+++ b/node-export-server/config.json
@@ -22,6 +22,17 @@
     "MGCP": "translations/MGCP_TRD4.js",
     "GGDMv30": "translations/GGDMv30.js"
   },
+  "tagOverrides": {
+    "attribution":"",
+    "security:resource_owner":"",
+    "security:classification":"",
+    "security:dissemination:control:ic":"",
+    "security:dissemination:control:non_ic":"",
+    "security:releasability":"",
+    "source:":"",
+    "source:non_spatial_source:type":"",
+    "source:copywrite":""
+  },
   "settings": {
     "cleanupDelay": 30000,
     "port": 8101

--- a/node-export-server/package.json
+++ b/node-export-server/package.json
@@ -8,8 +8,7 @@
     "express": "4.13.1",
     "lodash": "3.10.0",
     "node-uuid": "1.4.3",
-    "rimraf": "2.4.2",
-    "escape-json-node": "1.0.6"
+    "rimraf": "2.4.2"
   },
   "devDependencies": {
     "mocha": "2.2.5",

--- a/node-export-server/package.json
+++ b/node-export-server/package.json
@@ -8,7 +8,8 @@
     "express": "4.13.1",
     "lodash": "3.10.0",
     "node-uuid": "1.4.3",
-    "rimraf": "2.4.2"
+    "rimraf": "2.4.2",
+    "escape-json-node": "1.0.6"
   },
   "devDependencies": {
     "mocha": "2.2.5",

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -9,6 +9,7 @@ var config = require('configure');
 var _ = require('lodash');
 var rmdir = require('rimraf');
 var crypto = require('crypto');
+var escapeJSON = require('escape-json-node');
 var done = false;
 var dir;
 var jobs = {};
@@ -31,8 +32,7 @@ app.get('/options', function(req, res) {
     res.json({
         Datasource: _.keys(config.datasources),
         Schema: _.keys(config.schemas),
-        Format: _.keys(config.formats),
-        SetTagOverrides: JSON.stringify(config.tagOverrides)
+        Format: _.keys(config.formats)
     });
 });
 
@@ -235,7 +235,7 @@ function doExport(req, res, hash, input) {
             + '.zip';
 
         var command = '';
-        var overrideTags = JSON.stringify(config.tagOverrides);
+        var overrideTags = escapeJSON(JSON.stringify(config.tagOverrides));
         //if conn is url, write that response to a file
         //handle different flavors of bbox param
         var bbox_param = 'convert.bounding.box';
@@ -259,14 +259,14 @@ function doExport(req, res, hash, input) {
         if (isFile) {
             command += ' convert';
             if (bbox) command += ' -D ' + bbox_param + '=' + bbox;
-            if (req.query.overrideTags) command += ' -D tags.override=' + overrideTags;
+            if (req.query.overrideTags) command += ' -D translation.override=' + overrideTags;
             if (req.params.schema !== 'OSM' && config.schemas[req.params.schema] !== '') {
                 command += ' -D convert.ops=hoot::TranslationOp -D translation.script=' + config.schemas[req.params.schema] + ' -D translation.direction=toogr';
             }
         } else {
             command += ' osm2ogr';
             if (req.params.schema === 'OSM') command += ' -D writer.include.debug.tags=true';
-            if (req.query.overrideTags) command +=  ' -D tags.override=' + overrideTags;
+            if (req.query.overrideTags) command +=  ' -D translation.override=' + overrideTags;
             if (bbox) command += ' -D ' + bbox_param + '=' + bbox;
             command += ' ' + config.schemas[req.params.schema];
         }

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -9,7 +9,6 @@ var config = require('configure');
 var _ = require('lodash');
 var rmdir = require('rimraf');
 var crypto = require('crypto');
-var escapeJSON = require('escape-json-node');
 var done = false;
 var dir;
 var jobs = {};
@@ -235,7 +234,7 @@ function doExport(req, res, hash, input) {
             + '.zip';
 
         var command = '';
-        var overrideTags = escapeJSON(JSON.stringify(config.tagOverrides));
+        var overrideTags = "'" + JSON.stringify(config.tagOverrides) + "'";
         //if conn is url, write that response to a file
         //handle different flavors of bbox param
         var bbox_param = 'convert.bounding.box';
@@ -259,9 +258,17 @@ function doExport(req, res, hash, input) {
         if (isFile) {
             command += ' convert';
             if (bbox) command += ' -D ' + bbox_param + '=' + bbox;
-            if (req.query.overrideTags) command += ' -D translation.override=' + overrideTags;
+            if (req.query.overrideTags) {
+                if (req.params.schema === 'OSM') {
+                    command += ' -D convert.ops=hoot::TranslationOp';
+                    command += ' -D translation.script=translations/OSM_Ingest.js';
+                }
+                command += ' -D translation.override=' + overrideTags;
+            }
             if (req.params.schema !== 'OSM' && config.schemas[req.params.schema] !== '') {
-                command += ' -D convert.ops=hoot::TranslationOp -D translation.script=' + config.schemas[req.params.schema] + ' -D translation.direction=toogr';
+                command += ' -D convert.ops=hoot::TranslationOp';
+                command += ' -D translation.script=' + config.schemas[req.params.schema];
+                command += ' -D translation.direction=toogr';
             }
         } else {
             command += ' osm2ogr';

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -49,7 +49,7 @@ app.get('/job/:hash', function(req, res) {
 });
 
 /* Post export */
-// export/Overpass/OSM/Shapefile/overrideTags?
+// export/Overpass/OSM/Shapefile
 app.post('/export/:datasource/:schema/:format/', function(req, res) {
 
     //Build a hash for the input params used in file name
@@ -97,11 +97,10 @@ app.get('/export/:datasource/:schema/:format', function(req, res) {
     var params = req.params.datasource
         + req.params.schema
         + req.params.format
-        + req.params.tagOverrides
+        // + req.params.overrideTags
         + req.query.bbox;
     var hash = crypto.createHash('sha1').update(params).digest('hex');
     var input = config.datasources[req.params.datasource].conn;
-    console.log(params);
     doExport(req, res, hash, input);
 
 });
@@ -237,6 +236,8 @@ function doExport(req, res, hash, input) {
             + '.zip';
 
         var command = '';
+        var overrideTags = JSON.stringify(config.tagOverrides);
+        console.log(overrideTags);
         //if conn is url, write that response to a file
         //handle different flavors of bbox param
         var bbox_param = 'convert.bounding.box';
@@ -265,7 +266,7 @@ function doExport(req, res, hash, input) {
             }
         } else {
             command += ' osm2ogr';
-            if (req.params.schema === 'OSM') command += ' -D writer.include.debug.tags=true';
+            if (req.params.schema === 'OSM') command += ' -D writer.include.debug.tags=true tags.override='+ overrideTags;
             if (bbox) command += ' -D ' + bbox_param + '=' + bbox;
             command += ' ' + config.schemas[req.params.schema];
         }

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -35,6 +35,10 @@ app.get('/options', function(req, res) {
     });
 });
 
+app.get('/tagoverrides', function(req, res) {
+    res.json(config.tagOverrides);
+});
+
 /* Get job status*/
 app.get('/job/:hash', function(req, res) {
     var hash = req.params.hash;

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -31,7 +31,8 @@ app.get('/options', function(req, res) {
     res.json({
         Datasource: _.keys(config.datasources),
         Schema: _.keys(config.schemas),
-        Format: _.keys(config.formats)
+        Format: _.keys(config.formats),
+        SetTagOverrides: _.keys(config.tagOverrides)
     });
 });
 
@@ -48,8 +49,8 @@ app.get('/job/:hash', function(req, res) {
 });
 
 /* Post export */
-// export/Overpass/OSM/Shapefile
-app.post('/export/:datasource/:schema/:format', function(req, res) {
+// export/Overpass/OSM/Shapefile/overrideTags?
+app.post('/export/:datasource/:schema/:format/', function(req, res) {
 
     //Build a hash for the input params used in file name
     var params = (new Date()).getTime()
@@ -91,13 +92,16 @@ app.post('/export/:datasource/:schema/:format', function(req, res) {
 /* Get export */
 app.get('/export/:datasource/:schema/:format', function(req, res) {
 
+
     //Build a hash for the input params using base64
     var params = req.params.datasource
         + req.params.schema
         + req.params.format
+        + req.params.tagOverrides
         + req.query.bbox;
     var hash = crypto.createHash('sha1').update(params).digest('hex');
     var input = config.datasources[req.params.datasource].conn;
+    console.log(params);
     doExport(req, res, hash, input);
 
 });

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -50,7 +50,7 @@ app.get('/job/:hash', function(req, res) {
 
 /* Post export */
 // export/Overpass/OSM/Shapefile
-app.post('/export/:datasource/:schema/:format/', function(req, res) {
+app.post('/export/:datasource/:schema/:format', function(req, res) {
 
     //Build a hash for the input params used in file name
     var params = (new Date()).getTime()


### PR DESCRIPTION
`http://localhost:8101/export/API/OSM/Shapefile?bbox=-77.44911,37.53927,-77.44587,37.54333&overrideTags=true` will return:

```
wget -q  -O /home/vagrant/hoot/node-export-server/export_6e1e9550-f26b-11e7-aef6-0da8a3f2c6dd.osm http://192.168.33.12:3000/api/0.6/map?bbox=-77.44911,37.53927,-77.44587,37.54333 && hoot osm2ogr -D writer.include.debug.tags=true -D tags.override={"attribution":"","security:resource_owner":"","security:classification":"","security:dissemination:control:ic":"","security:dissemination:control:non_ic":"","security:releasability":"","source:":"","source:non_spatial_source:type":"","source:copywrite":""} translations/RenderDb.js "/home/vagrant/hoot/node-export-server/export_6e1e9550-f26b-11e7-aef6-0da8a3f2c6dd.osm" /home/vagrant/hoot/node-export-server/export_6e1e9550-f26b-11e7-aef6-0da8a3f2c6dd.shp
```

leaving the `overrideTags` part off (`http://localhost:8101/export/API/OSM/Shapefile?bbox=-77.44911,37.53927,-77.44587,37.54333`) will return:

```
wget -q  -O /home/vagrant/hoot/node-export-server/export_821869f0-f26b-11e7-aef6-0da8a3f2c6dd.osm http://192.168.33.12:3000/api/0.6/map?bbox=-77.44911,37.53927,-77.44587,37.54333 && hoot osm2ogr -D writer.include.debug.tags=true translations/RenderDb.js "/home/vagrant/hoot/node-export-server/export_821869f0-f26b-11e7-aef6-0da8a3f2c6dd.osm" /home/vagrant/hoot/node-export-server/export_821869f0-f26b-11e7-aef6-0da8a3f2c6dd.shp
```
  