### PR TITLE
Update Adv UI Opts to match what Network/Diff Conflation Expects

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -1418,16 +1418,6 @@ See also:
 The number of optimization iterations the network match creator will run when performing network
 conflation.
 
-=== network.pre.ops
-
-* Data Type: list
-* Default Value:
-** `hoot::CornerSplitter`
-** `hoot::RubberSheet`
-
-List of operations to apply immediately before conflating when using Network Conflation only.  Runs
-after the operations in `conflate.pre.ops`.
-
 === network.review.threshold
 
 * Data Type: double

--- a/conf/core/Diff.conf
+++ b/conf/core/Diff.conf
@@ -6,5 +6,6 @@
   "way.subline.matcher" : "hoot::MaximalSublineMatcher",
   "rubber.sheet.minimum.ties": 4,
   "rubber.sheet.ref": "true",
+  "conflate.pre.ops": "hoot::BuildingOutlineRemoveOp;hoot::MapCleaner;hoot::CornerSplitter;hoot::RubberSheet",
   "#": "end"
 }

--- a/conf/core/Diff.conf
+++ b/conf/core/Diff.conf
@@ -1,6 +1,6 @@
 {
   "match.creators" : "hoot::BuildingMatchCreator;hoot::ScriptMatchCreator,PoiGeneric.js;hoot::NetworkMatchCreator;hoot::ScriptMatchCreator,LinearWaterway.js;hoot::PoiPolygonMatchCreator;hoot::ScriptMatchCreator,Area.js",
-  "merger.creators" : "hoot::BuildingMergerCreator;hoot::ScriptMergerCreator;hoot::NetworkMergerCreator;hoot::PoiPolygonMergerCreator;hoot::ScriptMergerCreator",
+  "merger.creators" : "hoot::BuildingMergerCreator;hoot::ScriptMergerCreator;hoot::NetworkMergerCreator;hoot::ScriptMergerCreator;hoot::PoiPolygonMergerCreator;hoot::ScriptMergerCreator",
   "network.matcher" : "hoot::ConflictsNetworkMatcher",
   "conflate.match.highway.classifier" : "hoot::HighwayExpertClassifier",
   "way.subline.matcher" : "hoot::MaximalSublineMatcher",

--- a/conf/core/Network.conf
+++ b/conf/core/Network.conf
@@ -6,5 +6,6 @@
   "way.subline.matcher" : "hoot::MaximalSublineMatcher",
   "rubber.sheet.minimum.ties": 4,
   "rubber.sheet.ref": "true",
+  "conflate.pre.ops": "hoot::BuildingOutlineRemoveOp;hoot::MapCleaner;hoot::CornerSplitter;hoot::RubberSheet",
   "#": "end"
 }

--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -1019,17 +1019,17 @@
                 "id":"waterway_rubber_sheet_minimum_ties",
                 "minvalue":"0",
                 "elem_type":"int",
-                "description":"Sets the minimum number of tie points that will be used when calculating a rubber sheeting solution.",
+                "description":"Sets the minimum number of rubber sheet tie points that will be used when auto-calculating a search radius.  This is separate from the global Rubber Sheeting Minimum Ties option.",
                 "maxvalue":"",
-                "name":"Waterway Rubber Sheet Minimum Ties",
+                "name":"Waterway Auto-Search Radius Calculation Minimum Ties",
                 "defaultvalue":"5",
                 "hoot_key":"waterway.rubber.sheet.minimum.ties"
             },
             {
                 "id":"waterway_rubber_sheet_ref",
                 "elem_type":"bool",
-                "description":"If this configuration setting is set to true then the first layer is treated as the reference layer and will not be moved. If set to false the two layers will be moved towards each other. The weighting is determined based on the circular error.",
-                "name":"Waterway Rubber Sheet Ref",
+                "description":"When auto-calculating a search radius, if this configuration setting is set to true then the first layer is treated as the reference layer and will not be moved. If set to false, the two layers will be moved towards each other. The weighting is determined based on the circular error.  This is separate from the global Rubber Sheeting Ref option.",
+                "name":"Waterway Auto-Search Radius Calculation Rubber Sheet Ref",
                 "defaultvalue":"true",
                 "hoot_key":"waterway.rubber.sheet.ref"
             }

--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -77,6 +77,14 @@
                 "defaultvalue":"true"
             },
             {
+                "id":"corner_splitter",
+                "elem_type":"checkbox",
+                "description":"Split roads at sharp corners..",
+                "name":"Split Sharp Road Corners",
+                "hoot_val":"hoot::CornerSplitter",
+                "defaultvalue":"true"
+            },
+            {
                 "id":"implied_divided_marker",
                 "elem_type":"checkbox",
                 "description":"If two roads implicitly should be marked as divided based on the surrounding roads, mark it as such. This is primarily caused by the FACC+ spec which does not allow bridges to be marked as divided.",
@@ -168,7 +176,7 @@
                 "elem_type":"checkbox",
                 "description":"Enable rubber sheeting options",
                 "name":"Enabled",
-                "defaultvalue":"false",
+                "defaultvalue":"true",
                 "onchange":"true"
             },
             {
@@ -176,7 +184,7 @@
                 "elem_type":"checkbox",
                 "description":"If this configuration setting is set to true then the first layer is treated as the reference layer and will not be moved. If set to false the two layers will be moved towards each other. The weighting is determined based on the circular error.",
                 "name":"Rubber Sheet Ref",
-                "defaultvalue":"false",
+                "defaultvalue":"true",
                 "hoot_key":"rubber.sheet.ref"
             },
             {
@@ -186,7 +194,7 @@
                 "description":"Sets the minimum number of tie points that will be used when calculating a rubber sheeting solution.",
                 "maxvalue":"",
                 "name":"Rubber Sheet Minimum Ties",
-                "defaultvalue":"10",
+                "defaultvalue":"4",
                 "hoot_key":"rubber.sheet.minimum.ties"
             }
         ]

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -89,12 +89,6 @@ void DiffConflator::apply(OsmMapPtr& map)
   LOG_INFO("Applying pre diff-conflation operations...");
   NamedOp(ConfigOptions().getUnifyPreOps()).apply(map);
 
