### PR TITLE
Fix plugins-test dependency issue

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -138,7 +138,7 @@ ifneq ($(HADOOP_HOME),)
 	cd pretty-pipes/pp-lib/ ; $(MAKE) -f Makefile.mvn test
 endif
 
-plugins-test:
+plugins-test: build
 ifneq ($(shell which mocha),)
 	cd plugins; npm install && npm test
 else


### PR DESCRIPTION
The file lib/HootJs.node gets cleared out by 'make clean' and causes 'make clean && make test' to fail in the Mocha tests.  So, make sure it gets rebuilt before running the plugins-test targer.