### PR TITLE
Use temporary directory for OSM file when converting to GeoJSON.

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/BaseCalculateTilesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BaseCalculateTilesCmd.cpp
@@ -121,7 +121,7 @@ void BaseCalculateTilesCmd::_writeOutputAsGeoJson(
 {
   //write out to temp osm and then use ogr2ogr to convert to geojson
 
-  QTemporaryFile osmTempFile("calculate-tiles-temp-XXXXXX.osm");
+  QTemporaryFile osmTempFile("tmp/calculate-tiles-temp-XXXXXX.osm");
   if (!osmTempFile.open())
   {
     throw HootException(

--- a/hoot-core/src/main/cpp/hoot/core/cmd/BaseCalculateTilesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BaseCalculateTilesCmd.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "BaseCalculateTilesCmd.h"


### PR DESCRIPTION
Fixes #2224 by using `$HOOT_HOME/tmp` for the temporary OSM file when converting to GeoJSON.