-  if (ConfigOptions().getMatchCreators().contains("NetworkMatchCreator"))
-  {
-    LOG_INFO("Applying pre-network conflation operations...");
-    NamedOp(ConfigOptions().getNetworkPreOps()).apply(map);
-  }
-
   _stats.append(SingleStat("Apply Pre Ops Time (sec)", timer.getElapsedAndRestart()));
 
   // will reproject if necessary.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "UnifyingConflator.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -126,12 +126,6 @@ void UnifyingConflator::apply(OsmMapPtr& map)
   LOG_INFO("Applying pre-unifying conflation operations...");
   NamedOp(ConfigOptions().getUnifyPreOps()).apply(map);
 
-  if (ConfigOptions().getMatchCreators().contains("NetworkMatchCreator"))
-  {
-    LOG_INFO("Applying pre-network conflation operations...");
-    NamedOp(ConfigOptions().getNetworkPreOps()).apply(map);
-  }
-
   _stats.append(SingleStat("Apply Pre Ops Time (sec)", timer.getElapsedAndRestart()));
 
   // will reproject if necessary.

--- a/test-files/ui/features/advanced_options.feature
+++ b/test-files/ui/features/advanced_options.feature
@@ -30,6 +30,7 @@ Feature: Advanced Conflation Options
         And I should see checkbox "Remove Superfluous Ways" checked
         And I should see checkbox "Remove Unlikely Intersections" checked
         And I should see checkbox "Split Dual Ways" checked
+	And I should see checkbox "Split Sharp Road Corners" checked
         And I should see checkbox "Divided Road Marker Implied" checked
         And I should see checkbox "Merge Small Ways" checked
         And I should see element "#small_way_merger_threshold" with no value and placeholder "15"
@@ -39,9 +40,9 @@ Feature: Advanced Conflation Options
         Then I click on "#hoot_cleaning_options_label"
         And I should see "Rubber Sheeting Options"
         Then I click on "#hoot_rubber_sheeting_options_label"
-        And I should see checkbox "Enabled" unchecked
-        And I should see checkbox "Rubber Sheet Ref" unchecked
-        And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "10"
+        And I should see checkbox "Enabled" checked
+        And I should see checkbox "Rubber Sheet Ref" checked
+        And I should see element "#rubber_sheet_minimum_ties" with no value and placeholder "4"
         Then I click on "#hoot_rubber_sheeting_options_label"
         And I should see "General Conflation Options"
         Then I click on "#hoot_general_conflation_options_label"

--- a/test-files/ui/features/advanced_options.feature
+++ b/test-files/ui/features/advanced_options.feature
@@ -116,7 +116,7 @@ Feature: Advanced Conflation Options
         And I should see element "#search_radius_waterway" with no value and placeholder "-1"
         And I should see "Search Radius Waterway" not enabled
         And I should see element "#waterway_rubber_sheet_minimum_ties" with no value and placeholder "5"
-        And I should see checkbox "Waterway Rubber Sheet Ref" checked
+        And I should see checkbox "Waterway Auto-Search Radius Calculation Rubber Sheet Ref" checked
         And I click on "#hoot_waterway_options_label"
         Then I click the "x" icon
         And I accept the alert

--- a/test-files/ui/features/advanced_options_invalid_input.feature
+++ b/test-files/ui/features/advanced_options_invalid_input.feature
@@ -62,8 +62,8 @@ Feature: Advanced Conflation Options
 		Scenario: Open options that require checkbox for input
 			Then I should see "Rubber Sheeting Options"
 			Then I click on "#hoot_rubber_sheeting_options_label"
-			Then I check the "Enabled" checkbox
-			Then I check the "Rubber Sheet Ref" checkbox
+			Then I should see checkbox "Enabled" checked
+			Then I should see checkbox "Rubber Sheet Ref" checked
 			Then I should see "Waterway Options"
 			Then I click on "#hoot_waterway_options_label"
 			Then I uncheck the "Waterway Auto Calc Search Radius" checkbox
@@ -78,9 +78,9 @@ Feature: Advanced Conflation Options
 
 				Examples:
 				| element | placeholder | invalid argument |
-				| rubber_sheet_minimum_ties | 10 | "abcdef" |
-				| rubber_sheet_minimum_ties | 10 | "-10000" |
-				| rubber_sheet_minimum_ties | 10 | "&*^@(!" |
+				| rubber_sheet_minimum_ties | 4 | "abcdef" |
+				| rubber_sheet_minimum_ties | 4 | "-10000" |
+				| rubber_sheet_minimum_ties | 4 | "&*^@(!" |
 				| search_radius_waterway | "-1" | "abcdef" |
 				| search_radius_waterway | "-1" | "-10000" |
 				| search_radius_waterway | "-1" | "&*^@(!" |


### PR DESCRIPTION
Make UI opts defaults cater to Network/Diff.  A follow on UI task will make sure Unifying Roads gets the correct UI opts when it is enabled.