### PR TITLE
Modify corner splitter to only add 1/2 of the way it split for furthe…

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/splitter/CornerSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/splitter/CornerSplitter.cpp
@@ -113,7 +113,6 @@ void CornerSplitter::splitCorners()
           LOG_DEBUG("splitting way with delta: " << delta);
           _splitWay(pWay->getId(), nodeIdx, pWay->getNodeId(nodeIdx));
           split = true;
-          LOG_INFO("SPLITTING!!!")
         }
       }
     }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/splitter/CornerSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/splitter/CornerSplitter.cpp
@@ -85,7 +85,9 @@ void CornerSplitter::splitCorners()
     // If the way has just two nodes, there are no corners
     if (nodeCount > 2)
     {
-      for (size_t nodeIdx = 1; nodeIdx < nodeCount-1; nodeIdx++)
+      // Look until we find a split, or get to the end
+      bool split = false;
+      for (size_t nodeIdx = 1; nodeIdx < nodeCount-1 && !split; nodeIdx++)
       {
         WayLocation prev(_map, pWay, nodeIdx-1, 0.0);
         WayLocation current(_map, pWay, nodeIdx, 0.0);
@@ -110,6 +112,8 @@ void CornerSplitter::splitCorners()
         {
           LOG_DEBUG("splitting way with delta: " << delta);
           _splitWay(pWay->getId(), nodeIdx, pWay->getNodeId(nodeIdx));
+          split = true;
+          LOG_INFO("SPLITTING!!!")
         }
       }
     }
@@ -141,16 +145,17 @@ void CornerSplitter::_splitWay(long wayId, long nodeIdx, long nodeId)
 
     const ElementId splitWayId = pWay->getElementId();
 
-    QList<ElementPtr> newWays;
-    foreach (const boost::shared_ptr<Way>& w, splits)
-    {
-      newWays.append(w);
-      _todoWays.push_back(w->getId());
-    }
-
     // Make sure any ways that are part of relations continue to be part of those relations after
     // they're split.
+    QList<ElementPtr> newWays;
+    foreach (const boost::shared_ptr<Way>& w, splits)
+      newWays.append(w);
+
     _map->replace(pWay, newWays);
+
+    // Need to process the "right-hand-side" of the split, looking for more
+    // corners
+    _todoWays.push_back(splits[1]->getId());
 
     if (ConfigOptions().getPreserveUnknown1ElementIdWhenModifyingFeatures() &&
         pWay->getStatus() == Status::Unknown1)


### PR DESCRIPTION
Refs #2186 

Modify cornersplitter to only add 1/2 of the way it split for further processing. (efficiency)

Make it stop processing the nodes in a way once a split has been made. (correctness)