### PR TITLE
Adds script that wipes stale data

### DIFF
--- a/scripts/database/clean-datasets-node/.gitignore
+++ b/scripts/database/clean-datasets-node/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/database/clean-datasets-node/DeleteOldData.js
+++ b/scripts/database/clean-datasets-node/DeleteOldData.js
@@ -41,7 +41,7 @@ pgclient.connect(function(err){
       } else {
         // create new array with data id , last access date, and whether or not it's stale
         var data = rows.map(function(row){
-          var stale = moment().diff(moment(row.value), 'seconds') > 1;
+          var stale = moment().diff(moment(row.value), 'days') > 60;
           return {
             id: row.id,
             name: row.display_name,
@@ -53,6 +53,18 @@ pgclient.connect(function(err){
         data.forEach(function(d){
           if (d.stale) {
             pgclient.query("delete from maps where id=" + d.id);
+            // not sure if these are necessary
+            // pgclient.query("delete from folder_map_mappings where map_id=" + d.id);
+            // pgclient.query("drop table current_nodes_" + d.id + " cascade");
+            // pgclient.query("drop sequence changesets_" + d.id + "_id_seq");
+            // pgclient.query("drop table current_nodes_" + d.id + "cascade");
+            // pgclient.query("drop sequence current_nodes_" + d.id + "_id_seq");
+            // pgclient.query("drop table current_relation_members_" + d.id + "cascade");
+            // pgclient.query("drop sequence current_relations_" + d.id + "_id_seq");
+            // pgclient.query("drop table current_relations_" + d.id + "cascade");
+            // pgclient.query("drop table current_way_nodes_" + d.id + "cascade");
+            // pgclient.query("drop table current_ways_" + d.id + "cascade");
+            // pgclient.query("drop sequence current_ways_" + d.id + "_id_seq");
             console.log("deleted dataset " + d.name);
           }
         });

--- a/scripts/database/clean-datasets-node/DeleteOldData.js
+++ b/scripts/database/clean-datasets-node/DeleteOldData.js
@@ -1,7 +1,6 @@
 var pg = require('pg');
 var moment = require('moment');
-var now = moment();
-// config
+//config
 var pgclient = new pg.Client({
   host: 'localhost',
   database: 'hoot',
@@ -12,10 +11,13 @@ var pgclient = new pg.Client({
 
 // disconnect
 function disconnect() {
-  pgclient.end(function(err) {
-    console.log('client has disconnected');
-  });
-}
+pgclient.end(function(err){
+  console.log('disconnected');
+  if (err) {
+    console.log('error during disconnection', err.stack)
+  }
+});
+};
 
 pgclient.connect(function(err){
   if (err) {
@@ -24,23 +26,22 @@ pgclient.connect(function(err){
     // client has connected to pg
     console.log('connected');
     // get dataset ids, names, and lastAccessed dates from pg table
-    var query = pgclient.query("select id, display_name, (a).value from ( \
+    var getStaleData = pgclient.query("select id, display_name, (a).value from ( \
                                   select *, each(tags) as a \
                                   from maps \
                                 ) t;");
     var rows = [];
-    query.on('row', function(row, res) {
+    getStaleData.on('row', function(row, result) {
       rows.push(row);
     });
-    query.on('end', function(result){
+    getStaleData.on('end', function(result){
       if(rows[0] === undefined){
         // if no results are returned, disconnect
         console.log('no data returned');
-        disconnect();
       } else {
         // create new array with data id , last access date, and whether or not it's stale
         var data = rows.map(function(row){
-          var stale = moment().diff(moment(row.value), 'days') > 60;
+          var stale = moment().diff(moment(row.value), 'seconds') > 1;
           return {
             id: row.id,
             name: row.display_name,
@@ -48,16 +49,36 @@ pgclient.connect(function(err){
             stale: stale
           }
         });
-        console.log(data);
         // delete stale datasets
         data.forEach(function(d){
           if (d.stale) {
             pgclient.query("delete from maps where id=" + d.id);
             console.log("deleted dataset " + d.name);
           }
+        });
+      }
+    });
+
+    // get folders that don't have any datasets in them
+    var getEmptyFolders = pgclient.query("select id, display_name from folders \
+                                          where id not in \
+                                          (select folder_id from folder_map_mappings)");
+    var emptyFolders = [];
+    getEmptyFolders.on('row', function(row, result){
+      emptyFolders.push(row);
+    });
+    getEmptyFolders.on('end', function(result){
+      if(emptyFolders[0] === undefined) {
+        console.log('no empty folders');
+        disconnect();
+      } else {
+        // delete empty folders
+        emptyFolders.forEach(function(f){
+          pgclient.query("delete from folders where id="+f.id);
+          console.log("deleted folder " + f.display_name);
+          disconnect();
         })
       }
-      disconnect();
-    })
+    });
   }
 });

--- a/scripts/database/clean-datasets-node/DeleteOldData.js
+++ b/scripts/database/clean-datasets-node/DeleteOldData.js
@@ -1,0 +1,63 @@
+var pg = require('pg');
+var moment = require('moment');
+var now = moment();
+// config
+var pgclient = new pg.Client({
+  host: 'localhost',
+  database: 'hoot',
+  port: 5432,
+  user: 'hoot',
+  password: 'hoottest'
+});
+
+// disconnect
+function disconnect() {
+  pgclient.end(function(err) {
+    console.log('client has disconnected');
+  });
+}
+
+pgclient.connect(function(err){
+  if (err) {
+    console.error('connection error', err.stack);
+  } else {
+    // client has connected to pg
+    console.log('connected');
+    // get dataset ids, names, and lastAccessed dates from pg table
+    var query = pgclient.query("select id, display_name, (a).value from ( \
+                                  select *, each(tags) as a \
+                                  from maps \
+                                ) t;");
+    var rows = [];
+    query.on('row', function(row, res) {
+      rows.push(row);
+    });
+    query.on('end', function(result){
+      if(rows[0] === undefined){
+        // if no results are returned, disconnect
+        console.log('no data returned');
+        disconnect();
+      } else {
+        // create new array with data id , last access date, and whether or not it's stale
+        var data = rows.map(function(row){
+          var stale = moment().diff(moment(row.value), 'days') > 60;
+          return {
+            id: row.id,
+            name: row.display_name,
+            accessed: row.value,
+            stale: stale
+          }
+        });
+        console.log(data);
+        // delete stale datasets
+        data.forEach(function(d){
+          if (d.stale) {
+            pgclient.query("delete from maps where id=" + d.id);
+            console.log("deleted dataset " + d.name);
+          }
+        })
+      }
+      disconnect();
+    })
+  }
+});

--- a/scripts/database/clean-datasets-node/package.json
+++ b/scripts/database/clean-datasets-node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rm-old-hoot-data",
+  "version": "1.0.0",
+  "description": "Delete stale datasets from hoot based on their last accessed date, retrieved as an hstore tag",
+  "main": "DeleteOldData.js",
+  "scripts": {
+    "test": "npm test"
+  },
+  "author": "Rebecca Rice (@rmrice)",
+  "license": "ISC",
+  "dependencies": {
+    "pg": "4.4.3",
+    "moment": "~2.20.1"
+  }
+}


### PR DESCRIPTION
Assuming the config is set properly (works in my local vm), this should work.

To run:

```
vagrant ssh
cd hoot/scripts/database/clean-datasets-node
npm install
node DeleteOldData.js
```

To test locally, I just loaded in test data (`make load-data` from test-files/ui). Add some data to the map, wait a few min, then you can change `var stale` so it is:

```
var stale = moment().diff(moment(row.value), 'minutes') > 5;
``` 
or something like that.

Keep in mind I am using an older version of `pg` because our current hoot uses node v0.10. When you upgrade hoot you may have to update some stuff.