### PR TITLE
Add context exit to PluginContext destructor

### DIFF
--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
@@ -76,6 +76,10 @@ PluginContext::PluginContext()
 
 PluginContext::~PluginContext()
 {
+  // Get our context & exit
+  Isolate* current = v8Engine::getIsolate();
+  Handle<Context> context = _context.Get(current);
+  context->Exit();
 }
 
 Local<Value> PluginContext::call(Handle<Object> obj, QString name, QList<QVariant> args)


### PR DESCRIPTION
Prior to this change, running the MergePoisTest.js node script (in node) coughs up this error

FATAL ERROR: v8::Context::Exit() Cannot exit non-entered context
 1: node::Abort() [/usr/bin/node]
 2: 0x1216dfc [/usr/bin/node]
 3: v8::Utils::ReportApiFailure(char const*, char const*) [/usr/bin/node]
 4: v8::Context::Exit() [/usr/bin/node]
 5: node::Start(uv_loop_s*, int, char const* const*, int, char const* const*) [/usr/bin/node]
 6: node::Start(int, char**) [/usr/bin/node]
 7: __libc_start_main [/lib64/libc.so.6]
 8: 0x8ad63a [/usr/bin/node]

Which I attribute to us not being careful with contexts in the PluginContext class. Adding a context exit to the PluginContext destructor allows the code exec ion to get much further along (I think), to the point where the hoot node object is destroyed, and the v8Engine destructor is invoked. (Note the destructor seems to execute all the way through just fine) After this change, I'm seeing a SIGABRT generated from within Node, when a mutex _lock attempt fails.

Anyway, I think this change is progress...