### PR TITLE
Fix Floating Point Exception in quick tests

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/visitors/ImplicitTaggerBase.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ImplicitTaggerBase.cpp
@@ -247,7 +247,7 @@ void ImplicitTaggerBase::visit(const ElementPtr& e)
     }
 
     _numNodesParsed++;
-    if (_numNodesParsed % (_statusUpdateInterval % 10) == 0)
+    if (_numNodesParsed % (_statusUpdateInterval / 10) == 0)
     {
       PROGRESS_INFO(
         "Parsed " << StringUtils::formatLargeNumber(_numNodesParsed) << " nodes from input.");


### PR DESCRIPTION
Fixed mod operator to divide so that there isn't a divide by zero error.