### PR TITLE
Hoot API Database bulk writing fixes

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -35,6 +35,7 @@
 #include <hoot/core/io/HootApiDbBulkInserter.h>
 #include <hoot/core/io/HootApiDbReader.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/FileUtils.h>
 
 // Qt
 #include <QDir>
@@ -126,6 +127,21 @@ public:
     actualMapWriter->open(actualOutputFile);
     actualMapWriter->write(actualMap);
 
+    //Should be 4 changesets, but its 8.
+    HootApiDb database;
+    database.open(ServicesDbTestUtils::getDbModifyUrl(testName).toString());
+    database.setMapId(mapId);
+    database.setCreateIndexesOnClose(false);
+    database.setFlushOnClose(false);
+    const long numChangesets = database.numChangesets();
+    LOG_VARD(numChangesets);
+    CPPUNIT_ASSERT_EQUAL(8L, numChangesets);
+
+    //TODO: This needs to be enabled (or some check similar to it), but doing so will require
+    //ignoring the map and changeset ID's in the file that will change with each test run.
+//    TestUtils::verifyStdMatchesOutputIgnoreDate(
+//      "test-files/io/ServiceHootApiDbBulkInserterTest/psql-offline.sql",
+//      outFile);
     HOOT_FILE_EQUALS(
       "test-files/io/ServiceHootApiDbBulkInserterTest/psqlOffline.osm", actualOutputFile);
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -63,7 +63,9 @@ namespace hoot
 unsigned int HootApiDb::logWarnCount = 0;
 
 HootApiDb::HootApiDb() :
-_precision(ConfigOptions().getWriterPrecision())
+_precision(ConfigOptions().getWriterPrecision()),
+_createIndexesOnClose(true),
+_flushOnClose(true)
 {
   _init();
 }
