### PR TITLE
Fix install-other target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,7 @@ services-coverage:
 # Use some tar fanciness to grab all the files in conf, plugins, translations and scripts
 install-other:
 	mkdir -p tmp
-	$(TAR) cf tmp/other.tar conf plugins scripts translations rules reports
+	$(TAR) cf tmp/other.tar conf plugins scripts translations rules
 	mkdir -p $(localstatedir)
 	cat tmp/other.tar | $(TAR) xv -C $(localstatedir)
 	rm -f tmp/other.tar

--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,7 @@ services-coverage:
 # Use some tar fanciness to grab all the files in conf, plugins, translations and scripts
 install-other:
 	mkdir -p tmp
-	$(TAR) cf tmp/other.tar conf plugins scripts translations rules report
+	$(TAR) cf tmp/other.tar conf plugins scripts translations rules reports
 	mkdir -p $(localstatedir)
 	cat tmp/other.tar | $(TAR) xv -C $(localstatedir)
 	rm -f tmp/other.tar


### PR DESCRIPTION
Fixes #2282 by omitting the `report` directory from the `install-other` target.