### PR TITLE
Copyright scripts skipping hoot-core-test directory

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef TESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef TESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/AlphaShapeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/AlphaShapeTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/BufferedLineSegmentIntersectorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/BufferedLineSegmentIntersectorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/BufferedLineSegmentIntersectorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/BufferedLineSegmentIntersectorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/ExpectationIntersectionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/ExpectationIntersectionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/ExpectationIntersectionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/ExpectationIntersectionTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/LevenshteinDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/LevenshteinDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/LevenshteinDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/LevenshteinDistanceTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/LongestCommonNodeStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/LongestCommonNodeStringTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/LongestCommonNodeStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/LongestCommonNodeStringTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef MAXIMALNEARESTSUBLINETEST_H

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef MAXIMALNEARESTSUBLINETEST_H

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MeanWordSetDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MeanWordSetDistanceTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MeanWordSetDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MeanWordSetDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/SoundexTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/SoundexTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/SoundexTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/SoundexTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/TranslatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/TranslatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/TranslatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/TranslatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayMatchStringMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayMatchStringMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/LocationOfPointTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/LocationOfPointTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/LocationOfPointTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/LocationOfPointTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayStringTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayStringTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolverTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/MostEnglishNameTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/MostEnglishNameTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/MostEnglishNameTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/MostEnglishNameTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/SqliteWeightedWordDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/SqliteWeightedWordDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/SqliteWeightedWordDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/SqliteWeightedWordDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/StringTokenizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/StringTokenizerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/StringTokenizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/StringTokenizerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionaryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionaryTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionaryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionaryTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/WeightedWordDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/WeightedWordDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/WeightedWordDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/WeightedWordDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/BBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/BBoxTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/BBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/BBoxTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/RangeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/RangeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/RangeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/RangeTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZValueTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZValueTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZValueTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZValueTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/AlphaShapeGeneratorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/AlphaShapeGeneratorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/AlphaShapeGeneratorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/AlphaShapeGeneratorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflateStatsHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflateStatsHelperTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflateStatsHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflateStatsHelperTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/CookieCutterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/CookieCutterTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/CookieCutterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/CookieCutterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateNameRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateNameRemoverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateNameRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateNameRemoverTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateWayRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/DuplicateWayRemoverTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // GEOS

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/LargeWaySplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/LargeWaySplitterTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/MapCleanerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/MapCleanerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/MapCleanerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/MapCleanerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NoInformationElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NoInformationElementRemoverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NoInformationElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NoInformationElementRemoverTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeMatcherTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeReplacementsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeReplacementsTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ReviewMarkerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ReviewMarkerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ReviewMarkerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ReviewMarkerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/RubberSheetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/RubberSheetTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SmallWayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SmallWayMergerTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef TILEBOUNDSCALCULATORTEST_H

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/TileBoundsCalculatorTest.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef TILEBOUNDSCALCULATORTEST_H

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/TileConflatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/TileConflatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/WayCleanerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/WayCleanerTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/WayCleanerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/WayCleanerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include <hoot/core/conflate/extractors/Histogram.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include <hoot/core/conflate/extractors/Histogram.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/SampledAngleHistogramExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/SampledAngleHistogramExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/SampledAngleHistogramExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/SampledAngleHistogramExtractorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/WeightedMetricDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/WeightedMetricDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/WeightedMetricDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/WeightedMetricDistanceExtractorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/GreedyConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/GreedyConstrainedMatchesTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/GreedyConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/GreedyConstrainedMatchesTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/MatchGraphTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/MatchGraphTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/MatchGraphTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/MatchGraphTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/OptimalConstrainedMatchesTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/OptimalConstrainedMatchesTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 /*

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/BufferedOverlapExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/BufferedOverlapExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/BufferedOverlapExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/BufferedOverlapExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/CentroidDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/CentroidDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/CentroidDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/CentroidDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/EdgeDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/EdgeDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/EdgeDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/EdgeDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/DualWaySplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/DualWaySplitterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/DualWaySplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/DualWaySplitterTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/IntersectionSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/IntersectionSplitterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/IntersectionSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/IntersectionSplitterTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/AreaCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/AreaCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/AreaCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/AreaCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Boost

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Boost

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingWayNodeCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingWayNodeCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingWayNodeCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/BuildingWayNodeCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/NonBuildingAreaCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/NonBuildingAreaCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/NonBuildingAreaCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/NonBuildingAreaCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/WayCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/WayCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/filters/WayCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/filters/WayCriterionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/fourpass/FourPassManagerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/fourpass/FourPassManagerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/index/ClosePointHashTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/ClosePointHashTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/index/ClosePointHashTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/ClosePointHashTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RTreeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RTreeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Boost

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Boost

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementCacheLruTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementCacheLruTest.cpp
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ */
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementCacheLruTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementCacheLruTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementComparerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementComparerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementComparerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementComparerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ImplicitTagRulesSqliteReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ImplicitTagRulesSqliteReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // Hoot
 #include "../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectOutputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectOutputStreamTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectOutputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectOutputStreamTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmMapReaderFactoryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmMapReaderFactoryTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmMapReaderFactoryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmMapReaderFactoryTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfWriterTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ServicesDbTestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ServicesDbTestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SERVICESDBTESTUTILS_H
 #define SERVICESDBTESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SERVICESDBTESTUTILS_H
 #define SERVICESDBTESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayManipulationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayManipulationTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/WayMergeManipulationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/WayMergeManipulationTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/WayMergeManipulationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/WayMergeManipulationTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/ml/LogisticRegressionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ml/LogisticRegressionTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ml/LogisticRegressionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ml/LogisticRegressionTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineRemoveOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineRemoveOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineRemoveOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineRemoveOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineUpdateOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineUpdateOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineUpdateOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineUpdateOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingPartMergeOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingPartMergeOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingPartMergeOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingPartMergeOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/CalculateStatsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/CalculateStatsOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/CookieCutterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/CookieCutterOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/CookieCutterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/CookieCutterOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MapCropperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MapCropperTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MapCropperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MapCropperTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MergeNearbyNodesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MergeNearbyNodesTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RecursiveElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RecursiveElementRemoverTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RecursiveElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RecursiveElementRemoverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RefRemoveOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RefRemoveOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RefRemoveOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RefRemoveOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RemoveEmptyRelationsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RemoveEmptyRelationsOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToGeographicOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToGeographicOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToGeographicOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToGeographicOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/TrivialOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/TrivialOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/TrivialOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/TrivialOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/BigPertyOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/BigPertyOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/BigPertyOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/BigPertyOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyDuplicatePoiOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyDuplicatePoiOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyDuplicatePoiOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyDuplicatePoiOpTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyMatchScorerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyMatchScorerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyMatchScorerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyMatchScorerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyNameVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyNameVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveRandomElementVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveRandomElementVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // boost

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveRandomElementVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveRandomElementVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // boost

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveTagVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveTagVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveTagVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyRemoveTagVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyTestRunnerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyTestRunnerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyTestRunnerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyTestRunnerTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWayGeneralizeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWayGeneralizeVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWayGeneralizeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWayGeneralizeVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWaySplitVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWaySplitVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWaySplitVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/perty/PertyWaySplitVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/ImplicitTagRawRulesDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/ImplicitTagRawRulesDeriverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // Hoot
 #include "../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/ImplicitTagRulesDatabaseDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/ImplicitTagRulesDatabaseDeriverTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // Hoot
 #include "../TestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/OsmSchemaTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/OsmSchemaTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/OsmSchemaTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/OsmSchemaTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/OverwriteTagMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/OverwriteTagMergerTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/OverwriteTagMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/OverwriteTagMergerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/SchemaCheckerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/SchemaCheckerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/SchemaCheckerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/SchemaCheckerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/ScoreMatrixTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/ScoreMatrixTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/ScoreMatrixTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/ScoreMatrixTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagAncestorDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagAncestorDifferencerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagAncestorDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagAncestorDifferencerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagCategoryDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagCategoryDifferencerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagCategoryDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagCategoryDifferencerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagMergerFactoryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagMergerFactoryTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagMergerFactoryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagMergerFactoryTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TranslateStringDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TranslateStringDistanceTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TranslateStringDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TranslateStringDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TranslatedTagDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TranslatedTagDifferencerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TranslatedTagDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TranslatedTagDifferencerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/AttributeComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/AttributeComparatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/AttributeComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/AttributeComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MapScoringStatusAndRefTagValidatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MapScoringStatusAndRefTagValidatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MapScoringStatusAndRefTagValidatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MapScoringStatusAndRefTagValidatorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/RasterComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/RasterComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/RasterComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/RasterComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ConflateCaseTest.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ConflateCaseTest.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef CONFLATECASETEST_H
 #define CONFLATECASETEST_H

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef CONFLATECASETEST_H
 #define CONFLATECASETEST_H

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef CONFLATECASETESTSUITE_H
 #define CONFLATECASETESTSUITE_H

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef CONFLATECASETESTSUITE_H
 #define CONFLATECASETESTSUITE_H

