### PR TITLE
hoot delete-map leaves changesets_XXX_id_seq orphaned in db

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/DeleteMapCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DeleteMapCmd.cpp
@@ -22,34 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
- */
-
-/*
- * This file is part of Hootenanny.
- *
- * Hootenanny is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * --------------------------------------------------------------------
- *
- * The following copyright notices are generated automatically. If you
- * have a new notice to add, please use the format:
- * " * @copyright Copyright ..."
- * This will properly maintain the copyright information. DigitalGlobe
- * copyrights will be updated automatically.
- *
- * @copyright Copyright (C) 2012, 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HOOTAPIDB_H
 #define HOOTAPIDB_H
@@ -264,6 +264,16 @@ public:
    * Check if the database has table.
    */
   bool hasTable(const QString& tableName);
+
+  /**
+   * Drops the specified sequences and cascades. No warning or error will be given
+   * if the sequence does not exist.
+   *
+   * No validation is done on the sequence name. In other words, don't pass in user provided strings.
+   *
+   * @param sequenceName
+   */
+  void dropSequence(const QString& sequenceName);
 
   /**
    * Returns a map ID string suitable for using in table names. E.g. _1


### PR DESCRIPTION
Refs #2134 
Updated the HootApiDb class to delete all sequences associated with a map on delete.