### PR TITLE
Change OsmPbfReaderTest to use different output files for different t…

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
@@ -300,10 +300,10 @@ public:
 
     OsmXmlWriter writer;
     writer.setIncludeHootInfo(false);
-    writer.write(map, "test-output/io/OsmPbfReaderTest.osm");
+    writer.write(map, "test-output/io/OsmPbfReaderTest_1.osm");
 
     HOOT_FILE_EQUALS("test-files/io/OsmPbfReaderTest.osm",
-                     "test-output/io/OsmPbfReaderTest.osm");
+                     "test-output/io/OsmPbfReaderTest_1.osm");
   }
 
   void runToyRelationTest()
@@ -409,10 +409,10 @@ public:
     QDir().mkpath("test-output/io/");
     OsmXmlWriter writer;
     writer.setIncludeHootInfo(false);
-    writer.write(map, "test-output/io/OsmPbfReaderTest.osm");
+    writer.write(map, "test-output/io/OsmPbfReaderTest_2.osm");
 
     HOOT_FILE_EQUALS("test-files/io/OsmPbfReaderTest.osm",
-                     "test-output/io/OsmPbfReaderTest.osm");
+                     "test-output/io/OsmPbfReaderTest_2.osm");
   }
 
   void runFactoryReadMapTest()
@@ -425,10 +425,10 @@ public:
     QDir().mkpath("test-output/io/");
     OsmXmlWriter writer;
     writer.setIncludeHootInfo(false);
-    writer.write(map, "test-output/io/OsmPbfReaderTest.osm");
+    writer.write(map, "test-output/io/OsmPbfReaderTest_3.osm");
 
     HOOT_FILE_EQUALS("test-files/io/OsmPbfReaderTest.osm",
-                     "test-output/io/OsmPbfReaderTest.osm");
+                     "test-output/io/OsmPbfReaderTest_3.osm");
   }
 
   void runReadMapPartialTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/ImplicitTagRawRulesDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/ImplicitTagRawRulesDeriverTest.cpp
@@ -54,9 +54,25 @@ public:
   static QString inDir() { return "test-files/schema/ImplicitTagRawRulesDeriverTest"; }
   static QString outDir() { return "test-output/schema/ImplicitTagRawRulesDeriverTest"; }
 
+  // With parallel testing, these tests were all trying to create this same directory at once,
+  // failing occaisionally. This seems to help.
+  static void makeOutDir()
+  {
+    // Try twice, then die
+    if (!QDir().mkpath(outDir()))
+    {
+      sleep(100);
+      if (!QDir().mkpath(outDir()))
+      {
+        QString message = QString("Couldn't create output directory:") + outDir();
+        CPPUNIT_FAIL(message.toStdString());
+      }
+    }
+  }
+
   void runBasicPoiTest()
   {
-    QDir().mkpath(outDir());
+    makeOutDir();
 
     QStringList inputs;
     inputs.append(inDir() + "/yemen-crop-2.osm.pbf");
@@ -79,7 +95,7 @@ public:
 
   void runMultipleInputsPoiTest()
   {
-    QDir().mkpath(outDir());
+    makeOutDir();
 
     QStringList inputs;
     inputs.append(inDir() + "/yemen-crop-2.osm.pbf");
@@ -108,7 +124,7 @@ public:
   void runDuplicateWordKeyCountPoiTest()
   {
     DisableLog dl;
-    QDir().mkpath(outDir());
+    makeOutDir();
 
     boost::shared_ptr<QTemporaryFile> sortedCountFile(
       new QTemporaryFile(
@@ -117,6 +133,7 @@ public:
     sortedCountFile->setAutoRemove(false);
     if (!sortedCountFile->open())
     {
+      // Note: QTemporaryFile returns empty string for ->fileName() if it can't be opened
       throw HootException(
         QObject::tr("Error opening %1 for writing.").arg(sortedCountFile->fileName()));
     }
@@ -154,7 +171,7 @@ public:
     //Case is actually already handled correctly in runBasicTest, but this smaller input dataset
     //will make debugging case problems easier, if needed.
 
-    QDir().mkpath(outDir());
+    makeOutDir();
 
     QStringList inputs;
     inputs.append(inDir() + "/ImplicitTagRawRulesDeriverTest-runNameCaseTest.osm");
@@ -179,7 +196,7 @@ public:
 
   void runTranslateNamesFalsePoiTest()
   {
-    QDir().mkpath(outDir());
+    makeOutDir();
 
     QStringList inputs;
     inputs.append(inDir() + "/yemen-crop-2.osm.pbf");
@@ -203,7 +220,7 @@ public:
 
   void runBadInputsTest()
   {
-    QDir().mkpath(outDir());
+    makeOutDir();
 
     QString exceptionMsg("");
     QStringList inputs;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
@@ -482,7 +482,7 @@ void OsmPbfReader::_loadDenseNodes(const DenseNodes& dn)
         {
           // QT 4.6 does not have fromMSecsSinceEpoch
           //QDateTime dt = QDateTime::fromMSecsSinceEpoch(timestamp).toTimeSpec(Qt::UTC);
-    // same time, but friendly to earlier Qt version
+          // same time, but friendly to earlier Qt version
           QDateTime dt = QDateTime::fromTime_t(0).addMSecs(timestamp).toUTC();
           QString dts = dt.toString("yyyy-MM-ddThh:mm:ss.zzzZ");
           _denseNodeTmp[i]->setTag(MetadataTags::SourceDateTime(), dts);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmXmlReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -232,7 +232,7 @@ void OsmXmlReader::_createWay(const QXmlAttributes &attributes)
 
 bool OsmXmlReader::fatalError(const QXmlParseException &exception)
 {
-  _errorString = QObject::tr("Parse error at line %1, column %2:\n%3")
+  _errorString = QObject::tr("OsmXmlReader: Parse error at line %1, column %2:\n%3")
       .arg(exception.lineNumber())
       .arg(exception.columnNumber())
       .arg(exception.message());

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef SIGNALCATCHER_H

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
@@ -57,12 +57,13 @@ public:
 
   void unregisterHandler(unsigned int sig);
 
+  static void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63);
+
 private:
 
   SignalCatcher();
 
   static void default_handler(int sig);
-  static void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63);
   static void terminateHandler();
 
   static boost::shared_ptr<SignalCatcher> _instance;

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -73,7 +73,6 @@ pipeline {
                     // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
                     expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 21..23 }
                 }
-                not { branch 'PR-*' }
             }
             steps {
                 // Run configuration tests


### PR DESCRIPTION
Refs #2118 

Change OsmPbfReaderTest to use different output files for different tests.
Make output dir creation a little more robust in ImplicitTagRawRulesDeriverTest
Expose print_stack_trace (or whatever it's called) in SignalCatcher