@@ -158,9 +160,15 @@ void HootApiDb::close()
 {
   LOG_DEBUG("Closing database connection...");
 
-  createPendingMapIndexes();
-  _flushBulkInserts();
-  _flushBulkDeletes();
+  if (_createIndexesOnClose)
+  {
+    createPendingMapIndexes();
+  }
+  if (_flushOnClose)
+  {
+    _flushBulkInserts();
+    _flushBulkDeletes();
+  }
 
   _resetQueries();
 
@@ -231,7 +239,10 @@ void HootApiDb::_copyTableStructure(QString from, QString to)
 
 void HootApiDb::createPendingMapIndexes()
 {
-  LOG_TRACE("Creating map indexes...");
+  if (_pendingMapIndexes.size() > 0)
+  {
+    LOG_DEBUG("Creating " << _pendingMapIndexes.size() << " map indexes...");
+  }
 
   for (int i = 0; i < _pendingMapIndexes.size(); i++)
   {
@@ -456,32 +467,37 @@ QString HootApiDb::execToString(QString sql, QVariant v1, QVariant v2, QVariant 
 
 void HootApiDb::_flushBulkInserts()
 {
-  LOG_TRACE("Flushing bulk inserts...");
+  LOG_DEBUG("Flushing bulk inserts...");
 
   if (_nodeBulkInsert != 0)
   {
+    LOG_VARD(_nodeBulkInsert->getPendingCount());
     _nodeBulkInsert->flush();
   }
   if (_wayBulkInsert != 0)
   {
+    LOG_VARD(_wayBulkInsert->getPendingCount());
     _wayBulkInsert->flush();
   }
   if (_wayNodeBulkInsert != 0)
   {
+    LOG_VARD(_wayNodeBulkInsert->getPendingCount());
     _wayNodeBulkInsert->flush();
   }
   if (_relationBulkInsert != 0)
   {
+    LOG_VARD(_relationBulkInsert->getPendingCount());
     _relationBulkInsert->flush();
   }
 }
 
 void HootApiDb::_flushBulkDeletes()
 {
-  LOG_TRACE("Flushing bulk deletes...");
+  LOG_DEBUG("Flushing bulk deletes...");
 
   if (_nodeBulkDelete != 0)
   {
+    LOG_VARD(_nodeBulkDelete->getPendingCount());
     _nodeBulkDelete->flush();
   }
 }
@@ -1111,6 +1127,7 @@ void HootApiDb::_resetQueries()
   _mapExistsByName.reset();
   _getMapIdByName.reset();
   _insertChangeSet2.reset();
+  _numChangesets.reset();
 
   // bulk insert objects.
   _nodeBulkInsert.reset();
@@ -1245,6 +1262,37 @@ long HootApiDb::getMapIdByName(const QString name)
     }
   }
   _getMapIdByName->finish();
+  return result;
+}
+
+long HootApiDb::numChangesets()
+{
+  if (!_numChangesets)
+  {
+    _numChangesets.reset(new QSqlQuery(_db));
+    _numChangesets->prepare("SELECT COUNT(*) FROM " + getChangesetsTableName(_currMapId));
+  }
+  LOG_VARD(_numChangesets->lastQuery());
+
+  if (!_numChangesets->exec())
+  {
+    LOG_ERROR(_numChangesets->executedQuery());
+    LOG_ERROR(_numChangesets->lastError().text());
+    throw HootException(_numChangesets->lastError().text());
+  }
+
+  long result = -1;
+  if (_numChangesets->next())
+  {
+    bool ok;
+    result = _numChangesets->value(0).toLongLong(&ok);
+    if (!ok)
+    {
+      throw HootException(
+        "Count not changeset count for map with ID: " + QString::number(_currMapId));
+    }
+  }
+  _numChangesets->finish();
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -105,6 +105,13 @@ public:
   bool changesetExists(const long id);
 
   /**
+   * Returns the number of changesets for the given map in the database;
+   *
+   * @return the number of changesets for the map
+   */
+  long numChangesets();
+
+  /**
    * Closes an existing changeset
    */
   void endChangeset();
@@ -337,6 +344,9 @@ public:
    */
   static QString removeLayerName(const QString url);
 
+  void setCreateIndexesOnClose(bool create) { _createIndexesOnClose = create; }
+  void setFlushOnClose(bool flush) { _flushOnClose = flush; }
+
 protected:
 
   virtual void _resetQueries();
@@ -364,6 +374,7 @@ private:
   boost::shared_ptr<QSqlQuery> _mapExistsByName;
   boost::shared_ptr<QSqlQuery> _getMapIdByName;
   boost::shared_ptr<QSqlQuery> _insertChangeSet2;
+  boost::shared_ptr<QSqlQuery> _numChangesets;
 
   boost::shared_ptr<BulkInsert> _nodeBulkInsert;
   long _nodesPerBulkInsert;
@@ -410,6 +421,9 @@ private:
    * be executed.
    */
   QVector<QString> _postTransactionStatements;
+
+  bool _createIndexesOnClose;
+  bool _flushOnClose;
 
   /**
    * This is here to improve query caching. In most cases users open a single ServiceDb and then

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "HootApiDbBulkInserter.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.cpp
@@ -93,6 +93,8 @@ void HootApiDbBulkInserter::open(QString url)
       QString("a new one.  URL: ") + _outputUrl);
   }
   _database.open(_outputUrl);
+  _database.setCreateIndexesOnClose(false);
+  _database.setFlushOnClose(false);
 
   //not starting a transaction here, b/c the exec'd SQL file will declare one instead
   _getOrCreateMap();
@@ -226,7 +228,6 @@ void HootApiDbBulkInserter::_writeDataToDbPsql()
   LOG_VART(_outputUrl);
   LOG_VART(HootApiDb::removeLayerName(_outputUrl));
   ApiDb::execSqlFile(HootApiDb::removeLayerName(_outputUrl), _sqlOutputCombinedFile->fileName());
-  _database.close();
 
   LOG_INFO(
     "SQL execution complete.  Time elapsed: " << StringUtils::secondsToDhms(_timer->elapsed()));
@@ -234,13 +235,13 @@ void HootApiDbBulkInserter::_writeDataToDbPsql()
 
 void HootApiDbBulkInserter::_writeDataToDb()
 {
-  //indexes (and constraints?) are already being dropped in HootApiDb when the map is inserted,
-  //so don't worry about dropping them here
-
   _writeDataToDbPsql();
 
-  //this will re-create the previously dropped indexes
-  _database.close();
+  //hoot api db starts with no indexes at all, since a brand new databas is created for each layer,
+  //so let's create it now
+  //TODO: This causes SQL exceptions with certain datasets, so disabling index creation for now. -
+  //#2216
+  //_database.createPendingMapIndexes();
 }
 
 void HootApiDbBulkInserter::_writeCombinedSqlFile()
@@ -629,9 +630,9 @@ void HootApiDbBulkInserter::_writeRelation(const unsigned long relationDbId, con
 }
 
 void HootApiDbBulkInserter::_writeRelationMember(const unsigned long sourceRelationDbId,
-                                                const RelationData::Entry& member,
-                                                const unsigned long memberDbId,
-                                                const unsigned int memberSequenceIndex)
+                                                 const RelationData::Entry& member,
+                                                 const unsigned long memberDbId,
+                                                 const unsigned int memberSequenceIndex)
 {
   _outputSections[HootApiDb::getCurrentRelationMembersTableName(_database.getMapId())]->write(
     _sqlFormatter->relationMemberToSqlString(
@@ -641,10 +642,12 @@ void HootApiDbBulkInserter::_writeRelationMember(const unsigned long sourceRelat
 
 void HootApiDbBulkInserter::_incrementChangesInChangeset()
 {
-  //to stay in sync with how HootApiDb assigns changeset ID's we'll get the initial changeset ID
-  //if this is the first record being writen.  changeset ID's will be retrieved with each call to
-  //_writeChangeset
-  if (_changesetData.changesInChangeset == 0)
+  //To stay in sync with how HootApiDb assigns changeset ID's, we'll get the initial changeset ID
+  //if this is the first record being writen.  Changeset ID's will then be retrieved with each call
+  //to _writeChangeset.
+  //TODO: This seems to be writing double the amount of changesets needed with every other changeset
+  //being empty. - #2217
+  if (_changesetData.changesInChangeset ==/*>*/ 0)
   {
     _writeChangeset();
   }
@@ -672,12 +675,15 @@ void HootApiDbBulkInserter::_writeChangeset()
       "Invalid changeset user ID: " + QString::number(_changesetData.changesetUserId));
   }
 