--- a/hoot-core-test/src/test/cpp/hoot/core/util/GeometryConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/GeometryConverterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/util/GeometryConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/GeometryConverterTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/util/GeometryUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/GeometryUtilsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/util/GeometryUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/GeometryUtilsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/util/MapProjectorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/MapProjectorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // boost

--- a/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // geos

--- a/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/util/StringUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/StringUtilsTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/AddGeometryTypeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/AddGeometryTypeVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/AddGeometryTypeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/AddGeometryTypeVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/CalculateHashVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/CalculateHashVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/CalculateHashVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/CalculateHashVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/CountManualMatchesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/CountManualMatchesVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/CountManualMatchesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/CountManualMatchesVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/ImplicitPoiTaggerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/ImplicitPoiTaggerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepNodesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepNodesVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepNodesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepNodesVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepTagsVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepTagsVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MedianNodeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MedianNodeVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MedianNodeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MedianNodeVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitorTest.cpp
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ */
 
 // hoot
 #include <hoot/core/OsmMap.h>

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveElementsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveElementsVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveElementsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveElementsVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorMultipleCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorMultipleCriterionTest.cpp
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ */
 ///*
 // * This file is part of Hootenanny.
 // *

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SetTagVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SetTagVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SetTagVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SetTagVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include <limits> // for std::min
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ */
 #include <limits> // for std::min
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SumNumericTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SumNumericTagsVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SumNumericTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SumNumericTagsVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagCountVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagCountVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagKeyCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagKeyCountVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagKeyCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagKeyCountVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagRenameKeyVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagRenameKeyVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagRenameKeyVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagRenameKeyVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TransliterateNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TransliterateNameVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TransliterateNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TransliterateNameVisitorTest.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // hoot

