### PR TITLE
Copyright Script updates files that it shouldn't

### DIFF
--- a/scripts/copyright/UpdateCopyrightHeader.py
+++ b/scripts/copyright/UpdateCopyrightHeader.py
@@ -62,6 +62,7 @@ def run(args):
 
 def runcode(args):
     p = Popen(args, stderr=PIPE)
+    p.communicate()
     code = p.returncode
     return code
 

--- a/scripts/copyright/UpdateCopyrightHeader.py
+++ b/scripts/copyright/UpdateCopyrightHeader.py
@@ -60,6 +60,11 @@ def run(args):
     output = p.stdout.read()
     return output
 
+def runcode(args):
+    p = Popen(args, stderr=PIPE)
+    code = p.returncode
+    return code
+
 #
 # Read in the command-line arguments
 #
@@ -176,6 +181,10 @@ else:
 # =========================
 
 try:
+    # Check if the file is even tracked in git
+    retcode = runcode(["git", "ls-files", "--error-unmatch", options.fileName])
+    if retcode != 0:
+        exit(0)
     # A) Read in the standard copyright header
     copyrightHeaderStr = open(options.copyrightHeader, 'r').read()
 


### PR DESCRIPTION
Refs #2295 
Updated copyright header python script to use 'git ls-files' to only work on files indexed by git.

@sputnam would you take a look at this for me since it is more of a DevOps script and you are a python expert?