-  //rather than write the changeset as a COPY statement out to file, just going to write it directly
-  //to the db.  this helps this class and HootApiDbWriter play nicely when the two are mixed together
+  //Rather than write the changeset as a COPY statement out to file, just going to write it directly
+  //to the db.  Rhis helps this class and HootApiDbWriter play nicely when the two are mixed together
   //in a data workflow.  A downside to this is that the changeset insert isn't part of the SQL
   //transaction used with the copy statements.
   _changesetData.currentChangesetId =
     _database.insertChangeset(_changesetData.changesetBounds, _changesetTags, _maxChangesetSize);
+  LOG_TRACE(
+    "Inserted changeset with ID: " << _changesetData.currentChangesetId << " and " <<
+    _changesetData.changesInChangeset << " changes.");
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HOOTAPIDBBULKINSERTER_H
 #define HOOTAPIDBBULKINSERTER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
@@ -40,6 +40,10 @@ class HootApiDbSqlStatementFormatter;
  * creating new elements in a new database only.  See OsmApiDbBulkInserter.  This class implements
  * the offline workflow only and does not allow for writing to a SQL file.
  *
+ * Note: The constraint and index disable settings have no effect on this class since Hoot API
+ * database writing creates a brand new database for every layer that has no constraints to start
+ * with.
+ *
  * TODO: Having this class inheriting from OsmApiDbBulkInserter is not the cleanest approach but
  * allowed for reducing a lot of redundant code up front without involving a massive amount of
  * refactoring work.  The better long term approach is probably to create a ApiDbBulkinserter base

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.cpp
@@ -84,6 +84,7 @@ QString HootApiDbSqlStatementFormatter::_toTagsString(const Tags& tags)
     QString value = it.value().trimmed();
     if (!value.isEmpty())
     {
+      key.replace("\\", "/");
       key.replace("'", "\'");
       key.replace("=>", "\\=\\>");
       key.replace("\"", "\\\"");
@@ -91,6 +92,7 @@ QString HootApiDbSqlStatementFormatter::_toTagsString(const Tags& tags)
 
       tagsStr.append("=>");
 
+      value.replace("\\", "/");
       value.replace("'", "\'");
       value.replace("=>", "\\=\\>");
       value.replace("\"", "\\\"");
@@ -107,10 +109,8 @@ QString HootApiDbSqlStatementFormatter::_toTagsString(const Tags& tags)
   return tagsStr;
 }
 