--- a/scripts/copyright/UpdateAllCopyrightHeaders.sh
+++ b/scripts/copyright/UpdateAllCopyrightHeaders.sh
@@ -72,7 +72,7 @@ echo "logFile: " $logFile
 #exit 0
 
 # Updates all the copyright headers in all source directories.
-for i in $HOOT_HOME/hoot-core/ $HOOT_HOME/hoot-cmd/ $HOOT_HOME/hoot-test $HOOT_HOME/hoot-js $HOOT_HOME/hoot-rnd $HOOT_HOME/hoot-services $HOOT_HOME/tgs $HOOT_HOME/pretty-pipes $HOOT_HOME/tbs
+for i in $HOOT_HOME/hoot-cmd $HOOT_HOME/hoot-core $HOOT_HOME/hoot-core-test $HOOT_HOME/hoot-js $HOOT_HOME/hoot-rnd $HOOT_HOME/hoot-services $HOOT_HOME/hoot-test $HOOT_HOME/pretty-pipes $HOOT_HOME/tbs $HOOT_HOME/tgs
 do
     #echo $i
     cd $i

--- a/scripts/copyright/UpdateDirCopyrightHeaders.sh
+++ b/scripts/copyright/UpdateDirCopyrightHeaders.sh
@@ -10,7 +10,6 @@ else
     echo "Error: LicenseTemplate.txt not found"
     exit 1
 fi
-echo $LICENSE_TEMPLATE
 
 if [ $# -eq 0 ]; then
     # Need at least one arg which would be the log filename.


### PR DESCRIPTION
Refs #2164 
Missing the `hoot-core-test` directory.  Should be a lot of added years and removing spaces.

@mschicker would you take a quick look at this. 210 files is nothing, you'll be done before you know it.