### PR TITLE
test-files/DcOsmRoads.osm fails to load in Debug

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -870,7 +870,6 @@ ElementPtr OsmXmlReader::readNextElement()
 
   //we're parsed the entire node/way/relation, so return it
   //LOG_TRACE("Parsing end xml element: " << _streamReader.name().toString());
-  assert(_element.get());
   LOG_VART(_element);
   return _element;
 }


### PR DESCRIPTION
Refs #2153
Removing 'assert' for empty elements because element is empty when "action='delete'" is set as an attribute.