### PR TITLE
Tweaked the GeoJSON parser to handle single features

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
@@ -160,20 +160,36 @@ OsmMapPtr OsmGeoJsonReader::loadFromFile(QString path)
   return _map;
 }
 
+
 void OsmGeoJsonReader::_parseGeoJson()
 {
-  _generator = QString::fromStdString(_propTree.get("generator", string("")));
-  QString type = QString::fromStdString(_propTree.get("type", string("")));
-  if (_propTree.not_found() != _propTree.find("bbox"))
-  {
-    Envelope env = _parseBbox(_propTree.get_child("bbox"));
-  }
+    _generator = QString::fromStdString(_propTree.get("generator", string("")));
+    QString type = QString::fromStdString(_propTree.get("type", string("")));
+    if (_propTree.not_found() != _propTree.find("bbox"))
+    {
+        Envelope env = _parseBbox(_propTree.get_child("bbox"));
+    }
 
-  //  Make a map, and iterate through all of our features, adding them
-  pt::ptree features = _propTree.get_child("features");
-  for (pt::ptree::const_iterator featureIt = features.begin(); featureIt != features.end(); ++featureIt)
-  {
-    const pt::ptree& feature = featureIt->second;
+    // If we don't have a "features" child then we should just have a single feature
+    if (_propTree.not_found() != _propTree.find("features"))
+    {
+        // Iterate through all of our features, adding them to the map
+        pt::ptree features = _propTree.get_child("features");
+        for (pt::ptree::const_iterator featureIt = features.begin(); featureIt != features.end(); ++featureIt)
+        {
+            _parseGeoJsonFeature(featureIt->second);
+        }
+    }
+    else
+    {
+        // Single Feature
+        _parseGeoJsonFeature(_propTree);
+    }
+}
+
+
+void OsmGeoJsonReader::_parseGeoJsonFeature(const boost::property_tree::ptree& feature)
+{
     string id = feature.get("id", string(""));
     //  Some IDs may be strings that start with "node/" or "way/", remove that
     size_t pos = id.find("/");
@@ -238,8 +254,8 @@ void OsmGeoJsonReader::_parseGeoJson()
         }
       }
     }
-  }
 }
+
 
 geos::geom::Envelope OsmGeoJsonReader::_parseBbox(const boost::property_tree::ptree& bbox)
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmGeoJsonReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
@@ -109,6 +109,11 @@ private:
   void _parseGeoJson();
 
   /**
+   * @brief _parseGeoJsonFeature Parse a feature and add it to a map
+   */
+  void _parseGeoJsonFeature(const boost::property_tree::ptree &feature);
+
+  /**
    * @brief _parseGeoJsonNode Reads node info out of the property tree and
    *        builds a Node object. Adds the node to the map.
    * @param id Element ID string

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef OSM_GEOJSON_READER_H


### PR DESCRIPTION
refs: #2040 

Split the _parseGeojson() function and created a _parseGeoJsonFeature() function so the we can handle files with one feature in them and files with multiple features.

Note: The diff looks funky but the code is OK.