### PR TITLE
Support for preprovisioned hootenanny vagrant box

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -34,9 +34,12 @@ sudo yum -y install epel-release >> CentOS_upgrade.txt 2>&1
 echo "### Add Hoot repo ###" >> CentOS_upgrade.txt
 $HOOT_HOME/scripts/hoot-repo/yum-configure.sh
 
-# add the Postgres repo
-echo "### Add Postgres repo ###" >> CentOS_upgrade.txt
-sudo rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm  >> CentOS_upgrade.txt 2>&1
+# check to see if postgres is already installed
+if ! rpm -qa | grep -q pgdg-centos95-9.5-3 ; then
+  # add the Postgres repo
+  echo "### Add Postgres repo ###" >> CentOS_upgrade.txt
+  sudo rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm  >> CentOS_upgrade.txt 2>&1
+fi
 
 echo "Updating OS..."
 echo "### Update ###" >> CentOS_upgrade.txt
@@ -215,7 +218,10 @@ fi
 echo "### Configuring Postgres..."
 cd /tmp # Stop postgres "could not change directory to" warnings
 
-sudo PGSETUP_INITDB_OPTIONS="-E 'UTF-8' --lc-collate='en_US.UTF-8' --lc-ctype='en_US.UTF-8'" /usr/pgsql-$PG_VERSION/bin/postgresql95-setup initdb
+# Test to see if postgres cluster already created
+if ! sudo -u postgres test -f /var/lib/pgsql/$PG_VERSION/data/PG_VERSION; then
+  sudo PGSETUP_INITDB_OPTIONS="-E 'UTF-8' --lc-collate='en_US.UTF-8' --lc-ctype='en_US.UTF-8'" /usr/pgsql-$PG_VERSION/bin/postgresql95-setup initdb
+fi
 sudo systemctl start postgresql-$PG_VERSION
 sudo systemctl enable postgresql-$PG_VERSION
 
@@ -237,7 +243,6 @@ if ! sudo -u postgres psql -c "\du" | grep -iw --quiet $DB_USER_OSMAPI; then
     sudo -u postgres createuser --superuser $DB_USER_OSMAPI
     sudo -u postgres psql -c "alter user $DB_USER_OSMAPI with password '$DB_PASSWORD_OSMAPI';"
 fi
-
 
 # Check for a hoot Db
 if ! sudo -u postgres psql -lqt | grep -iw --quiet $DB_NAME; then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -176,7 +176,7 @@ Vagrant.configure(2) do |config|
     #hoot_ubuntu1604.vm.provision "mapnik", type: "shell", :privileged => false, :inline => "sudo service node-mapnik-server start", run: "always"
   end
 
-  # Centos7 box
+  # Centos7 box - minimal
   config.vm.define "hoot_centos7", autostart: false do |hoot_centos7|
     hoot_centos7.vm.box = "hoot/centos7-minimal"
     hoot_centos7.vm.hostname = "hoot-centos"
@@ -189,6 +189,21 @@ Vagrant.configure(2) do |config|
     hoot_centos7.vm.provision "export", type: "shell", :privileged => false, :inline => "sudo systemctl restart node-export", run: "always"
 
     aws_provider(hoot_centos7, 'CentOS7')
+  end
+
+  # Centos7 box - Preprovisioned for compiling hootenanny
+  config.vm.define "hoot_centos7_prov", autostart: false do |hoot_centos7_prov|
+    hoot_centos7_prov.vm.box = "hoot/centos7-hoot"
+    hoot_centos7_prov.vm.hostname = "centos7-hoot"
+    hoot_centos7_prov.vm.synced_folder ".", "/home/vagrant/hoot"
+
+    hoot_centos7_prov.vm.provision "hoot", type: "shell", :privileged => false, :path => "VagrantProvisionCentOS7.sh"
+    hoot_centos7_prov.vm.provision "build", type: "shell", :privileged => false, :path => "VagrantBuild.sh"
+    hoot_centos7_prov.vm.provision "tomcat", type: "shell", :privileged => false, :inline => "sudo systemctl restart tomcat8", run: "always"
+    hoot_centos7_prov.vm.provision "mapnik", type: "shell", :privileged => false, :inline => "sudo systemctl restart node-mapnik", run: "always"
+    hoot_centos7_prov.vm.provision "export", type: "shell", :privileged => false, :inline => "sudo systemctl restart node-export", run: "always"
+
+    aws_provider(hoot_centos7_prov, 'CentOS7')
   end
 
   # Centos7 - Hoot core ONLY. No UI

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         stage("Vagrant Up") {
             steps {
                 // NOTE: Only installs hoot build dependencies
-                sh "vagrant up ${params.Box} --provision-with software,hoot --provider aws"
+                sh "vagrant up ${params.Box} --provision-with software --provider aws"
             }       
         }
         stage("Test Configure") {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         booleanParam(name: 'Core_tests', defaultValue: true)
         booleanParam(name: 'Services_tests', defaultValue: true)
         booleanParam(name: 'UI_tests', defaultValue: true)
-        string(name: 'Box', defaultValue: 'hoot_centos7', description: 'Vagrant Box')
+        string(name: 'Box', defaultValue: 'hoot_centos7_prov', description: 'Vagrant Box')
     }
     stages {
         stage("Setup") {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         stage("Vagrant Up") {
             steps {
                 // NOTE: Only installs hoot build dependencies
-                sh "vagrant up ${params.Box} --provision-with software --provider aws"
+                sh "vagrant up ${params.Box} --provision-with software,hoot --provider aws"
             }       
         }
         stage("Test Configure") {


### PR DESCRIPTION
This adds preprovisioned hootenannt vagrant box support to the vagrantfile.  Updates to provisioning script to allow for being run twice (added checks to see if stuff was already installed).  Defaulted pipeline to use preprovisioned box, but one can rerun job and change parameter and use CentOS minimal again if they want.