-QString HootApiDbSqlStatementFormatter::nodeToSqlString(const ConstNodePtr& node,
-                                                            const long nodeId,
-                                                            const long changesetId,
-                                                            const bool validate)
+QString HootApiDbSqlStatementFormatter::nodeToSqlString(const ConstNodePtr& node, const long nodeId,
+                                                        const long changesetId, const bool validate)
 {
   const QString nodeIdStr = QString::number(nodeId);
   if (validate)

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "HootApiDbSqlStatementFormatter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
@@ -413,9 +413,7 @@ void OsmApiDbBulkInserter::finalizePartial()
 
 bool OsmApiDbBulkInserter::_destinationIsDatabase() const
 {
-  return
-    _outputUrl.toLower().startsWith("osmapidb://");// ||
-    //_outputUrl.toLower().startsWith("hootapidb://");
+  return _outputUrl.toLower().startsWith("osmapidb://");
 }
 
 void OsmApiDbBulkInserter::_writeDataToDbPsql()

--- a/test-files/io/ServiceHootApiDbBulkInserterTest/psql-offline.sql
+++ b/test-files/io/ServiceHootApiDbBulkInserterTest/psql-offline.sql
@@ -1,63 +1,56 @@
 BEGIN TRANSACTION;
 
-COPY changesets_22 (id, user_id, created_at, min_lat, max_lat, min_lon, max_lon, closed_at, num_changes, tags) FROM stdin;
-1	3	2017-09-19 14:39:32.974	0	-1	0	-1	2017-09-19 14:39:32.974	5	"bot"=>"yes","created_by"=>"hootenanny"
-2	3	2017-09-19 14:39:32.974	0	-1	0	-1	2017-09-19 14:39:32.974	5	"bot"=>"yes","created_by"=>"hootenanny"
-3	3	2017-09-19 14:39:32.974	0	-1	0	-1	2017-09-19 14:39:32.974	5	"bot"=>"yes","created_by"=>"hootenanny"
-4	3	2017-09-19 14:39:32.974	0	-1	0	-1	2017-09-19 14:39:32.974	5	"bot"=>"yes","created_by"=>"hootenanny"
+COPY current_nodes_70 (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version, tags) FROM stdin;
+14	38.05	-77.59999999999999	130	t	2018-03-02 14:29:01.607	1704239955	1	\N
+13	38.01	-77.65000000000001	130	t	2018-03-02 14:29:01.607	1704239316	1	\N
+12	38.01	-77.55	130	t	2018-03-02 14:29:01.607	1704239836	1	\N
+11	38.1	-77.59999999999999	130	t	2018-03-02 14:29:01.607	1704240727	1	\N
+10	38	-77.7	131	t	2018-03-02 14:29:01.607	1704233711	1	\N
+9	38	-77.5	132	t	2018-03-02 14:29:01.607	1704241231	1	\N
+8	38.1	-77.40000000000001	132	t	2018-03-02 14:29:01.607	1704242807	1	\N
+7	38	-77.40000000000001	132	t	2018-03-02 14:29:01.607	1704241767	1	\N
+6	38.1	-77.3	132	t	2018-03-02 14:29:01.607	1704330453	1	\N
+5	38	-77.3	133	t	2018-03-02 14:29:01.607	1704329413	1	\N
+4	38.1	-77.2	134	t	2018-03-02 14:29:01.607	1704330973	1	\N
+3	38	-77.2	134	t	2018-03-02 14:29:01.607	1704329933	1	\N
+2	38	-77.09999999999999	134	t	2018-03-02 14:29:01.607	1704331493	1	\N
+1	38	-77	134	t	2018-03-02 14:29:01.607	1704332013	1	"building"=>"yes","name"=>"n1 - n2"
 \.
 
-COPY current_nodes_22 (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version, tags) FROM stdin;
-1	38.05	-77.59999999999999	1	t	2017-09-19 14:39:32.974	1704239955	1	\N
-2	38.01	-77.65000000000001	1	t	2017-09-19 14:39:32.974	1704239316	1	\N
-3	38.01	-77.55	1	t	2017-09-19 14:39:32.974	1704239836	1	\N
-4	38.1	-77.59999999999999	1	t	2017-09-19 14:39:32.974	1704240727	1	\N
-5	38	-77.7	1	t	2017-09-19 14:39:32.974	1704233711	1	\N
-6	38	-77.5	2	t	2017-09-19 14:39:32.974	1704241231	1	\N
-7	38.1	-77.40000000000001	2	t	2017-09-19 14:39:32.974	1704242807	1	\N
-8	38	-77.40000000000001	2	t	2017-09-19 14:39:32.974	1704241767	1	\N
-9	38.1	-77.3	2	t	2017-09-19 14:39:32.974	1704330453	1	\N
-10	38	-77.3	2	t	2017-09-19 14:39:32.974	1704329413	1	\N
-11	38.1	-77.2	3	t	2017-09-19 14:39:32.974	1704330973	1	\N
-12	38	-77.2	3	t	2017-09-19 14:39:32.974	1704329933	1	\N
-13	38	-77.09999999999999	3	t	2017-09-19 14:39:32.974	1704331493	1	\N
-14	38	-77	3	t	2017-09-19 14:39:32.974	1704332013	1	"building"=>"yes","name"=>"n1 - n2"
+COPY current_ways_70 (id, changeset_id, "timestamp", visible, version, tags) FROM stdin;
+5	135	2018-03-02 14:29:01.607	t	1	\N
+4	136	2018-03-02 14:29:01.607	t	1	\N
+3	136	2018-03-02 14:29:01.607	t	1	"name"=>"w3","highway"=>"road"
+2	136	2018-03-02 14:29:01.607	t	1	"name"=>"w2","highway"=>"track"
+1	136	2018-03-02 14:29:01.607	t	1	"building"=>"yes","area"=>"yes","name"=>"w1"
 \.
 
-COPY current_ways_22 (id, changeset_id, "timestamp", visible, version, tags) FROM stdin;
-1	3	2017-09-19 14:39:32.974	t	1	\N
-2	4	2017-09-19 14:39:32.974	t	1	\N
-3	4	2017-09-19 14:39:32.974	t	1	\N
-4	4	2017-09-19 14:39:32.974	t	1	\N
-5	4	2017-09-19 14:39:32.974	t	1	\N
+COPY current_way_nodes_70 (way_id, node_id, sequence_id) FROM stdin;
+5	12	1
+5	13	2
+5	14	3
+5	12	4
+4	9	1
+4	10	2
+4	11	3
+4	9	4
+3	7	1
+3	8	2
+2	5	1
+2	6	2
+1	2	1
+1	3	2
+1	4	3
+1	2	4
 \.
 
-COPY current_way_nodes_22 (way_id, node_id, sequence_id) FROM stdin;
-1	3	1
-1	2	2
-1	1	3
-1	3	4
-2	6	1
-2	5	2
-2	4	3
-2	6	4
-3	8	1
-3	7	2
-4	10	1
-4	9	2
-5	13	1
-5	12	2
-5	11	3
-5	13	4
+COPY current_relations_70 (id, changeset_id, "timestamp", visible, version, tags) FROM stdin;
+1	137	2018-03-02 14:29:01.607	t	1	"building"=>"yes","type"=>"multipolygon","name"=>"r1"
 \.
 
-COPY current_relations_22 (id, changeset_id, "timestamp", visible, version, tags) FROM stdin;
-1	4	2017-09-19 14:39:32.974	t	1	\N
-\.
-
-COPY current_relation_members_22 (relation_id, member_type, member_id, member_role, sequence_id) FROM stdin;
-1	way	2	outer	1
-1	way	1	inner	2
+COPY current_relation_members_70 (relation_id, member_type, member_id, member_role, sequence_id) FROM stdin;
+1	way	4	outer	1
+1	way	5	inner	2
 \.
 
 COMMIT;


### PR DESCRIPTION
* fixes issue parsing tag with '\\' in value in GeoFabrik Delaware data
* fixes issue where creating indexes during the Hoot API db bulk write was throwing SQL exceptions
* resulting associated issues created: #2216, #2217