### PR TITLE
Update DuplicateWayRemover

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -381,7 +381,8 @@ See also:
 ** `hoot::RemoveDuplicateReviewsOp` - Removes any duplicate reviews
 ** `hoot::BuildingOutlineUpdateOp` - Updates any multi-part building outlines that may have changed during conflation.
 ** `hoot::WayJoinerOp` - Join up any previously split ways that can be rejoined.
-** `hoot::RemoveInvalidMultilineStringMembersVisitor` - Removes invalid multilinestring relations.
+** `hoot::RemoveInvalidMultilineStringVisitor` - Removes invalid multilinestring relations and duplicate members.
+** `hoot::RemoveInvalidMultilineStringMembersVisitor` - Removes invalid multilinestring relation members.
 ** `hoot::SuperfluousWayRemover` - Remove all ways that contain no nodes or all the nodes are exactly the same.
 ** `hoot::RemoveDuplicateWayNodesVisitor` - Remove all nodes that are unnecessarily duplicated in a way.
 ** `hoot::AddHilbertReviewSortOrderOp` - Adds a sorting value to all reviews.  By processing reviews in sorted order the results are a little more logically ordered.

--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -381,7 +381,7 @@ See also:
 ** `hoot::RemoveDuplicateReviewsOp` - Removes any duplicate reviews
 ** `hoot::BuildingOutlineUpdateOp` - Updates any multi-part building outlines that may have changed during conflation.
 ** `hoot::WayJoinerOp` - Join up any previously split ways that can be rejoined.
-** `hoot::RemoveInvalidMultilineStringVisitor` - Removes invalid multilinestring relations and duplicate members.
+** `hoot::RemoveInvalidRelationVisitor` - Removes invalid multilinestring/review relations and duplicate members.
 ** `hoot::RemoveInvalidMultilineStringMembersVisitor` - Removes invalid multilinestring relation members.
 ** `hoot::SuperfluousWayRemover` - Remove all ways that contain no nodes or all the nodes are exactly the same.
 ** `hoot::RemoveDuplicateWayNodesVisitor` - Remove all nodes that are unnecessarily duplicated in a way.

--- a/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
@@ -47,7 +47,6 @@
 #include <hoot/core/ops/RemoveWayOp.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
-#include <hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.h>
 using namespace hoot;
 
 // Qt

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DuplicateWayRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DuplicateWayRemover.cpp
@@ -176,6 +176,11 @@ void DuplicateWayRemover::_splitDuplicateWays(WayPtr w1, WayPtr w2, bool rev1, b
     {
       //  Merge the two ways' tags
       w1->setTags(mergedTags);
+      //  Pass along the parent id or set w2 as the parent
+      long pid = Way::getPid(w1, w2);
+      if (pid == WayData::CHANGESET_EMPTY)
+        pid = w2->getId();
+      w1->setPid(pid);
       //  Remove w2
       _replaceMultiple(w2, vector<WayPtr>());
     }
@@ -186,6 +191,11 @@ void DuplicateWayRemover::_splitDuplicateWays(WayPtr w1, WayPtr w2, bool rev1, b
       ways1.push_back(w2);
       //  Merge the tags into w2
       w2->setTags(mergedTags);
+      //  Pass along the parent id or set w1 as the parent
+      long pid = Way::getPid(w2, w1);
+      if (pid == WayData::CHANGESET_EMPTY)
+        pid = w1->getId();
+      w2->setPid(pid);
       //  Replace w1 with both w1 and w2
       _replaceMultiple(w1, ways1);
     }
@@ -280,19 +290,8 @@ WayPtr DuplicateWayRemover::_getUpdatedWay(WayPtr way, const vector<long>& nodes
     WayPtr newWay;
     newWay.reset(new Way(way->getStatus(), _map->createNextWayId(), way->getRawCircularError()));
     newWay->addNodes(nodes);
-    newWay->setPid(way->getPid());
+    newWay->setPid(way->getId());
     newWay->setTags(way->getTags());
-
-    // see comments for similar functionality in HighwaySnapMerger::_mergePair
-    if (ConfigOptions().getPreserveUnknown1ElementIdWhenModifyingFeatures() &&
-        way->getStatus() == Status::Unknown1)
-    {
-      LOG_TRACE(
-        "Setting unknown1 " << way->getElementId().getId() << " on " <<
-        newWay->getElementId() << "...");
-      newWay->setId(way->getElementId().getId());
-    }
-
     _map->addWay(newWay);
     LOG_TRACE(
       "Created new way: " << newWay->getElementId() << " from old way: " << way->getElementId() <<

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -346,12 +346,15 @@ bool Way::isFirstLastNodeIdentical() const
 
 long Way::getPid(const ConstWayPtr& p, const ConstWayPtr& c)
 {
-  if (!p && !c)                                     return WayData::PID_EMPTY;
-  else if (p && c && p->hasPid() && c->hasPid())    return p->getPid();
-  else if (p && !c && p->hasPid())                  return p->getPid();
-  else if (!p && c && c->hasPid())                  return c->getPid();
-  else                                              return WayData::PID_EMPTY;
+  if (!p && !c)   return WayData::PID_EMPTY;
+  else            return Way::getPid(p->getPid(), c->getPid());
 }
 
+long Way::getPid(long p, long c)
+{
+  if (p != WayData::PID_EMPTY)      return p;
+  else if(c != WayData::PID_EMPTY)  return c;
+  else                              return WayData::PID_EMPTY;
+}
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -188,6 +188,7 @@ public:
   void setPid(long pid) { _wayData->setPid(pid); }
   void resetPid() { _wayData->setPid(WayData::PID_EMPTY); }
   static long getPid(const boost::shared_ptr<const Way>& p, const boost::shared_ptr<const Way>& c);
+  static long getPid(long p, long c);
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringVisitor.cpp
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "RemoveInvalidMultilineStringVisitor.h"
+
+//  hoot
+#include <hoot/core/OsmMap.h>
+#include <hoot/core/conflate/ReviewMarker.h>
+#include <hoot/core/ops/RemoveRelationOp.h>
+#include <hoot/core/schema/TagMergerFactory.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/MetadataTags.h>
+
+//  Standard library
+#include <unordered_set>
+
+using namespace std;
+
+namespace hoot
+{
+
+HOOT_FACTORY_REGISTER(ConstElementVisitor, RemoveInvalidMultilineStringVisitor)
+
+RemoveInvalidMultilineStringVisitor::RemoveInvalidMultilineStringVisitor()
+{
+}
+
+void RemoveInvalidMultilineStringVisitor::visit(const ElementPtr& e)
+{
+  //  Ignore everything but relations
+  if (e->getElementType() == ElementType::Relation)
+  {
+    Relation* r = dynamic_cast<Relation*>(e.get());
+    assert(r != 0);
+
+    LOG_VART(r->getId());
+    //  Only multilinestring relations
+    if (r->getType() == MetadataTags::RelationMultilineString())
+    {
+      vector<RelationData::Entry> members = r->getMembers();
+      unordered_set<long> total_members;
+      //  Iterate all of the members and remove the duplicates
+      for (vector<RelationData::Entry>::const_iterator it = members.begin(); it != members.end(); ++it)
+      {
+        ElementId eid = it->getElementId();
+        long id = eid.getId();
+        if (total_members.find(id) == total_members.end())
+          total_members.insert(id);
+        else
+        {
+          LOG_TRACE("Removing multilinestring relation element with ID: " << eid.getId());
+          r->removeElement(eid);
+        }
+      }
+      //  Get a new copy of the relation members
+      members = r->getMembers();
+      //  Any multilinestring that doesn't have 2 or more linestrings, isn't a multilinestring, remove it
+      if (members.size() < 2)
+      {
+        LOG_TRACE("Removing multilinestring relation with ID: " << r->getId());
+        if (members.size() == 1)
+        {
+          //  Merge the relation tags back on to the single way before deleting the relation
+          ElementPtr element = _map->getElement(members[0].getElementId());
+          Tags merged = TagMergerFactory::getInstance().mergeTags(element->getTags(), r->getTags(), ElementType::Relation);
+          element->setTags(merged);
+        }
+        //  Delete the relation
+        RemoveRelationOp::removeRelation(_map->shared_from_this(), r->getId());
+      }
+    }
+  }
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringVisitor.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef REMOVEINVALIDMULTILINESTRINGVISITOR_H
+#define REMOVEINVALIDMULTILINESTRINGVISITOR_H
+
+#include "ElementOsmMapVisitor.h"
+
+namespace hoot
+{
+
+/**
+ * Remove all duplicate linestrings from multilinestring relations and
+ * and multilinestring relation that has less that two members thus
+ * making them not "multi" linestrings.
+ */
+class RemoveInvalidMultilineStringVisitor : public ElementOsmMapVisitor
+{
+public:
+
+  static std::string className() { return "hoot::RemoveInvalidMultilineStringVisitor"; }
+
+  RemoveInvalidMultilineStringVisitor();
+
+  virtual void visit(const ElementPtr& e);
+
+  virtual QString getName() const { return "Remove Invalid Multilinestring Relations"; }
+
+  virtual QString getDescription() const
+  {
+    return "Removes duplicate ways in multilinestring relations and invalid multilinestring relations";
+  }
+};
+
+}
+
+#endif // REMOVEINVALIDMULTILINESTRINGVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidRelationVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidRelationVisitor.h
@@ -25,10 +25,12 @@
  * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-#ifndef REMOVEINVALIDMULTILINESTRINGVISITOR_H
-#define REMOVEINVALIDMULTILINESTRINGVISITOR_H
+#ifndef REMOVE_INVALID_RELATION_VISITOR_H
+#define REMOVE_INVALID_RELATION_VISITOR_H
 
-#include "ElementOsmMapVisitor.h"
+//  Hoot
+#include <hoot/core/elements/Relation.h>
+#include <hoot/core/visitors/ElementOsmMapVisitor.h>
 
 namespace hoot
 {
@@ -38,24 +40,28 @@ namespace hoot
  * and multilinestring relation that has less that two members thus
  * making them not "multi" linestrings.
  */
-class RemoveInvalidMultilineStringVisitor : public ElementOsmMapVisitor
+class RemoveInvalidRelationVisitor : public ElementOsmMapVisitor
 {
 public:
 
-  static std::string className() { return "hoot::RemoveInvalidMultilineStringVisitor"; }
+  static std::string className() { return "hoot::RemoveInvalidRelationVisitor"; }
 
-  RemoveInvalidMultilineStringVisitor();
+  RemoveInvalidRelationVisitor();
 
   virtual void visit(const ElementPtr& e);
 
-  virtual QString getName() const { return "Remove Invalid Multilinestring Relations"; }
+  virtual QString getName() const { return "Remove Invalid Relations"; }
 
   virtual QString getDescription() const
   {
-    return "Removes duplicate ways in multilinestring relations and invalid multilinestring relations";
+    return "Removes duplicate ways in relations and invalid relations";
   }
+
+private:
+
+  void _removeDuplicates(const RelationPtr& r);
 };
 
 }
 
-#endif // REMOVEINVALIDMULTILINESTRINGVISITOR_H
+#endif // REMOVE_INVALID_RELATION_VISITOR_H

--- a/test-files/algorithms/wayjoiner/WayJoinerConflateExpected.osm
+++ b/test-files/algorithms/wayjoiner/WayJoinerConflateExpected.osm
@@ -159,28 +159,18 @@
         <tag k="error:circular" v="15"/>
         <tag k="hoot:id" v="-143"/>
     </way>
-    <way visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
         <nd ref="-4"/>
         <nd ref="-5"/>
         <nd ref="-6"/>
         <nd ref="-7"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-140"/>
-    </way>
-    <way visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7"/>
         <nd ref="-32"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-136"/>
-    </way>
-    <way visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31"/>
+        <nd ref="-30"/>
+        <nd ref="-36"/>
+        <nd ref="-29"/>
+        <nd ref="-28"/>
         <nd ref="-138"/>
         <nd ref="-27"/>
         <nd ref="-26"/>
@@ -205,33 +195,11 @@
         <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-133"/>
-    </way>
-    <way visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-36"/>
-        <nd ref="-29"/>
-        <nd ref="-28"/>
-        <nd ref="-138"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-126"/>
-    </way>
-    <way visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35"/>
-        <nd ref="-34"/>
-        <nd ref="-33"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-123"/>
+        <tag k="hoot:id" v="-136"/>
     </way>
     <way visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35"/>
+        <nd ref="-34"/>
         <nd ref="-33"/>
         <nd ref="-30"/>
         <tag k="note" v="2"/>

--- a/test-files/cases/hoot-rnd/network/conflicts/highway-025/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/conflicts/highway-025/Expected.osm
@@ -1595,15 +1595,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-64"/>
     </way>
-    <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-408"/>
-        <nd ref="-237"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-51"/>
-    </way>
     <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-241"/>
         <nd ref="-177"/>
@@ -1613,18 +1604,10 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-50"/>
     </way>
-    <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-249"/>
-        <nd ref="-485"/>
-        <tag k="name" v="US Hwy 1"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-48"/>
-    </way>
     <way visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-409"/>
         <nd ref="-408"/>
+        <nd ref="-237"/>
         <tag k="alt_name" v="15th St NW"/>
         <tag k="name" v="Pennsylvania Ave NW"/>
         <tag k="highway" v="unclassified"/>
@@ -1633,9 +1616,10 @@
         <tag k="hoot:id" v="-47"/>
     </way>
     <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-249"/>
         <nd ref="-485"/>
         <nd ref="-179"/>
-        <tag k="alt_name" v="US Hwy 50;Constitution Ave NW"/>
+        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
         <tag k="name" v="US Hwy 1"/>
         <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="2"/>

--- a/test-files/cases/hoot-rnd/network/conflicts/highway-030/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/conflicts/highway-030/Expected.osm
@@ -295,12 +295,11 @@
         <tag k="hoot:id" v="-30"/>
     </relation>
     <relation visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-9" role="reviewee"/>
-        <member type="way" ref="-9" role="reviewee"/>
         <member type="way" ref="-1" role="reviewee"/>
+        <member type="way" ref="-9" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-29"/>

--- a/test-files/cases/hoot-rnd/network/conflicts/pap-007/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/conflicts/pap-007/Expected.osm
@@ -5058,23 +5058,21 @@
         <tag k="hoot:id" v="-1"/>
     </way>
     <relation visible="true" id="-309" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-100" role="reviewee"/>
         <member type="way" ref="-137" role="reviewee"/>
         <member type="way" ref="-100" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-309"/>
     </relation>
     <relation visible="true" id="-308" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-131" role="reviewee"/>
-        <member type="way" ref="-131" role="reviewee"/>
         <member type="way" ref="-137" role="reviewee"/>
+        <member type="way" ref="-131" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-308"/>

--- a/test-files/cases/hoot-rnd/roundabouts/rcase-001/Expected.osm
+++ b/test-files/cases/hoot-rnd/roundabouts/rcase-001/Expected.osm
@@ -1556,10 +1556,9 @@
     <relation visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-40" role="reviewee"/>
         <member type="way" ref="-36" role="reviewee"/>
-        <member type="way" ref="-36" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-106"/>
@@ -1567,10 +1566,9 @@
     <relation visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-40" role="reviewee"/>
         <member type="way" ref="-17" role="reviewee"/>
-        <member type="way" ref="-17" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-105"/>

--- a/test-files/cmd/glacial/NetworkConflateCmdInputReverseTest/output.osm
+++ b/test-files/cmd/glacial/NetworkConflateCmdInputReverseTest/output.osm
@@ -8684,12 +8684,11 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1911" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-128" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <member type="way" ref="-128" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.409163"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="12"/>
@@ -8774,31 +8773,24 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1901" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
         <member type="way" ref="-273" role="reviewee"/>
+        <member type="way" ref="-26" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.715482"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="30"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1900" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
-        <member type="way" ref="-279" role="reviewee"/>
         <member type="way" ref="-871" role="reviewee"/>
-        <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-279" role="reviewee"/>
+        <member type="way" ref="-170" role="reviewee"/>
+        <member type="way" ref="-126" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="8"/>
+        <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.619623"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="14"/>
@@ -8807,55 +8799,47 @@
     <relation visible="true" id="-1899" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-191" role="reviewee"/>
         <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-279" role="reviewee"/>
         <member type="way" ref="-871" role="reviewee"/>
         <member type="way" ref="-170" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="7"/>
+        <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.606918"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="15"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1898" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-191" role="reviewee"/>
-        <member type="way" ref="-191" role="reviewee"/>
-        <member type="way" ref="-191" role="reviewee"/>
         <member type="way" ref="-945" role="reviewee"/>
         <member type="way" ref="-191" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.667822"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="5"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1897" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-191" role="reviewee"/>
-        <member type="way" ref="-191" role="reviewee"/>
         <member type="way" ref="-945" role="reviewee"/>
         <member type="way" ref="-198" role="reviewee"/>
+        <member type="way" ref="-191" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="4"/>
+        <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.543185"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="7"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1896" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-191" role="reviewee"/>
-        <member type="way" ref="-191" role="reviewee"/>
         <member type="way" ref="-945" role="reviewee"/>
         <member type="way" ref="-126" role="reviewee"/>
         <member type="way" ref="-191" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.623008"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="16"/>
@@ -8863,15 +8847,13 @@
     </relation>
     <relation visible="true" id="-1895" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-279" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
         <member type="way" ref="-126" role="reviewee"/>
         <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-273" role="reviewee"/>
+        <member type="way" ref="-26" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="7"/>
+        <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.596795"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="23"/>
@@ -8889,26 +8871,24 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1893" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-26" role="reviewee"/>
         <member type="way" ref="-198" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
         <member type="way" ref="-273" role="reviewee"/>
+        <member type="way" ref="-26" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="4"/>
+        <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.608843"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="0"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1892" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-26" role="reviewee"/>
         <member type="way" ref="-198" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
         <member type="way" ref="-273" role="reviewee"/>
+        <member type="way" ref="-26" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="4"/>
+        <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.60885"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="1"/>
@@ -8926,16 +8906,13 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1890" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-279" role="reviewee"/>
         <member type="way" ref="-871" role="reviewee"/>
+        <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="7"/>
+        <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.603484"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="17"/>
@@ -8954,48 +8931,37 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1888" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-279" role="reviewee"/>
-        <member type="way" ref="-279" role="reviewee"/>
-        <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-26" role="reviewee"/>
-        <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-279" role="reviewee"/>
         <member type="way" ref="-273" role="reviewee"/>
+        <member type="way" ref="-126" role="reviewee"/>
+        <member type="way" ref="-26" role="reviewee"/>
+        <member type="way" ref="-279" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="10"/>
+        <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.586489"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="24"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1887" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-871" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
-        <member type="way" ref="-170" role="reviewee"/>
         <member type="way" ref="-170" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.690225"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="6"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1886" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-191" role="reviewee"/>
-        <member type="way" ref="-191" role="reviewee"/>
         <member type="way" ref="-945" role="reviewee"/>
         <member type="way" ref="-126" role="reviewee"/>
-        <member type="way" ref="-191" role="reviewee"/>
         <member type="way" ref="-279" role="reviewee"/>
+        <member type="way" ref="-191" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="6"/>
+        <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.625311"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="18"/>

--- a/test-files/cmd/glacial/NetworkConflateCmdInputReverseTest/output.osm
+++ b/test-files/cmd/glacial/NetworkConflateCmdInputReverseTest/output.osm
@@ -3384,128 +3384,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-19612" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2237"/>
-        <nd ref="-2240"/>
-        <nd ref="-2243"/>
-        <nd ref="-2246"/>
-        <nd ref="-2249"/>
-        <nd ref="-2252"/>
-        <nd ref="-2255"/>
-        <nd ref="-2258"/>
-        <nd ref="-2261"/>
-        <nd ref="-2263"/>
-        <nd ref="-2265"/>
-        <nd ref="-2267"/>
-        <nd ref="-2269"/>
-        <nd ref="-2271"/>
-        <nd ref="-2982"/>
-        <nd ref="-2273"/>
-        <nd ref="-2275"/>
-        <nd ref="-2277"/>
-        <nd ref="-2279"/>
-        <nd ref="-2280"/>
-        <nd ref="-2281"/>
-        <nd ref="-2282"/>
-        <nd ref="-2283"/>
-        <nd ref="-2284"/>
-        <nd ref="-2285"/>
-        <nd ref="-2286"/>
-        <nd ref="-2287"/>
-        <nd ref="-2288"/>
-        <nd ref="-2289"/>
-        <nd ref="-2290"/>
-        <nd ref="-2291"/>
-        <nd ref="-2292"/>
-        <nd ref="-2293"/>
-        <nd ref="-2294"/>
-        <nd ref="-2296"/>
-        <nd ref="-2298"/>
-        <nd ref="-2300"/>
-        <nd ref="-2302"/>
-        <nd ref="-2304"/>
-        <nd ref="-2306"/>
-        <nd ref="-2308"/>
-        <nd ref="-2310"/>
-        <nd ref="-2311"/>
-        <nd ref="-2312"/>
-        <nd ref="-2313"/>
-        <nd ref="-2314"/>
-        <nd ref="-2316"/>
-        <nd ref="-2318"/>
-        <nd ref="-2320"/>
-        <nd ref="-2322"/>
-        <nd ref="-2324"/>
-        <nd ref="-3007"/>
-        <nd ref="-2326"/>
-        <nd ref="-18197"/>
-        <nd ref="-2328"/>
-        <nd ref="-2330"/>
-        <nd ref="-2332"/>
-        <nd ref="-7"/>
-        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
-        <tag k="name" v="Independence Ave SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-19582" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-893"/>
-        <nd ref="-3034"/>
-        <nd ref="-3036"/>
-        <nd ref="-3038"/>
-        <nd ref="-2387"/>
-        <nd ref="-3039"/>
-        <nd ref="-272"/>
-        <nd ref="-3040"/>
-        <nd ref="-3041"/>
-        <nd ref="-785"/>
-        <nd ref="-3042"/>
-        <nd ref="-3043"/>
-        <nd ref="-3044"/>
-        <nd ref="-3045"/>
-        <nd ref="-3046"/>
-        <nd ref="-3047"/>
-        <nd ref="-18043"/>
-        <nd ref="-3049"/>
-        <nd ref="-1349"/>
-        <nd ref="-3051"/>
-        <nd ref="-3053"/>
-        <nd ref="-3055"/>
-        <nd ref="-3056"/>
-        <nd ref="-3057"/>
-        <nd ref="-3058"/>
-        <nd ref="-3059"/>
-        <nd ref="-1906"/>
-        <nd ref="-3061"/>
-        <nd ref="-3063"/>
-        <nd ref="-3065"/>
-        <nd ref="-3067"/>
-        <nd ref="-3069"/>
-        <nd ref="-3071"/>
-        <nd ref="-3073"/>
-        <nd ref="-3075"/>
-        <nd ref="-3077"/>
-        <nd ref="-3079"/>
-        <nd ref="-3081"/>
-        <nd ref="-3083"/>
-        <nd ref="-3085"/>
-        <nd ref="-3087"/>
-        <nd ref="-3088"/>
-        <nd ref="-3089"/>
-        <nd ref="-3090"/>
-        <nd ref="-3091"/>
-        <nd ref="-3092"/>
-        <nd ref="-3093"/>
-        <nd ref="-3094"/>
-        <nd ref="-3095"/>
-        <nd ref="-3096"/>
-        <nd ref="-3097"/>
-        <nd ref="-2710"/>
-        <tag k="alt_name" v="INTERSTATE 66  BN"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-19578" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-18034"/>
         <nd ref="-3505"/>
@@ -3743,6 +3621,35 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
+    <way visible="true" id="-19434" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17476"/>
+        <nd ref="-2896"/>
+        <nd ref="-2897"/>
+        <nd ref="-2898"/>
+        <nd ref="-2374"/>
+        <nd ref="-2375"/>
+        <nd ref="-2376"/>
+        <nd ref="-2377"/>
+        <nd ref="-2378"/>
+        <nd ref="-2379"/>
+        <nd ref="-2380"/>
+        <nd ref="-2381"/>
+        <nd ref="-2382"/>
+        <nd ref="-2383"/>
+        <nd ref="-2384"/>
+        <nd ref="-2387"/>
+        <nd ref="-2389"/>
+        <nd ref="-2392"/>
+        <nd ref="-2395"/>
+        <nd ref="-2398"/>
+        <nd ref="-2401"/>
+        <nd ref="-2404"/>
+        <nd ref="-853"/>
+        <tag k="alt_name" v="25TH ST NW;New Hampshire Ave NW"/>
+        <tag k="name" v="25th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
+    </way>
     <way visible="true" id="-19430" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19"/>
         <nd ref="-73"/>
@@ -3829,7 +3736,12 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-19412" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-19411" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2547"/>
+        <nd ref="-659"/>
+        <nd ref="-661"/>
+        <nd ref="-663"/>
+        <nd ref="-665"/>
         <nd ref="-17378"/>
         <nd ref="-667"/>
         <nd ref="-669"/>
@@ -3838,19 +3750,7 @@
         <nd ref="-675"/>
         <nd ref="-677"/>
         <nd ref="-1833"/>
-        <tag k="alt_name" v="15TH ST SW;15th St SW"/>
-        <tag k="name" v="Raoul Wallenberg Pl SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-19411" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2547"/>
-        <nd ref="-659"/>
-        <nd ref="-661"/>
-        <nd ref="-663"/>
-        <nd ref="-665"/>
-        <nd ref="-17378"/>
-        <tag k="alt_name" v="15TH ST NW;15th St SW"/>
+        <tag k="alt_name" v="15TH ST NW;15TH ST SW;15th St SW"/>
         <tag k="name" v="Raoul Wallenberg Pl SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -4025,6 +3925,149 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
+    <way visible="true" id="-811" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18043"/>
+        <nd ref="-3049"/>
+        <nd ref="-1349"/>
+        <nd ref="-3051"/>
+        <nd ref="-3053"/>
+        <nd ref="-3055"/>
+        <nd ref="-3056"/>
+        <nd ref="-3057"/>
+        <nd ref="-3058"/>
+        <nd ref="-3059"/>
+        <nd ref="-1906"/>
+        <nd ref="-3061"/>
+        <nd ref="-3063"/>
+        <nd ref="-3065"/>
+        <nd ref="-3067"/>
+        <nd ref="-3069"/>
+        <nd ref="-3071"/>
+        <nd ref="-3073"/>
+        <nd ref="-3075"/>
+        <nd ref="-3077"/>
+        <nd ref="-3079"/>
+        <nd ref="-3081"/>
+        <nd ref="-3083"/>
+        <nd ref="-3085"/>
+        <nd ref="-3087"/>
+        <nd ref="-3088"/>
+        <nd ref="-3089"/>
+        <nd ref="-3090"/>
+        <nd ref="-3091"/>
+        <nd ref="-3092"/>
+        <nd ref="-3093"/>
+        <nd ref="-3094"/>
+        <nd ref="-3095"/>
+        <nd ref="-3096"/>
+        <nd ref="-3097"/>
+        <nd ref="-2710"/>
+        <tag k="alt_name" v="INTERSTATE 66  BN"/>
+        <tag k="name" v="I- 66"/>
+        <tag k="highway" v="primary"/>
+        <tag k="error:circular" v="5"/>
+    </way>
+    <way visible="true" id="-753" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1680"/>
+        <nd ref="-2124"/>
+        <nd ref="-2127"/>
+        <nd ref="-2130"/>
+        <nd ref="-2133"/>
+        <nd ref="-2136"/>
+        <nd ref="-2139"/>
+        <nd ref="-2142"/>
+        <nd ref="-2145"/>
+        <nd ref="-2148"/>
+        <nd ref="-2151"/>
+        <nd ref="-2154"/>
+        <nd ref="-2157"/>
+        <nd ref="-17637"/>
+        <nd ref="-2160"/>
+        <nd ref="-2163"/>
+        <nd ref="-2167"/>
+        <nd ref="-2171"/>
+        <nd ref="-2175"/>
+        <nd ref="-2179"/>
+        <nd ref="-2182"/>
+        <nd ref="-2185"/>
+        <nd ref="-2188"/>
+        <nd ref="-2191"/>
+        <nd ref="-2194"/>
+        <nd ref="-2198"/>
+        <nd ref="-2202"/>
+        <nd ref="-2206"/>
+        <nd ref="-2210"/>
+        <nd ref="-2213"/>
+        <nd ref="-2216"/>
+        <nd ref="-2219"/>
+        <nd ref="-2222"/>
+        <nd ref="-2225"/>
+        <nd ref="-2228"/>
+        <nd ref="-2231"/>
+        <nd ref="-2234"/>
+        <nd ref="-2237"/>
+        <nd ref="-2240"/>
+        <nd ref="-2243"/>
+        <nd ref="-2246"/>
+        <nd ref="-2249"/>
+        <nd ref="-2252"/>
+        <nd ref="-2255"/>
+        <nd ref="-2258"/>
+        <nd ref="-2261"/>
+        <nd ref="-2263"/>
+        <nd ref="-2265"/>
+        <nd ref="-2267"/>
+        <nd ref="-2269"/>
+        <nd ref="-2271"/>
+        <nd ref="-2982"/>
+        <nd ref="-2273"/>
+        <nd ref="-2275"/>
+        <nd ref="-2277"/>
+        <nd ref="-2279"/>
+        <nd ref="-2280"/>
+        <nd ref="-2281"/>
+        <nd ref="-2282"/>
+        <nd ref="-2283"/>
+        <nd ref="-2284"/>
+        <nd ref="-2285"/>
+        <nd ref="-2286"/>
+        <nd ref="-2287"/>
+        <nd ref="-2288"/>
+        <nd ref="-2289"/>
+        <nd ref="-2290"/>
+        <nd ref="-2291"/>
+        <nd ref="-2292"/>
+        <nd ref="-2293"/>
+        <nd ref="-2294"/>
+        <nd ref="-2296"/>
+        <nd ref="-2298"/>
+        <nd ref="-2300"/>
+        <nd ref="-2302"/>
+        <nd ref="-2304"/>
+        <nd ref="-2306"/>
+        <nd ref="-2308"/>
+        <nd ref="-2310"/>
+        <nd ref="-2311"/>
+        <nd ref="-2312"/>
+        <nd ref="-2313"/>
+        <nd ref="-2314"/>
+        <nd ref="-2316"/>
+        <nd ref="-2318"/>
+        <nd ref="-2320"/>
+        <nd ref="-2322"/>
+        <nd ref="-2324"/>
+        <nd ref="-3007"/>
+        <nd ref="-2326"/>
+        <nd ref="-18197"/>
+        <nd ref="-2328"/>
+        <nd ref="-2330"/>
+        <nd ref="-2332"/>
+        <nd ref="-7"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
+        <tag k="name" v="Independence Ave SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
+    </way>
     <way visible="true" id="-625" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7"/>
         <nd ref="-2334"/>
@@ -4060,178 +4103,6 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-615" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2715"/>
-        <nd ref="-1443"/>
-        <tag k="name" v="US Hwy 29"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-614" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-405"/>
-        <nd ref="-2711"/>
-        <tag k="name" v="US Hwy 29"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-613" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2737"/>
-        <nd ref="-2912"/>
-        <tag k="name" v="14th St SW"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-612" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-207"/>
-        <nd ref="-183"/>
-        <nd ref="-184"/>
-        <nd ref="-185"/>
-        <nd ref="-186"/>
-        <nd ref="-187"/>
-        <nd ref="-188"/>
-        <nd ref="-189"/>
-        <nd ref="-190"/>
-        <nd ref="-191"/>
-        <nd ref="-192"/>
-        <nd ref="-193"/>
-        <nd ref="-194"/>
-        <nd ref="-195"/>
-        <nd ref="-2404"/>
-        <nd ref="-196"/>
-        <nd ref="-197"/>
-        <nd ref="-198"/>
-        <nd ref="-797"/>
-        <nd ref="-199"/>
-        <nd ref="-200"/>
-        <nd ref="-201"/>
-        <nd ref="-202"/>
-        <nd ref="-203"/>
-        <nd ref="-204"/>
-        <nd ref="-205"/>
-        <nd ref="-206"/>
-        <nd ref="-208"/>
-        <nd ref="-210"/>
-        <nd ref="-212"/>
-        <nd ref="-213"/>
-        <nd ref="-214"/>
-        <nd ref="-215"/>
-        <nd ref="-216"/>
-        <nd ref="-217"/>
-        <nd ref="-218"/>
-        <nd ref="-2111"/>
-        <nd ref="-219"/>
-        <nd ref="-220"/>
-        <nd ref="-221"/>
-        <nd ref="-222"/>
-        <nd ref="-223"/>
-        <nd ref="-224"/>
-        <nd ref="-225"/>
-        <nd ref="-226"/>
-        <nd ref="-227"/>
-        <nd ref="-228"/>
-        <nd ref="-229"/>
-        <nd ref="-230"/>
-        <nd ref="-231"/>
-        <nd ref="-232"/>
-        <nd ref="-233"/>
-        <nd ref="-234"/>
-        <nd ref="-235"/>
-        <nd ref="-236"/>
-        <nd ref="-237"/>
-        <nd ref="-1545"/>
-        <nd ref="-238"/>
-        <nd ref="-239"/>
-        <nd ref="-240"/>
-        <nd ref="-241"/>
-        <nd ref="-242"/>
-        <nd ref="-243"/>
-        <nd ref="-244"/>
-        <nd ref="-245"/>
-        <nd ref="-246"/>
-        <nd ref="-247"/>
-        <nd ref="-248"/>
-        <nd ref="-249"/>
-        <nd ref="-250"/>
-        <nd ref="-251"/>
-        <nd ref="-252"/>
-        <nd ref="-253"/>
-        <nd ref="-254"/>
-        <nd ref="-2196"/>
-        <nd ref="-255"/>
-        <nd ref="-256"/>
-        <nd ref="-257"/>
-        <nd ref="-2081"/>
-        <nd ref="-258"/>
-        <nd ref="-259"/>
-        <nd ref="-260"/>
-        <nd ref="-261"/>
-        <nd ref="-262"/>
-        <nd ref="-263"/>
-        <nd ref="-264"/>
-        <nd ref="-265"/>
-        <nd ref="-266"/>
-        <nd ref="-267"/>
-        <nd ref="-268"/>
-        <nd ref="-269"/>
-        <nd ref="-270"/>
-        <nd ref="-1174"/>
-        <tag k="alt_name" v="INTERSTATE 66  BN"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-611" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1177"/>
-        <nd ref="-2703"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-610" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2696"/>
-        <nd ref="-1665"/>
-        <tag k="name" v="14th St SW"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-609" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3017"/>
-        <nd ref="-3018"/>
-        <nd ref="-3019"/>
-        <nd ref="-3020"/>
-        <nd ref="-3021"/>
-        <nd ref="-3022"/>
-        <nd ref="-3023"/>
-        <nd ref="-1159"/>
-        <tag k="alt_name" v="14TH ST NW;US Hwy 1"/>
-        <tag k="name" v="14th St NW"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-608" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1150"/>
-        <nd ref="-2734"/>
-        <tag k="name" v="US Hwy 1"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-607" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-756"/>
-        <nd ref="-2682"/>
-        <tag k="name" v="US Hwy 29"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-606" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-797"/>
-        <nd ref="-272"/>
-        <nd ref="-2384"/>
-        <nd ref="-271"/>
-        <nd ref="-2704"/>
-        <tag k="name" v="Virginia Avenue North W"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-605" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1835"/>
         <nd ref="-1837"/>
@@ -4240,55 +4111,6 @@
         <nd ref="-1840"/>
         <tag k="alt_name" v="15th St SW;RAOUL WALLENBERG PL SW;Raoul Wallenberg Pl SW"/>
         <tag k="name" v="Raoul Wallenberg Pl"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-604" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2581"/>
-        <nd ref="-2583"/>
-        <nd ref="-2585"/>
-        <nd ref="-2587"/>
-        <nd ref="-2019"/>
-        <nd ref="-1351"/>
-        <nd ref="-2589"/>
-        <nd ref="-2591"/>
-        <nd ref="-2593"/>
-        <nd ref="-2595"/>
-        <nd ref="-2597"/>
-        <nd ref="-2599"/>
-        <tag k="alt_name" v="15TH ST NW"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-603" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2446"/>
-        <nd ref="-2448"/>
-        <nd ref="-2450"/>
-        <nd ref="-2452"/>
-        <nd ref="-2454"/>
-        <nd ref="-2456"/>
-        <nd ref="-2458"/>
-        <nd ref="-2119"/>
-        <nd ref="-2460"/>
-        <nd ref="-2462"/>
-        <nd ref="-2464"/>
-        <nd ref="-2466"/>
-        <nd ref="-2468"/>
-        <nd ref="-2471"/>
-        <nd ref="-1041"/>
-        <nd ref="-2474"/>
-        <nd ref="-2477"/>
-        <nd ref="-2480"/>
-        <nd ref="-2483"/>
-        <nd ref="-2485"/>
-        <nd ref="-2487"/>
-        <nd ref="-2489"/>
-        <nd ref="-2491"/>
-        <nd ref="-2493"/>
-        <nd ref="-2495"/>
-        <tag k="alt_name" v="E ST NW"/>
-        <tag k="name" v="E St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -4544,16 +4366,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2440"/>
-        <nd ref="-2442"/>
-        <nd ref="-2444"/>
-        <nd ref="-2446"/>
-        <tag k="alt_name" v="E ST NW;E St NW"/>
-        <tag k="name" v="Ellipse Rd NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1476"/>
         <nd ref="-2115"/>
@@ -4737,20 +4549,24 @@
         <nd ref="-2574"/>
         <nd ref="-2397"/>
         <nd ref="-2575"/>
-        <tag k="alt_name" v="15TH ST NW"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2575"/>
         <nd ref="-2576"/>
         <nd ref="-2577"/>
         <nd ref="-2578"/>
         <nd ref="-2579"/>
         <nd ref="-2581"/>
-        <tag k="alt_name" v="15TH ST NW;15th St NW"/>
-        <tag k="name" v="Pennsylvania Ave NW"/>
+        <nd ref="-2583"/>
+        <nd ref="-2585"/>
+        <nd ref="-2587"/>
+        <nd ref="-2019"/>
+        <nd ref="-1351"/>
+        <nd ref="-2589"/>
+        <nd ref="-2591"/>
+        <nd ref="-2593"/>
+        <nd ref="-2595"/>
+        <nd ref="-2597"/>
+        <nd ref="-2599"/>
+        <tag k="alt_name" v="15TH ST NW;Pennsylvania Ave NW"/>
+        <tag k="name" v="15th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -4799,7 +4615,34 @@
         <nd ref="-2436"/>
         <nd ref="-2438"/>
         <nd ref="-2440"/>
-        <tag k="alt_name" v="E ST NW;PENNSYLVANIA AVE NW"/>
+        <nd ref="-2442"/>
+        <nd ref="-2444"/>
+        <nd ref="-2446"/>
+        <nd ref="-2448"/>
+        <nd ref="-2450"/>
+        <nd ref="-2452"/>
+        <nd ref="-2454"/>
+        <nd ref="-2456"/>
+        <nd ref="-2458"/>
+        <nd ref="-2119"/>
+        <nd ref="-2460"/>
+        <nd ref="-2462"/>
+        <nd ref="-2464"/>
+        <nd ref="-2466"/>
+        <nd ref="-2468"/>
+        <nd ref="-2471"/>
+        <nd ref="-1041"/>
+        <nd ref="-2474"/>
+        <nd ref="-2477"/>
+        <nd ref="-2480"/>
+        <nd ref="-2483"/>
+        <nd ref="-2485"/>
+        <nd ref="-2487"/>
+        <nd ref="-2489"/>
+        <nd ref="-2491"/>
+        <nd ref="-2493"/>
+        <nd ref="-2495"/>
+        <tag k="alt_name" v="E ST NW;Ellipse Rd NW;PENNSYLVANIA AVE NW"/>
         <tag k="name" v="E St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -5048,16 +4891,6 @@
         <nd ref="-605"/>
         <tag k="alt_name" v="LINCOLN MEMORIAL CIR NW;LINCOLN MEMORIAL CIR SW"/>
         <tag k="name" v="Lincoln Memorial Cir"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2070"/>
-        <nd ref="-2072"/>
-        <nd ref="-2075"/>
-        <nd ref="-797"/>
-        <tag k="alt_name" v="Virginia Avenue North W"/>
-        <tag k="name" v="G St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -5756,6 +5589,7 @@
         <nd ref="-22"/>
         <nd ref="-753"/>
         <nd ref="-756"/>
+        <nd ref="-2682"/>
         <tag k="alt_name" v="K ST NW;US Hwy 29"/>
         <tag k="name" v="K St NW"/>
         <tag k="highway" v="secondary"/>
@@ -6087,6 +5921,7 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2696"/>
         <nd ref="-1665"/>
         <nd ref="-1668"/>
         <nd ref="-1671"/>
@@ -6287,9 +6122,102 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-207"/>
+        <nd ref="-183"/>
+        <nd ref="-184"/>
+        <nd ref="-185"/>
+        <nd ref="-186"/>
+        <nd ref="-187"/>
+        <nd ref="-188"/>
+        <nd ref="-189"/>
+        <nd ref="-190"/>
+        <nd ref="-191"/>
+        <nd ref="-192"/>
+        <nd ref="-193"/>
+        <nd ref="-194"/>
+        <nd ref="-195"/>
+        <nd ref="-2404"/>
+        <nd ref="-196"/>
+        <nd ref="-197"/>
+        <nd ref="-198"/>
+        <nd ref="-797"/>
+        <nd ref="-199"/>
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-202"/>
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-205"/>
+        <nd ref="-206"/>
+        <nd ref="-208"/>
+        <nd ref="-210"/>
+        <nd ref="-212"/>
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <nd ref="-217"/>
+        <nd ref="-218"/>
+        <nd ref="-2111"/>
+        <nd ref="-219"/>
+        <nd ref="-220"/>
+        <nd ref="-221"/>
+        <nd ref="-222"/>
+        <nd ref="-223"/>
+        <nd ref="-224"/>
+        <nd ref="-225"/>
+        <nd ref="-226"/>
+        <nd ref="-227"/>
+        <nd ref="-228"/>
+        <nd ref="-229"/>
+        <nd ref="-230"/>
+        <nd ref="-231"/>
+        <nd ref="-232"/>
+        <nd ref="-233"/>
+        <nd ref="-234"/>
+        <nd ref="-235"/>
+        <nd ref="-236"/>
+        <nd ref="-237"/>
+        <nd ref="-1545"/>
+        <nd ref="-238"/>
+        <nd ref="-239"/>
+        <nd ref="-240"/>
+        <nd ref="-241"/>
+        <nd ref="-242"/>
+        <nd ref="-243"/>
+        <nd ref="-244"/>
+        <nd ref="-245"/>
+        <nd ref="-246"/>
+        <nd ref="-247"/>
+        <nd ref="-248"/>
+        <nd ref="-249"/>
+        <nd ref="-250"/>
+        <nd ref="-251"/>
+        <nd ref="-252"/>
+        <nd ref="-253"/>
+        <nd ref="-254"/>
+        <nd ref="-2196"/>
+        <nd ref="-255"/>
+        <nd ref="-256"/>
+        <nd ref="-257"/>
+        <nd ref="-2081"/>
+        <nd ref="-258"/>
+        <nd ref="-259"/>
+        <nd ref="-260"/>
+        <nd ref="-261"/>
+        <nd ref="-262"/>
+        <nd ref="-263"/>
+        <nd ref="-264"/>
+        <nd ref="-265"/>
+        <nd ref="-266"/>
+        <nd ref="-267"/>
+        <nd ref="-268"/>
+        <nd ref="-269"/>
+        <nd ref="-270"/>
         <nd ref="-1174"/>
         <nd ref="-1177"/>
-        <tag k="alt_name" v="I- 66"/>
+        <nd ref="-2703"/>
+        <tag k="alt_name" v="I- 66;INTERSTATE 66  BN"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="primary"/>
         <tag k="error:circular" v="5"/>
@@ -6323,6 +6251,14 @@
         <nd ref="-924"/>
         <nd ref="-1383"/>
         <nd ref="-2070"/>
+        <nd ref="-2072"/>
+        <nd ref="-2075"/>
+        <nd ref="-797"/>
+        <nd ref="-272"/>
+        <nd ref="-2384"/>
+        <nd ref="-271"/>
+        <nd ref="-2704"/>
+        <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -6421,6 +6357,29 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
+    <way visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-893"/>
+        <nd ref="-3034"/>
+        <nd ref="-3036"/>
+        <nd ref="-3038"/>
+        <nd ref="-2387"/>
+        <nd ref="-3039"/>
+        <nd ref="-272"/>
+        <nd ref="-3040"/>
+        <nd ref="-3041"/>
+        <nd ref="-785"/>
+        <nd ref="-3042"/>
+        <nd ref="-3043"/>
+        <nd ref="-3044"/>
+        <nd ref="-3045"/>
+        <nd ref="-3046"/>
+        <nd ref="-3047"/>
+        <nd ref="-18043"/>
+        <tag k="alt_name" v="INTERSTATE 66  BN"/>
+        <tag k="name" v="I- 66"/>
+        <tag k="highway" v="primary"/>
+        <tag k="error:circular" v="5"/>
+    </way>
     <way visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-732"/>
         <nd ref="-15"/>
@@ -6437,6 +6396,7 @@
         <nd ref="-1836"/>
         <nd ref="-26"/>
         <nd ref="-405"/>
+        <nd ref="-2711"/>
         <tag k="alt_name" v="K ST NW;US Hwy 29"/>
         <tag k="name" v="K St NW"/>
         <tag k="highway" v="secondary"/>
@@ -6555,6 +6515,7 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2715"/>
         <nd ref="-1443"/>
         <nd ref="-1444"/>
         <nd ref="-2819"/>
@@ -7110,6 +7071,13 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-3017"/>
+        <nd ref="-3018"/>
+        <nd ref="-3019"/>
+        <nd ref="-3020"/>
+        <nd ref="-3021"/>
+        <nd ref="-3022"/>
+        <nd ref="-3023"/>
         <nd ref="-1159"/>
         <nd ref="-1158"/>
         <nd ref="-1157"/>
@@ -7120,7 +7088,8 @@
         <nd ref="-1152"/>
         <nd ref="-1151"/>
         <nd ref="-1150"/>
-        <tag k="alt_name" v="CONSTITUTION AVE NW;US Hwy 1;US Hwy 50"/>
+        <nd ref="-2734"/>
+        <tag k="alt_name" v="14TH ST NW;14th St NW;CONSTITUTION AVE NW;US Hwy 1;US Hwy 50"/>
         <tag k="name" v="Constitution Ave NW"/>
         <tag k="highway" v="secondary"/>
         <tag k="error:circular" v="5"/>
@@ -7159,6 +7128,7 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2737"/>
         <nd ref="-2912"/>
         <nd ref="-2913"/>
         <nd ref="-2914"/>
@@ -7351,31 +7321,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2374"/>
-        <nd ref="-2375"/>
-        <nd ref="-2376"/>
-        <nd ref="-2377"/>
-        <nd ref="-2378"/>
-        <nd ref="-2379"/>
-        <nd ref="-2380"/>
-        <nd ref="-2381"/>
-        <nd ref="-2382"/>
-        <nd ref="-2383"/>
-        <nd ref="-2384"/>
-        <nd ref="-2387"/>
-        <nd ref="-2389"/>
-        <nd ref="-2392"/>
-        <nd ref="-2395"/>
-        <nd ref="-2398"/>
-        <nd ref="-2401"/>
-        <nd ref="-2404"/>
-        <nd ref="-853"/>
-        <tag k="alt_name" v="25TH ST NW;25th St NW"/>
-        <tag k="name" v="New Hampshire Ave NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3054"/>
         <nd ref="-2630"/>
@@ -7395,31 +7340,6 @@
         <nd ref="-2073"/>
         <nd ref="-2373"/>
         <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-800"/>
-        <nd ref="-803"/>
-        <nd ref="-806"/>
-        <nd ref="-809"/>
-        <nd ref="-812"/>
-        <nd ref="-815"/>
-        <nd ref="-818"/>
-        <nd ref="-821"/>
-        <nd ref="-824"/>
-        <nd ref="-827"/>
-        <nd ref="-830"/>
-        <nd ref="-833"/>
-        <nd ref="-836"/>
-        <nd ref="-839"/>
-        <nd ref="-842"/>
-        <nd ref="-845"/>
-        <nd ref="-848"/>
-        <nd ref="-851"/>
-        <nd ref="-853"/>
-        <tag k="alt_name" v="25TH ST NW;25th St NW"/>
-        <tag k="name" v="Whitehurst Fwy Rmp"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -8041,10 +7961,6 @@
         <nd ref="-2894"/>
         <nd ref="-2895"/>
         <nd ref="-17476"/>
-        <nd ref="-2896"/>
-        <nd ref="-2897"/>
-        <nd ref="-2898"/>
-        <nd ref="-2374"/>
         <tag k="alt_name" v="25TH ST NW"/>
         <tag k="name" v="25th St NW"/>
         <tag k="highway" v="unclassified"/>
@@ -8123,18 +8039,6 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1044"/>
-        <nd ref="-1113"/>
-        <nd ref="-1114"/>
-        <nd ref="-1115"/>
-        <nd ref="-1116"/>
-        <nd ref="-1117"/>
-        <tag k="alt_name" v="E ST NW;E St NW"/>
-        <tag k="name" v="Rawlings Sq NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-8"/>
         <nd ref="-682"/>
@@ -8185,6 +8089,11 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1044"/>
+        <nd ref="-1113"/>
+        <nd ref="-1114"/>
+        <nd ref="-1115"/>
+        <nd ref="-1116"/>
         <nd ref="-1117"/>
         <nd ref="-1118"/>
         <nd ref="-1119"/>
@@ -8219,7 +8128,7 @@
         <nd ref="-1147"/>
         <nd ref="-1148"/>
         <nd ref="-1149"/>
-        <tag k="alt_name" v="E ST NW"/>
+        <tag k="alt_name" v="E ST NW;Rawlings Sq NW"/>
         <tag k="name" v="E St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -8343,7 +8252,25 @@
         <nd ref="-794"/>
         <nd ref="-797"/>
         <nd ref="-800"/>
-        <tag k="alt_name" v="25TH ST NW"/>
+        <nd ref="-803"/>
+        <nd ref="-806"/>
+        <nd ref="-809"/>
+        <nd ref="-812"/>
+        <nd ref="-815"/>
+        <nd ref="-818"/>
+        <nd ref="-821"/>
+        <nd ref="-824"/>
+        <nd ref="-827"/>
+        <nd ref="-830"/>
+        <nd ref="-833"/>
+        <nd ref="-836"/>
+        <nd ref="-839"/>
+        <nd ref="-842"/>
+        <nd ref="-845"/>
+        <nd ref="-848"/>
+        <nd ref="-851"/>
+        <nd ref="-853"/>
+        <tag k="alt_name" v="25TH ST NW;Whitehurst Fwy Rmp"/>
         <tag k="name" v="25th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -8497,50 +8424,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1680"/>
-        <nd ref="-2124"/>
-        <nd ref="-2127"/>
-        <nd ref="-2130"/>
-        <nd ref="-2133"/>
-        <nd ref="-2136"/>
-        <nd ref="-2139"/>
-        <nd ref="-2142"/>
-        <nd ref="-2145"/>
-        <nd ref="-2148"/>
-        <nd ref="-2151"/>
-        <nd ref="-2154"/>
-        <nd ref="-2157"/>
-        <nd ref="-17637"/>
-        <nd ref="-2160"/>
-        <nd ref="-2163"/>
-        <nd ref="-2167"/>
-        <nd ref="-2171"/>
-        <nd ref="-2175"/>
-        <nd ref="-2179"/>
-        <nd ref="-2182"/>
-        <nd ref="-2185"/>
-        <nd ref="-2188"/>
-        <nd ref="-2191"/>
-        <nd ref="-2194"/>
-        <nd ref="-2198"/>
-        <nd ref="-2202"/>
-        <nd ref="-2206"/>
-        <nd ref="-2210"/>
-        <nd ref="-2213"/>
-        <nd ref="-2216"/>
-        <nd ref="-2219"/>
-        <nd ref="-2222"/>
-        <nd ref="-2225"/>
-        <nd ref="-2228"/>
-        <nd ref="-2231"/>
-        <nd ref="-2234"/>
-        <nd ref="-2237"/>
-        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
-        <tag k="name" v="Independence Ave SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1352"/>
         <nd ref="-1353"/>
@@ -8685,7 +8568,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.408346"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="17"/>
+        <tag k="hoot:review:sort_order" v="10"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1921" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8696,7 +8579,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.408346"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="18"/>
+        <tag k="hoot:review:sort_order" v="11"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1920" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8707,7 +8590,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.682679"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="29"/>
+        <tag k="hoot:review:sort_order" v="28"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1919" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8718,18 +8601,18 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.699909"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="28"/>
+        <tag k="hoot:review:sort_order" v="27"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1918" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-606" role="reviewee"/>
+        <member type="way" ref="-126" role="reviewee"/>
         <member type="way" ref="-486" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.504213"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="27"/>
+        <tag k="hoot:review:sort_order" v="25"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1917" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8740,7 +8623,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.500179"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="21"/>
+        <tag k="hoot:review:sort_order" v="19"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1916" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8752,7 +8635,7 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.68502"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="15"/>
+        <tag k="hoot:review:sort_order" v="8"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1915" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8764,18 +8647,18 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.701381"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="16"/>
+        <tag k="hoot:review:sort_order" v="9"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1914" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-608" role="reviewee"/>
+        <member type="way" ref="-89" role="reviewee"/>
         <member type="way" ref="-502" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.411556"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="31"/>
+        <tag k="hoot:review:sort_order" v="33"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1913" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8786,7 +8669,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.411556"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="32"/>
+        <tag k="hoot:review:sort_order" v="31"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1912" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8797,11 +8680,11 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.411556"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="33"/>
+        <tag k="hoot:review:sort_order" v="32"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1911" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-611" role="reviewee"/>
+        <member type="way" ref="-128" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <member type="way" ref="-128" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -8809,7 +8692,7 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.409163"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="19"/>
+        <tag k="hoot:review:sort_order" v="12"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1910" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8821,7 +8704,7 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.409163"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="20"/>
+        <tag k="hoot:review:sort_order" v="13"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1909" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8832,7 +8715,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="-1"/>
         <tag k="hoot:review:note" v="Ambiguous intersection match. Possible dogleg? Very short segment? Please verify merge and fix as needed."/>
-        <tag k="hoot:review:sort_order" v="30"/>
+        <tag k="hoot:review:sort_order" v="29"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1908" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8847,7 +8730,7 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1907" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-613" role="reviewee"/>
+        <member type="way" ref="-86" role="reviewee"/>
         <member type="way" ref="-452" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
@@ -8859,7 +8742,7 @@
     </relation>
     <relation visible="true" id="-1904" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2384" role="reviewee"/>
-        <member type="way" ref="-70" role="reviewee"/>
+        <member type="way" ref="-19434" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
         <tag k="hoot:review:members" v="2"/>
@@ -8876,7 +8759,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.706507"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="22"/>
+        <tag k="hoot:review:sort_order" v="20"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1902" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8887,7 +8770,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.664974"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="23"/>
+        <tag k="hoot:review:sort_order" v="21"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1901" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8901,7 +8784,7 @@
         <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.715482"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="25"/>
+        <tag k="hoot:review:sort_order" v="30"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1900" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8918,7 +8801,7 @@
         <tag k="hoot:review:members" v="8"/>
         <tag k="hoot:review:score" v="0.619623"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:sort_order" v="14"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1899" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8934,7 +8817,7 @@
         <tag k="hoot:review:members" v="7"/>
         <tag k="hoot:review:score" v="0.606918"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="2"/>
+        <tag k="hoot:review:sort_order" v="15"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1898" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8948,7 +8831,7 @@
         <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.667822"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="12"/>
+        <tag k="hoot:review:sort_order" v="5"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1897" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8961,7 +8844,7 @@
         <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.543185"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="14"/>
+        <tag k="hoot:review:sort_order" v="7"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1896" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8975,7 +8858,7 @@
         <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.623008"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="3"/>
+        <tag k="hoot:review:sort_order" v="16"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1895" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8991,7 +8874,7 @@
         <tag k="hoot:review:members" v="7"/>
         <tag k="hoot:review:score" v="0.596795"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="6"/>
+        <tag k="hoot:review:sort_order" v="23"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1894" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9002,7 +8885,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.632469"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:sort_order" v="2"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1893" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9015,7 +8898,7 @@
         <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.608843"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="8"/>
+        <tag k="hoot:review:sort_order" v="0"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1892" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9028,7 +8911,7 @@
         <tag k="hoot:review:members" v="4"/>
         <tag k="hoot:review:score" v="0.60885"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="9"/>
+        <tag k="hoot:review:sort_order" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1891" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9039,7 +8922,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.648769"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="24"/>
+        <tag k="hoot:review:sort_order" v="22"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1890" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9055,7 +8938,7 @@
         <tag k="hoot:review:members" v="7"/>
         <tag k="hoot:review:score" v="0.603484"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="4"/>
+        <tag k="hoot:review:sort_order" v="17"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1889" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9067,7 +8950,7 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.543144"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="10"/>
+        <tag k="hoot:review:sort_order" v="3"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1888" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9086,7 +8969,7 @@
         <tag k="hoot:review:members" v="10"/>
         <tag k="hoot:review:score" v="0.586489"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="7"/>
+        <tag k="hoot:review:sort_order" v="24"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1887" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9100,7 +8983,7 @@
         <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.690225"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="13"/>
+        <tag k="hoot:review:sort_order" v="6"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1886" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9115,7 +8998,7 @@
         <tag k="hoot:review:members" v="6"/>
         <tag k="hoot:review:score" v="0.625311"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="5"/>
+        <tag k="hoot:review:sort_order" v="18"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1885" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9127,7 +9010,7 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.543075"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="11"/>
+        <tag k="hoot:review:sort_order" v="4"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cmd/glacial/NetworkConflateCmdTest/output.osm
+++ b/test-files/cmd/glacial/NetworkConflateCmdTest/output.osm
@@ -31368,12 +31368,11 @@
         <tag k="hoot:id" v="-1907"/>
     </relation>
     <relation visible="true" id="-1906" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-502" role="reviewee"/>
-        <member type="way" ref="-502" role="reviewee"/>
         <member type="way" ref="-233" role="reviewee"/>
+        <member type="way" ref="-502" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.40955"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="10"/>
@@ -31447,14 +31446,11 @@
         <tag k="hoot:id" v="-1901"/>
     </relation>
     <relation visible="true" id="-1900" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-13" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-636" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.663166"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="4"/>
@@ -31477,15 +31473,13 @@
     </relation>
     <relation visible="true" id="-1898" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-52" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-13" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-500" role="reviewee"/>
         <member type="way" ref="-633" role="reviewee"/>
         <member type="way" ref="-636" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="7"/>
+        <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.537042"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="11"/>
@@ -31496,12 +31490,9 @@
     <relation visible="true" id="-1897" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-14" role="reviewee"/>
         <member type="way" ref="-633" role="reviewee"/>
-        <member type="way" ref="-633" role="reviewee"/>
-        <member type="way" ref="-633" role="reviewee"/>
-        <member type="way" ref="-633" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.651848"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="3"/>

--- a/test-files/cmd/glacial/NetworkConflateCmdTest/output.osm
+++ b/test-files/cmd/glacial/NetworkConflateCmdTest/output.osm
@@ -24636,24 +24636,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-613"/>
     </way>
-    <way visible="true" id="-611" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5501"/>
-        <nd ref="-7027"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-611"/>
-    </way>
-    <way visible="true" id="-610" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7020"/>
-        <nd ref="-5989"/>
-        <tag k="name" v="14th St SW"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-610"/>
-    </way>
     <way visible="true" id="-608" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2603"/>
         <nd ref="-7058"/>
@@ -24671,68 +24653,6 @@
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-607"/>
-    </way>
-    <way visible="true" id="-606" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20330"/>
-        <nd ref="-19957"/>
-        <nd ref="-2727"/>
-        <nd ref="-4595"/>
-        <nd ref="-7028"/>
-        <tag k="name" v="Virginia Avenue North W"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-606"/>
-    </way>
-    <way visible="true" id="-602" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3198"/>
-        <nd ref="-2365"/>
-        <nd ref="-2364"/>
-        <nd ref="-2363"/>
-        <nd ref="-2362"/>
-        <nd ref="-2361"/>
-        <nd ref="-2360"/>
-        <nd ref="-2359"/>
-        <nd ref="-2358"/>
-        <nd ref="-2357"/>
-        <nd ref="-2356"/>
-        <nd ref="-2355"/>
-        <nd ref="-2354"/>
-        <nd ref="-2353"/>
-        <nd ref="-2352"/>
-        <nd ref="-2351"/>
-        <nd ref="-2350"/>
-        <nd ref="-2349"/>
-        <nd ref="-2348"/>
-        <nd ref="-2347"/>
-        <nd ref="-2346"/>
-        <nd ref="-2345"/>
-        <nd ref="-2344"/>
-        <nd ref="-2343"/>
-        <nd ref="-2342"/>
-        <nd ref="-2341"/>
-        <nd ref="-2340"/>
-        <nd ref="-2339"/>
-        <nd ref="-2338"/>
-        <nd ref="-2337"/>
-        <nd ref="-2336"/>
-        <nd ref="-2335"/>
-        <nd ref="-2334"/>
-        <nd ref="-2333"/>
-        <nd ref="-2332"/>
-        <nd ref="-2331"/>
-        <nd ref="-2330"/>
-        <nd ref="-2329"/>
-        <nd ref="-2328"/>
-        <nd ref="-2327"/>
-        <nd ref="-2326"/>
-        <nd ref="-2325"/>
-        <nd ref="-2324"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-602"/>
     </way>
     <way visible="true" id="-600" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5430"/>
@@ -24889,18 +24809,6 @@
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-568"/>
-    </way>
-    <way visible="true" id="-566" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-6394"/>
-        <nd ref="-6396"/>
-        <nd ref="-6399"/>
-        <nd ref="-20330"/>
-        <tag k="alt_name" v="Virginia Avenue North W"/>
-        <tag k="name" v="G St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-566"/>
     </way>
     <way visible="true" id="-564" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7307"/>
@@ -25295,6 +25203,7 @@
         <tag k="hoot:id" v="-512"/>
     </way>
     <way visible="true" id="-510" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-7020"/>
         <nd ref="-5989"/>
         <nd ref="-19721"/>
         <nd ref="-19338"/>
@@ -25349,6 +25258,7 @@
     <way visible="true" id="-502" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-109"/>
         <nd ref="-5501"/>
+        <nd ref="-7027"/>
         <tag k="alt_name" v="I- 66"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="primary"/>
@@ -25387,6 +25297,14 @@
         <nd ref="-294"/>
         <nd ref="-5707"/>
         <nd ref="-6394"/>
+        <nd ref="-6396"/>
+        <nd ref="-6399"/>
+        <nd ref="-20330"/>
+        <nd ref="-19957"/>
+        <nd ref="-2727"/>
+        <nd ref="-4595"/>
+        <nd ref="-7028"/>
+        <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="2"/>
@@ -30367,6 +30285,48 @@
         <tag k="hoot:id" v="-58"/>
     </way>
     <way visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-3198"/>
+        <nd ref="-2365"/>
+        <nd ref="-2364"/>
+        <nd ref="-2363"/>
+        <nd ref="-2362"/>
+        <nd ref="-2361"/>
+        <nd ref="-2360"/>
+        <nd ref="-2359"/>
+        <nd ref="-2358"/>
+        <nd ref="-2357"/>
+        <nd ref="-2356"/>
+        <nd ref="-2355"/>
+        <nd ref="-2354"/>
+        <nd ref="-2353"/>
+        <nd ref="-2352"/>
+        <nd ref="-2351"/>
+        <nd ref="-2350"/>
+        <nd ref="-2349"/>
+        <nd ref="-2348"/>
+        <nd ref="-2347"/>
+        <nd ref="-2346"/>
+        <nd ref="-2345"/>
+        <nd ref="-2344"/>
+        <nd ref="-2343"/>
+        <nd ref="-2342"/>
+        <nd ref="-2341"/>
+        <nd ref="-2340"/>
+        <nd ref="-2339"/>
+        <nd ref="-2338"/>
+        <nd ref="-2337"/>
+        <nd ref="-2336"/>
+        <nd ref="-2335"/>
+        <nd ref="-2334"/>
+        <nd ref="-2333"/>
+        <nd ref="-2332"/>
+        <nd ref="-2331"/>
+        <nd ref="-2330"/>
+        <nd ref="-2329"/>
+        <nd ref="-2328"/>
+        <nd ref="-2327"/>
+        <nd ref="-2326"/>
+        <nd ref="-2325"/>
         <nd ref="-2324"/>
         <nd ref="-1828"/>
         <tag k="alt_name" v="Arlington Memorial Brg"/>
@@ -31296,7 +31256,7 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.685692"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="6"/>
+        <tag k="hoot:review:sort_order" v="5"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1915"/>
@@ -31310,13 +31270,13 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.701798"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="7"/>
+        <tag k="hoot:review:sort_order" v="6"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1914"/>
     </relation>
     <relation visible="true" id="-1913" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-606" role="reviewee"/>
+        <member type="way" ref="-500" role="reviewee"/>
         <member type="way" ref="-259" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
@@ -31349,7 +31309,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.395381"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="8"/>
+        <tag k="hoot:review:sort_order" v="7"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1911"/>
@@ -31362,7 +31322,7 @@
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.395381"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="9"/>
+        <tag k="hoot:review:sort_order" v="8"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1910"/>
@@ -31402,21 +31362,20 @@
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.40955"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="10"/>
+        <tag k="hoot:review:sort_order" v="9"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1907"/>
     </relation>
     <relation visible="true" id="-1906" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-611" role="reviewee"/>
-        <member type="way" ref="-502" role="reviewee"/>
         <member type="way" ref="-233" role="reviewee"/>
+        <member type="way" ref="-502" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="3"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.40955"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="11"/>
+        <tag k="hoot:review:sort_order" v="10"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1906"/>
@@ -31462,7 +31421,7 @@
     </relation>
     <relation visible="true" id="-1902" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-1138" role="reviewee"/>
-        <member type="way" ref="-602" role="reviewee"/>
+        <member type="way" ref="-57" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
         <tag k="hoot:review:members" v="2"/>
@@ -31474,7 +31433,7 @@
         <tag k="hoot:id" v="-1902"/>
     </relation>
     <relation visible="true" id="-1901" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-602" role="reviewee"/>
+        <member type="way" ref="-57" role="reviewee"/>
         <member type="way" ref="-564" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
@@ -31487,17 +31446,14 @@
         <tag k="hoot:id" v="-1901"/>
     </relation>
     <relation visible="true" id="-1900" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-13" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-636" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.663166"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="5"/>
+        <tag k="hoot:review:sort_order" v="4"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1900"/>
@@ -31517,18 +31473,16 @@
     </relation>
     <relation visible="true" id="-1898" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-52" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-13" role="reviewee"/>
-        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-500" role="reviewee"/>
         <member type="way" ref="-633" role="reviewee"/>
         <member type="way" ref="-636" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="7"/>
+        <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.537042"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="3"/>
+        <tag k="hoot:review:sort_order" v="11"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1898"/>
@@ -31536,15 +31490,12 @@
     <relation visible="true" id="-1897" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-14" role="reviewee"/>
         <member type="way" ref="-633" role="reviewee"/>
-        <member type="way" ref="-633" role="reviewee"/>
-        <member type="way" ref="-633" role="reviewee"/>
-        <member type="way" ref="-633" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:score" v="0.651848"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
-        <tag k="hoot:review:sort_order" v="4"/>
+        <tag k="hoot:review:sort_order" v="3"/>
         <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:id" v="-1897"/>

--- a/test-files/cmd/glacial/NetworkConflateCmdTest/output.osm
+++ b/test-files/cmd/glacial/NetworkConflateCmdTest/output.osm
@@ -31368,11 +31368,12 @@
         <tag k="hoot:id" v="-1907"/>
     </relation>
     <relation visible="true" id="-1906" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-233" role="reviewee"/>
         <member type="way" ref="-502" role="reviewee"/>
+        <member type="way" ref="-502" role="reviewee"/>
+        <member type="way" ref="-233" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:score" v="0.40955"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="10"/>
@@ -31446,11 +31447,14 @@
         <tag k="hoot:id" v="-1901"/>
     </relation>
     <relation visible="true" id="-1900" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-13" role="reviewee"/>
+        <member type="way" ref="-636" role="reviewee"/>
+        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-636" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.663166"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="4"/>
@@ -31473,13 +31477,15 @@
     </relation>
     <relation visible="true" id="-1898" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-52" role="reviewee"/>
+        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-13" role="reviewee"/>
+        <member type="way" ref="-636" role="reviewee"/>
         <member type="way" ref="-500" role="reviewee"/>
         <member type="way" ref="-633" role="reviewee"/>
         <member type="way" ref="-636" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:members" v="7"/>
         <tag k="hoot:review:score" v="0.537042"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="11"/>
@@ -31490,9 +31496,12 @@
     <relation visible="true" id="-1897" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-14" role="reviewee"/>
         <member type="way" ref="-633" role="reviewee"/>
+        <member type="way" ref="-633" role="reviewee"/>
+        <member type="way" ref="-633" role="reviewee"/>
+        <member type="way" ref="-633" role="reviewee"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:members" v="5"/>
         <tag k="hoot:review:score" v="0.651848"/>
         <tag k="hoot:review:note" v="A complex road situation was found with multiple plausible solutions. Please reference input data/imagery and manually merge or modify as needed."/>
         <tag k="hoot:review:sort_order" v="3"/>

--- a/test-files/cmd/glacial/RubberSheetConflateTest/output.osm
+++ b/test-files/cmd/glacial/RubberSheetConflateTest/output.osm
@@ -7080,34 +7080,10 @@
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920849899679411" lon="-77.0283332867985706"/>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920851758921842" lon="-77.0281790136031788"/>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920852742206549" lon="-77.0281002665473409"/>
-    <way visible="true" id="-36372" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37369"/>
-        <nd ref="-4891"/>
-        <nd ref="-4894"/>
-        <nd ref="-37370"/>
-        <nd ref="-4897"/>
-        <nd ref="-37120"/>
-        <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-36370" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-28235"/>
         <nd ref="-37369"/>
         <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36367" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37248"/>
-        <nd ref="-4874"/>
-        <nd ref="-4876"/>
-        <nd ref="-4878"/>
-        <nd ref="-4880"/>
-        <nd ref="-4882"/>
-        <nd ref="-4885"/>
-        <nd ref="-4888"/>
-        <nd ref="-37369"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -7141,23 +7117,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-36325" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37347"/>
-        <nd ref="-6199"/>
-        <nd ref="-37348"/>
-        <nd ref="-260"/>
-        <nd ref="-5188"/>
-        <nd ref="-261"/>
-        <nd ref="-262"/>
-        <nd ref="-263"/>
-        <nd ref="-5191"/>
-        <nd ref="-264"/>
-        <nd ref="-28607"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-36323" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36361"/>
         <nd ref="-259"/>
@@ -7190,15 +7149,6 @@
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36295" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37328"/>
-        <nd ref="-4953"/>
-        <nd ref="-1529"/>
-        <nd ref="-37329"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-36294" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37328"/>
@@ -7242,6 +7192,9 @@
     <way visible="true" id="-36276" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37242"/>
         <nd ref="-37316"/>
+        <nd ref="-895"/>
+        <nd ref="-37317"/>
+        <tag k="alt_name" v="E ST NW"/>
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -7258,7 +7211,11 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-36262" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-36260" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37167"/>
+        <nd ref="-1853"/>
+        <nd ref="-1854"/>
+        <nd ref="-1855"/>
         <nd ref="-37311"/>
         <nd ref="-1856"/>
         <nd ref="-1857"/>
@@ -7276,16 +7233,6 @@
         <nd ref="-1864"/>
         <nd ref="-33076"/>
         <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-36260" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37167"/>
-        <nd ref="-1853"/>
-        <nd ref="-1854"/>
-        <nd ref="-1855"/>
-        <nd ref="-37311"/>
         <tag k="name" v="WASHINGTON CIR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
@@ -7315,35 +7262,6 @@
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-35916" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37150"/>
-        <nd ref="-7373"/>
-        <nd ref="-37064"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-35914" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37149"/>
-        <nd ref="-975"/>
-        <nd ref="-7367"/>
-        <nd ref="-974"/>
-        <nd ref="-7368"/>
-        <nd ref="-7369"/>
-        <nd ref="-973"/>
-        <nd ref="-972"/>
-        <nd ref="-971"/>
-        <nd ref="-970"/>
-        <nd ref="-969"/>
-        <nd ref="-7370"/>
-        <nd ref="-968"/>
-        <nd ref="-7371"/>
-        <nd ref="-37150"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-35913" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37149"/>
@@ -7450,6 +7368,22 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-35786" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37149"/>
+        <nd ref="-975"/>
+        <nd ref="-7367"/>
+        <nd ref="-974"/>
+        <nd ref="-7368"/>
+        <nd ref="-7369"/>
+        <nd ref="-973"/>
+        <nd ref="-972"/>
+        <nd ref="-971"/>
+        <nd ref="-970"/>
+        <nd ref="-969"/>
+        <nd ref="-7370"/>
+        <nd ref="-968"/>
+        <nd ref="-7371"/>
+        <nd ref="-37150"/>
+        <nd ref="-7373"/>
         <nd ref="-37064"/>
         <nd ref="-4076"/>
         <nd ref="-4075"/>
@@ -7521,28 +7455,6 @@
         <nd ref="-37354"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-35686" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36989"/>
-        <nd ref="-6997"/>
-        <nd ref="-6999"/>
-        <nd ref="-7001"/>
-        <nd ref="-7003"/>
-        <nd ref="-7005"/>
-        <nd ref="-36915"/>
-        <tag k="name" v="Independence Ave SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-35633" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36955"/>
-        <nd ref="-7064"/>
-        <nd ref="-7065"/>
-        <nd ref="-37256"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-35632" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -7619,12 +7531,116 @@
         <nd ref="-7418"/>
         <nd ref="-651"/>
         <nd ref="-37021"/>
+        <nd ref="-4040"/>
+        <nd ref="-4039"/>
+        <nd ref="-4038"/>
+        <nd ref="-4037"/>
+        <nd ref="-7420"/>
+        <nd ref="-4036"/>
+        <nd ref="-4035"/>
+        <nd ref="-4034"/>
+        <nd ref="-4033"/>
+        <nd ref="-4032"/>
+        <nd ref="-4031"/>
+        <nd ref="-4030"/>
+        <nd ref="-7421"/>
+        <nd ref="-4029"/>
+        <nd ref="-37022"/>
         <tag k="alt_name" v="I- 66"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-35557" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36743"/>
+        <nd ref="-550"/>
+        <nd ref="-4535"/>
+        <nd ref="-4533"/>
+        <nd ref="-547"/>
+        <nd ref="-545"/>
+        <nd ref="-543"/>
+        <nd ref="-541"/>
+        <nd ref="-539"/>
+        <nd ref="-36742"/>
+        <nd ref="-537"/>
+        <nd ref="-535"/>
+        <nd ref="-4507"/>
+        <nd ref="-533"/>
+        <nd ref="-531"/>
+        <nd ref="-4508"/>
+        <nd ref="-529"/>
+        <nd ref="-4509"/>
+        <nd ref="-527"/>
+        <nd ref="-4510"/>
+        <nd ref="-525"/>
+        <nd ref="-4511"/>
+        <nd ref="-523"/>
+        <nd ref="-521"/>
+        <nd ref="-4512"/>
+        <nd ref="-519"/>
+        <nd ref="-517"/>
+        <nd ref="-4513"/>
+        <nd ref="-515"/>
+        <nd ref="-4514"/>
+        <nd ref="-513"/>
+        <nd ref="-4515"/>
+        <nd ref="-511"/>
+        <nd ref="-509"/>
+        <nd ref="-4516"/>
+        <nd ref="-4517"/>
+        <nd ref="-4518"/>
+        <nd ref="-507"/>
+        <nd ref="-4519"/>
+        <nd ref="-36750"/>
+        <nd ref="-505"/>
+        <nd ref="-4520"/>
+        <nd ref="-37024"/>
+        <nd ref="-4522"/>
+        <nd ref="-37186"/>
+        <nd ref="-503"/>
+        <nd ref="-4523"/>
+        <nd ref="-501"/>
+        <nd ref="-37232"/>
+        <nd ref="-499"/>
+        <nd ref="-4525"/>
+        <nd ref="-4526"/>
+        <nd ref="-497"/>
+        <nd ref="-4527"/>
+        <nd ref="-495"/>
+        <nd ref="-4528"/>
+        <nd ref="-493"/>
+        <nd ref="-491"/>
+        <nd ref="-4529"/>
+        <nd ref="-489"/>
+        <nd ref="-4530"/>
+        <nd ref="-487"/>
+        <nd ref="-485"/>
+        <nd ref="-484"/>
+        <nd ref="-4532"/>
+        <nd ref="-4534"/>
+        <nd ref="-483"/>
+        <nd ref="-482"/>
+        <nd ref="-481"/>
+        <nd ref="-480"/>
+        <nd ref="-479"/>
+        <nd ref="-4536"/>
+        <nd ref="-478"/>
+        <nd ref="-477"/>
+        <nd ref="-37233"/>
+        <nd ref="-476"/>
+        <nd ref="-475"/>
+        <nd ref="-474"/>
+        <nd ref="-473"/>
+        <nd ref="-472"/>
+        <nd ref="-471"/>
+        <nd ref="-470"/>
+        <nd ref="-469"/>
+        <nd ref="-468"/>
+        <nd ref="-467"/>
+        <nd ref="-4538"/>
+        <nd ref="-466"/>
+        <nd ref="-465"/>
+        <nd ref="-4539"/>
         <nd ref="-37223"/>
         <nd ref="-464"/>
         <nd ref="-463"/>
@@ -7658,6 +7674,29 @@
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-35475" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36842"/>
+        <nd ref="-5589"/>
+        <nd ref="-5591"/>
+        <nd ref="-5593"/>
+        <nd ref="-5595"/>
+        <nd ref="-5597"/>
+        <nd ref="-5599"/>
+        <nd ref="-5601"/>
+        <nd ref="-5603"/>
+        <nd ref="-5605"/>
+        <nd ref="-5607"/>
+        <nd ref="-5609"/>
+        <nd ref="-5611"/>
+        <nd ref="-5613"/>
+        <nd ref="-5615"/>
+        <nd ref="-5617"/>
+        <nd ref="-5619"/>
+        <nd ref="-5621"/>
+        <nd ref="-6285"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-35474" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36841"/>
@@ -7728,38 +7767,6 @@
         <tag k="alt_name" v="W Basin Dr SW"/>
         <tag k="name" v="WEST BASIN DR SW"/>
         <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-35394" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36800"/>
-        <nd ref="-2301"/>
-        <nd ref="-36801"/>
-        <nd ref="-4347"/>
-        <nd ref="-2303"/>
-        <nd ref="-4348"/>
-        <nd ref="-4349"/>
-        <nd ref="-2305"/>
-        <nd ref="-2307"/>
-        <nd ref="-2309"/>
-        <nd ref="-36784"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-35311" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36742"/>
-        <nd ref="-539"/>
-        <nd ref="-541"/>
-        <nd ref="-543"/>
-        <nd ref="-545"/>
-        <nd ref="-547"/>
-        <nd ref="-4533"/>
-        <nd ref="-4535"/>
-        <nd ref="-550"/>
-        <nd ref="-36743"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-35280" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -7888,13 +7895,6 @@
         <nd ref="-4787"/>
         <nd ref="-1297"/>
         <nd ref="-36484"/>
-        <tag k="alt_name" v="US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-34867" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36484"/>
         <nd ref="-1298"/>
         <nd ref="-1299"/>
         <nd ref="-1300"/>
@@ -7915,6 +7915,14 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
+    <way visible="true" id="-34654" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36989"/>
+        <nd ref="-6460"/>
+        <nd ref="-22590"/>
+        <tag k="name" v="Independence Ave SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
+    </way>
     <way visible="true" id="-34653" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36915"/>
         <nd ref="-6448"/>
@@ -7933,6 +7941,12 @@
         <nd ref="-36988"/>
         <nd ref="-6995"/>
         <nd ref="-36989"/>
+        <nd ref="-6997"/>
+        <nd ref="-6999"/>
+        <nd ref="-7001"/>
+        <nd ref="-7003"/>
+        <nd ref="-7005"/>
+        <nd ref="-36915"/>
         <tag k="alt_name" v="Independence Ave SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
@@ -8113,19 +8127,6 @@
         <nd ref="-5375"/>
         <nd ref="-2129"/>
         <nd ref="-35849"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-34059" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37361"/>
-        <nd ref="-37362"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-34003" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35849"/>
         <nd ref="-5379"/>
         <nd ref="-2127"/>
         <nd ref="-2125"/>
@@ -8152,25 +8153,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-33963" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37114"/>
-        <nd ref="-3626"/>
-        <nd ref="-3623"/>
-        <nd ref="-5852"/>
-        <nd ref="-3620"/>
-        <nd ref="-3617"/>
-        <nd ref="-5855"/>
-        <nd ref="-3614"/>
-        <nd ref="-5858"/>
-        <nd ref="-3611"/>
-        <nd ref="-5862"/>
-        <nd ref="-3608"/>
-        <nd ref="-5866"/>
-        <nd ref="-35778"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-33833" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36299"/>
         <nd ref="-7218"/>
@@ -8186,7 +8168,34 @@
         <nd ref="-2753"/>
         <nd ref="-2752"/>
         <nd ref="-35699"/>
-        <tag k="alt_name" v="25th St NW"/>
+        <nd ref="-2750"/>
+        <nd ref="-6699"/>
+        <nd ref="-2749"/>
+        <nd ref="-6700"/>
+        <nd ref="-2748"/>
+        <nd ref="-2747"/>
+        <nd ref="-6701"/>
+        <nd ref="-2746"/>
+        <nd ref="-6702"/>
+        <nd ref="-2745"/>
+        <nd ref="-2744"/>
+        <nd ref="-2743"/>
+        <nd ref="-2742"/>
+        <nd ref="-6703"/>
+        <nd ref="-2741"/>
+        <nd ref="-2740"/>
+        <nd ref="-6704"/>
+        <nd ref="-2739"/>
+        <nd ref="-6705"/>
+        <nd ref="-2737"/>
+        <nd ref="-2735"/>
+        <nd ref="-6706"/>
+        <nd ref="-2733"/>
+        <nd ref="-2731"/>
+        <nd ref="-6707"/>
+        <nd ref="-2729"/>
+        <nd ref="-33457"/>
+        <tag k="alt_name" v="25th St NW;New Hampshire Ave NW"/>
         <tag k="name" v="25TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
@@ -8207,6 +8216,14 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-33682" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24433"/>
+        <nd ref="-2763"/>
+        <nd ref="-5755"/>
+        <nd ref="-2764"/>
+        <nd ref="-2765"/>
+        <nd ref="-5756"/>
+        <nd ref="-2766"/>
+        <nd ref="-2767"/>
         <nd ref="-35620"/>
         <nd ref="-2768"/>
         <nd ref="-35656"/>
@@ -8300,52 +8317,6 @@
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-33131" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35233"/>
-        <nd ref="-1537"/>
-        <nd ref="-5846"/>
-        <nd ref="-1539"/>
-        <nd ref="-1541"/>
-        <nd ref="-5847"/>
-        <nd ref="-1543"/>
-        <nd ref="-5848"/>
-        <nd ref="-1545"/>
-        <nd ref="-1547"/>
-        <nd ref="-5850"/>
-        <nd ref="-1549"/>
-        <nd ref="-1551"/>
-        <nd ref="-5853"/>
-        <nd ref="-1553"/>
-        <nd ref="-1555"/>
-        <nd ref="-5856"/>
-        <nd ref="-1557"/>
-        <nd ref="-1559"/>
-        <nd ref="-5859"/>
-        <nd ref="-1561"/>
-        <nd ref="-1563"/>
-        <nd ref="-5863"/>
-        <nd ref="-1565"/>
-        <nd ref="-1567"/>
-        <nd ref="-5867"/>
-        <nd ref="-1569"/>
-        <nd ref="-1571"/>
-        <nd ref="-5870"/>
-        <nd ref="-1573"/>
-        <nd ref="-1575"/>
-        <nd ref="-5873"/>
-        <nd ref="-1577"/>
-        <nd ref="-5876"/>
-        <nd ref="-1579"/>
-        <nd ref="-1581"/>
-        <nd ref="-5879"/>
-        <nd ref="-1583"/>
-        <nd ref="-1585"/>
-        <nd ref="-1587"/>
-        <nd ref="-36349"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-33113" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35220"/>
         <nd ref="-2801"/>
@@ -8384,124 +8355,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-32979" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36800"/>
-        <nd ref="-2771"/>
-        <nd ref="-35148"/>
-        <nd ref="-2772"/>
-        <nd ref="-5759"/>
-        <nd ref="-2773"/>
-        <nd ref="-2774"/>
-        <nd ref="-5760"/>
-        <nd ref="-2775"/>
-        <nd ref="-35879"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32935" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37268"/>
-        <nd ref="-3642"/>
-        <nd ref="-6672"/>
-        <nd ref="-3639"/>
-        <nd ref="-6674"/>
-        <nd ref="-3636"/>
-        <nd ref="-3633"/>
-        <nd ref="-3630"/>
-        <nd ref="-3627"/>
-        <nd ref="-6676"/>
-        <nd ref="-3624"/>
-        <nd ref="-3621"/>
-        <nd ref="-3618"/>
-        <nd ref="-3615"/>
-        <nd ref="-3612"/>
-        <nd ref="-3609"/>
-        <nd ref="-3606"/>
-        <nd ref="-3604"/>
-        <nd ref="-3602"/>
-        <nd ref="-3600"/>
-        <nd ref="-3598"/>
-        <nd ref="-3596"/>
-        <nd ref="-3594"/>
-        <nd ref="-6678"/>
-        <nd ref="-3592"/>
-        <nd ref="-35108"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32934" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37268"/>
-        <nd ref="-37291"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32882" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35108"/>
-        <nd ref="-3590"/>
-        <nd ref="-3588"/>
-        <nd ref="-3586"/>
-        <nd ref="-3584"/>
-        <nd ref="-3582"/>
-        <nd ref="-3580"/>
-        <nd ref="-6680"/>
-        <nd ref="-3578"/>
-        <nd ref="-3576"/>
-        <nd ref="-3574"/>
-        <nd ref="-3572"/>
-        <nd ref="-6682"/>
-        <nd ref="-3570"/>
-        <nd ref="-3568"/>
-        <nd ref="-3566"/>
-        <nd ref="-3564"/>
-        <nd ref="-3562"/>
-        <nd ref="-3560"/>
-        <nd ref="-3558"/>
-        <nd ref="-3557"/>
-        <nd ref="-3556"/>
-        <nd ref="-3555"/>
-        <nd ref="-3554"/>
-        <nd ref="-3553"/>
-        <nd ref="-6684"/>
-        <nd ref="-3552"/>
-        <nd ref="-3551"/>
-        <nd ref="-6686"/>
-        <nd ref="-3550"/>
-        <nd ref="-3549"/>
-        <nd ref="-3548"/>
-        <nd ref="-6687"/>
-        <nd ref="-3547"/>
-        <nd ref="-3546"/>
-        <nd ref="-6688"/>
-        <nd ref="-3545"/>
-        <nd ref="-6689"/>
-        <nd ref="-3544"/>
-        <nd ref="-6690"/>
-        <nd ref="-3543"/>
-        <nd ref="-3542"/>
-        <nd ref="-3541"/>
-        <nd ref="-6691"/>
-        <nd ref="-3540"/>
-        <nd ref="-6692"/>
-        <nd ref="-3539"/>
-        <nd ref="-6693"/>
-        <nd ref="-3538"/>
-        <nd ref="-3537"/>
-        <nd ref="-3536"/>
-        <nd ref="-3535"/>
-        <nd ref="-3534"/>
-        <nd ref="-6694"/>
-        <nd ref="-3533"/>
-        <nd ref="-3532"/>
-        <nd ref="-35063"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-32880" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-34957"/>
         <nd ref="-3527"/>
@@ -8518,6 +8371,73 @@
         <nd ref="-35034"/>
         <nd ref="-3508"/>
         <nd ref="-35035"/>
+        <nd ref="-1735"/>
+        <nd ref="-6950"/>
+        <nd ref="-1733"/>
+        <nd ref="-1731"/>
+        <nd ref="-1729"/>
+        <nd ref="-6951"/>
+        <nd ref="-1727"/>
+        <nd ref="-1725"/>
+        <nd ref="-6952"/>
+        <nd ref="-1723"/>
+        <nd ref="-1721"/>
+        <nd ref="-6953"/>
+        <nd ref="-1719"/>
+        <nd ref="-6955"/>
+        <nd ref="-1717"/>
+        <nd ref="-6957"/>
+        <nd ref="-1715"/>
+        <nd ref="-6959"/>
+        <nd ref="-1713"/>
+        <nd ref="-33250"/>
+        <nd ref="-1709"/>
+        <nd ref="-6963"/>
+        <nd ref="-1707"/>
+        <nd ref="-1705"/>
+        <nd ref="-1703"/>
+        <nd ref="-6965"/>
+        <nd ref="-1701"/>
+        <nd ref="-1699"/>
+        <nd ref="-6967"/>
+        <nd ref="-1697"/>
+        <nd ref="-1695"/>
+        <nd ref="-6968"/>
+        <nd ref="-1693"/>
+        <nd ref="-6969"/>
+        <nd ref="-1691"/>
+        <nd ref="-6970"/>
+        <nd ref="-1689"/>
+        <nd ref="-6971"/>
+        <nd ref="-1687"/>
+        <nd ref="-6972"/>
+        <nd ref="-1685"/>
+        <nd ref="-6973"/>
+        <nd ref="-1683"/>
+        <nd ref="-6974"/>
+        <nd ref="-1681"/>
+        <nd ref="-1679"/>
+        <nd ref="-6975"/>
+        <nd ref="-1677"/>
+        <nd ref="-1675"/>
+        <nd ref="-6977"/>
+        <nd ref="-1673"/>
+        <nd ref="-6979"/>
+        <nd ref="-6981"/>
+        <nd ref="-1671"/>
+        <nd ref="-1669"/>
+        <nd ref="-6983"/>
+        <nd ref="-1667"/>
+        <nd ref="-6985"/>
+        <nd ref="-1665"/>
+        <nd ref="-1663"/>
+        <nd ref="-1661"/>
+        <nd ref="-6987"/>
+        <nd ref="-1659"/>
+        <nd ref="-1657"/>
+        <nd ref="-6989"/>
+        <nd ref="-6991"/>
+        <nd ref="-36988"/>
         <tag k="alt_name" v="Independence Ave SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
@@ -8556,18 +8476,6 @@
         <nd ref="-34957"/>
         <tag k="alt_name" v="Independence Ave SW;Kutz Brg"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32720" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37361"/>
-        <nd ref="-6658"/>
-        <nd ref="-741"/>
-        <nd ref="-6660"/>
-        <nd ref="-742"/>
-        <nd ref="-34914"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="OHIO DR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -8670,103 +8578,60 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-32265" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37317"/>
-        <nd ref="-896"/>
-        <nd ref="-897"/>
-        <nd ref="-5459"/>
-        <nd ref="-898"/>
-        <nd ref="-899"/>
-        <nd ref="-900"/>
-        <nd ref="-901"/>
-        <nd ref="-5460"/>
-        <nd ref="-902"/>
-        <nd ref="-34559"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
+    <way visible="true" id="-31987" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36361"/>
+        <nd ref="-75"/>
+        <nd ref="-4810"/>
+        <nd ref="-77"/>
+        <nd ref="-4812"/>
+        <nd ref="-78"/>
+        <nd ref="-4813"/>
+        <nd ref="-79"/>
+        <nd ref="-80"/>
+        <nd ref="-4814"/>
+        <nd ref="-82"/>
+        <nd ref="-84"/>
+        <nd ref="-4815"/>
+        <nd ref="-86"/>
+        <nd ref="-88"/>
+        <nd ref="-4816"/>
+        <nd ref="-89"/>
+        <nd ref="-90"/>
+        <nd ref="-4817"/>
+        <nd ref="-91"/>
+        <nd ref="-4818"/>
+        <nd ref="-92"/>
+        <nd ref="-93"/>
+        <nd ref="-4819"/>
+        <nd ref="-94"/>
+        <nd ref="-4820"/>
+        <nd ref="-95"/>
+        <nd ref="-4821"/>
+        <nd ref="-96"/>
+        <nd ref="-97"/>
+        <nd ref="-4822"/>
+        <nd ref="-35593"/>
+        <nd ref="-98"/>
+        <nd ref="-99"/>
+        <nd ref="-35956"/>
+        <nd ref="-35989"/>
+        <nd ref="-4823"/>
+        <nd ref="-102"/>
+        <nd ref="-103"/>
+        <nd ref="-4824"/>
+        <nd ref="-104"/>
+        <nd ref="-105"/>
+        <nd ref="-4825"/>
+        <nd ref="-106"/>
+        <nd ref="-107"/>
+        <nd ref="-4826"/>
+        <nd ref="-4827"/>
+        <nd ref="-108"/>
+        <nd ref="-37082"/>
+        <tag k="alt_name" v="US Hwy 50"/>
+        <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32263" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37316"/>
-        <nd ref="-895"/>
-        <nd ref="-37317"/>
-        <tag k="alt_name" v="Virginia Avenue North W"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32196" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34559"/>
-        <nd ref="-903"/>
-        <nd ref="-904"/>
-        <nd ref="-905"/>
-        <nd ref="-906"/>
-        <nd ref="-34501"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32117" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28868"/>
-        <nd ref="-1518"/>
-        <nd ref="-1519"/>
-        <nd ref="-1520"/>
-        <nd ref="-34426"/>
-        <nd ref="-1521"/>
-        <nd ref="-1522"/>
-        <nd ref="-4734"/>
-        <nd ref="-1523"/>
-        <nd ref="-4736"/>
-        <nd ref="-1524"/>
-        <nd ref="-4737"/>
-        <nd ref="-1525"/>
-        <nd ref="-4738"/>
-        <nd ref="-1526"/>
-        <nd ref="-1527"/>
-        <nd ref="-4739"/>
-        <nd ref="-1528"/>
-        <nd ref="-4740"/>
-        <nd ref="-1530"/>
-        <nd ref="-4741"/>
-        <nd ref="-1532"/>
-        <nd ref="-4742"/>
-        <nd ref="-1534"/>
-        <nd ref="-4743"/>
-        <nd ref="-1536"/>
-        <nd ref="-4744"/>
-        <nd ref="-1538"/>
-        <nd ref="-4745"/>
-        <nd ref="-1540"/>
-        <nd ref="-4746"/>
-        <nd ref="-1542"/>
-        <nd ref="-4747"/>
-        <nd ref="-1544"/>
-        <nd ref="-4748"/>
-        <nd ref="-1546"/>
-        <nd ref="-4749"/>
-        <nd ref="-1548"/>
-        <nd ref="-4750"/>
-        <nd ref="-1550"/>
-        <nd ref="-4751"/>
-        <nd ref="-1552"/>
-        <nd ref="-1554"/>
-        <nd ref="-4752"/>
-        <nd ref="-1556"/>
-        <nd ref="-4753"/>
-        <nd ref="-1558"/>
-        <nd ref="-4755"/>
-        <nd ref="-1560"/>
-        <nd ref="-4757"/>
-        <nd ref="-1562"/>
-        <nd ref="-36893"/>
-        <nd ref="-1564"/>
-        <nd ref="-1566"/>
-        <nd ref="-30517"/>
-        <tag k="name" v="E ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-31923" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37255"/>
@@ -8779,69 +8644,49 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-31922" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37166"/>
-        <nd ref="-1849"/>
-        <nd ref="-1850"/>
-        <nd ref="-1851"/>
-        <nd ref="-1852"/>
-        <nd ref="-37167"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-31887" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34119"/>
-        <nd ref="-3207"/>
-        <nd ref="-3209"/>
-        <nd ref="-34221"/>
-        <nd ref="-3211"/>
-        <nd ref="-6089"/>
-        <nd ref="-3213"/>
-        <nd ref="-6091"/>
-        <nd ref="-3215"/>
-        <nd ref="-6093"/>
-        <nd ref="-3217"/>
-        <nd ref="-34222"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-31843" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36692"/>
-        <nd ref="-5219"/>
-        <nd ref="-983"/>
-        <nd ref="-5221"/>
-        <nd ref="-984"/>
-        <nd ref="-5223"/>
-        <nd ref="-985"/>
-        <nd ref="-986"/>
-        <nd ref="-5225"/>
-        <nd ref="-987"/>
-        <nd ref="-5227"/>
-        <nd ref="-988"/>
-        <nd ref="-5229"/>
-        <nd ref="-989"/>
-        <nd ref="-5231"/>
-        <nd ref="-990"/>
-        <nd ref="-5233"/>
-        <nd ref="-991"/>
-        <nd ref="-5235"/>
-        <nd ref="-992"/>
-        <nd ref="-5237"/>
-        <nd ref="-993"/>
-        <nd ref="-5239"/>
-        <nd ref="-994"/>
-        <nd ref="-995"/>
-        <nd ref="-996"/>
-        <nd ref="-5241"/>
-        <nd ref="-997"/>
-        <nd ref="-5243"/>
-        <nd ref="-998"/>
-        <nd ref="-5245"/>
         <nd ref="-34190"/>
+        <nd ref="-5245"/>
+        <nd ref="-998"/>
+        <nd ref="-5243"/>
+        <nd ref="-997"/>
+        <nd ref="-5241"/>
+        <nd ref="-996"/>
+        <nd ref="-995"/>
+        <nd ref="-994"/>
+        <nd ref="-5239"/>
+        <nd ref="-993"/>
+        <nd ref="-5237"/>
+        <nd ref="-992"/>
+        <nd ref="-5235"/>
+        <nd ref="-991"/>
+        <nd ref="-5233"/>
+        <nd ref="-990"/>
+        <nd ref="-5231"/>
+        <nd ref="-989"/>
+        <nd ref="-5229"/>
+        <nd ref="-988"/>
+        <nd ref="-5227"/>
+        <nd ref="-987"/>
+        <nd ref="-5225"/>
+        <nd ref="-986"/>
+        <nd ref="-985"/>
+        <nd ref="-5223"/>
+        <nd ref="-984"/>
+        <nd ref="-5221"/>
+        <nd ref="-983"/>
+        <nd ref="-5219"/>
+        <nd ref="-36692"/>
+        <nd ref="-982"/>
+        <nd ref="-981"/>
+        <nd ref="-7358"/>
+        <nd ref="-980"/>
+        <nd ref="-7360"/>
+        <nd ref="-979"/>
+        <nd ref="-7362"/>
+        <nd ref="-36979"/>
+        <nd ref="-37308"/>
+        <tag k="alt_name" v="I- 66"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
@@ -8868,6 +8713,17 @@
         <nd ref="-34118"/>
         <nd ref="-3203"/>
         <nd ref="-34119"/>
+        <nd ref="-3207"/>
+        <nd ref="-3209"/>
+        <nd ref="-34221"/>
+        <nd ref="-3211"/>
+        <nd ref="-6089"/>
+        <nd ref="-3213"/>
+        <nd ref="-6091"/>
+        <nd ref="-3215"/>
+        <nd ref="-6093"/>
+        <nd ref="-3217"/>
+        <nd ref="-34222"/>
         <tag k="alt_name" v="22nd St NW"/>
         <tag k="name" v="22ND ST NW"/>
         <tag k="highway" v="road"/>
@@ -8882,6 +8738,11 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-31649" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33960"/>
+        <nd ref="-3489"/>
+        <nd ref="-3490"/>
+        <nd ref="-7324"/>
+        <nd ref="-3491"/>
         <nd ref="-34038"/>
         <nd ref="-7325"/>
         <nd ref="-3492"/>
@@ -8905,18 +8766,6 @@
         <nd ref="-3505"/>
         <nd ref="-3506"/>
         <nd ref="-36327"/>
-        <tag k="alt_name" v="Daniel French Dr SW"/>
-        <tag k="name" v="DANIEL C FRENCH DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-31573" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33960"/>
-        <nd ref="-3489"/>
-        <nd ref="-3490"/>
-        <nd ref="-7324"/>
-        <nd ref="-3491"/>
-        <nd ref="-34038"/>
         <tag k="alt_name" v="Daniel French Dr SW"/>
         <tag k="name" v="DANIEL C FRENCH DR SW"/>
         <tag k="highway" v="road"/>
@@ -9012,40 +8861,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-30992" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35699"/>
-        <nd ref="-2750"/>
-        <nd ref="-6699"/>
-        <nd ref="-2749"/>
-        <nd ref="-6700"/>
-        <nd ref="-2748"/>
-        <nd ref="-2747"/>
-        <nd ref="-6701"/>
-        <nd ref="-2746"/>
-        <nd ref="-6702"/>
-        <nd ref="-2745"/>
-        <nd ref="-2744"/>
-        <nd ref="-2743"/>
-        <nd ref="-2742"/>
-        <nd ref="-6703"/>
-        <nd ref="-2741"/>
-        <nd ref="-2740"/>
-        <nd ref="-6704"/>
-        <nd ref="-2739"/>
-        <nd ref="-6705"/>
-        <nd ref="-2737"/>
-        <nd ref="-2735"/>
-        <nd ref="-6706"/>
-        <nd ref="-2733"/>
-        <nd ref="-2731"/>
-        <nd ref="-6707"/>
-        <nd ref="-2729"/>
-        <nd ref="-33457"/>
-        <tag k="alt_name" v="25th St NW;New Hampshire Ave NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-30990" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27277"/>
         <nd ref="-33457"/>
@@ -9053,7 +8868,26 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-30910" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-30908" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36158"/>
+        <nd ref="-2365"/>
+        <nd ref="-5034"/>
+        <nd ref="-2364"/>
+        <nd ref="-5032"/>
+        <nd ref="-2363"/>
+        <nd ref="-2362"/>
+        <nd ref="-5030"/>
+        <nd ref="-2361"/>
+        <nd ref="-2360"/>
+        <nd ref="-2359"/>
+        <nd ref="-5028"/>
+        <nd ref="-2358"/>
+        <nd ref="-5025"/>
+        <nd ref="-2357"/>
+        <nd ref="-2356"/>
+        <nd ref="-2355"/>
+        <nd ref="-2354"/>
+        <nd ref="-2353"/>
         <nd ref="-36157"/>
         <nd ref="-2352"/>
         <nd ref="-4828"/>
@@ -9096,31 +8930,6 @@
         <nd ref="-4841"/>
         <nd ref="-2325"/>
         <nd ref="-33370"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30908" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36157"/>
-        <nd ref="-2353"/>
-        <nd ref="-2354"/>
-        <nd ref="-2355"/>
-        <nd ref="-2356"/>
-        <nd ref="-2357"/>
-        <nd ref="-5025"/>
-        <nd ref="-2358"/>
-        <nd ref="-5028"/>
-        <nd ref="-2359"/>
-        <nd ref="-2360"/>
-        <nd ref="-2361"/>
-        <nd ref="-5030"/>
-        <nd ref="-2362"/>
-        <nd ref="-2363"/>
-        <nd ref="-5032"/>
-        <nd ref="-2364"/>
-        <nd ref="-5034"/>
-        <nd ref="-2365"/>
-        <nd ref="-36158"/>
         <tag k="alt_name" v="Lincoln Memorial Cir"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
         <tag k="highway" v="road"/>
@@ -9192,82 +9001,67 @@
         <nd ref="-2275"/>
         <nd ref="-2274"/>
         <nd ref="-37248"/>
+        <nd ref="-4874"/>
+        <nd ref="-4876"/>
+        <nd ref="-4878"/>
+        <nd ref="-4880"/>
+        <nd ref="-4882"/>
+        <nd ref="-4885"/>
+        <nd ref="-4888"/>
+        <nd ref="-37369"/>
+        <nd ref="-4891"/>
+        <nd ref="-4894"/>
+        <nd ref="-37370"/>
+        <nd ref="-4897"/>
+        <nd ref="-37120"/>
+        <nd ref="-4900"/>
+        <nd ref="-4903"/>
+        <nd ref="-4907"/>
+        <nd ref="-4910"/>
+        <nd ref="-4913"/>
+        <nd ref="-4916"/>
+        <nd ref="-4919"/>
+        <nd ref="-4921"/>
+        <nd ref="-4923"/>
+        <nd ref="-4925"/>
+        <nd ref="-4927"/>
+        <nd ref="-28148"/>
+        <nd ref="-4931"/>
+        <nd ref="-4933"/>
+        <nd ref="-4935"/>
+        <nd ref="-4937"/>
+        <nd ref="-4939"/>
+        <nd ref="-4941"/>
+        <nd ref="-4943"/>
+        <nd ref="-4945"/>
+        <nd ref="-4947"/>
+        <nd ref="-4949"/>
+        <nd ref="-4950"/>
+        <nd ref="-4951"/>
+        <nd ref="-4952"/>
+        <nd ref="-37328"/>
+        <nd ref="-4953"/>
+        <nd ref="-1529"/>
+        <nd ref="-37329"/>
+        <nd ref="-3408"/>
+        <nd ref="-3409"/>
+        <nd ref="-4954"/>
+        <nd ref="-3410"/>
+        <nd ref="-3411"/>
+        <nd ref="-4955"/>
+        <nd ref="-3412"/>
+        <nd ref="-3413"/>
+        <nd ref="-4956"/>
+        <nd ref="-3414"/>
+        <nd ref="-3415"/>
+        <nd ref="-3416"/>
+        <nd ref="-3417"/>
+        <nd ref="-4957"/>
+        <nd ref="-3418"/>
+        <nd ref="-3419"/>
+        <nd ref="-35778"/>
+        <tag k="alt_name" v="INTERSTATE 66  BN;OHIO DR NW;ROCK CREEK &amp; POTOMAC PKWY NW"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30775" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33250"/>
-        <nd ref="-2040"/>
-        <nd ref="-4877"/>
-        <nd ref="-2038"/>
-        <nd ref="-2036"/>
-        <nd ref="-4879"/>
-        <nd ref="-2034"/>
-        <nd ref="-4881"/>
-        <nd ref="-2032"/>
-        <nd ref="-4883"/>
-        <nd ref="-2030"/>
-        <nd ref="-4886"/>
-        <nd ref="-2028"/>
-        <nd ref="-2026"/>
-        <nd ref="-4889"/>
-        <nd ref="-4892"/>
-        <nd ref="-2024"/>
-        <nd ref="-2022"/>
-        <nd ref="-4895"/>
-        <nd ref="-2020"/>
-        <nd ref="-4898"/>
-        <nd ref="-2018"/>
-        <nd ref="-4901"/>
-        <nd ref="-4904"/>
-        <nd ref="-2016"/>
-        <nd ref="-2014"/>
-        <nd ref="-2012"/>
-        <nd ref="-4908"/>
-        <nd ref="-2010"/>
-        <nd ref="-4911"/>
-        <nd ref="-2008"/>
-        <nd ref="-2006"/>
-        <nd ref="-4914"/>
-        <nd ref="-2004"/>
-        <nd ref="-2002"/>
-        <nd ref="-4917"/>
-        <nd ref="-2000"/>
-        <nd ref="-4920"/>
-        <nd ref="-1998"/>
-        <nd ref="-1996"/>
-        <nd ref="-1994"/>
-        <nd ref="-4922"/>
-        <nd ref="-1992"/>
-        <nd ref="-4924"/>
-        <nd ref="-1990"/>
-        <nd ref="-1988"/>
-        <nd ref="-4926"/>
-        <nd ref="-1986"/>
-        <nd ref="-1984"/>
-        <nd ref="-4928"/>
-        <nd ref="-1982"/>
-        <nd ref="-1980"/>
-        <nd ref="-4930"/>
-        <nd ref="-1978"/>
-        <nd ref="-4932"/>
-        <nd ref="-1976"/>
-        <nd ref="-1974"/>
-        <nd ref="-4934"/>
-        <nd ref="-1972"/>
-        <nd ref="-1970"/>
-        <nd ref="-4936"/>
-        <nd ref="-1969"/>
-        <nd ref="-1968"/>
-        <nd ref="-4938"/>
-        <nd ref="-1967"/>
-        <nd ref="-4940"/>
-        <nd ref="-1966"/>
-        <nd ref="-1965"/>
-        <nd ref="-37142"/>
-        <tag k="alt_name" v="Maine Ave SW"/>
-        <tag k="name" v="MAINE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -9288,25 +9082,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-30368" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34114"/>
-        <nd ref="-1865"/>
-        <nd ref="-4367"/>
-        <nd ref="-1866"/>
-        <nd ref="-4368"/>
-        <nd ref="-1867"/>
-        <nd ref="-4369"/>
-        <nd ref="-1868"/>
-        <nd ref="-4370"/>
-        <nd ref="-1869"/>
-        <nd ref="-4371"/>
-        <nd ref="-1870"/>
-        <nd ref="-33002"/>
-        <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-30361" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24736"/>
         <nd ref="-4699"/>
@@ -9319,37 +9094,17 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-30333" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32921"/>
-        <nd ref="-35726"/>
-        <tag k="name" v="26th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-30216" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32833"/>
-        <nd ref="-1875"/>
-        <nd ref="-1876"/>
-        <nd ref="-32834"/>
-        <nd ref="-1877"/>
-        <nd ref="-1878"/>
-        <nd ref="-4377"/>
-        <nd ref="-1879"/>
-        <nd ref="-4378"/>
-        <nd ref="-1880"/>
-        <nd ref="-4379"/>
-        <nd ref="-1881"/>
-        <nd ref="-1882"/>
-        <nd ref="-4380"/>
-        <nd ref="-1883"/>
-        <nd ref="-4381"/>
-        <nd ref="-27725"/>
-        <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-30113" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36800"/>
+        <nd ref="-2301"/>
+        <nd ref="-36801"/>
+        <nd ref="-4347"/>
+        <nd ref="-2303"/>
+        <nd ref="-4348"/>
+        <nd ref="-4349"/>
+        <nd ref="-2305"/>
+        <nd ref="-2307"/>
+        <nd ref="-2309"/>
         <nd ref="-36784"/>
         <nd ref="-4350"/>
         <nd ref="-35726"/>
@@ -9408,24 +9163,6 @@
         <nd ref="-2585"/>
         <nd ref="-32758"/>
         <tag k="name" v="SOUTH EXECUTIVE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30074" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32758"/>
-        <nd ref="-2586"/>
-        <nd ref="-6914"/>
-        <nd ref="-2587"/>
-        <nd ref="-6916"/>
-        <nd ref="-2588"/>
-        <nd ref="-6918"/>
-        <nd ref="-2589"/>
-        <nd ref="-6920"/>
-        <nd ref="-2590"/>
-        <nd ref="-32759"/>
-        <tag k="alt_name" v="South Pl NW"/>
-        <tag k="name" v="SOUTH EXECUTIVE AVE NW"/>
-        <tag k="foot" v="designated"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -9511,6 +9248,111 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-29162" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37042"/>
+        <nd ref="-1718"/>
+        <nd ref="-6312"/>
+        <nd ref="-1720"/>
+        <nd ref="-1722"/>
+        <nd ref="-1724"/>
+        <nd ref="-6314"/>
+        <nd ref="-1726"/>
+        <nd ref="-1728"/>
+        <nd ref="-6316"/>
+        <nd ref="-1730"/>
+        <nd ref="-1732"/>
+        <nd ref="-6318"/>
+        <nd ref="-1734"/>
+        <nd ref="-6320"/>
+        <nd ref="-1736"/>
+        <nd ref="-6322"/>
+        <nd ref="-1737"/>
+        <nd ref="-1738"/>
+        <nd ref="-6324"/>
+        <nd ref="-1739"/>
+        <nd ref="-36660"/>
+        <nd ref="-1740"/>
+        <nd ref="-6326"/>
+        <nd ref="-1741"/>
+        <nd ref="-6328"/>
+        <nd ref="-1742"/>
+        <nd ref="-6330"/>
+        <nd ref="-1743"/>
+        <nd ref="-6332"/>
+        <nd ref="-1744"/>
+        <nd ref="-6334"/>
+        <nd ref="-1745"/>
+        <nd ref="-6336"/>
+        <nd ref="-1746"/>
+        <nd ref="-1747"/>
+        <nd ref="-6338"/>
+        <nd ref="-1748"/>
+        <nd ref="-6340"/>
+        <nd ref="-1749"/>
+        <nd ref="-1750"/>
+        <nd ref="-6342"/>
+        <nd ref="-1751"/>
+        <nd ref="-6344"/>
+        <nd ref="-1752"/>
+        <nd ref="-1753"/>
+        <nd ref="-1754"/>
+        <nd ref="-6346"/>
+        <nd ref="-1755"/>
+        <nd ref="-1756"/>
+        <nd ref="-6348"/>
+        <nd ref="-1757"/>
+        <nd ref="-1758"/>
+        <nd ref="-6350"/>
+        <nd ref="-1759"/>
+        <nd ref="-1760"/>
+        <nd ref="-6352"/>
+        <nd ref="-1761"/>
+        <nd ref="-6354"/>
+        <nd ref="-1762"/>
+        <nd ref="-1763"/>
+        <nd ref="-6356"/>
+        <nd ref="-1764"/>
+        <nd ref="-1765"/>
+        <nd ref="-6358"/>
+        <nd ref="-1766"/>
+        <nd ref="-6360"/>
+        <nd ref="-1767"/>
+        <nd ref="-6362"/>
+        <nd ref="-1768"/>
+        <nd ref="-6364"/>
+        <nd ref="-1769"/>
+        <nd ref="-1770"/>
+        <nd ref="-1771"/>
+        <nd ref="-6366"/>
+        <nd ref="-1772"/>
+        <nd ref="-6368"/>
+        <nd ref="-1773"/>
+        <nd ref="-6370"/>
+        <nd ref="-1774"/>
+        <nd ref="-6372"/>
+        <nd ref="-1775"/>
+        <nd ref="-1776"/>
+        <nd ref="-1777"/>
+        <nd ref="-6374"/>
+        <nd ref="-1778"/>
+        <nd ref="-6376"/>
+        <nd ref="-1779"/>
+        <nd ref="-6378"/>
+        <nd ref="-1780"/>
+        <nd ref="-1781"/>
+        <nd ref="-1782"/>
+        <nd ref="-30517"/>
+        <nd ref="-5801"/>
+        <nd ref="-1783"/>
+        <nd ref="-5802"/>
+        <nd ref="-1784"/>
+        <nd ref="-1785"/>
+        <nd ref="-5803"/>
+        <nd ref="-1786"/>
+        <nd ref="-5804"/>
+        <nd ref="-1787"/>
+        <nd ref="-1788"/>
+        <nd ref="-5805"/>
+        <nd ref="-1789"/>
         <nd ref="-31828"/>
         <nd ref="-5640"/>
         <nd ref="-1790"/>
@@ -9594,21 +9436,6 @@
         <nd ref="-37"/>
         <nd ref="-36"/>
         <nd ref="-31688"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-28996" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31687"/>
-        <nd ref="-48"/>
-        <nd ref="-31881"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-28771" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31688"/>
         <nd ref="-35"/>
         <nd ref="-34"/>
         <nd ref="-33"/>
@@ -9623,6 +9450,14 @@
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-28996" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31687"/>
+        <nd ref="-48"/>
+        <nd ref="-31881"/>
+        <tag k="name" v="CONSTITUTION AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-28769" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30937"/>
@@ -9646,6 +9481,15 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-28604" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31439"/>
+        <nd ref="-2384"/>
+        <nd ref="-5900"/>
+        <nd ref="-2385"/>
+        <nd ref="-5901"/>
+        <nd ref="-2386"/>
+        <nd ref="-5902"/>
+        <nd ref="-2387"/>
+        <nd ref="-2388"/>
         <nd ref="-31397"/>
         <nd ref="-13"/>
         <nd ref="-15"/>
@@ -9655,13 +9499,6 @@
         <nd ref="-23"/>
         <nd ref="-25"/>
         <nd ref="-31461"/>
-        <tag k="alt_name" v="C St SW"/>
-        <tag k="name" v="C ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-28603" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31461"/>
         <nd ref="-27"/>
         <nd ref="-36914"/>
         <tag k="alt_name" v="C St SW"/>
@@ -9670,6 +9507,15 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-28550" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31431"/>
+        <nd ref="-3475"/>
+        <nd ref="-3476"/>
+        <nd ref="-6794"/>
+        <nd ref="-3477"/>
+        <nd ref="-3478"/>
+        <nd ref="-6797"/>
+        <nd ref="-3479"/>
+        <nd ref="-3480"/>
         <nd ref="-31357"/>
         <nd ref="-3481"/>
         <nd ref="-3482"/>
@@ -9687,13 +9533,19 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-27697" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-27889" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-32432"/>
         <nd ref="-1702"/>
         <nd ref="-1704"/>
         <nd ref="-1706"/>
         <nd ref="-6844"/>
         <nd ref="-1708"/>
+        <nd ref="-35989"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-27697" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35989"/>
         <nd ref="-1710"/>
         <nd ref="-6846"/>
@@ -9769,11 +9621,16 @@
         <nd ref="-1419"/>
         <nd ref="-7212"/>
         <nd ref="-31828"/>
-        <tag k="name" v="E ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-27380" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-4352"/>
+        <nd ref="-1421"/>
+        <nd ref="-1422"/>
+        <nd ref="-4353"/>
+        <nd ref="-1423"/>
+        <nd ref="-4354"/>
+        <nd ref="-1425"/>
+        <nd ref="-4355"/>
+        <nd ref="-1427"/>
+        <nd ref="-1429"/>
         <nd ref="-30518"/>
         <nd ref="-5677"/>
         <nd ref="-1433"/>
@@ -9816,7 +9673,7 @@
         <nd ref="-31799"/>
         <tag k="name" v="E ST EXPY NW"/>
         <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-27379" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37021"/>
@@ -9862,6 +9719,67 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-26852" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27465"/>
+        <nd ref="-4176"/>
+        <nd ref="-6576"/>
+        <nd ref="-4177"/>
+        <nd ref="-6579"/>
+        <nd ref="-4178"/>
+        <nd ref="-29521"/>
+        <nd ref="-2933"/>
+        <nd ref="-6585"/>
+        <nd ref="-2935"/>
+        <nd ref="-2937"/>
+        <nd ref="-6587"/>
+        <nd ref="-2939"/>
+        <nd ref="-2941"/>
+        <nd ref="-2943"/>
+        <nd ref="-6589"/>
+        <nd ref="-2945"/>
+        <nd ref="-6591"/>
+        <nd ref="-2947"/>
+        <nd ref="-6593"/>
+        <nd ref="-2949"/>
+        <nd ref="-2950"/>
+        <nd ref="-6595"/>
+        <nd ref="-2951"/>
+        <nd ref="-2952"/>
+        <nd ref="-2953"/>
+        <nd ref="-29612"/>
+        <nd ref="-2954"/>
+        <nd ref="-2955"/>
+        <nd ref="-2956"/>
+        <nd ref="-6597"/>
+        <nd ref="-2957"/>
+        <nd ref="-2958"/>
+        <nd ref="-6599"/>
+        <nd ref="-2959"/>
+        <nd ref="-2960"/>
+        <nd ref="-2961"/>
+        <nd ref="-2962"/>
+        <nd ref="-6601"/>
+        <nd ref="-2963"/>
+        <nd ref="-2964"/>
+        <nd ref="-2966"/>
+        <nd ref="-2968"/>
+        <nd ref="-2970"/>
+        <nd ref="-2972"/>
+        <nd ref="-6603"/>
+        <nd ref="-2974"/>
+        <nd ref="-2976"/>
+        <nd ref="-6604"/>
+        <nd ref="-2978"/>
+        <nd ref="-2979"/>
+        <nd ref="-6605"/>
+        <nd ref="-2980"/>
+        <nd ref="-2981"/>
+        <nd ref="-6606"/>
+        <nd ref="-2982"/>
+        <nd ref="-2983"/>
+        <nd ref="-6607"/>
+        <nd ref="-2984"/>
+        <nd ref="-2985"/>
+        <nd ref="-2986"/>
         <nd ref="-29698"/>
         <nd ref="-2987"/>
         <nd ref="-6609"/>
@@ -9959,106 +9877,50 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-26851" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37291"/>
-        <nd ref="-37292"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-26774" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29612"/>
-        <nd ref="-2954"/>
-        <nd ref="-2955"/>
-        <nd ref="-2956"/>
-        <nd ref="-6597"/>
-        <nd ref="-2957"/>
-        <nd ref="-2958"/>
-        <nd ref="-6599"/>
-        <nd ref="-2959"/>
-        <nd ref="-2960"/>
-        <nd ref="-2961"/>
-        <nd ref="-2962"/>
-        <nd ref="-6601"/>
-        <nd ref="-2963"/>
-        <nd ref="-2964"/>
-        <nd ref="-2966"/>
-        <nd ref="-2968"/>
-        <nd ref="-2970"/>
-        <nd ref="-2972"/>
-        <nd ref="-6603"/>
-        <nd ref="-2974"/>
-        <nd ref="-2976"/>
-        <nd ref="-6604"/>
-        <nd ref="-2978"/>
-        <nd ref="-2979"/>
-        <nd ref="-6605"/>
-        <nd ref="-2980"/>
-        <nd ref="-2981"/>
-        <nd ref="-6606"/>
-        <nd ref="-2982"/>
-        <nd ref="-2983"/>
-        <nd ref="-6607"/>
-        <nd ref="-2984"/>
-        <nd ref="-2985"/>
-        <nd ref="-2986"/>
-        <nd ref="-29698"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-26698" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29521"/>
-        <nd ref="-2933"/>
-        <nd ref="-6585"/>
-        <nd ref="-2935"/>
-        <nd ref="-2937"/>
-        <nd ref="-6587"/>
-        <nd ref="-2939"/>
-        <nd ref="-2941"/>
-        <nd ref="-2943"/>
-        <nd ref="-6589"/>
-        <nd ref="-2945"/>
-        <nd ref="-6591"/>
-        <nd ref="-2947"/>
-        <nd ref="-6593"/>
-        <nd ref="-2949"/>
-        <nd ref="-2950"/>
-        <nd ref="-6595"/>
-        <nd ref="-2951"/>
-        <nd ref="-2952"/>
-        <nd ref="-2953"/>
-        <nd ref="-29612"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-26393" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34501"/>
-        <nd ref="-907"/>
-        <nd ref="-908"/>
-        <nd ref="-909"/>
-        <nd ref="-910"/>
-        <nd ref="-911"/>
-        <nd ref="-912"/>
-        <nd ref="-913"/>
-        <nd ref="-914"/>
-        <nd ref="-915"/>
-        <nd ref="-916"/>
-        <nd ref="-917"/>
-        <nd ref="-918"/>
-        <nd ref="-919"/>
-        <nd ref="-921"/>
-        <nd ref="-923"/>
-        <nd ref="-29235"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-26264" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37347"/>
+        <nd ref="-6199"/>
+        <nd ref="-37348"/>
+        <nd ref="-260"/>
+        <nd ref="-5188"/>
+        <nd ref="-261"/>
+        <nd ref="-262"/>
+        <nd ref="-263"/>
+        <nd ref="-5191"/>
+        <nd ref="-264"/>
+        <nd ref="-28607"/>
+        <nd ref="-266"/>
+        <nd ref="-267"/>
+        <nd ref="-268"/>
+        <nd ref="-5197"/>
+        <nd ref="-269"/>
+        <nd ref="-5200"/>
+        <nd ref="-270"/>
+        <nd ref="-5203"/>
+        <nd ref="-271"/>
+        <nd ref="-272"/>
+        <nd ref="-5206"/>
+        <nd ref="-273"/>
+        <nd ref="-274"/>
+        <nd ref="-28789"/>
+        <nd ref="-3917"/>
+        <nd ref="-5212"/>
+        <nd ref="-3919"/>
+        <nd ref="-3921"/>
+        <nd ref="-5214"/>
+        <nd ref="-3923"/>
+        <nd ref="-3925"/>
+        <nd ref="-5216"/>
+        <nd ref="-3927"/>
+        <nd ref="-5218"/>
+        <nd ref="-3929"/>
+        <nd ref="-28868"/>
+        <nd ref="-5222"/>
+        <nd ref="-3933"/>
+        <nd ref="-35901"/>
+        <nd ref="-3937"/>
+        <nd ref="-5226"/>
+        <nd ref="-3939"/>
         <nd ref="-29235"/>
         <nd ref="-275"/>
         <nd ref="-276"/>
@@ -10145,24 +10007,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-25860" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28676"/>
-        <nd ref="-2681"/>
-        <nd ref="-6849"/>
-        <nd ref="-2682"/>
-        <nd ref="-6850"/>
-        <nd ref="-2683"/>
-        <nd ref="-6851"/>
-        <nd ref="-2684"/>
-        <nd ref="-6852"/>
-        <nd ref="-6853"/>
-        <nd ref="-2685"/>
-        <nd ref="-28677"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-25858" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-23852"/>
         <nd ref="-28676"/>
@@ -10171,6 +10015,13 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-25684" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31694"/>
+        <nd ref="-3237"/>
+        <nd ref="-7066"/>
+        <nd ref="-3238"/>
+        <nd ref="-7067"/>
+        <nd ref="-3239"/>
+        <nd ref="-3240"/>
         <nd ref="-28586"/>
         <nd ref="-7068"/>
         <nd ref="-3242"/>
@@ -10199,7 +10050,7 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-25145" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-25144" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-28043"/>
         <nd ref="-2776"/>
         <nd ref="-2777"/>
@@ -10240,13 +10091,6 @@
         <nd ref="-4979"/>
         <nd ref="-2832"/>
         <nd ref="-2835"/>
-        <nd ref="-28148"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-25144" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-28148"/>
         <nd ref="-2838"/>
         <nd ref="-4980"/>
@@ -10308,17 +10152,9 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-24721" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36989"/>
-        <nd ref="-6460"/>
         <nd ref="-22590"/>
         <nd ref="-6466"/>
         <nd ref="-6469"/>
-        <nd ref="-27618"/>
-        <tag k="name" v="Independence Ave SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-24720" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27618"/>
         <nd ref="-4128"/>
         <nd ref="-4129"/>
@@ -10390,10 +10226,10 @@
         <nd ref="-6558"/>
         <nd ref="-4169"/>
         <nd ref="-30951"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
+        <tag k="name" v="Independence Ave SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-24718" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36988"/>
@@ -10402,7 +10238,8 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-24564" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-24562" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30951"/>
         <nd ref="-27545"/>
         <nd ref="-4171"/>
         <nd ref="-6567"/>
@@ -10417,41 +10254,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-24562" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-30951"/>
-        <nd ref="-27545"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-24446" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27465"/>
-        <nd ref="-4176"/>
-        <nd ref="-6576"/>
-        <nd ref="-4177"/>
-        <nd ref="-6579"/>
-        <nd ref="-4178"/>
-        <nd ref="-29521"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-24090" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27002"/>
-        <nd ref="-1047"/>
-        <nd ref="-1048"/>
-        <nd ref="-6872"/>
-        <nd ref="-6873"/>
-        <nd ref="-1049"/>
-        <nd ref="-1050"/>
-        <nd ref="-27003"/>
-        <tag k="alt_name" v="15th St NW;Raoul Wallenberg Pl SW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-24088" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25763"/>
         <nd ref="-1043"/>
@@ -10463,21 +10265,20 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-23997" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36955"/>
-        <nd ref="-3192"/>
-        <nd ref="-6087"/>
-        <nd ref="-3194"/>
-        <nd ref="-3196"/>
-        <nd ref="-3197"/>
-        <nd ref="-3199"/>
-        <nd ref="-26915"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-23925" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27725"/>
+        <nd ref="-961"/>
+        <nd ref="-4383"/>
+        <nd ref="-962"/>
+        <nd ref="-4384"/>
+        <nd ref="-963"/>
+        <nd ref="-4385"/>
+        <nd ref="-964"/>
+        <nd ref="-965"/>
+        <nd ref="-4386"/>
+        <nd ref="-966"/>
+        <nd ref="-967"/>
+        <nd ref="-4387"/>
         <nd ref="-26842"/>
         <nd ref="-4388"/>
         <nd ref="-1834"/>
@@ -10500,34 +10301,63 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-23891" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26806"/>
-        <nd ref="-877"/>
-        <nd ref="-6772"/>
-        <nd ref="-878"/>
-        <nd ref="-879"/>
-        <nd ref="-6774"/>
-        <nd ref="-880"/>
-        <nd ref="-6776"/>
-        <nd ref="-881"/>
-        <nd ref="-882"/>
-        <nd ref="-26807"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-23838" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37339"/>
         <nd ref="-886"/>
         <nd ref="-887"/>
         <nd ref="-26769"/>
+        <nd ref="-3079"/>
+        <nd ref="-6786"/>
+        <nd ref="-3080"/>
+        <nd ref="-3081"/>
+        <nd ref="-6788"/>
+        <nd ref="-3082"/>
+        <nd ref="-6790"/>
+        <nd ref="-3083"/>
+        <nd ref="-3084"/>
+        <nd ref="-6792"/>
+        <nd ref="-3085"/>
+        <nd ref="-6795"/>
+        <nd ref="-3086"/>
+        <nd ref="-3087"/>
+        <nd ref="-23349"/>
+        <nd ref="-6798"/>
+        <nd ref="-3088"/>
+        <nd ref="-6801"/>
+        <nd ref="-3089"/>
+        <nd ref="-3090"/>
+        <nd ref="-3091"/>
+        <nd ref="-6804"/>
+        <nd ref="-3092"/>
+        <nd ref="-6807"/>
+        <nd ref="-3093"/>
+        <nd ref="-3094"/>
+        <nd ref="-6809"/>
+        <nd ref="-23467"/>
+        <nd ref="-3095"/>
+        <nd ref="-6813"/>
+        <nd ref="-3096"/>
+        <nd ref="-3097"/>
+        <nd ref="-6815"/>
+        <nd ref="-3098"/>
+        <nd ref="-6817"/>
+        <nd ref="-31568"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-23686" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17025"/>
+        <nd ref="-1076"/>
+        <nd ref="-1078"/>
+        <nd ref="-1079"/>
+        <nd ref="-6907"/>
+        <nd ref="-1080"/>
+        <nd ref="-6909"/>
+        <nd ref="-1081"/>
+        <nd ref="-6911"/>
+        <nd ref="-1082"/>
         <nd ref="-26621"/>
         <nd ref="-2262"/>
         <nd ref="-2263"/>
@@ -10614,7 +10444,7 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-23553" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-23379" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26573"/>
         <nd ref="-592"/>
         <nd ref="-6044"/>
@@ -10646,41 +10476,6 @@
         <nd ref="-6068"/>
         <nd ref="-6070"/>
         <nd ref="-607"/>
-        <nd ref="-26523"/>
-        <tag k="alt_name" v="Ellipse Rd NW"/>
-        <tag k="name" v="ELLIPSE RD NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23381" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26435"/>
-        <nd ref="-7282"/>
-        <nd ref="-4239"/>
-        <nd ref="-4240"/>
-        <nd ref="-7283"/>
-        <nd ref="-4241"/>
-        <nd ref="-7284"/>
-        <nd ref="-4242"/>
-        <nd ref="-7285"/>
-        <nd ref="-4243"/>
-        <nd ref="-7286"/>
-        <nd ref="-4244"/>
-        <nd ref="-7287"/>
-        <nd ref="-4245"/>
-        <nd ref="-7288"/>
-        <nd ref="-4246"/>
-        <nd ref="-7289"/>
-        <nd ref="-4247"/>
-        <nd ref="-7290"/>
-        <nd ref="-4248"/>
-        <nd ref="-4249"/>
-        <nd ref="-26382"/>
-        <tag k="alt_name" v="Ellipse Rd NW"/>
-        <tag k="name" v="ELLIPSE RD NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23379" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26523"/>
         <nd ref="-6074"/>
         <nd ref="-4207"/>
@@ -10719,6 +10514,27 @@
         <nd ref="-4237"/>
         <nd ref="-4238"/>
         <nd ref="-26435"/>
+        <nd ref="-7282"/>
+        <nd ref="-4239"/>
+        <nd ref="-4240"/>
+        <nd ref="-7283"/>
+        <nd ref="-4241"/>
+        <nd ref="-7284"/>
+        <nd ref="-4242"/>
+        <nd ref="-7285"/>
+        <nd ref="-4243"/>
+        <nd ref="-7286"/>
+        <nd ref="-4244"/>
+        <nd ref="-7287"/>
+        <nd ref="-4245"/>
+        <nd ref="-7288"/>
+        <nd ref="-4246"/>
+        <nd ref="-7289"/>
+        <nd ref="-4247"/>
+        <nd ref="-7290"/>
+        <nd ref="-4248"/>
+        <nd ref="-4249"/>
+        <nd ref="-26382"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="highway" v="road"/>
@@ -10753,18 +10569,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-23292" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26300"/>
-        <nd ref="-3177"/>
-        <nd ref="-3179"/>
-        <nd ref="-6430"/>
-        <nd ref="-3181"/>
-        <nd ref="-26301"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-23291" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26301"/>
         <nd ref="-3183"/>
@@ -10773,31 +10577,9 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-23260" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26279"/>
-        <nd ref="-6442"/>
-        <nd ref="-3185"/>
-        <nd ref="-3187"/>
-        <nd ref="-6445"/>
-        <nd ref="-3189"/>
-        <nd ref="-3191"/>
-        <nd ref="-3193"/>
-        <nd ref="-3195"/>
-        <nd ref="-26280"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23087" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-23086" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26088"/>
         <nd ref="-2421"/>
-        <nd ref="-26190"/>
-        <tag k="name" v="17TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23086" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26190"/>
         <nd ref="-29521"/>
         <tag k="name" v="17TH ST SW"/>
@@ -10829,6 +10611,18 @@
         <nd ref="-2551"/>
         <nd ref="-2552"/>
         <nd ref="-25955"/>
+        <nd ref="-6003"/>
+        <nd ref="-2554"/>
+        <nd ref="-2555"/>
+        <nd ref="-6006"/>
+        <nd ref="-2556"/>
+        <nd ref="-2557"/>
+        <nd ref="-23985"/>
+        <nd ref="-2144"/>
+        <nd ref="-2145"/>
+        <nd ref="-2146"/>
+        <nd ref="-2147"/>
+        <nd ref="-23986"/>
         <tag k="alt_name" v="14th St NW"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -10843,6 +10637,49 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-22927" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26621"/>
+        <nd ref="-2626"/>
+        <nd ref="-2628"/>
+        <nd ref="-6345"/>
+        <nd ref="-2630"/>
+        <nd ref="-2632"/>
+        <nd ref="-18244"/>
+        <nd ref="-3446"/>
+        <nd ref="-3447"/>
+        <nd ref="-6349"/>
+        <nd ref="-3448"/>
+        <nd ref="-6351"/>
+        <nd ref="-3449"/>
+        <nd ref="-3450"/>
+        <nd ref="-3451"/>
+        <nd ref="-18245"/>
+        <nd ref="-2636"/>
+        <nd ref="-2638"/>
+        <nd ref="-2640"/>
+        <nd ref="-2642"/>
+        <nd ref="-18242"/>
+        <nd ref="-6357"/>
+        <nd ref="-2646"/>
+        <nd ref="-2648"/>
+        <nd ref="-6359"/>
+        <nd ref="-2650"/>
+        <nd ref="-2652"/>
+        <nd ref="-17861"/>
+        <nd ref="-3705"/>
+        <nd ref="-6363"/>
+        <nd ref="-3707"/>
+        <nd ref="-3709"/>
+        <nd ref="-6365"/>
+        <nd ref="-3711"/>
+        <nd ref="-6367"/>
+        <nd ref="-3713"/>
+        <nd ref="-6369"/>
+        <nd ref="-3715"/>
+        <nd ref="-3717"/>
+        <nd ref="-6371"/>
+        <nd ref="-3719"/>
+        <nd ref="-3721"/>
+        <nd ref="-6373"/>
         <nd ref="-25938"/>
         <nd ref="-3452"/>
         <nd ref="-6375"/>
@@ -10861,7 +10698,63 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-22782" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-22781" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25380"/>
+        <nd ref="-2914"/>
+        <nd ref="-2915"/>
+        <nd ref="-6103"/>
+        <nd ref="-2916"/>
+        <nd ref="-6104"/>
+        <nd ref="-2917"/>
+        <nd ref="-6105"/>
+        <nd ref="-2918"/>
+        <nd ref="-6106"/>
+        <nd ref="-2919"/>
+        <nd ref="-6107"/>
+        <nd ref="-2920"/>
+        <nd ref="-6108"/>
+        <nd ref="-2921"/>
+        <nd ref="-6109"/>
+        <nd ref="-2922"/>
+        <nd ref="-2923"/>
+        <nd ref="-6110"/>
+        <nd ref="-6111"/>
+        <nd ref="-2924"/>
+        <nd ref="-6112"/>
+        <nd ref="-2925"/>
+        <nd ref="-2926"/>
+        <nd ref="-25330"/>
+        <nd ref="-1010"/>
+        <nd ref="-1011"/>
+        <nd ref="-6114"/>
+        <nd ref="-1012"/>
+        <nd ref="-1013"/>
+        <nd ref="-6115"/>
+        <nd ref="-1014"/>
+        <nd ref="-1015"/>
+        <nd ref="-6116"/>
+        <nd ref="-1016"/>
+        <nd ref="-6117"/>
+        <nd ref="-1017"/>
+        <nd ref="-6118"/>
+        <nd ref="-1018"/>
+        <nd ref="-6121"/>
+        <nd ref="-1019"/>
+        <nd ref="-6124"/>
+        <nd ref="-1020"/>
+        <nd ref="-6127"/>
+        <nd ref="-1021"/>
+        <nd ref="-6130"/>
+        <nd ref="-1022"/>
+        <nd ref="-6133"/>
+        <nd ref="-1023"/>
+        <nd ref="-1024"/>
+        <nd ref="-6136"/>
+        <nd ref="-1025"/>
+        <nd ref="-6139"/>
+        <nd ref="-1026"/>
+        <nd ref="-6142"/>
+        <nd ref="-1027"/>
         <nd ref="-25814"/>
         <nd ref="-6148"/>
         <nd ref="-2929"/>
@@ -10871,13 +10764,6 @@
         <nd ref="-2931"/>
         <nd ref="-2932"/>
         <nd ref="-2934"/>
-        <nd ref="-25881"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-22781" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25881"/>
         <nd ref="-6156"/>
         <nd ref="-2936"/>
@@ -10891,6 +10777,21 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-22752" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17717"/>
+        <nd ref="-2866"/>
+        <nd ref="-4447"/>
+        <nd ref="-2870"/>
+        <nd ref="-2874"/>
+        <nd ref="-4448"/>
+        <nd ref="-4449"/>
+        <nd ref="-2878"/>
+        <nd ref="-2882"/>
+        <nd ref="-25773"/>
+        <nd ref="-4450"/>
+        <nd ref="-2886"/>
+        <nd ref="-2890"/>
+        <nd ref="-4451"/>
+        <nd ref="-2894"/>
         <nd ref="-35332"/>
         <nd ref="-4452"/>
         <nd ref="-3676"/>
@@ -10929,6 +10830,45 @@
         <nd ref="-5923"/>
         <nd ref="-246"/>
         <nd ref="-25523"/>
+        <nd ref="-2148"/>
+        <nd ref="-2149"/>
+        <nd ref="-2150"/>
+        <nd ref="-5925"/>
+        <nd ref="-2151"/>
+        <nd ref="-2152"/>
+        <nd ref="-5926"/>
+        <nd ref="-2153"/>
+        <nd ref="-2154"/>
+        <nd ref="-5927"/>
+        <nd ref="-2155"/>
+        <nd ref="-5928"/>
+        <nd ref="-2156"/>
+        <nd ref="-2157"/>
+        <nd ref="-5929"/>
+        <nd ref="-2158"/>
+        <nd ref="-5930"/>
+        <nd ref="-2159"/>
+        <nd ref="-5931"/>
+        <nd ref="-5932"/>
+        <nd ref="-2160"/>
+        <nd ref="-2161"/>
+        <nd ref="-5933"/>
+        <nd ref="-2162"/>
+        <nd ref="-5934"/>
+        <nd ref="-2163"/>
+        <nd ref="-2164"/>
+        <nd ref="-2165"/>
+        <nd ref="-5935"/>
+        <nd ref="-2166"/>
+        <nd ref="-5936"/>
+        <nd ref="-5937"/>
+        <nd ref="-2167"/>
+        <nd ref="-2168"/>
+        <nd ref="-2169"/>
+        <nd ref="-5938"/>
+        <nd ref="-2170"/>
+        <nd ref="-2171"/>
+        <nd ref="-21477"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
@@ -10968,6 +10908,8 @@
         <nd ref="-5953"/>
         <nd ref="-2190"/>
         <nd ref="-24736"/>
+        <nd ref="-5954"/>
+        <nd ref="-5955"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
@@ -10991,6 +10933,23 @@
         <nd ref="-876"/>
         <nd ref="-6745"/>
         <nd ref="-24649"/>
+        <nd ref="-3064"/>
+        <nd ref="-6751"/>
+        <nd ref="-3065"/>
+        <nd ref="-6754"/>
+        <nd ref="-3066"/>
+        <nd ref="-3067"/>
+        <nd ref="-6757"/>
+        <nd ref="-3068"/>
+        <nd ref="-3069"/>
+        <nd ref="-6760"/>
+        <nd ref="-3070"/>
+        <nd ref="-3071"/>
+        <nd ref="-6762"/>
+        <nd ref="-3072"/>
+        <nd ref="-3073"/>
+        <nd ref="-3074"/>
+        <nd ref="-26315"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
@@ -11003,21 +10962,6 @@
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-21321" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24433"/>
-        <nd ref="-2763"/>
-        <nd ref="-5755"/>
-        <nd ref="-2764"/>
-        <nd ref="-2765"/>
-        <nd ref="-5756"/>
-        <nd ref="-2766"/>
-        <nd ref="-2767"/>
-        <nd ref="-35620"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-21045" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25933"/>
@@ -11039,20 +10983,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-21009" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35331"/>
-        <nd ref="-6400"/>
-        <nd ref="-2658"/>
-        <nd ref="-2660"/>
-        <nd ref="-2662"/>
-        <nd ref="-2664"/>
-        <nd ref="-2666"/>
-        <nd ref="-24165"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-21007" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35331"/>
         <nd ref="-2656"/>
@@ -11064,6 +10994,17 @@
     <way visible="true" id="-20961" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15845"/>
         <nd ref="-24133"/>
+        <nd ref="-5980"/>
+        <nd ref="-2063"/>
+        <nd ref="-5982"/>
+        <nd ref="-2064"/>
+        <nd ref="-2065"/>
+        <nd ref="-24134"/>
+        <nd ref="-2533"/>
+        <nd ref="-2534"/>
+        <nd ref="-2535"/>
+        <nd ref="-35221"/>
+        <tag k="alt_name" v="14TH ST NW"/>
         <tag k="name" v="14th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -11076,6 +11017,21 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-18880" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25763"/>
+        <nd ref="-4991"/>
+        <nd ref="-3822"/>
+        <nd ref="-4993"/>
+        <nd ref="-3823"/>
+        <nd ref="-4995"/>
+        <nd ref="-3824"/>
+        <nd ref="-4997"/>
+        <nd ref="-3825"/>
+        <nd ref="-3826"/>
+        <nd ref="-4999"/>
+        <nd ref="-3827"/>
+        <nd ref="-3828"/>
+        <nd ref="-3829"/>
+        <nd ref="-5001"/>
         <nd ref="-25764"/>
         <nd ref="-2390"/>
         <nd ref="-2391"/>
@@ -11136,22 +11092,6 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-1121" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36692"/>
-        <nd ref="-982"/>
-        <nd ref="-981"/>
-        <nd ref="-7358"/>
-        <nd ref="-980"/>
-        <nd ref="-7360"/>
-        <nd ref="-979"/>
-        <nd ref="-7362"/>
-        <nd ref="-36979"/>
-        <nd ref="-37308"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-1112" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37256"/>
         <nd ref="-5094"/>
@@ -11165,96 +11105,24 @@
     <way visible="true" id="-1111" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37256"/>
         <nd ref="-37166"/>
+        <nd ref="-1849"/>
+        <nd ref="-1850"/>
+        <nd ref="-1851"/>
+        <nd ref="-1852"/>
+        <nd ref="-37167"/>
+        <tag k="alt_name" v="WASHINGTON CIR NW"/>
         <tag k="name" v="Pennsylvania Ave NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-1054" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36742"/>
-        <nd ref="-537"/>
-        <nd ref="-535"/>
-        <nd ref="-4507"/>
-        <nd ref="-533"/>
-        <nd ref="-531"/>
-        <nd ref="-4508"/>
-        <nd ref="-529"/>
-        <nd ref="-4509"/>
-        <nd ref="-527"/>
-        <nd ref="-4510"/>
-        <nd ref="-525"/>
-        <nd ref="-4511"/>
-        <nd ref="-523"/>
-        <nd ref="-521"/>
-        <nd ref="-4512"/>
-        <nd ref="-519"/>
-        <nd ref="-517"/>
-        <nd ref="-4513"/>
-        <nd ref="-515"/>
-        <nd ref="-4514"/>
-        <nd ref="-513"/>
-        <nd ref="-4515"/>
-        <nd ref="-511"/>
-        <nd ref="-509"/>
-        <nd ref="-4516"/>
-        <nd ref="-4517"/>
-        <nd ref="-4518"/>
-        <nd ref="-507"/>
-        <nd ref="-4519"/>
-        <nd ref="-36750"/>
-        <nd ref="-505"/>
-        <nd ref="-4520"/>
-        <nd ref="-37024"/>
-        <nd ref="-4522"/>
-        <nd ref="-37186"/>
-        <nd ref="-503"/>
-        <nd ref="-4523"/>
-        <nd ref="-501"/>
-        <nd ref="-37232"/>
-        <nd ref="-499"/>
-        <nd ref="-4525"/>
-        <nd ref="-4526"/>
-        <nd ref="-497"/>
-        <nd ref="-4527"/>
-        <nd ref="-495"/>
-        <nd ref="-4528"/>
-        <nd ref="-493"/>
-        <nd ref="-491"/>
-        <nd ref="-4529"/>
-        <nd ref="-489"/>
-        <nd ref="-4530"/>
-        <nd ref="-487"/>
-        <nd ref="-485"/>
-        <nd ref="-484"/>
-        <nd ref="-4532"/>
-        <nd ref="-4534"/>
-        <nd ref="-483"/>
-        <nd ref="-482"/>
-        <nd ref="-481"/>
-        <nd ref="-480"/>
-        <nd ref="-479"/>
-        <nd ref="-4536"/>
-        <nd ref="-478"/>
-        <nd ref="-477"/>
-        <nd ref="-37233"/>
-        <nd ref="-476"/>
-        <nd ref="-475"/>
-        <nd ref="-474"/>
-        <nd ref="-473"/>
-        <nd ref="-472"/>
-        <nd ref="-471"/>
-        <nd ref="-470"/>
-        <nd ref="-469"/>
-        <nd ref="-468"/>
-        <nd ref="-467"/>
-        <nd ref="-4538"/>
-        <nd ref="-466"/>
-        <nd ref="-465"/>
-        <nd ref="-4539"/>
-        <nd ref="-37223"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
+    <way visible="true" id="-1102" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36801"/>
+        <nd ref="-34148"/>
+        <nd ref="-5080"/>
+        <tag k="alt_name" v="K St NW"/>
+        <tag k="name" v="US Hwy 29"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-1030" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35336"/>
@@ -11327,6 +11195,74 @@
         <nd ref="-2042"/>
         <nd ref="-4875"/>
         <nd ref="-33250"/>
+        <nd ref="-2040"/>
+        <nd ref="-4877"/>
+        <nd ref="-2038"/>
+        <nd ref="-2036"/>
+        <nd ref="-4879"/>
+        <nd ref="-2034"/>
+        <nd ref="-4881"/>
+        <nd ref="-2032"/>
+        <nd ref="-4883"/>
+        <nd ref="-2030"/>
+        <nd ref="-4886"/>
+        <nd ref="-2028"/>
+        <nd ref="-2026"/>
+        <nd ref="-4889"/>
+        <nd ref="-4892"/>
+        <nd ref="-2024"/>
+        <nd ref="-2022"/>
+        <nd ref="-4895"/>
+        <nd ref="-2020"/>
+        <nd ref="-4898"/>
+        <nd ref="-2018"/>
+        <nd ref="-4901"/>
+        <nd ref="-4904"/>
+        <nd ref="-2016"/>
+        <nd ref="-2014"/>
+        <nd ref="-2012"/>
+        <nd ref="-4908"/>
+        <nd ref="-2010"/>
+        <nd ref="-4911"/>
+        <nd ref="-2008"/>
+        <nd ref="-2006"/>
+        <nd ref="-4914"/>
+        <nd ref="-2004"/>
+        <nd ref="-2002"/>
+        <nd ref="-4917"/>
+        <nd ref="-2000"/>
+        <nd ref="-4920"/>
+        <nd ref="-1998"/>
+        <nd ref="-1996"/>
+        <nd ref="-1994"/>
+        <nd ref="-4922"/>
+        <nd ref="-1992"/>
+        <nd ref="-4924"/>
+        <nd ref="-1990"/>
+        <nd ref="-1988"/>
+        <nd ref="-4926"/>
+        <nd ref="-1986"/>
+        <nd ref="-1984"/>
+        <nd ref="-4928"/>
+        <nd ref="-1982"/>
+        <nd ref="-1980"/>
+        <nd ref="-4930"/>
+        <nd ref="-1978"/>
+        <nd ref="-4932"/>
+        <nd ref="-1976"/>
+        <nd ref="-1974"/>
+        <nd ref="-4934"/>
+        <nd ref="-1972"/>
+        <nd ref="-1970"/>
+        <nd ref="-4936"/>
+        <nd ref="-1969"/>
+        <nd ref="-1968"/>
+        <nd ref="-4938"/>
+        <nd ref="-1967"/>
+        <nd ref="-4940"/>
+        <nd ref="-1966"/>
+        <nd ref="-1965"/>
+        <nd ref="-37142"/>
         <tag k="alt_name" v="Maine Ave SW"/>
         <tag k="name" v="MAINE AVE SW"/>
         <tag k="highway" v="road"/>
@@ -11336,9 +11272,6 @@
         <nd ref="-34914"/>
         <nd ref="-6662"/>
         <nd ref="-37362"/>
-        <nd ref="-6666"/>
-        <nd ref="-6668"/>
-        <nd ref="-37268"/>
         <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -11348,77 +11281,76 @@
         <nd ref="-4731"/>
         <nd ref="-5080"/>
         <nd ref="-35681"/>
+        <nd ref="-4733"/>
+        <nd ref="-4735"/>
+        <nd ref="-1041"/>
+        <nd ref="-35682"/>
+        <tag k="alt_name" v="26TH ST NW"/>
         <tag k="name" v="26th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-951" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24736"/>
-        <nd ref="-5954"/>
-        <nd ref="-5955"/>
-        <tag k="name" v="I St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-946" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36361"/>
-        <nd ref="-75"/>
-        <nd ref="-4810"/>
-        <nd ref="-77"/>
-        <nd ref="-4812"/>
-        <nd ref="-78"/>
-        <nd ref="-4813"/>
-        <nd ref="-79"/>
-        <nd ref="-80"/>
-        <nd ref="-4814"/>
-        <nd ref="-82"/>
-        <nd ref="-84"/>
-        <nd ref="-4815"/>
-        <nd ref="-86"/>
-        <nd ref="-88"/>
-        <nd ref="-4816"/>
-        <nd ref="-89"/>
-        <nd ref="-90"/>
-        <nd ref="-4817"/>
-        <nd ref="-91"/>
-        <nd ref="-4818"/>
-        <nd ref="-92"/>
-        <nd ref="-93"/>
-        <nd ref="-4819"/>
-        <nd ref="-94"/>
-        <nd ref="-4820"/>
-        <nd ref="-95"/>
-        <nd ref="-4821"/>
-        <nd ref="-96"/>
-        <nd ref="-97"/>
-        <nd ref="-4822"/>
         <nd ref="-35593"/>
         <nd ref="-6224"/>
-        <tag k="alt_name" v="US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-934" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-30517"/>
-        <nd ref="-5801"/>
-        <nd ref="-1783"/>
-        <nd ref="-5802"/>
-        <nd ref="-1784"/>
-        <nd ref="-1785"/>
-        <nd ref="-5803"/>
-        <nd ref="-1786"/>
-        <nd ref="-5804"/>
-        <nd ref="-1787"/>
-        <nd ref="-1788"/>
-        <nd ref="-5805"/>
-        <nd ref="-1789"/>
-        <nd ref="-31828"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-933" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28868"/>
+        <nd ref="-1518"/>
+        <nd ref="-1519"/>
+        <nd ref="-1520"/>
+        <nd ref="-34426"/>
+        <nd ref="-1521"/>
+        <nd ref="-1522"/>
+        <nd ref="-4734"/>
+        <nd ref="-1523"/>
+        <nd ref="-4736"/>
+        <nd ref="-1524"/>
+        <nd ref="-4737"/>
+        <nd ref="-1525"/>
+        <nd ref="-4738"/>
+        <nd ref="-1526"/>
+        <nd ref="-1527"/>
+        <nd ref="-4739"/>
+        <nd ref="-1528"/>
+        <nd ref="-4740"/>
+        <nd ref="-1530"/>
+        <nd ref="-4741"/>
+        <nd ref="-1532"/>
+        <nd ref="-4742"/>
+        <nd ref="-1534"/>
+        <nd ref="-4743"/>
+        <nd ref="-1536"/>
+        <nd ref="-4744"/>
+        <nd ref="-1538"/>
+        <nd ref="-4745"/>
+        <nd ref="-1540"/>
+        <nd ref="-4746"/>
+        <nd ref="-1542"/>
+        <nd ref="-4747"/>
+        <nd ref="-1544"/>
+        <nd ref="-4748"/>
+        <nd ref="-1546"/>
+        <nd ref="-4749"/>
+        <nd ref="-1548"/>
+        <nd ref="-4750"/>
+        <nd ref="-1550"/>
+        <nd ref="-4751"/>
+        <nd ref="-1552"/>
+        <nd ref="-1554"/>
+        <nd ref="-4752"/>
+        <nd ref="-1556"/>
+        <nd ref="-4753"/>
+        <nd ref="-1558"/>
+        <nd ref="-4755"/>
+        <nd ref="-1560"/>
+        <nd ref="-4757"/>
+        <nd ref="-1562"/>
+        <nd ref="-36893"/>
+        <nd ref="-1564"/>
+        <nd ref="-1566"/>
         <nd ref="-30517"/>
         <nd ref="-5505"/>
         <nd ref="-1570"/>
@@ -11427,15 +11359,6 @@
         <tag k="name" v="E ST EXPY NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-921" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24075"/>
-        <nd ref="-6168"/>
-        <nd ref="-6169"/>
-        <nd ref="-35221"/>
-        <tag k="name" v="Pennsylvania Ave NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-920" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24075"/>
@@ -11450,6 +11373,97 @@
         <nd ref="-4595"/>
         <nd ref="-7028"/>
         <tag k="name" v="Virginia Avenue North W"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
+    </way>
+    <way visible="true" id="-901" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37362"/>
+        <nd ref="-6666"/>
+        <nd ref="-6668"/>
+        <nd ref="-37268"/>
+        <nd ref="-3642"/>
+        <nd ref="-6672"/>
+        <nd ref="-3639"/>
+        <nd ref="-6674"/>
+        <nd ref="-3636"/>
+        <nd ref="-3633"/>
+        <nd ref="-3630"/>
+        <nd ref="-3627"/>
+        <nd ref="-6676"/>
+        <nd ref="-3624"/>
+        <nd ref="-3621"/>
+        <nd ref="-3618"/>
+        <nd ref="-3615"/>
+        <nd ref="-3612"/>
+        <nd ref="-3609"/>
+        <nd ref="-3606"/>
+        <nd ref="-3604"/>
+        <nd ref="-3602"/>
+        <nd ref="-3600"/>
+        <nd ref="-3598"/>
+        <nd ref="-3596"/>
+        <nd ref="-3594"/>
+        <nd ref="-6678"/>
+        <nd ref="-3592"/>
+        <nd ref="-35108"/>
+        <nd ref="-3590"/>
+        <nd ref="-3588"/>
+        <nd ref="-3586"/>
+        <nd ref="-3584"/>
+        <nd ref="-3582"/>
+        <nd ref="-3580"/>
+        <nd ref="-6680"/>
+        <nd ref="-3578"/>
+        <nd ref="-3576"/>
+        <nd ref="-3574"/>
+        <nd ref="-3572"/>
+        <nd ref="-6682"/>
+        <nd ref="-3570"/>
+        <nd ref="-3568"/>
+        <nd ref="-3566"/>
+        <nd ref="-3564"/>
+        <nd ref="-3562"/>
+        <nd ref="-3560"/>
+        <nd ref="-3558"/>
+        <nd ref="-3557"/>
+        <nd ref="-3556"/>
+        <nd ref="-3555"/>
+        <nd ref="-3554"/>
+        <nd ref="-3553"/>
+        <nd ref="-6684"/>
+        <nd ref="-3552"/>
+        <nd ref="-3551"/>
+        <nd ref="-6686"/>
+        <nd ref="-3550"/>
+        <nd ref="-3549"/>
+        <nd ref="-3548"/>
+        <nd ref="-6687"/>
+        <nd ref="-3547"/>
+        <nd ref="-3546"/>
+        <nd ref="-6688"/>
+        <nd ref="-3545"/>
+        <nd ref="-6689"/>
+        <nd ref="-3544"/>
+        <nd ref="-6690"/>
+        <nd ref="-3543"/>
+        <nd ref="-3542"/>
+        <nd ref="-3541"/>
+        <nd ref="-6691"/>
+        <nd ref="-3540"/>
+        <nd ref="-6692"/>
+        <nd ref="-3539"/>
+        <nd ref="-6693"/>
+        <nd ref="-3538"/>
+        <nd ref="-3537"/>
+        <nd ref="-3536"/>
+        <nd ref="-3535"/>
+        <nd ref="-3534"/>
+        <nd ref="-6694"/>
+        <nd ref="-3533"/>
+        <nd ref="-3532"/>
+        <nd ref="-35063"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
+        <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -11486,152 +11500,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-863" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31828"/>
-        <nd ref="-4352"/>
-        <nd ref="-1421"/>
-        <nd ref="-1422"/>
-        <nd ref="-4353"/>
-        <nd ref="-1423"/>
-        <nd ref="-4354"/>
-        <nd ref="-1425"/>
-        <nd ref="-4355"/>
-        <nd ref="-1427"/>
-        <nd ref="-1429"/>
-        <nd ref="-30518"/>
-        <tag k="name" v="E ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-853" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37042"/>
-        <nd ref="-1718"/>
-        <nd ref="-6312"/>
-        <nd ref="-1720"/>
-        <nd ref="-1722"/>
-        <nd ref="-1724"/>
-        <nd ref="-6314"/>
-        <nd ref="-1726"/>
-        <nd ref="-1728"/>
-        <nd ref="-6316"/>
-        <nd ref="-1730"/>
-        <nd ref="-1732"/>
-        <nd ref="-6318"/>
-        <nd ref="-1734"/>
-        <nd ref="-6320"/>
-        <nd ref="-1736"/>
-        <nd ref="-6322"/>
-        <nd ref="-1737"/>
-        <nd ref="-1738"/>
-        <nd ref="-6324"/>
-        <nd ref="-1739"/>
-        <nd ref="-36660"/>
-        <nd ref="-1740"/>
-        <nd ref="-6326"/>
-        <nd ref="-1741"/>
-        <nd ref="-6328"/>
-        <nd ref="-1742"/>
-        <nd ref="-6330"/>
-        <nd ref="-1743"/>
-        <nd ref="-6332"/>
-        <nd ref="-1744"/>
-        <nd ref="-6334"/>
-        <nd ref="-1745"/>
-        <nd ref="-6336"/>
-        <nd ref="-1746"/>
-        <nd ref="-1747"/>
-        <nd ref="-6338"/>
-        <nd ref="-1748"/>
-        <nd ref="-6340"/>
-        <nd ref="-1749"/>
-        <nd ref="-1750"/>
-        <nd ref="-6342"/>
-        <nd ref="-1751"/>
-        <nd ref="-6344"/>
-        <nd ref="-1752"/>
-        <nd ref="-1753"/>
-        <nd ref="-1754"/>
-        <nd ref="-6346"/>
-        <nd ref="-1755"/>
-        <nd ref="-1756"/>
-        <nd ref="-6348"/>
-        <nd ref="-1757"/>
-        <nd ref="-1758"/>
-        <nd ref="-6350"/>
-        <nd ref="-1759"/>
-        <nd ref="-1760"/>
-        <nd ref="-6352"/>
-        <nd ref="-1761"/>
-        <nd ref="-6354"/>
-        <nd ref="-1762"/>
-        <nd ref="-1763"/>
-        <nd ref="-6356"/>
-        <nd ref="-1764"/>
-        <nd ref="-1765"/>
-        <nd ref="-6358"/>
-        <nd ref="-1766"/>
-        <nd ref="-6360"/>
-        <nd ref="-1767"/>
-        <nd ref="-6362"/>
-        <nd ref="-1768"/>
-        <nd ref="-6364"/>
-        <nd ref="-1769"/>
-        <nd ref="-1770"/>
-        <nd ref="-1771"/>
-        <nd ref="-6366"/>
-        <nd ref="-1772"/>
-        <nd ref="-6368"/>
-        <nd ref="-1773"/>
-        <nd ref="-6370"/>
-        <nd ref="-1774"/>
-        <nd ref="-6372"/>
-        <nd ref="-1775"/>
-        <nd ref="-1776"/>
-        <nd ref="-1777"/>
-        <nd ref="-6374"/>
-        <nd ref="-1778"/>
-        <nd ref="-6376"/>
-        <nd ref="-1779"/>
-        <nd ref="-6378"/>
-        <nd ref="-1780"/>
-        <nd ref="-1781"/>
-        <nd ref="-1782"/>
-        <nd ref="-30517"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-849" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37120"/>
-        <nd ref="-4900"/>
-        <nd ref="-4903"/>
-        <nd ref="-4907"/>
-        <nd ref="-4910"/>
-        <nd ref="-4913"/>
-        <nd ref="-4916"/>
-        <nd ref="-4919"/>
-        <nd ref="-4921"/>
-        <nd ref="-4923"/>
-        <nd ref="-4925"/>
-        <nd ref="-4927"/>
-        <nd ref="-28148"/>
-        <nd ref="-4931"/>
-        <nd ref="-4933"/>
-        <nd ref="-4935"/>
-        <nd ref="-4937"/>
-        <nd ref="-4939"/>
-        <nd ref="-4941"/>
-        <nd ref="-4943"/>
-        <nd ref="-4945"/>
-        <nd ref="-4947"/>
-        <nd ref="-4949"/>
-        <nd ref="-4950"/>
-        <nd ref="-4951"/>
-        <nd ref="-4952"/>
-        <nd ref="-37328"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-816" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-29174"/>
         <nd ref="-5469"/>
@@ -11651,6 +11519,14 @@
         <tag k="name" v="OHIO DR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-804" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37317"/>
+        <nd ref="-6556"/>
+        <nd ref="-29109"/>
+        <tag k="name" v="Virginia Avenue North W"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-798" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25277"/>
@@ -11715,8 +11591,6 @@
         <nd ref="-32833"/>
         <nd ref="-35656"/>
         <nd ref="-36801"/>
-        <nd ref="-34148"/>
-        <nd ref="-5080"/>
         <tag k="alt_name" v="K St NW"/>
         <tag k="name" v="US Hwy 29"/>
         <tag k="highway" v="secondary"/>
@@ -11725,41 +11599,32 @@
     <way visible="true" id="-694" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21477"/>
         <nd ref="-24271"/>
+        <nd ref="-247"/>
+        <nd ref="-5939"/>
+        <nd ref="-248"/>
+        <nd ref="-249"/>
+        <nd ref="-5940"/>
+        <nd ref="-250"/>
+        <nd ref="-5941"/>
+        <nd ref="-251"/>
+        <nd ref="-5942"/>
+        <nd ref="-252"/>
+        <nd ref="-253"/>
+        <nd ref="-5943"/>
+        <nd ref="-254"/>
+        <nd ref="-255"/>
+        <nd ref="-5944"/>
+        <nd ref="-256"/>
+        <nd ref="-5945"/>
+        <nd ref="-24202"/>
+        <nd ref="-2172"/>
+        <nd ref="-5946"/>
+        <nd ref="-5947"/>
+        <nd ref="-2173"/>
+        <nd ref="-2174"/>
+        <nd ref="-25814"/>
+        <tag k="alt_name" v="I ST NW"/>
         <tag k="name" v="I St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-656" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33960"/>
-        <nd ref="-5057"/>
-        <nd ref="-5060"/>
-        <nd ref="-5063"/>
-        <nd ref="-5066"/>
-        <nd ref="-5069"/>
-        <nd ref="-5072"/>
-        <nd ref="-5075"/>
-        <nd ref="-5078"/>
-        <nd ref="-5081"/>
-        <nd ref="-5083"/>
-        <nd ref="-5086"/>
-        <nd ref="-5089"/>
-        <nd ref="-5092"/>
-        <nd ref="-5095"/>
-        <nd ref="-5098"/>
-        <nd ref="-5100"/>
-        <nd ref="-5102"/>
-        <nd ref="-5104"/>
-        <nd ref="-5106"/>
-        <nd ref="-5108"/>
-        <nd ref="-5110"/>
-        <nd ref="-5113"/>
-        <nd ref="-5116"/>
-        <nd ref="-5119"/>
-        <nd ref="-5122"/>
-        <nd ref="-5125"/>
-        <nd ref="-5128"/>
-        <nd ref="-27996"/>
-        <tag k="name" v="Lincoln Memorial Cir"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -11880,53 +11745,14 @@
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-651" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35593"/>
-        <nd ref="-98"/>
-        <nd ref="-99"/>
-        <nd ref="-35956"/>
-        <nd ref="-35989"/>
-        <nd ref="-4823"/>
-        <nd ref="-102"/>
-        <nd ref="-103"/>
-        <nd ref="-4824"/>
-        <nd ref="-104"/>
-        <nd ref="-105"/>
-        <nd ref="-4825"/>
-        <nd ref="-106"/>
-        <nd ref="-107"/>
-        <nd ref="-4826"/>
-        <nd ref="-4827"/>
-        <nd ref="-108"/>
-        <nd ref="-37082"/>
-        <tag k="alt_name" v="US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-650" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36842"/>
-        <nd ref="-5589"/>
-        <nd ref="-5591"/>
-        <nd ref="-5593"/>
-        <nd ref="-5595"/>
-        <nd ref="-5597"/>
-        <nd ref="-5599"/>
-        <nd ref="-5601"/>
-        <nd ref="-5603"/>
-        <nd ref="-5605"/>
-        <nd ref="-5607"/>
-        <nd ref="-5609"/>
-        <nd ref="-5611"/>
-        <nd ref="-5613"/>
-        <nd ref="-5615"/>
-        <nd ref="-5617"/>
-        <nd ref="-5619"/>
-        <nd ref="-5621"/>
         <nd ref="-6285"/>
         <nd ref="-5623"/>
         <nd ref="-5625"/>
         <nd ref="-37268"/>
+        <nd ref="-37291"/>
+        <nd ref="-37292"/>
+        <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -11950,11 +11776,14 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-641" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37317"/>
-        <nd ref="-6556"/>
         <nd ref="-29109"/>
         <nd ref="-5707"/>
         <nd ref="-6394"/>
+        <nd ref="-6396"/>
+        <nd ref="-6399"/>
+        <nd ref="-37186"/>
+        <nd ref="-37307"/>
+        <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -11980,13 +11809,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-610" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7020"/>
-        <nd ref="-5989"/>
-        <tag k="name" v="14th St SW"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-608" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-34278"/>
         <nd ref="-7058"/>
@@ -11999,13 +11821,6 @@
         <nd ref="-7006"/>
         <tag k="name" v="US Hwy 29"/>
         <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-606" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37186"/>
-        <nd ref="-37307"/>
-        <tag k="name" v="Virginia Avenue North W"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-600" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -12025,6 +11840,47 @@
         <nd ref="-5844"/>
         <nd ref="-5845"/>
         <nd ref="-35233"/>
+        <nd ref="-1537"/>
+        <nd ref="-5846"/>
+        <nd ref="-1539"/>
+        <nd ref="-1541"/>
+        <nd ref="-5847"/>
+        <nd ref="-1543"/>
+        <nd ref="-5848"/>
+        <nd ref="-1545"/>
+        <nd ref="-1547"/>
+        <nd ref="-5850"/>
+        <nd ref="-1549"/>
+        <nd ref="-1551"/>
+        <nd ref="-5853"/>
+        <nd ref="-1553"/>
+        <nd ref="-1555"/>
+        <nd ref="-5856"/>
+        <nd ref="-1557"/>
+        <nd ref="-1559"/>
+        <nd ref="-5859"/>
+        <nd ref="-1561"/>
+        <nd ref="-1563"/>
+        <nd ref="-5863"/>
+        <nd ref="-1565"/>
+        <nd ref="-1567"/>
+        <nd ref="-5867"/>
+        <nd ref="-1569"/>
+        <nd ref="-1571"/>
+        <nd ref="-5870"/>
+        <nd ref="-1573"/>
+        <nd ref="-1575"/>
+        <nd ref="-5873"/>
+        <nd ref="-1577"/>
+        <nd ref="-5876"/>
+        <nd ref="-1579"/>
+        <nd ref="-1581"/>
+        <nd ref="-5879"/>
+        <nd ref="-1583"/>
+        <nd ref="-1585"/>
+        <nd ref="-1587"/>
+        <nd ref="-36349"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -12132,16 +11988,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-566" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-6394"/>
-        <nd ref="-6396"/>
-        <nd ref="-6399"/>
-        <nd ref="-37186"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="Virginia Avenue North W"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-562" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36639"/>
         <nd ref="-37178"/>
@@ -12185,6 +12031,9 @@
         <nd ref="-4626"/>
         <nd ref="-4627"/>
         <nd ref="-27699"/>
+        <nd ref="-135"/>
+        <nd ref="-24202"/>
+        <tag k="alt_name" v="NEW HAMPSHIRE AVE NW"/>
         <tag k="name" v="New Hampshire Ave NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12430,6 +12279,7 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-510" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-7020"/>
         <nd ref="-5989"/>
         <nd ref="-35200"/>
         <nd ref="-31461"/>
@@ -12476,6 +12326,27 @@
     <way visible="true" id="-504" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4408"/>
         <nd ref="-23818"/>
+        <nd ref="-4410"/>
+        <nd ref="-4266"/>
+        <nd ref="-4268"/>
+        <nd ref="-4411"/>
+        <nd ref="-4270"/>
+        <nd ref="-4412"/>
+        <nd ref="-4272"/>
+        <nd ref="-4413"/>
+        <nd ref="-4274"/>
+        <nd ref="-4414"/>
+        <nd ref="-4276"/>
+        <nd ref="-4415"/>
+        <nd ref="-4277"/>
+        <nd ref="-4416"/>
+        <nd ref="-4278"/>
+        <nd ref="-4417"/>
+        <nd ref="-4279"/>
+        <nd ref="-4280"/>
+        <nd ref="-4418"/>
+        <nd ref="-31568"/>
+        <tag k="alt_name" v="20TH ST NW"/>
         <tag k="name" v="20th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12571,6 +12442,8 @@
         <nd ref="-7312"/>
         <nd ref="-7313"/>
         <nd ref="-37361"/>
+        <nd ref="-37362"/>
+        <tag k="name" v="OHIO DR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -12600,6 +12473,23 @@
     <way visible="true" id="-470" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7051"/>
         <nd ref="-22515"/>
+        <nd ref="-853"/>
+        <nd ref="-854"/>
+        <nd ref="-5413"/>
+        <nd ref="-855"/>
+        <nd ref="-856"/>
+        <nd ref="-857"/>
+        <nd ref="-858"/>
+        <nd ref="-5415"/>
+        <nd ref="-859"/>
+        <nd ref="-5417"/>
+        <nd ref="-860"/>
+        <nd ref="-5419"/>
+        <nd ref="-861"/>
+        <nd ref="-862"/>
+        <nd ref="-863"/>
+        <nd ref="-36915"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
         <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12611,8 +12501,35 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-462" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30938"/>
+        <nd ref="-24"/>
+        <nd ref="-22"/>
+        <nd ref="-5482"/>
+        <nd ref="-20"/>
+        <nd ref="-5481"/>
+        <nd ref="-18"/>
+        <nd ref="-16"/>
+        <nd ref="-14"/>
+        <nd ref="-12"/>
+        <nd ref="-5480"/>
+        <nd ref="-11"/>
+        <nd ref="-5479"/>
+        <nd ref="-10"/>
+        <nd ref="-5478"/>
+        <nd ref="-9"/>
+        <nd ref="-5477"/>
+        <nd ref="-8"/>
+        <nd ref="-7"/>
+        <nd ref="-6"/>
+        <nd ref="-5476"/>
+        <nd ref="-5"/>
+        <nd ref="-5475"/>
+        <nd ref="-4"/>
+        <nd ref="-3"/>
+        <nd ref="-2"/>
         <nd ref="-34278"/>
         <nd ref="-7059"/>
+        <tag k="alt_name" v="CONSTITUTION AVE NW;Constitution Ave NW;US Hwy 1"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="secondary"/>
         <tag k="error:circular" v="5"/>
@@ -12725,6 +12642,20 @@
     <way visible="true" id="-423" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4338"/>
         <nd ref="-37114"/>
+        <nd ref="-3626"/>
+        <nd ref="-3623"/>
+        <nd ref="-5852"/>
+        <nd ref="-3620"/>
+        <nd ref="-3617"/>
+        <nd ref="-5855"/>
+        <nd ref="-3614"/>
+        <nd ref="-5858"/>
+        <nd ref="-3611"/>
+        <nd ref="-5862"/>
+        <nd ref="-3608"/>
+        <nd ref="-5866"/>
+        <nd ref="-35778"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -12732,6 +12663,13 @@
         <nd ref="-25881"/>
         <nd ref="-5888"/>
         <nd ref="-32902"/>
+        <nd ref="-5889"/>
+        <nd ref="-335"/>
+        <nd ref="-336"/>
+        <nd ref="-5890"/>
+        <nd ref="-337"/>
+        <nd ref="-32936"/>
+        <tag k="alt_name" v="QUEEN ANNES LN NW"/>
         <tag k="name" v="Queen Annes Ln NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12850,6 +12788,17 @@
         <nd ref="-6910"/>
         <nd ref="-6912"/>
         <nd ref="-32758"/>
+        <nd ref="-2586"/>
+        <nd ref="-6914"/>
+        <nd ref="-2587"/>
+        <nd ref="-6916"/>
+        <nd ref="-2588"/>
+        <nd ref="-6918"/>
+        <nd ref="-2589"/>
+        <nd ref="-6920"/>
+        <nd ref="-2590"/>
+        <nd ref="-32759"/>
+        <tag k="alt_name" v="SOUTH EXECUTIVE AVE NW"/>
         <tag k="name" v="South Pl NW"/>
         <tag k="foot" v="designated"/>
         <tag k="highway" v="path"/>
@@ -12915,70 +12864,18 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-374" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25330"/>
-        <nd ref="-1010"/>
-        <nd ref="-1011"/>
-        <nd ref="-6114"/>
-        <nd ref="-1012"/>
-        <nd ref="-1013"/>
-        <nd ref="-6115"/>
-        <nd ref="-1014"/>
-        <nd ref="-1015"/>
-        <nd ref="-6116"/>
-        <nd ref="-1016"/>
-        <nd ref="-6117"/>
-        <nd ref="-1017"/>
-        <nd ref="-6118"/>
-        <nd ref="-1018"/>
-        <nd ref="-6121"/>
-        <nd ref="-1019"/>
-        <nd ref="-6124"/>
-        <nd ref="-1020"/>
-        <nd ref="-6127"/>
-        <nd ref="-1021"/>
-        <nd ref="-6130"/>
-        <nd ref="-1022"/>
-        <nd ref="-6133"/>
-        <nd ref="-1023"/>
-        <nd ref="-1024"/>
-        <nd ref="-6136"/>
-        <nd ref="-1025"/>
-        <nd ref="-6139"/>
-        <nd ref="-1026"/>
-        <nd ref="-6142"/>
-        <nd ref="-1027"/>
-        <nd ref="-25814"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-373" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19520"/>
-        <nd ref="-3302"/>
-        <nd ref="-3303"/>
-        <nd ref="-3304"/>
-        <nd ref="-3305"/>
-        <nd ref="-3306"/>
-        <nd ref="-3307"/>
-        <nd ref="-3308"/>
-        <nd ref="-3309"/>
-        <nd ref="-3310"/>
-        <nd ref="-3311"/>
-        <nd ref="-3312"/>
-        <nd ref="-3313"/>
-        <nd ref="-3314"/>
-        <nd ref="-3315"/>
-        <nd ref="-3316"/>
-        <nd ref="-3317"/>
-        <nd ref="-29305"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-372" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25437"/>
+        <nd ref="-3251"/>
+        <nd ref="-7076"/>
+        <nd ref="-3252"/>
+        <nd ref="-7078"/>
+        <nd ref="-3253"/>
+        <nd ref="-34786"/>
+        <nd ref="-3255"/>
+        <nd ref="-34360"/>
+        <nd ref="-7080"/>
+        <nd ref="-3257"/>
         <nd ref="-25611"/>
         <nd ref="-3296"/>
         <nd ref="-7082"/>
@@ -12993,25 +12890,17 @@
         <nd ref="-7092"/>
         <nd ref="-3301"/>
         <nd ref="-20435"/>
+        <nd ref="-7094"/>
+        <nd ref="-3260"/>
+        <nd ref="-7096"/>
+        <nd ref="-3261"/>
+        <nd ref="-3262"/>
+        <nd ref="-7098"/>
+        <nd ref="-3263"/>
+        <nd ref="-3264"/>
+        <nd ref="-19701"/>
         <tag k="alt_name" v="21st St NW"/>
         <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-371" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19031"/>
-        <nd ref="-3291"/>
-        <nd ref="-4433"/>
-        <nd ref="-3292"/>
-        <nd ref="-4434"/>
-        <nd ref="-3293"/>
-        <nd ref="-4435"/>
-        <nd ref="-3294"/>
-        <nd ref="-4436"/>
-        <nd ref="-3295"/>
-        <nd ref="-19598"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -13036,6 +12925,63 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-369" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20856"/>
+        <nd ref="-608"/>
+        <nd ref="-609"/>
+        <nd ref="-5807"/>
+        <nd ref="-610"/>
+        <nd ref="-5808"/>
+        <nd ref="-611"/>
+        <nd ref="-612"/>
+        <nd ref="-613"/>
+        <nd ref="-614"/>
+        <nd ref="-20283"/>
+        <nd ref="-1105"/>
+        <nd ref="-5809"/>
+        <nd ref="-5810"/>
+        <nd ref="-1106"/>
+        <nd ref="-1107"/>
+        <nd ref="-5811"/>
+        <nd ref="-5812"/>
+        <nd ref="-1108"/>
+        <nd ref="-1109"/>
+        <nd ref="-20205"/>
+        <nd ref="-1110"/>
+        <nd ref="-5814"/>
+        <nd ref="-1111"/>
+        <nd ref="-1112"/>
+        <nd ref="-5815"/>
+        <nd ref="-1113"/>
+        <nd ref="-1114"/>
+        <nd ref="-20065"/>
+        <nd ref="-1115"/>
+        <nd ref="-1116"/>
+        <nd ref="-5817"/>
+        <nd ref="-5818"/>
+        <nd ref="-5819"/>
+        <nd ref="-1117"/>
+        <nd ref="-1118"/>
+        <nd ref="-1119"/>
+        <nd ref="-20435"/>
+        <nd ref="-5821"/>
+        <nd ref="-615"/>
+        <nd ref="-616"/>
+        <nd ref="-5822"/>
+        <nd ref="-617"/>
+        <nd ref="-618"/>
+        <nd ref="-5823"/>
+        <nd ref="-619"/>
+        <nd ref="-620"/>
+        <nd ref="-5824"/>
+        <nd ref="-621"/>
+        <nd ref="-622"/>
+        <nd ref="-5825"/>
+        <nd ref="-623"/>
+        <nd ref="-624"/>
+        <nd ref="-625"/>
+        <nd ref="-626"/>
+        <nd ref="-627"/>
+        <nd ref="-5826"/>
         <nd ref="-21579"/>
         <nd ref="-1120"/>
         <nd ref="-1121"/>
@@ -13086,97 +13032,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-368" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20065"/>
-        <nd ref="-1115"/>
-        <nd ref="-1116"/>
-        <nd ref="-5817"/>
-        <nd ref="-5818"/>
-        <nd ref="-5819"/>
-        <nd ref="-1117"/>
-        <nd ref="-1118"/>
-        <nd ref="-1119"/>
-        <nd ref="-20435"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-366" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20205"/>
-        <nd ref="-1110"/>
-        <nd ref="-5814"/>
-        <nd ref="-1111"/>
-        <nd ref="-1112"/>
-        <nd ref="-5815"/>
-        <nd ref="-1113"/>
-        <nd ref="-1114"/>
-        <nd ref="-20065"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-365" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25380"/>
-        <nd ref="-2914"/>
-        <nd ref="-2915"/>
-        <nd ref="-6103"/>
-        <nd ref="-2916"/>
-        <nd ref="-6104"/>
-        <nd ref="-2917"/>
-        <nd ref="-6105"/>
-        <nd ref="-2918"/>
-        <nd ref="-6106"/>
-        <nd ref="-2919"/>
-        <nd ref="-6107"/>
-        <nd ref="-2920"/>
-        <nd ref="-6108"/>
-        <nd ref="-2921"/>
-        <nd ref="-6109"/>
-        <nd ref="-2922"/>
-        <nd ref="-2923"/>
-        <nd ref="-6110"/>
-        <nd ref="-6111"/>
-        <nd ref="-2924"/>
-        <nd ref="-6112"/>
-        <nd ref="-2925"/>
-        <nd ref="-2926"/>
-        <nd ref="-25330"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-364" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20283"/>
-        <nd ref="-1105"/>
-        <nd ref="-5809"/>
-        <nd ref="-5810"/>
-        <nd ref="-1106"/>
-        <nd ref="-1107"/>
-        <nd ref="-5811"/>
-        <nd ref="-5812"/>
-        <nd ref="-1108"/>
-        <nd ref="-1109"/>
-        <nd ref="-20205"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-362" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16502"/>
-        <nd ref="-1102"/>
-        <nd ref="-7250"/>
-        <nd ref="-1103"/>
-        <nd ref="-1104"/>
-        <nd ref="-16443"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-360" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16562"/>
         <nd ref="-1092"/>
@@ -13191,113 +13046,13 @@
         <nd ref="-7249"/>
         <nd ref="-1101"/>
         <nd ref="-16502"/>
+        <nd ref="-1102"/>
+        <nd ref="-7250"/>
+        <nd ref="-1103"/>
+        <nd ref="-1104"/>
+        <nd ref="-16443"/>
         <tag k="alt_name" v="F St NW"/>
         <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-358" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19154"/>
-        <nd ref="-7112"/>
-        <nd ref="-3278"/>
-        <nd ref="-7113"/>
-        <nd ref="-3279"/>
-        <nd ref="-3280"/>
-        <nd ref="-19520"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-357" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26300"/>
-        <nd ref="-3272"/>
-        <nd ref="-7107"/>
-        <nd ref="-3273"/>
-        <nd ref="-7108"/>
-        <nd ref="-3274"/>
-        <nd ref="-7109"/>
-        <nd ref="-3275"/>
-        <nd ref="-7110"/>
-        <nd ref="-3276"/>
-        <nd ref="-19154"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-356" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19701"/>
-        <nd ref="-3266"/>
-        <nd ref="-7102"/>
-        <nd ref="-3267"/>
-        <nd ref="-7104"/>
-        <nd ref="-3268"/>
-        <nd ref="-7105"/>
-        <nd ref="-3269"/>
-        <nd ref="-7106"/>
-        <nd ref="-3270"/>
-        <nd ref="-26300"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-355" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20435"/>
-        <nd ref="-7094"/>
-        <nd ref="-3260"/>
-        <nd ref="-7096"/>
-        <nd ref="-3261"/>
-        <nd ref="-3262"/>
-        <nd ref="-7098"/>
-        <nd ref="-3263"/>
-        <nd ref="-3264"/>
-        <nd ref="-19701"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-354" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25437"/>
-        <nd ref="-3251"/>
-        <nd ref="-7076"/>
-        <nd ref="-3252"/>
-        <nd ref="-7078"/>
-        <nd ref="-3253"/>
-        <nd ref="-34786"/>
-        <nd ref="-3255"/>
-        <nd ref="-34360"/>
-        <nd ref="-7080"/>
-        <nd ref="-3257"/>
-        <nd ref="-25611"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-353" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22285"/>
-        <nd ref="-1347"/>
-        <nd ref="-6741"/>
-        <nd ref="-1348"/>
-        <nd ref="-6744"/>
-        <nd ref="-1349"/>
-        <nd ref="-6747"/>
-        <nd ref="-1350"/>
-        <nd ref="-6750"/>
-        <nd ref="-1351"/>
-        <nd ref="-6753"/>
-        <nd ref="-1352"/>
-        <nd ref="-1353"/>
-        <nd ref="-6756"/>
-        <nd ref="-1354"/>
-        <nd ref="-6759"/>
-        <nd ref="-1355"/>
-        <nd ref="-27003"/>
-        <tag k="alt_name" v="Madison Dr NW"/>
-        <tag k="name" v="MADISON DR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -13327,32 +13082,25 @@
         <nd ref="-6738"/>
         <nd ref="-1346"/>
         <nd ref="-22285"/>
+        <nd ref="-1347"/>
+        <nd ref="-6741"/>
+        <nd ref="-1348"/>
+        <nd ref="-6744"/>
+        <nd ref="-1349"/>
+        <nd ref="-6747"/>
+        <nd ref="-1350"/>
+        <nd ref="-6750"/>
+        <nd ref="-1351"/>
+        <nd ref="-6753"/>
+        <nd ref="-1352"/>
+        <nd ref="-1353"/>
+        <nd ref="-6756"/>
+        <nd ref="-1354"/>
+        <nd ref="-6759"/>
+        <nd ref="-1355"/>
+        <nd ref="-27003"/>
         <tag k="alt_name" v="Madison Dr NW"/>
         <tag k="name" v="MADISON DR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-350" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31694"/>
-        <nd ref="-3237"/>
-        <nd ref="-7066"/>
-        <nd ref="-3238"/>
-        <nd ref="-7067"/>
-        <nd ref="-3239"/>
-        <nd ref="-3240"/>
-        <nd ref="-28586"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-347" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24935"/>
-        <nd ref="-6214"/>
-        <nd ref="-81"/>
-        <nd ref="-35347"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -13369,15 +13117,15 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-345" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24075"/>
-        <nd ref="-24134"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-343" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18245"/>
+        <nd ref="-3846"/>
+        <nd ref="-3848"/>
+        <nd ref="-7348"/>
+        <nd ref="-3850"/>
+        <nd ref="-7349"/>
+        <nd ref="-3853"/>
+        <nd ref="-3856"/>
         <nd ref="-18228"/>
         <nd ref="-7351"/>
         <nd ref="-383"/>
@@ -13385,6 +13133,12 @@
         <nd ref="-387"/>
         <nd ref="-389"/>
         <nd ref="-23981"/>
+        <nd ref="-715"/>
+        <nd ref="-718"/>
+        <nd ref="-721"/>
+        <nd ref="-7352"/>
+        <nd ref="-724"/>
+        <nd ref="-23982"/>
         <tag k="alt_name" v="16th St NW"/>
         <tag k="name" v="16TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -13554,23 +13308,14 @@
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-340" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31431"/>
-        <nd ref="-3475"/>
-        <nd ref="-3476"/>
-        <nd ref="-6794"/>
-        <nd ref="-3477"/>
-        <nd ref="-3478"/>
-        <nd ref="-6797"/>
-        <nd ref="-3479"/>
-        <nd ref="-3480"/>
-        <nd ref="-31357"/>
-        <tag k="alt_name" v="D St SW"/>
-        <tag k="name" v="D ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-338" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32759"/>
+        <nd ref="-6490"/>
+        <nd ref="-1087"/>
+        <nd ref="-6494"/>
+        <nd ref="-1089"/>
+        <nd ref="-6498"/>
+        <nd ref="-1091"/>
         <nd ref="-23686"/>
         <nd ref="-1093"/>
         <nd ref="-6502"/>
@@ -13624,22 +13369,43 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-336" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32759"/>
-        <nd ref="-6490"/>
-        <nd ref="-1087"/>
-        <nd ref="-6494"/>
-        <nd ref="-1089"/>
-        <nd ref="-6498"/>
-        <nd ref="-1091"/>
-        <nd ref="-23686"/>
-        <tag k="alt_name" v="State Pl NW"/>
-        <tag k="name" v="STATE PL NW"/>
-        <tag k="foot" v="designated"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-335" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21579"/>
+        <nd ref="-5973"/>
+        <nd ref="-163"/>
+        <nd ref="-5974"/>
+        <nd ref="-164"/>
+        <nd ref="-165"/>
+        <nd ref="-166"/>
+        <nd ref="-167"/>
+        <nd ref="-5975"/>
+        <nd ref="-168"/>
+        <nd ref="-169"/>
+        <nd ref="-5977"/>
+        <nd ref="-170"/>
+        <nd ref="-5979"/>
+        <nd ref="-171"/>
+        <nd ref="-172"/>
+        <nd ref="-173"/>
+        <nd ref="-5981"/>
+        <nd ref="-174"/>
+        <nd ref="-5983"/>
+        <nd ref="-175"/>
+        <nd ref="-5985"/>
+        <nd ref="-176"/>
+        <nd ref="-177"/>
+        <nd ref="-178"/>
+        <nd ref="-5987"/>
+        <nd ref="-179"/>
+        <nd ref="-5990"/>
+        <nd ref="-180"/>
+        <nd ref="-181"/>
+        <nd ref="-5993"/>
+        <nd ref="-182"/>
+        <nd ref="-183"/>
+        <nd ref="-5996"/>
+        <nd ref="-184"/>
+        <nd ref="-185"/>
         <nd ref="-21350"/>
         <nd ref="-6002"/>
         <nd ref="-3155"/>
@@ -13688,797 +13454,6 @@
         <nd ref="-6037"/>
         <nd ref="-3186"/>
         <nd ref="-26280"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-334" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25227"/>
-        <nd ref="-5964"/>
-        <nd ref="-3131"/>
-        <nd ref="-3132"/>
-        <nd ref="-3133"/>
-        <nd ref="-5965"/>
-        <nd ref="-3134"/>
-        <nd ref="-5966"/>
-        <nd ref="-3135"/>
-        <nd ref="-3136"/>
-        <nd ref="-5967"/>
-        <nd ref="-3137"/>
-        <nd ref="-5968"/>
-        <nd ref="-3138"/>
-        <nd ref="-3139"/>
-        <nd ref="-3140"/>
-        <nd ref="-5969"/>
-        <nd ref="-3141"/>
-        <nd ref="-3142"/>
-        <nd ref="-5970"/>
-        <nd ref="-3143"/>
-        <nd ref="-3144"/>
-        <nd ref="-3145"/>
-        <nd ref="-3146"/>
-        <nd ref="-3147"/>
-        <nd ref="-3148"/>
-        <nd ref="-5971"/>
-        <nd ref="-3149"/>
-        <nd ref="-3150"/>
-        <nd ref="-3151"/>
-        <nd ref="-5972"/>
-        <nd ref="-3152"/>
-        <nd ref="-21579"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-333" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24005"/>
-        <nd ref="-1185"/>
-        <nd ref="-5797"/>
-        <nd ref="-5798"/>
-        <nd ref="-1186"/>
-        <nd ref="-1187"/>
-        <nd ref="-1188"/>
-        <nd ref="-5799"/>
-        <nd ref="-29305"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-332" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24134"/>
-        <nd ref="-228"/>
-        <nd ref="-6715"/>
-        <nd ref="-229"/>
-        <nd ref="-6718"/>
-        <nd ref="-230"/>
-        <nd ref="-231"/>
-        <nd ref="-24099"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-331" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23999"/>
-        <nd ref="-5792"/>
-        <nd ref="-1180"/>
-        <nd ref="-1181"/>
-        <nd ref="-5793"/>
-        <nd ref="-1182"/>
-        <nd ref="-5794"/>
-        <nd ref="-1183"/>
-        <nd ref="-5795"/>
-        <nd ref="-1184"/>
-        <nd ref="-24005"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-330" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22265"/>
-        <nd ref="-224"/>
-        <nd ref="-6166"/>
-        <nd ref="-225"/>
-        <nd ref="-6167"/>
-        <nd ref="-226"/>
-        <nd ref="-24075"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-328" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32939"/>
-        <nd ref="-4372"/>
-        <nd ref="-1871"/>
-        <nd ref="-4373"/>
-        <nd ref="-1872"/>
-        <nd ref="-1873"/>
-        <nd ref="-4374"/>
-        <nd ref="-36185"/>
-        <nd ref="-1874"/>
-        <nd ref="-32833"/>
-        <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-327" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19031"/>
-        <nd ref="-3000"/>
-        <nd ref="-6418"/>
-        <nd ref="-6421"/>
-        <nd ref="-3002"/>
-        <nd ref="-3004"/>
-        <nd ref="-6424"/>
-        <nd ref="-3006"/>
-        <nd ref="-3008"/>
-        <nd ref="-3010"/>
-        <nd ref="-3012"/>
-        <nd ref="-26300"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-325" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32902"/>
-        <nd ref="-5889"/>
-        <nd ref="-335"/>
-        <nd ref="-336"/>
-        <nd ref="-5890"/>
-        <nd ref="-337"/>
-        <nd ref="-32936"/>
-        <tag k="alt_name" v="Queen Annes Ln NW"/>
-        <tag k="name" v="QUEEN ANNES LN NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-322" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25773"/>
-        <nd ref="-4450"/>
-        <nd ref="-2886"/>
-        <nd ref="-2890"/>
-        <nd ref="-4451"/>
-        <nd ref="-2894"/>
-        <nd ref="-35332"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-321" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17717"/>
-        <nd ref="-2866"/>
-        <nd ref="-4447"/>
-        <nd ref="-2870"/>
-        <nd ref="-2874"/>
-        <nd ref="-4448"/>
-        <nd ref="-4449"/>
-        <nd ref="-2878"/>
-        <nd ref="-2882"/>
-        <nd ref="-25773"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-320" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20817"/>
-        <nd ref="-2862"/>
-        <nd ref="-4445"/>
-        <nd ref="-17717"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-319" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19555"/>
-        <nd ref="-1149"/>
-        <nd ref="-1150"/>
-        <nd ref="-1151"/>
-        <nd ref="-19625"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-318" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20925"/>
-        <nd ref="-2834"/>
-        <nd ref="-2837"/>
-        <nd ref="-7231"/>
-        <nd ref="-7232"/>
-        <nd ref="-2840"/>
-        <nd ref="-7233"/>
-        <nd ref="-2843"/>
-        <nd ref="-2846"/>
-        <nd ref="-2850"/>
-        <nd ref="-2854"/>
-        <nd ref="-20817"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="foot" v="designated"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-317" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35221"/>
-        <nd ref="-2810"/>
-        <nd ref="-6170"/>
-        <nd ref="-2813"/>
-        <nd ref="-6171"/>
-        <nd ref="-2816"/>
-        <nd ref="-6172"/>
-        <nd ref="-6173"/>
-        <nd ref="-2819"/>
-        <nd ref="-6174"/>
-        <nd ref="-2822"/>
-        <nd ref="-6175"/>
-        <nd ref="-2825"/>
-        <nd ref="-2828"/>
-        <nd ref="-20879"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-316" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23818"/>
-        <nd ref="-6204"/>
-        <nd ref="-999"/>
-        <nd ref="-6206"/>
-        <nd ref="-1000"/>
-        <nd ref="-25437"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-315" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21477"/>
-        <nd ref="-321"/>
-        <nd ref="-322"/>
-        <nd ref="-5334"/>
-        <nd ref="-323"/>
-        <nd ref="-5335"/>
-        <nd ref="-324"/>
-        <nd ref="-5336"/>
-        <nd ref="-325"/>
-        <nd ref="-5337"/>
-        <nd ref="-326"/>
-        <nd ref="-5338"/>
-        <nd ref="-327"/>
-        <nd ref="-328"/>
-        <nd ref="-329"/>
-        <nd ref="-26842"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-313" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21715"/>
-        <nd ref="-295"/>
-        <nd ref="-296"/>
-        <nd ref="-297"/>
-        <nd ref="-5275"/>
-        <nd ref="-298"/>
-        <nd ref="-5277"/>
-        <nd ref="-299"/>
-        <nd ref="-300"/>
-        <nd ref="-5279"/>
-        <nd ref="-301"/>
-        <nd ref="-5281"/>
-        <nd ref="-302"/>
-        <nd ref="-5283"/>
-        <nd ref="-303"/>
-        <nd ref="-304"/>
-        <nd ref="-305"/>
-        <nd ref="-5285"/>
-        <nd ref="-306"/>
-        <nd ref="-5287"/>
-        <nd ref="-307"/>
-        <nd ref="-308"/>
-        <nd ref="-309"/>
-        <nd ref="-310"/>
-        <nd ref="-5289"/>
-        <nd ref="-311"/>
-        <nd ref="-312"/>
-        <nd ref="-5291"/>
-        <nd ref="-313"/>
-        <nd ref="-314"/>
-        <nd ref="-5293"/>
-        <nd ref="-315"/>
-        <nd ref="-5295"/>
-        <nd ref="-316"/>
-        <nd ref="-317"/>
-        <nd ref="-5297"/>
-        <nd ref="-318"/>
-        <nd ref="-319"/>
-        <nd ref="-5299"/>
-        <nd ref="-320"/>
-        <nd ref="-21605"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-311" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21809"/>
-        <nd ref="-5733"/>
-        <nd ref="-2482"/>
-        <nd ref="-2483"/>
-        <nd ref="-5734"/>
-        <nd ref="-2484"/>
-        <nd ref="-5735"/>
-        <nd ref="-2485"/>
-        <nd ref="-5736"/>
-        <nd ref="-2486"/>
-        <nd ref="-5737"/>
-        <nd ref="-2487"/>
-        <nd ref="-2488"/>
-        <nd ref="-5738"/>
-        <nd ref="-2489"/>
-        <nd ref="-5739"/>
-        <nd ref="-2490"/>
-        <nd ref="-5740"/>
-        <nd ref="-2491"/>
-        <nd ref="-5741"/>
-        <nd ref="-2492"/>
-        <nd ref="-5743"/>
-        <nd ref="-2493"/>
-        <nd ref="-2494"/>
-        <nd ref="-5745"/>
-        <nd ref="-2495"/>
-        <nd ref="-5747"/>
-        <nd ref="-2496"/>
-        <nd ref="-2497"/>
-        <nd ref="-2498"/>
-        <nd ref="-2499"/>
-        <nd ref="-5749"/>
-        <nd ref="-2500"/>
-        <nd ref="-24271"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-310" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28607"/>
-        <nd ref="-266"/>
-        <nd ref="-267"/>
-        <nd ref="-268"/>
-        <nd ref="-5197"/>
-        <nd ref="-269"/>
-        <nd ref="-5200"/>
-        <nd ref="-270"/>
-        <nd ref="-5203"/>
-        <nd ref="-271"/>
-        <nd ref="-272"/>
-        <nd ref="-5206"/>
-        <nd ref="-273"/>
-        <nd ref="-274"/>
-        <nd ref="-28789"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-309" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24988"/>
-        <nd ref="-5717"/>
-        <nd ref="-2459"/>
-        <nd ref="-5718"/>
-        <nd ref="-2460"/>
-        <nd ref="-5719"/>
-        <nd ref="-2461"/>
-        <nd ref="-5720"/>
-        <nd ref="-2462"/>
-        <nd ref="-5721"/>
-        <nd ref="-2463"/>
-        <nd ref="-2464"/>
-        <nd ref="-5722"/>
-        <nd ref="-2465"/>
-        <nd ref="-5723"/>
-        <nd ref="-2466"/>
-        <nd ref="-5724"/>
-        <nd ref="-2467"/>
-        <nd ref="-5725"/>
-        <nd ref="-2468"/>
-        <nd ref="-5726"/>
-        <nd ref="-2469"/>
-        <nd ref="-2470"/>
-        <nd ref="-5727"/>
-        <nd ref="-2471"/>
-        <nd ref="-5728"/>
-        <nd ref="-2472"/>
-        <nd ref="-5729"/>
-        <nd ref="-2473"/>
-        <nd ref="-2474"/>
-        <nd ref="-5730"/>
-        <nd ref="-2475"/>
-        <nd ref="-5731"/>
-        <nd ref="-2476"/>
-        <nd ref="-2477"/>
-        <nd ref="-2478"/>
-        <nd ref="-2479"/>
-        <nd ref="-5732"/>
-        <nd ref="-2480"/>
-        <nd ref="-21809"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-307" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28043"/>
-        <nd ref="-36361"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-306" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23651"/>
-        <nd ref="-1069"/>
-        <nd ref="-1071"/>
-        <nd ref="-1073"/>
-        <nd ref="-1075"/>
-        <nd ref="-7436"/>
-        <nd ref="-1077"/>
-        <nd ref="-22758"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-305" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21279"/>
-        <nd ref="-7133"/>
-        <nd ref="-1256"/>
-        <nd ref="-7135"/>
-        <nd ref="-1258"/>
-        <nd ref="-7137"/>
-        <nd ref="-1260"/>
-        <nd ref="-1262"/>
-        <nd ref="-21247"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-304" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16898"/>
-        <nd ref="-1065"/>
-        <nd ref="-6939"/>
-        <nd ref="-17025"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-303" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22265"/>
-        <nd ref="-7115"/>
-        <nd ref="-1248"/>
-        <nd ref="-1250"/>
-        <nd ref="-22232"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-302" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21279"/>
-        <nd ref="-1059"/>
-        <nd ref="-1061"/>
-        <nd ref="-6932"/>
-        <nd ref="-6933"/>
-        <nd ref="-1063"/>
-        <nd ref="-21263"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-301" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24045"/>
-        <nd ref="-3318"/>
-        <nd ref="-3319"/>
-        <nd ref="-3320"/>
-        <nd ref="-5790"/>
-        <nd ref="-3321"/>
-        <nd ref="-3322"/>
-        <nd ref="-3323"/>
-        <nd ref="-23999"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-300" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22753"/>
-        <nd ref="-1034"/>
-        <nd ref="-22754"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-299" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24005"/>
-        <nd ref="-1172"/>
-        <nd ref="-1173"/>
-        <nd ref="-1174"/>
-        <nd ref="-1175"/>
-        <nd ref="-4444"/>
-        <nd ref="-1176"/>
-        <nd ref="-1177"/>
-        <nd ref="-24006"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-298" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23985"/>
-        <nd ref="-2144"/>
-        <nd ref="-2145"/>
-        <nd ref="-2146"/>
-        <nd ref="-2147"/>
-        <nd ref="-23986"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-297" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34278"/>
-        <nd ref="-5742"/>
-        <nd ref="-2604"/>
-        <nd ref="-5744"/>
-        <nd ref="-2605"/>
-        <nd ref="-5746"/>
-        <nd ref="-2606"/>
-        <nd ref="-5748"/>
-        <nd ref="-2607"/>
-        <nd ref="-15703"/>
-        <tag k="alt_name" v="12th St NW"/>
-        <tag k="name" v="12TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-296" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24192"/>
-        <nd ref="-2669"/>
-        <nd ref="-7145"/>
-        <nd ref="-2671"/>
-        <nd ref="-22740"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-295" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34277"/>
-        <nd ref="-34278"/>
-        <tag k="alt_name" v="12th St NW"/>
-        <tag k="name" v="12TH ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-293" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29305"/>
-        <nd ref="-3283"/>
-        <nd ref="-3284"/>
-        <nd ref="-3285"/>
-        <nd ref="-3286"/>
-        <nd ref="-3287"/>
-        <nd ref="-3288"/>
-        <nd ref="-3289"/>
-        <nd ref="-24014"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-292" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23999"/>
-        <nd ref="-4203"/>
-        <nd ref="-4204"/>
-        <nd ref="-7163"/>
-        <nd ref="-4205"/>
-        <nd ref="-7165"/>
-        <nd ref="-4206"/>
-        <nd ref="-24000"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-291" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24045"/>
-        <nd ref="-5410"/>
-        <nd ref="-149"/>
-        <nd ref="-150"/>
-        <nd ref="-5412"/>
-        <nd ref="-151"/>
-        <nd ref="-24046"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-290" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24271"/>
-        <nd ref="-5751"/>
-        <nd ref="-2378"/>
-        <nd ref="-2379"/>
-        <nd ref="-5752"/>
-        <nd ref="-2380"/>
-        <nd ref="-5753"/>
-        <nd ref="-2381"/>
-        <nd ref="-2382"/>
-        <nd ref="-24433"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-289" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34114"/>
-        <nd ref="-332"/>
-        <nd ref="-7055"/>
-        <nd ref="-333"/>
-        <nd ref="-34115"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-288" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25554"/>
-        <nd ref="-5709"/>
-        <nd ref="-5710"/>
-        <nd ref="-2367"/>
-        <nd ref="-2368"/>
-        <nd ref="-5711"/>
-        <nd ref="-2369"/>
-        <nd ref="-5712"/>
-        <nd ref="-2370"/>
-        <nd ref="-2371"/>
-        <nd ref="-5713"/>
-        <nd ref="-2372"/>
-        <nd ref="-5714"/>
-        <nd ref="-2373"/>
-        <nd ref="-5715"/>
-        <nd ref="-2374"/>
-        <nd ref="-2375"/>
-        <nd ref="-24988"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-287" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23981"/>
-        <nd ref="-715"/>
-        <nd ref="-718"/>
-        <nd ref="-721"/>
-        <nd ref="-7352"/>
-        <nd ref="-724"/>
-        <nd ref="-23982"/>
-        <tag k="alt_name" v="16th St NW"/>
-        <tag k="name" v="16TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-286" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35879"/>
-        <nd ref="-769"/>
-        <nd ref="-771"/>
-        <nd ref="-34720"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-285" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19625"/>
-        <nd ref="-1157"/>
-        <nd ref="-1158"/>
-        <nd ref="-1159"/>
-        <nd ref="-1160"/>
-        <nd ref="-4440"/>
-        <nd ref="-1161"/>
-        <nd ref="-1162"/>
-        <nd ref="-1163"/>
-        <nd ref="-1164"/>
-        <nd ref="-4441"/>
-        <nd ref="-1165"/>
-        <nd ref="-4442"/>
-        <nd ref="-1166"/>
-        <nd ref="-1167"/>
-        <nd ref="-4443"/>
-        <nd ref="-1168"/>
-        <nd ref="-1169"/>
-        <nd ref="-1170"/>
-        <nd ref="-24005"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-284" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35681"/>
-        <nd ref="-4733"/>
-        <nd ref="-4735"/>
-        <nd ref="-1041"/>
-        <nd ref="-35682"/>
-        <tag k="alt_name" v="26th St NW"/>
-        <tag k="name" v="26TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-283" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19598"/>
-        <nd ref="-1153"/>
-        <nd ref="-4438"/>
-        <nd ref="-1154"/>
-        <nd ref="-1155"/>
-        <nd ref="-19625"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-282" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23996"/>
-        <nd ref="-1238"/>
-        <nd ref="-1240"/>
-        <nd ref="-1242"/>
-        <nd ref="-5898"/>
-        <nd ref="-23997"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-281" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25523"/>
-        <nd ref="-211"/>
-        <nd ref="-6073"/>
-        <nd ref="-212"/>
-        <nd ref="-6075"/>
-        <nd ref="-213"/>
-        <nd ref="-6077"/>
-        <nd ref="-214"/>
-        <nd ref="-6079"/>
-        <nd ref="-215"/>
-        <nd ref="-216"/>
-        <nd ref="-6081"/>
-        <nd ref="-217"/>
-        <nd ref="-6083"/>
-        <nd ref="-218"/>
-        <nd ref="-219"/>
-        <nd ref="-6085"/>
-        <nd ref="-220"/>
-        <nd ref="-221"/>
-        <nd ref="-222"/>
-        <nd ref="-36955"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-279" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26280"/>
         <nd ref="-6039"/>
         <nd ref="-186"/>
         <nd ref="-187"/>
@@ -14526,6 +13501,702 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
+    <way visible="true" id="-334" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25227"/>
+        <nd ref="-5964"/>
+        <nd ref="-3131"/>
+        <nd ref="-3132"/>
+        <nd ref="-3133"/>
+        <nd ref="-5965"/>
+        <nd ref="-3134"/>
+        <nd ref="-5966"/>
+        <nd ref="-3135"/>
+        <nd ref="-3136"/>
+        <nd ref="-5967"/>
+        <nd ref="-3137"/>
+        <nd ref="-5968"/>
+        <nd ref="-3138"/>
+        <nd ref="-3139"/>
+        <nd ref="-3140"/>
+        <nd ref="-5969"/>
+        <nd ref="-3141"/>
+        <nd ref="-3142"/>
+        <nd ref="-5970"/>
+        <nd ref="-3143"/>
+        <nd ref="-3144"/>
+        <nd ref="-3145"/>
+        <nd ref="-3146"/>
+        <nd ref="-3147"/>
+        <nd ref="-3148"/>
+        <nd ref="-5971"/>
+        <nd ref="-3149"/>
+        <nd ref="-3150"/>
+        <nd ref="-3151"/>
+        <nd ref="-5972"/>
+        <nd ref="-3152"/>
+        <nd ref="-21579"/>
+        <tag k="alt_name" v="22nd St NW"/>
+        <tag k="name" v="22ND ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-332" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24075"/>
+        <nd ref="-24134"/>
+        <nd ref="-228"/>
+        <nd ref="-6715"/>
+        <nd ref="-229"/>
+        <nd ref="-6718"/>
+        <nd ref="-230"/>
+        <nd ref="-231"/>
+        <nd ref="-24099"/>
+        <tag k="alt_name" v="E St NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-330" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22265"/>
+        <nd ref="-224"/>
+        <nd ref="-6166"/>
+        <nd ref="-225"/>
+        <nd ref="-6167"/>
+        <nd ref="-226"/>
+        <nd ref="-24075"/>
+        <nd ref="-6168"/>
+        <nd ref="-6169"/>
+        <nd ref="-35221"/>
+        <nd ref="-2810"/>
+        <nd ref="-6170"/>
+        <nd ref="-2813"/>
+        <nd ref="-6171"/>
+        <nd ref="-2816"/>
+        <nd ref="-6172"/>
+        <nd ref="-6173"/>
+        <nd ref="-2819"/>
+        <nd ref="-6174"/>
+        <nd ref="-2822"/>
+        <nd ref="-6175"/>
+        <nd ref="-2825"/>
+        <nd ref="-2828"/>
+        <nd ref="-20879"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-328" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32939"/>
+        <nd ref="-4372"/>
+        <nd ref="-1871"/>
+        <nd ref="-4373"/>
+        <nd ref="-1872"/>
+        <nd ref="-1873"/>
+        <nd ref="-4374"/>
+        <nd ref="-36185"/>
+        <nd ref="-1874"/>
+        <nd ref="-32833"/>
+        <nd ref="-1875"/>
+        <nd ref="-1876"/>
+        <nd ref="-32834"/>
+        <nd ref="-1877"/>
+        <nd ref="-1878"/>
+        <nd ref="-4377"/>
+        <nd ref="-1879"/>
+        <nd ref="-4378"/>
+        <nd ref="-1880"/>
+        <nd ref="-4379"/>
+        <nd ref="-1881"/>
+        <nd ref="-1882"/>
+        <nd ref="-4380"/>
+        <nd ref="-1883"/>
+        <nd ref="-4381"/>
+        <nd ref="-27725"/>
+        <tag k="alt_name" v="Washington Cir NW"/>
+        <tag k="name" v="WASHINGTON CIR NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-320" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20817"/>
+        <nd ref="-2862"/>
+        <nd ref="-4445"/>
+        <nd ref="-17717"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-319" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19555"/>
+        <nd ref="-1149"/>
+        <nd ref="-1150"/>
+        <nd ref="-1151"/>
+        <nd ref="-19625"/>
+        <nd ref="-2509"/>
+        <nd ref="-4710"/>
+        <nd ref="-2510"/>
+        <nd ref="-19520"/>
+        <tag k="alt_name" v="I St NW"/>
+        <tag k="name" v="I ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-318" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20925"/>
+        <nd ref="-2834"/>
+        <nd ref="-2837"/>
+        <nd ref="-7231"/>
+        <nd ref="-7232"/>
+        <nd ref="-2840"/>
+        <nd ref="-7233"/>
+        <nd ref="-2843"/>
+        <nd ref="-2846"/>
+        <nd ref="-2850"/>
+        <nd ref="-2854"/>
+        <nd ref="-20817"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="foot" v="designated"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-311" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25554"/>
+        <nd ref="-5709"/>
+        <nd ref="-5710"/>
+        <nd ref="-2367"/>
+        <nd ref="-2368"/>
+        <nd ref="-5711"/>
+        <nd ref="-2369"/>
+        <nd ref="-5712"/>
+        <nd ref="-2370"/>
+        <nd ref="-2371"/>
+        <nd ref="-5713"/>
+        <nd ref="-2372"/>
+        <nd ref="-5714"/>
+        <nd ref="-2373"/>
+        <nd ref="-5715"/>
+        <nd ref="-2374"/>
+        <nd ref="-2375"/>
+        <nd ref="-24988"/>
+        <nd ref="-5717"/>
+        <nd ref="-2459"/>
+        <nd ref="-5718"/>
+        <nd ref="-2460"/>
+        <nd ref="-5719"/>
+        <nd ref="-2461"/>
+        <nd ref="-5720"/>
+        <nd ref="-2462"/>
+        <nd ref="-5721"/>
+        <nd ref="-2463"/>
+        <nd ref="-2464"/>
+        <nd ref="-5722"/>
+        <nd ref="-2465"/>
+        <nd ref="-5723"/>
+        <nd ref="-2466"/>
+        <nd ref="-5724"/>
+        <nd ref="-2467"/>
+        <nd ref="-5725"/>
+        <nd ref="-2468"/>
+        <nd ref="-5726"/>
+        <nd ref="-2469"/>
+        <nd ref="-2470"/>
+        <nd ref="-5727"/>
+        <nd ref="-2471"/>
+        <nd ref="-5728"/>
+        <nd ref="-2472"/>
+        <nd ref="-5729"/>
+        <nd ref="-2473"/>
+        <nd ref="-2474"/>
+        <nd ref="-5730"/>
+        <nd ref="-2475"/>
+        <nd ref="-5731"/>
+        <nd ref="-2476"/>
+        <nd ref="-2477"/>
+        <nd ref="-2478"/>
+        <nd ref="-2479"/>
+        <nd ref="-5732"/>
+        <nd ref="-2480"/>
+        <nd ref="-21809"/>
+        <nd ref="-5733"/>
+        <nd ref="-2482"/>
+        <nd ref="-2483"/>
+        <nd ref="-5734"/>
+        <nd ref="-2484"/>
+        <nd ref="-5735"/>
+        <nd ref="-2485"/>
+        <nd ref="-5736"/>
+        <nd ref="-2486"/>
+        <nd ref="-5737"/>
+        <nd ref="-2487"/>
+        <nd ref="-2488"/>
+        <nd ref="-5738"/>
+        <nd ref="-2489"/>
+        <nd ref="-5739"/>
+        <nd ref="-2490"/>
+        <nd ref="-5740"/>
+        <nd ref="-2491"/>
+        <nd ref="-5741"/>
+        <nd ref="-2492"/>
+        <nd ref="-5743"/>
+        <nd ref="-2493"/>
+        <nd ref="-2494"/>
+        <nd ref="-5745"/>
+        <nd ref="-2495"/>
+        <nd ref="-5747"/>
+        <nd ref="-2496"/>
+        <nd ref="-2497"/>
+        <nd ref="-2498"/>
+        <nd ref="-2499"/>
+        <nd ref="-5749"/>
+        <nd ref="-2500"/>
+        <nd ref="-24271"/>
+        <nd ref="-5751"/>
+        <nd ref="-2378"/>
+        <nd ref="-2379"/>
+        <nd ref="-5752"/>
+        <nd ref="-2380"/>
+        <nd ref="-5753"/>
+        <nd ref="-2381"/>
+        <nd ref="-2382"/>
+        <nd ref="-24433"/>
+        <tag k="alt_name" v="24th St NW"/>
+        <tag k="name" v="24TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-307" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28043"/>
+        <nd ref="-36361"/>
+        <tag k="alt_name" v="23rd St NW"/>
+        <tag k="name" v="23RD ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-306" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23687"/>
+        <nd ref="-2057"/>
+        <nd ref="-2058"/>
+        <nd ref="-7433"/>
+        <nd ref="-2059"/>
+        <nd ref="-2060"/>
+        <nd ref="-7434"/>
+        <nd ref="-2062"/>
+        <nd ref="-23651"/>
+        <nd ref="-1069"/>
+        <nd ref="-1071"/>
+        <nd ref="-1073"/>
+        <nd ref="-1075"/>
+        <nd ref="-7436"/>
+        <nd ref="-1077"/>
+        <nd ref="-22758"/>
+        <tag k="alt_name" v="New York Ave NW"/>
+        <tag k="name" v="NEW YORK AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-304" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21279"/>
+        <nd ref="-1059"/>
+        <nd ref="-1061"/>
+        <nd ref="-6932"/>
+        <nd ref="-6933"/>
+        <nd ref="-1063"/>
+        <nd ref="-21263"/>
+        <nd ref="-1178"/>
+        <nd ref="-6935"/>
+        <nd ref="-1179"/>
+        <nd ref="-16898"/>
+        <nd ref="-1065"/>
+        <nd ref="-6939"/>
+        <nd ref="-17025"/>
+        <tag k="alt_name" v="New York Ave NW"/>
+        <tag k="name" v="NEW YORK AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-303" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22265"/>
+        <nd ref="-7115"/>
+        <nd ref="-1248"/>
+        <nd ref="-1250"/>
+        <nd ref="-22232"/>
+        <tag k="alt_name" v="13th St NW"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-301" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23981"/>
+        <nd ref="-4018"/>
+        <nd ref="-5783"/>
+        <nd ref="-4019"/>
+        <nd ref="-5784"/>
+        <nd ref="-4020"/>
+        <nd ref="-5785"/>
+        <nd ref="-4021"/>
+        <nd ref="-23996"/>
+        <nd ref="-4022"/>
+        <nd ref="-22748"/>
+        <nd ref="-2726"/>
+        <nd ref="-2728"/>
+        <nd ref="-2730"/>
+        <nd ref="-5788"/>
+        <nd ref="-2732"/>
+        <nd ref="-5789"/>
+        <nd ref="-2734"/>
+        <nd ref="-2736"/>
+        <nd ref="-2738"/>
+        <nd ref="-24045"/>
+        <nd ref="-3318"/>
+        <nd ref="-3319"/>
+        <nd ref="-3320"/>
+        <nd ref="-5790"/>
+        <nd ref="-3321"/>
+        <nd ref="-3322"/>
+        <nd ref="-3323"/>
+        <nd ref="-23999"/>
+        <nd ref="-5792"/>
+        <nd ref="-1180"/>
+        <nd ref="-1181"/>
+        <nd ref="-5793"/>
+        <nd ref="-1182"/>
+        <nd ref="-5794"/>
+        <nd ref="-1183"/>
+        <nd ref="-5795"/>
+        <nd ref="-1184"/>
+        <nd ref="-24005"/>
+        <nd ref="-1185"/>
+        <nd ref="-5797"/>
+        <nd ref="-5798"/>
+        <nd ref="-1186"/>
+        <nd ref="-1187"/>
+        <nd ref="-1188"/>
+        <nd ref="-5799"/>
+        <nd ref="-29305"/>
+        <nd ref="-5059"/>
+        <nd ref="-2289"/>
+        <nd ref="-34119"/>
+        <nd ref="-2291"/>
+        <nd ref="-37167"/>
+        <nd ref="-36185"/>
+        <nd ref="-2297"/>
+        <nd ref="-36230"/>
+        <nd ref="-2299"/>
+        <nd ref="-36800"/>
+        <tag k="alt_name" v="K St NW;US Hwy 29"/>
+        <tag k="name" v="K ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-300" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20961"/>
+        <nd ref="-1029"/>
+        <nd ref="-4688"/>
+        <nd ref="-1030"/>
+        <nd ref="-4690"/>
+        <nd ref="-1031"/>
+        <nd ref="-1032"/>
+        <nd ref="-22753"/>
+        <nd ref="-1034"/>
+        <nd ref="-22754"/>
+        <tag k="alt_name" v="15th St NW"/>
+        <tag k="name" v="15TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-297" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34278"/>
+        <nd ref="-5742"/>
+        <nd ref="-2604"/>
+        <nd ref="-5744"/>
+        <nd ref="-2605"/>
+        <nd ref="-5746"/>
+        <nd ref="-2606"/>
+        <nd ref="-5748"/>
+        <nd ref="-2607"/>
+        <nd ref="-15703"/>
+        <tag k="alt_name" v="12th St NW"/>
+        <tag k="name" v="12TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-296" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22232"/>
+        <nd ref="-7117"/>
+        <nd ref="-2621"/>
+        <nd ref="-7118"/>
+        <nd ref="-2623"/>
+        <nd ref="-7119"/>
+        <nd ref="-2625"/>
+        <nd ref="-2627"/>
+        <nd ref="-16562"/>
+        <nd ref="-2631"/>
+        <nd ref="-7121"/>
+        <nd ref="-2633"/>
+        <nd ref="-2635"/>
+        <nd ref="-16634"/>
+        <nd ref="-2639"/>
+        <nd ref="-7125"/>
+        <nd ref="-2641"/>
+        <nd ref="-7127"/>
+        <nd ref="-2643"/>
+        <nd ref="-2645"/>
+        <nd ref="-7129"/>
+        <nd ref="-2647"/>
+        <nd ref="-2649"/>
+        <nd ref="-21274"/>
+        <nd ref="-2653"/>
+        <nd ref="-2655"/>
+        <nd ref="-7131"/>
+        <nd ref="-2657"/>
+        <nd ref="-21279"/>
+        <nd ref="-7133"/>
+        <nd ref="-1256"/>
+        <nd ref="-7135"/>
+        <nd ref="-1258"/>
+        <nd ref="-7137"/>
+        <nd ref="-1260"/>
+        <nd ref="-1262"/>
+        <nd ref="-21247"/>
+        <nd ref="-7141"/>
+        <nd ref="-2659"/>
+        <nd ref="-2661"/>
+        <nd ref="-2663"/>
+        <nd ref="-2665"/>
+        <nd ref="-24192"/>
+        <nd ref="-2669"/>
+        <nd ref="-7145"/>
+        <nd ref="-2671"/>
+        <nd ref="-22740"/>
+        <tag k="alt_name" v="13th St NW"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-295" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34277"/>
+        <nd ref="-34278"/>
+        <tag k="alt_name" v="12th St NW"/>
+        <tag k="name" v="12TH ST EXPY NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-293" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19701"/>
+        <nd ref="-3266"/>
+        <nd ref="-7102"/>
+        <nd ref="-3267"/>
+        <nd ref="-7104"/>
+        <nd ref="-3268"/>
+        <nd ref="-7105"/>
+        <nd ref="-3269"/>
+        <nd ref="-7106"/>
+        <nd ref="-3270"/>
+        <nd ref="-26300"/>
+        <nd ref="-3272"/>
+        <nd ref="-7107"/>
+        <nd ref="-3273"/>
+        <nd ref="-7108"/>
+        <nd ref="-3274"/>
+        <nd ref="-7109"/>
+        <nd ref="-3275"/>
+        <nd ref="-7110"/>
+        <nd ref="-3276"/>
+        <nd ref="-19154"/>
+        <nd ref="-7112"/>
+        <nd ref="-3278"/>
+        <nd ref="-7113"/>
+        <nd ref="-3279"/>
+        <nd ref="-3280"/>
+        <nd ref="-19520"/>
+        <nd ref="-3302"/>
+        <nd ref="-3303"/>
+        <nd ref="-3304"/>
+        <nd ref="-3305"/>
+        <nd ref="-3306"/>
+        <nd ref="-3307"/>
+        <nd ref="-3308"/>
+        <nd ref="-3309"/>
+        <nd ref="-3310"/>
+        <nd ref="-3311"/>
+        <nd ref="-3312"/>
+        <nd ref="-3313"/>
+        <nd ref="-3314"/>
+        <nd ref="-3315"/>
+        <nd ref="-3316"/>
+        <nd ref="-3317"/>
+        <nd ref="-29305"/>
+        <nd ref="-3283"/>
+        <nd ref="-3284"/>
+        <nd ref="-3285"/>
+        <nd ref="-3286"/>
+        <nd ref="-3287"/>
+        <nd ref="-3288"/>
+        <nd ref="-3289"/>
+        <nd ref="-24014"/>
+        <tag k="alt_name" v="21st St NW"/>
+        <tag k="name" v="21ST ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-289" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34114"/>
+        <nd ref="-332"/>
+        <nd ref="-7055"/>
+        <nd ref="-333"/>
+        <nd ref="-34115"/>
+        <tag k="alt_name" v="23rd St NW"/>
+        <tag k="name" v="23RD ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-286" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36800"/>
+        <nd ref="-2771"/>
+        <nd ref="-35148"/>
+        <nd ref="-2772"/>
+        <nd ref="-5759"/>
+        <nd ref="-2773"/>
+        <nd ref="-2774"/>
+        <nd ref="-5760"/>
+        <nd ref="-2775"/>
+        <nd ref="-35879"/>
+        <nd ref="-769"/>
+        <nd ref="-771"/>
+        <nd ref="-34720"/>
+        <tag k="alt_name" v="24th St NW"/>
+        <tag k="name" v="24TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-285" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20065"/>
+        <nd ref="-4287"/>
+        <nd ref="-4424"/>
+        <nd ref="-4288"/>
+        <nd ref="-4425"/>
+        <nd ref="-4289"/>
+        <nd ref="-4290"/>
+        <nd ref="-4426"/>
+        <nd ref="-4291"/>
+        <nd ref="-4292"/>
+        <nd ref="-4427"/>
+        <nd ref="-4293"/>
+        <nd ref="-19895"/>
+        <nd ref="-4295"/>
+        <nd ref="-4429"/>
+        <nd ref="-4296"/>
+        <nd ref="-4298"/>
+        <nd ref="-4430"/>
+        <nd ref="-4300"/>
+        <nd ref="-4431"/>
+        <nd ref="-4302"/>
+        <nd ref="-4304"/>
+        <nd ref="-4432"/>
+        <nd ref="-19031"/>
+        <nd ref="-3291"/>
+        <nd ref="-4433"/>
+        <nd ref="-3292"/>
+        <nd ref="-4434"/>
+        <nd ref="-3293"/>
+        <nd ref="-4435"/>
+        <nd ref="-3294"/>
+        <nd ref="-4436"/>
+        <nd ref="-3295"/>
+        <nd ref="-19598"/>
+        <nd ref="-1153"/>
+        <nd ref="-4438"/>
+        <nd ref="-1154"/>
+        <nd ref="-1155"/>
+        <nd ref="-19625"/>
+        <nd ref="-1157"/>
+        <nd ref="-1158"/>
+        <nd ref="-1159"/>
+        <nd ref="-1160"/>
+        <nd ref="-4440"/>
+        <nd ref="-1161"/>
+        <nd ref="-1162"/>
+        <nd ref="-1163"/>
+        <nd ref="-1164"/>
+        <nd ref="-4441"/>
+        <nd ref="-1165"/>
+        <nd ref="-4442"/>
+        <nd ref="-1166"/>
+        <nd ref="-1167"/>
+        <nd ref="-4443"/>
+        <nd ref="-1168"/>
+        <nd ref="-1169"/>
+        <nd ref="-1170"/>
+        <nd ref="-24005"/>
+        <nd ref="-1172"/>
+        <nd ref="-1173"/>
+        <nd ref="-1174"/>
+        <nd ref="-1175"/>
+        <nd ref="-4444"/>
+        <nd ref="-1176"/>
+        <nd ref="-1177"/>
+        <nd ref="-24006"/>
+        <tag k="alt_name" v="20th St NW"/>
+        <tag k="name" v="20TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-282" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17889"/>
+        <nd ref="-5895"/>
+        <nd ref="-1228"/>
+        <nd ref="-1230"/>
+        <nd ref="-5896"/>
+        <nd ref="-1232"/>
+        <nd ref="-5897"/>
+        <nd ref="-1234"/>
+        <nd ref="-23996"/>
+        <nd ref="-1238"/>
+        <nd ref="-1240"/>
+        <nd ref="-1242"/>
+        <nd ref="-5898"/>
+        <nd ref="-23997"/>
+        <tag k="alt_name" v="17th St NW"/>
+        <tag k="name" v="17TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-281" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25523"/>
+        <nd ref="-211"/>
+        <nd ref="-6073"/>
+        <nd ref="-212"/>
+        <nd ref="-6075"/>
+        <nd ref="-213"/>
+        <nd ref="-6077"/>
+        <nd ref="-214"/>
+        <nd ref="-6079"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <nd ref="-6081"/>
+        <nd ref="-217"/>
+        <nd ref="-6083"/>
+        <nd ref="-218"/>
+        <nd ref="-219"/>
+        <nd ref="-6085"/>
+        <nd ref="-220"/>
+        <nd ref="-221"/>
+        <nd ref="-222"/>
+        <nd ref="-36955"/>
+        <nd ref="-3192"/>
+        <nd ref="-6087"/>
+        <nd ref="-3194"/>
+        <nd ref="-3196"/>
+        <nd ref="-3197"/>
+        <nd ref="-3199"/>
+        <nd ref="-26915"/>
+        <tag k="alt_name" v="22nd St NW"/>
+        <tag k="name" v="22ND ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
     <way visible="true" id="-278" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16611"/>
         <nd ref="-3437"/>
@@ -14543,50 +14214,56 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-277" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21579"/>
-        <nd ref="-5973"/>
-        <nd ref="-163"/>
-        <nd ref="-5974"/>
-        <nd ref="-164"/>
-        <nd ref="-165"/>
-        <nd ref="-166"/>
-        <nd ref="-167"/>
-        <nd ref="-5975"/>
-        <nd ref="-168"/>
-        <nd ref="-169"/>
-        <nd ref="-5977"/>
-        <nd ref="-170"/>
-        <nd ref="-5979"/>
-        <nd ref="-171"/>
-        <nd ref="-172"/>
-        <nd ref="-173"/>
-        <nd ref="-5981"/>
-        <nd ref="-174"/>
-        <nd ref="-5983"/>
-        <nd ref="-175"/>
-        <nd ref="-5985"/>
-        <nd ref="-176"/>
-        <nd ref="-177"/>
-        <nd ref="-178"/>
-        <nd ref="-5987"/>
-        <nd ref="-179"/>
-        <nd ref="-5990"/>
-        <nd ref="-180"/>
-        <nd ref="-181"/>
-        <nd ref="-5993"/>
-        <nd ref="-182"/>
-        <nd ref="-183"/>
-        <nd ref="-5996"/>
-        <nd ref="-184"/>
-        <nd ref="-185"/>
-        <nd ref="-21350"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-276" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19701"/>
+        <nd ref="-3904"/>
+        <nd ref="-3905"/>
+        <nd ref="-6245"/>
+        <nd ref="-3906"/>
+        <nd ref="-6247"/>
+        <nd ref="-3907"/>
+        <nd ref="-3908"/>
+        <nd ref="-3909"/>
+        <nd ref="-6249"/>
+        <nd ref="-3910"/>
+        <nd ref="-6250"/>
+        <nd ref="-3911"/>
+        <nd ref="-3912"/>
+        <nd ref="-6252"/>
+        <nd ref="-3913"/>
+        <nd ref="-3914"/>
+        <nd ref="-21350"/>
+        <nd ref="-496"/>
+        <nd ref="-498"/>
+        <nd ref="-500"/>
+        <nd ref="-502"/>
+        <nd ref="-504"/>
+        <nd ref="-506"/>
+        <nd ref="-6254"/>
+        <nd ref="-508"/>
+        <nd ref="-510"/>
+        <nd ref="-6256"/>
+        <nd ref="-512"/>
+        <nd ref="-514"/>
+        <nd ref="-516"/>
+        <nd ref="-6257"/>
+        <nd ref="-518"/>
+        <nd ref="-520"/>
+        <nd ref="-6258"/>
+        <nd ref="-522"/>
+        <nd ref="-524"/>
+        <nd ref="-6259"/>
+        <nd ref="-526"/>
+        <nd ref="-6260"/>
+        <nd ref="-528"/>
+        <nd ref="-6261"/>
+        <nd ref="-530"/>
+        <nd ref="-532"/>
+        <nd ref="-534"/>
+        <nd ref="-6262"/>
+        <nd ref="-536"/>
+        <nd ref="-6263"/>
+        <nd ref="-538"/>
         <nd ref="-21715"/>
         <nd ref="-3916"/>
         <nd ref="-6264"/>
@@ -14626,6 +14303,31 @@
         <nd ref="-6277"/>
         <nd ref="-3960"/>
         <nd ref="-24988"/>
+        <nd ref="-540"/>
+        <nd ref="-542"/>
+        <nd ref="-6278"/>
+        <nd ref="-544"/>
+        <nd ref="-546"/>
+        <nd ref="-549"/>
+        <nd ref="-552"/>
+        <nd ref="-554"/>
+        <nd ref="-556"/>
+        <nd ref="-558"/>
+        <nd ref="-6279"/>
+        <nd ref="-560"/>
+        <nd ref="-562"/>
+        <nd ref="-6280"/>
+        <nd ref="-564"/>
+        <nd ref="-566"/>
+        <nd ref="-568"/>
+        <nd ref="-6281"/>
+        <nd ref="-570"/>
+        <nd ref="-6282"/>
+        <nd ref="-572"/>
+        <nd ref="-6283"/>
+        <nd ref="-574"/>
+        <nd ref="-6284"/>
+        <nd ref="-24935"/>
         <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>
@@ -14660,30 +14362,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-273" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19701"/>
-        <nd ref="-3904"/>
-        <nd ref="-3905"/>
-        <nd ref="-6245"/>
-        <nd ref="-3906"/>
-        <nd ref="-6247"/>
-        <nd ref="-3907"/>
-        <nd ref="-3908"/>
-        <nd ref="-3909"/>
-        <nd ref="-6249"/>
-        <nd ref="-3910"/>
-        <nd ref="-6250"/>
-        <nd ref="-3911"/>
-        <nd ref="-3912"/>
-        <nd ref="-6252"/>
-        <nd ref="-3913"/>
-        <nd ref="-3914"/>
-        <nd ref="-21350"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-272" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16371"/>
         <nd ref="-7241"/>
@@ -14698,38 +14376,6 @@
         <nd ref="-16562"/>
         <tag k="alt_name" v="F St NW"/>
         <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-271" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19895"/>
-        <nd ref="-3897"/>
-        <nd ref="-3898"/>
-        <nd ref="-6243"/>
-        <nd ref="-3899"/>
-        <nd ref="-3900"/>
-        <nd ref="-3901"/>
-        <nd ref="-3902"/>
-        <nd ref="-3903"/>
-        <nd ref="-19701"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20086"/>
-        <nd ref="-3892"/>
-        <nd ref="-6237"/>
-        <nd ref="-3893"/>
-        <nd ref="-6239"/>
-        <nd ref="-3894"/>
-        <nd ref="-3895"/>
-        <nd ref="-6241"/>
-        <nd ref="-3896"/>
-        <nd ref="-19895"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -14772,28 +14418,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20268"/>
-        <nd ref="-3884"/>
-        <nd ref="-6225"/>
-        <nd ref="-6226"/>
-        <nd ref="-3885"/>
-        <nd ref="-3886"/>
-        <nd ref="-6227"/>
-        <nd ref="-6228"/>
-        <nd ref="-3887"/>
-        <nd ref="-3888"/>
-        <nd ref="-6229"/>
-        <nd ref="-3889"/>
-        <nd ref="-3890"/>
-        <nd ref="-6231"/>
-        <nd ref="-3891"/>
-        <nd ref="-20219"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37291"/>
         <nd ref="-3671"/>
@@ -14815,7 +14439,18 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-16634"/>
+        <nd ref="-3864"/>
+        <nd ref="-3866"/>
+        <nd ref="-3868"/>
+        <nd ref="-6941"/>
+        <nd ref="-6942"/>
+        <nd ref="-3870"/>
+        <nd ref="-3872"/>
+        <nd ref="-3874"/>
+        <nd ref="-3876"/>
+        <nd ref="-6943"/>
         <nd ref="-16639"/>
         <nd ref="-3878"/>
         <nd ref="-6944"/>
@@ -14830,60 +14465,12 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27277"/>
-        <nd ref="-6218"/>
-        <nd ref="-83"/>
-        <nd ref="-6220"/>
-        <nd ref="-85"/>
-        <nd ref="-6222"/>
-        <nd ref="-87"/>
-        <nd ref="-27278"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16634"/>
-        <nd ref="-3864"/>
-        <nd ref="-3866"/>
-        <nd ref="-3868"/>
-        <nd ref="-6941"/>
-        <nd ref="-6942"/>
-        <nd ref="-3870"/>
-        <nd ref="-3872"/>
-        <nd ref="-3874"/>
-        <nd ref="-3876"/>
-        <nd ref="-6943"/>
-        <nd ref="-16639"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3671"/>
         <nd ref="-36327"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31123"/>
-        <nd ref="-409"/>
-        <nd ref="-411"/>
-        <nd ref="-4504"/>
-        <nd ref="-413"/>
-        <nd ref="-415"/>
-        <nd ref="-4505"/>
-        <nd ref="-4506"/>
-        <nd ref="-417"/>
-        <nd ref="-31124"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16427"/>
@@ -14939,6 +14526,13 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35331"/>
+        <nd ref="-6400"/>
+        <nd ref="-2658"/>
+        <nd ref="-2660"/>
+        <nd ref="-2662"/>
+        <nd ref="-2664"/>
+        <nd ref="-2666"/>
         <nd ref="-24165"/>
         <nd ref="-2668"/>
         <nd ref="-2670"/>
@@ -14950,6 +14544,22 @@
         <nd ref="-6412"/>
         <nd ref="-2675"/>
         <nd ref="-19031"/>
+        <nd ref="-3000"/>
+        <nd ref="-6418"/>
+        <nd ref="-6421"/>
+        <nd ref="-3002"/>
+        <nd ref="-3004"/>
+        <nd ref="-6424"/>
+        <nd ref="-3006"/>
+        <nd ref="-3008"/>
+        <nd ref="-3010"/>
+        <nd ref="-3012"/>
+        <nd ref="-26300"/>
+        <nd ref="-3177"/>
+        <nd ref="-3179"/>
+        <nd ref="-6430"/>
+        <nd ref="-3181"/>
+        <nd ref="-26301"/>
         <tag k="alt_name" v="H St NW"/>
         <tag k="name" v="H ST NW"/>
         <tag k="highway" v="road"/>
@@ -14975,35 +14585,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18242"/>
-        <nd ref="-6357"/>
-        <nd ref="-2646"/>
-        <nd ref="-2648"/>
-        <nd ref="-6359"/>
-        <nd ref="-2650"/>
-        <nd ref="-2652"/>
-        <nd ref="-17861"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18468"/>
-        <nd ref="-4457"/>
-        <nd ref="-338"/>
-        <nd ref="-4458"/>
-        <nd ref="-339"/>
-        <nd ref="-340"/>
-        <nd ref="-4459"/>
-        <nd ref="-341"/>
-        <nd ref="-19598"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21278"/>
         <nd ref="-21279"/>
@@ -15012,45 +14593,16 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18245"/>
-        <nd ref="-2636"/>
-        <nd ref="-2638"/>
-        <nd ref="-2640"/>
-        <nd ref="-2642"/>
-        <nd ref="-18242"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26621"/>
-        <nd ref="-2626"/>
-        <nd ref="-2628"/>
-        <nd ref="-6345"/>
-        <nd ref="-2630"/>
-        <nd ref="-2632"/>
-        <nd ref="-18244"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16899"/>
-        <nd ref="-2619"/>
-        <nd ref="-6341"/>
-        <nd ref="-2620"/>
-        <nd ref="-2622"/>
-        <nd ref="-2624"/>
-        <nd ref="-26621"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21274"/>
+        <nd ref="-2608"/>
+        <nd ref="-6319"/>
+        <nd ref="-6321"/>
+        <nd ref="-2609"/>
+        <nd ref="-6323"/>
+        <nd ref="-2610"/>
+        <nd ref="-6325"/>
+        <nd ref="-2611"/>
         <nd ref="-21263"/>
         <nd ref="-6329"/>
         <nd ref="-2613"/>
@@ -15064,6 +14616,12 @@
         <nd ref="-6337"/>
         <nd ref="-2618"/>
         <nd ref="-16899"/>
+        <nd ref="-2619"/>
+        <nd ref="-6341"/>
+        <nd ref="-2620"/>
+        <nd ref="-2622"/>
+        <nd ref="-2624"/>
+        <nd ref="-26621"/>
         <tag k="alt_name" v="H St NW"/>
         <tag k="name" v="H ST NW"/>
         <tag k="highway" v="road"/>
@@ -15117,6 +14675,15 @@
         <nd ref="-666"/>
         <nd ref="-4503"/>
         <nd ref="-31123"/>
+        <nd ref="-409"/>
+        <nd ref="-411"/>
+        <nd ref="-4504"/>
+        <nd ref="-413"/>
+        <nd ref="-415"/>
+        <nd ref="-4505"/>
+        <nd ref="-4506"/>
+        <nd ref="-417"/>
+        <nd ref="-31124"/>
         <tag k="alt_name" v="F St NW"/>
         <tag k="name" v="F ST NW"/>
         <tag k="highway" v="road"/>
@@ -15128,49 +14695,6 @@
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21274"/>
-        <nd ref="-2608"/>
-        <nd ref="-6319"/>
-        <nd ref="-6321"/>
-        <nd ref="-2609"/>
-        <nd ref="-6323"/>
-        <nd ref="-2610"/>
-        <nd ref="-6325"/>
-        <nd ref="-2611"/>
-        <nd ref="-21263"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20435"/>
-        <nd ref="-5821"/>
-        <nd ref="-615"/>
-        <nd ref="-616"/>
-        <nd ref="-5822"/>
-        <nd ref="-617"/>
-        <nd ref="-618"/>
-        <nd ref="-5823"/>
-        <nd ref="-619"/>
-        <nd ref="-620"/>
-        <nd ref="-5824"/>
-        <nd ref="-621"/>
-        <nd ref="-622"/>
-        <nd ref="-5825"/>
-        <nd ref="-623"/>
-        <nd ref="-624"/>
-        <nd ref="-625"/>
-        <nd ref="-626"/>
-        <nd ref="-627"/>
-        <nd ref="-5826"/>
-        <nd ref="-21579"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-22748"/>
@@ -15205,23 +14729,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20856"/>
-        <nd ref="-608"/>
-        <nd ref="-609"/>
-        <nd ref="-5807"/>
-        <nd ref="-610"/>
-        <nd ref="-5808"/>
-        <nd ref="-611"/>
-        <nd ref="-612"/>
-        <nd ref="-613"/>
-        <nd ref="-614"/>
-        <nd ref="-20283"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35188"/>
         <nd ref="-3818"/>
@@ -15248,47 +14755,6 @@
         <nd ref="-31963"/>
         <tag k="alt_name" v="Arlington Memorial Brg"/>
         <tag k="name" v="ARLINGTON MEMORIAL BRG SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37021"/>
-        <nd ref="-4040"/>
-        <nd ref="-4039"/>
-        <nd ref="-4038"/>
-        <nd ref="-4037"/>
-        <nd ref="-7420"/>
-        <nd ref="-4036"/>
-        <nd ref="-4035"/>
-        <nd ref="-4034"/>
-        <nd ref="-4033"/>
-        <nd ref="-4032"/>
-        <nd ref="-4031"/>
-        <nd ref="-4030"/>
-        <nd ref="-7421"/>
-        <nd ref="-4029"/>
-        <nd ref="-37022"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20219"/>
-        <nd ref="-5380"/>
-        <nd ref="-144"/>
-        <nd ref="-5382"/>
-        <nd ref="-145"/>
-        <nd ref="-5384"/>
-        <nd ref="-146"/>
-        <nd ref="-5386"/>
-        <nd ref="-5388"/>
-        <nd ref="-147"/>
-        <nd ref="-5390"/>
-        <nd ref="-148"/>
-        <nd ref="-25773"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -15403,6 +14869,23 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31439"/>
+        <nd ref="-3831"/>
+        <nd ref="-6304"/>
+        <nd ref="-3833"/>
+        <nd ref="-6305"/>
+        <nd ref="-3835"/>
+        <nd ref="-3837"/>
+        <nd ref="-3839"/>
+        <nd ref="-3841"/>
+        <nd ref="-3843"/>
+        <nd ref="-6306"/>
+        <nd ref="-3845"/>
+        <nd ref="-3847"/>
+        <nd ref="-6307"/>
+        <nd ref="-3849"/>
+        <nd ref="-3852"/>
+        <nd ref="-6308"/>
         <nd ref="-31431"/>
         <nd ref="-3858"/>
         <nd ref="-3861"/>
@@ -15450,36 +14933,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17025"/>
-        <nd ref="-1076"/>
-        <nd ref="-1078"/>
-        <nd ref="-1079"/>
-        <nd ref="-6907"/>
-        <nd ref="-1080"/>
-        <nd ref="-6909"/>
-        <nd ref="-1081"/>
-        <nd ref="-6911"/>
-        <nd ref="-1082"/>
-        <nd ref="-26621"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24133"/>
-        <nd ref="-5980"/>
-        <nd ref="-2063"/>
-        <nd ref="-5982"/>
-        <nd ref="-2064"/>
-        <nd ref="-2065"/>
-        <nd ref="-24134"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30937"/>
         <nd ref="-6892"/>
@@ -15507,85 +14960,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21247"/>
-        <nd ref="-7141"/>
-        <nd ref="-2659"/>
-        <nd ref="-2661"/>
-        <nd ref="-2663"/>
-        <nd ref="-2665"/>
-        <nd ref="-24192"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19895"/>
-        <nd ref="-4295"/>
-        <nd ref="-4429"/>
-        <nd ref="-4296"/>
-        <nd ref="-4298"/>
-        <nd ref="-4430"/>
-        <nd ref="-4300"/>
-        <nd ref="-4431"/>
-        <nd ref="-4302"/>
-        <nd ref="-4304"/>
-        <nd ref="-4432"/>
-        <nd ref="-19031"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21274"/>
-        <nd ref="-2653"/>
-        <nd ref="-2655"/>
-        <nd ref="-7131"/>
-        <nd ref="-2657"/>
-        <nd ref="-21279"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20065"/>
-        <nd ref="-4287"/>
-        <nd ref="-4424"/>
-        <nd ref="-4288"/>
-        <nd ref="-4425"/>
-        <nd ref="-4289"/>
-        <nd ref="-4290"/>
-        <nd ref="-4426"/>
-        <nd ref="-4291"/>
-        <nd ref="-4292"/>
-        <nd ref="-4427"/>
-        <nd ref="-4293"/>
-        <nd ref="-19895"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16634"/>
-        <nd ref="-2639"/>
-        <nd ref="-7125"/>
-        <nd ref="-2641"/>
-        <nd ref="-7127"/>
-        <nd ref="-2643"/>
-        <nd ref="-2645"/>
-        <nd ref="-7129"/>
-        <nd ref="-2647"/>
-        <nd ref="-2649"/>
-        <nd ref="-21274"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-31568"/>
         <nd ref="-4282"/>
@@ -15596,45 +14970,18 @@
         <nd ref="-4285"/>
         <nd ref="-4286"/>
         <nd ref="-31505"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16562"/>
-        <nd ref="-2631"/>
-        <nd ref="-7121"/>
-        <nd ref="-2633"/>
-        <nd ref="-2635"/>
-        <nd ref="-16634"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23818"/>
-        <nd ref="-4410"/>
-        <nd ref="-4266"/>
-        <nd ref="-4268"/>
-        <nd ref="-4411"/>
-        <nd ref="-4270"/>
-        <nd ref="-4412"/>
-        <nd ref="-4272"/>
-        <nd ref="-4413"/>
-        <nd ref="-4274"/>
-        <nd ref="-4414"/>
-        <nd ref="-4276"/>
-        <nd ref="-4415"/>
-        <nd ref="-4277"/>
-        <nd ref="-4416"/>
-        <nd ref="-4278"/>
-        <nd ref="-4417"/>
-        <nd ref="-4279"/>
-        <nd ref="-4280"/>
-        <nd ref="-4418"/>
-        <nd ref="-31568"/>
+        <nd ref="-3373"/>
+        <nd ref="-4421"/>
+        <nd ref="-3374"/>
+        <nd ref="-3375"/>
+        <nd ref="-3376"/>
+        <nd ref="-3377"/>
+        <nd ref="-4422"/>
+        <nd ref="-3378"/>
+        <nd ref="-3379"/>
+        <nd ref="-4423"/>
+        <nd ref="-3380"/>
+        <nd ref="-20065"/>
         <tag k="alt_name" v="20th St NW"/>
         <tag k="name" v="20TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -15653,23 +15000,16 @@
         <nd ref="-4632"/>
         <nd ref="-4028"/>
         <nd ref="-24433"/>
+        <nd ref="-137"/>
+        <nd ref="-4633"/>
+        <nd ref="-138"/>
+        <nd ref="-139"/>
+        <nd ref="-140"/>
+        <nd ref="-4634"/>
+        <nd ref="-141"/>
+        <nd ref="-27725"/>
         <tag k="alt_name" v="New Hampshire Ave NW"/>
         <tag k="name" v="NEW HAMPSHIRE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22232"/>
-        <nd ref="-7117"/>
-        <nd ref="-2621"/>
-        <nd ref="-7118"/>
-        <nd ref="-2623"/>
-        <nd ref="-7119"/>
-        <nd ref="-2625"/>
-        <nd ref="-2627"/>
-        <nd ref="-16562"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -15712,62 +15052,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21263"/>
-        <nd ref="-1178"/>
-        <nd ref="-6935"/>
-        <nd ref="-1179"/>
-        <nd ref="-16898"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20086"/>
-        <nd ref="-4197"/>
-        <nd ref="-7154"/>
-        <nd ref="-4198"/>
-        <nd ref="-4199"/>
-        <nd ref="-7155"/>
-        <nd ref="-4200"/>
-        <nd ref="-4201"/>
-        <nd ref="-4202"/>
-        <nd ref="-24165"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23851"/>
-        <nd ref="-4185"/>
-        <nd ref="-7126"/>
-        <nd ref="-4186"/>
-        <nd ref="-7128"/>
-        <nd ref="-4187"/>
-        <nd ref="-7130"/>
-        <nd ref="-4188"/>
-        <nd ref="-7132"/>
-        <nd ref="-4189"/>
-        <nd ref="-7134"/>
-        <nd ref="-4190"/>
-        <nd ref="-7136"/>
-        <nd ref="-4191"/>
-        <nd ref="-4192"/>
-        <nd ref="-7138"/>
-        <nd ref="-4193"/>
-        <nd ref="-7140"/>
-        <nd ref="-4194"/>
-        <nd ref="-4195"/>
-        <nd ref="-7142"/>
-        <nd ref="-4196"/>
-        <nd ref="-23467"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-18244"/>
         <nd ref="-1944"/>
@@ -15800,43 +15084,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20961"/>
-        <nd ref="-1029"/>
-        <nd ref="-4688"/>
-        <nd ref="-1030"/>
-        <nd ref="-4690"/>
-        <nd ref="-1031"/>
-        <nd ref="-1032"/>
-        <nd ref="-22753"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17861"/>
-        <nd ref="-3705"/>
-        <nd ref="-6363"/>
-        <nd ref="-3707"/>
-        <nd ref="-3709"/>
-        <nd ref="-6365"/>
-        <nd ref="-3711"/>
-        <nd ref="-6367"/>
-        <nd ref="-3713"/>
-        <nd ref="-6369"/>
-        <nd ref="-3715"/>
-        <nd ref="-3717"/>
-        <nd ref="-6371"/>
-        <nd ref="-3719"/>
-        <nd ref="-3721"/>
-        <nd ref="-6373"/>
-        <nd ref="-25938"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19555"/>
         <nd ref="-4122"/>
@@ -15846,29 +15093,101 @@
         <nd ref="-4125"/>
         <nd ref="-4126"/>
         <nd ref="-23999"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18468"/>
-        <nd ref="-4115"/>
-        <nd ref="-4116"/>
-        <nd ref="-7158"/>
-        <nd ref="-4117"/>
-        <nd ref="-7159"/>
-        <nd ref="-4118"/>
-        <nd ref="-7160"/>
-        <nd ref="-4119"/>
-        <nd ref="-4120"/>
-        <nd ref="-19555"/>
+        <nd ref="-4203"/>
+        <nd ref="-4204"/>
+        <nd ref="-7163"/>
+        <nd ref="-4205"/>
+        <nd ref="-7165"/>
+        <nd ref="-4206"/>
+        <nd ref="-24000"/>
         <tag k="alt_name" v="19th St NW"/>
         <tag k="name" v="19TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26279"/>
+        <nd ref="-6442"/>
+        <nd ref="-3185"/>
+        <nd ref="-3187"/>
+        <nd ref="-6445"/>
+        <nd ref="-3189"/>
+        <nd ref="-3191"/>
+        <nd ref="-3193"/>
+        <nd ref="-3195"/>
+        <nd ref="-26280"/>
+        <nd ref="-3764"/>
+        <nd ref="-6450"/>
+        <nd ref="-3766"/>
+        <nd ref="-3768"/>
+        <nd ref="-6453"/>
+        <nd ref="-3770"/>
+        <nd ref="-6456"/>
+        <nd ref="-3772"/>
+        <nd ref="-3774"/>
+        <nd ref="-6459"/>
+        <nd ref="-3776"/>
+        <nd ref="-3778"/>
+        <nd ref="-3780"/>
+        <nd ref="-6462"/>
+        <nd ref="-3782"/>
+        <nd ref="-6465"/>
+        <nd ref="-3784"/>
+        <nd ref="-6468"/>
+        <nd ref="-3786"/>
+        <nd ref="-6471"/>
+        <nd ref="-3788"/>
+        <nd ref="-3790"/>
+        <nd ref="-6474"/>
+        <nd ref="-21605"/>
+        <nd ref="-2412"/>
+        <nd ref="-2414"/>
+        <nd ref="-6477"/>
+        <nd ref="-2416"/>
+        <nd ref="-6480"/>
+        <nd ref="-2418"/>
+        <nd ref="-6483"/>
+        <nd ref="-2420"/>
+        <nd ref="-6486"/>
+        <nd ref="-2422"/>
+        <nd ref="-2423"/>
+        <nd ref="-2424"/>
+        <nd ref="-6489"/>
+        <nd ref="-2425"/>
+        <nd ref="-6493"/>
+        <nd ref="-2426"/>
+        <nd ref="-6497"/>
+        <nd ref="-2427"/>
+        <nd ref="-2428"/>
+        <nd ref="-2429"/>
+        <nd ref="-6501"/>
+        <nd ref="-2430"/>
+        <nd ref="-21809"/>
+        <nd ref="-6508"/>
+        <nd ref="-2431"/>
+        <nd ref="-2432"/>
+        <nd ref="-2433"/>
+        <nd ref="-6511"/>
+        <nd ref="-6514"/>
+        <nd ref="-2434"/>
+        <nd ref="-2435"/>
+        <nd ref="-6517"/>
+        <nd ref="-2436"/>
+        <nd ref="-2437"/>
+        <nd ref="-6521"/>
+        <nd ref="-2438"/>
+        <nd ref="-6525"/>
+        <nd ref="-2439"/>
+        <nd ref="-6529"/>
+        <nd ref="-2440"/>
+        <nd ref="-6533"/>
+        <nd ref="-6536"/>
+        <nd ref="-2441"/>
+        <nd ref="-2442"/>
+        <nd ref="-2443"/>
+        <nd ref="-6539"/>
+        <nd ref="-2444"/>
+        <nd ref="-2445"/>
         <nd ref="-27699"/>
         <nd ref="-3792"/>
         <nd ref="-3794"/>
@@ -15907,73 +15226,50 @@
         <nd ref="-7157"/>
         <nd ref="-4113"/>
         <nd ref="-18468"/>
+        <nd ref="-4115"/>
+        <nd ref="-4116"/>
+        <nd ref="-7158"/>
+        <nd ref="-4117"/>
+        <nd ref="-7159"/>
+        <nd ref="-4118"/>
+        <nd ref="-7160"/>
+        <nd ref="-4119"/>
+        <nd ref="-4120"/>
+        <nd ref="-19555"/>
         <tag k="alt_name" v="19th St NW"/>
         <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26280"/>
-        <nd ref="-3764"/>
-        <nd ref="-6450"/>
-        <nd ref="-3766"/>
-        <nd ref="-3768"/>
-        <nd ref="-6453"/>
-        <nd ref="-3770"/>
-        <nd ref="-6456"/>
-        <nd ref="-3772"/>
-        <nd ref="-3774"/>
-        <nd ref="-6459"/>
-        <nd ref="-3776"/>
-        <nd ref="-3778"/>
-        <nd ref="-3780"/>
-        <nd ref="-6462"/>
-        <nd ref="-3782"/>
-        <nd ref="-6465"/>
-        <nd ref="-3784"/>
-        <nd ref="-6468"/>
-        <nd ref="-3786"/>
-        <nd ref="-6471"/>
-        <nd ref="-3788"/>
-        <nd ref="-3790"/>
-        <nd ref="-6474"/>
-        <nd ref="-21605"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25955"/>
-        <nd ref="-6003"/>
-        <nd ref="-2554"/>
-        <nd ref="-2555"/>
-        <nd ref="-6006"/>
-        <nd ref="-2556"/>
-        <nd ref="-2557"/>
-        <nd ref="-23985"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20205"/>
-        <nd ref="-4102"/>
-        <nd ref="-7151"/>
-        <nd ref="-4103"/>
-        <nd ref="-4104"/>
-        <nd ref="-4105"/>
-        <nd ref="-4106"/>
-        <nd ref="-7152"/>
-        <nd ref="-4107"/>
-        <nd ref="-20086"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23851"/>
+        <nd ref="-4185"/>
+        <nd ref="-7126"/>
+        <nd ref="-4186"/>
+        <nd ref="-7128"/>
+        <nd ref="-4187"/>
+        <nd ref="-7130"/>
+        <nd ref="-4188"/>
+        <nd ref="-7132"/>
+        <nd ref="-4189"/>
+        <nd ref="-7134"/>
+        <nd ref="-4190"/>
+        <nd ref="-7136"/>
+        <nd ref="-4191"/>
+        <nd ref="-4192"/>
+        <nd ref="-7138"/>
+        <nd ref="-4193"/>
+        <nd ref="-7140"/>
+        <nd ref="-4194"/>
+        <nd ref="-4195"/>
+        <nd ref="-7142"/>
+        <nd ref="-4196"/>
+        <nd ref="-23467"/>
+        <nd ref="-4089"/>
+        <nd ref="-7144"/>
+        <nd ref="-4090"/>
+        <nd ref="-7146"/>
+        <nd ref="-4091"/>
         <nd ref="-22921"/>
         <nd ref="-7147"/>
         <nd ref="-4093"/>
@@ -15988,37 +15284,39 @@
         <nd ref="-4099"/>
         <nd ref="-4100"/>
         <nd ref="-20205"/>
+        <nd ref="-4102"/>
+        <nd ref="-7151"/>
+        <nd ref="-4103"/>
+        <nd ref="-4104"/>
+        <nd ref="-4105"/>
+        <nd ref="-4106"/>
+        <nd ref="-7152"/>
+        <nd ref="-4107"/>
+        <nd ref="-20086"/>
+        <nd ref="-4197"/>
+        <nd ref="-7154"/>
+        <nd ref="-4198"/>
+        <nd ref="-4199"/>
+        <nd ref="-7155"/>
+        <nd ref="-4200"/>
+        <nd ref="-4201"/>
+        <nd ref="-4202"/>
+        <nd ref="-24165"/>
         <tag k="alt_name" v="19th St NW"/>
         <tag k="name" v="19TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16898"/>
-        <nd ref="-2545"/>
-        <nd ref="-2546"/>
-        <nd ref="-2547"/>
-        <nd ref="-2548"/>
-        <nd ref="-16899"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23467"/>
-        <nd ref="-4089"/>
-        <nd ref="-7144"/>
-        <nd ref="-4090"/>
-        <nd ref="-7146"/>
-        <nd ref="-4091"/>
-        <nd ref="-22921"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35221"/>
+        <nd ref="-2138"/>
+        <nd ref="-2139"/>
+        <nd ref="-5986"/>
+        <nd ref="-2140"/>
+        <nd ref="-2141"/>
+        <nd ref="-16502"/>
+        <nd ref="-2536"/>
+        <nd ref="-2537"/>
         <nd ref="-16639"/>
         <nd ref="-2539"/>
         <nd ref="-5994"/>
@@ -16027,6 +15325,11 @@
         <nd ref="-2542"/>
         <nd ref="-2543"/>
         <nd ref="-16898"/>
+        <nd ref="-2545"/>
+        <nd ref="-2546"/>
+        <nd ref="-2547"/>
+        <nd ref="-2548"/>
+        <nd ref="-16899"/>
         <tag k="alt_name" v="14th St NW"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -16046,27 +15349,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16502"/>
-        <nd ref="-2536"/>
-        <nd ref="-2537"/>
-        <nd ref="-16639"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24134"/>
-        <nd ref="-2533"/>
-        <nd ref="-2534"/>
-        <nd ref="-2535"/>
-        <nd ref="-35221"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-22285"/>
         <nd ref="-2524"/>
@@ -16079,20 +15361,6 @@
         <nd ref="-7347"/>
         <nd ref="-2530"/>
         <nd ref="-30938"/>
-        <tag k="alt_name" v="14th St NW;US Hwy 1"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22300"/>
-        <nd ref="-2520"/>
-        <nd ref="-7342"/>
-        <nd ref="-7343"/>
-        <nd ref="-2521"/>
-        <nd ref="-7344"/>
-        <nd ref="-2522"/>
-        <nd ref="-22285"/>
         <tag k="alt_name" v="14th St NW;US Hwy 1"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -16118,61 +15386,36 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19625"/>
-        <nd ref="-2509"/>
-        <nd ref="-4710"/>
-        <nd ref="-2510"/>
-        <nd ref="-19520"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-17889"/>
         <nd ref="-4704"/>
         <nd ref="-2508"/>
         <nd ref="-17999"/>
+        <nd ref="-2126"/>
+        <nd ref="-2128"/>
+        <nd ref="-4706"/>
+        <nd ref="-2130"/>
+        <nd ref="-2132"/>
+        <nd ref="-18123"/>
+        <nd ref="-2134"/>
+        <nd ref="-4708"/>
+        <nd ref="-2135"/>
+        <nd ref="-2136"/>
+        <nd ref="-19555"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19520"/>
-        <nd ref="-4319"/>
-        <nd ref="-4465"/>
-        <nd ref="-4320"/>
-        <nd ref="-4466"/>
-        <nd ref="-4321"/>
-        <nd ref="-4467"/>
-        <nd ref="-4322"/>
-        <nd ref="-36955"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25955"/>
-        <nd ref="-2501"/>
-        <nd ref="-4681"/>
-        <nd ref="-2502"/>
-        <nd ref="-2503"/>
-        <nd ref="-2504"/>
-        <nd ref="-4682"/>
-        <nd ref="-2505"/>
-        <nd ref="-2506"/>
-        <nd ref="-2507"/>
-        <nd ref="-4683"/>
-        <nd ref="-21165"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18468"/>
+        <nd ref="-4457"/>
+        <nd ref="-338"/>
+        <nd ref="-4458"/>
+        <nd ref="-339"/>
+        <nd ref="-340"/>
+        <nd ref="-4459"/>
+        <nd ref="-341"/>
         <nd ref="-19598"/>
         <nd ref="-4312"/>
         <nd ref="-4460"/>
@@ -16186,49 +15429,19 @@
         <nd ref="-4463"/>
         <nd ref="-4318"/>
         <nd ref="-19520"/>
+        <nd ref="-4319"/>
+        <nd ref="-4465"/>
+        <nd ref="-4320"/>
+        <nd ref="-4466"/>
+        <nd ref="-4321"/>
+        <nd ref="-4467"/>
+        <nd ref="-4322"/>
+        <nd ref="-36955"/>
+        <nd ref="-7064"/>
+        <nd ref="-7065"/>
+        <nd ref="-37256"/>
         <tag k="alt_name" v="Pennsylvania Ave NW"/>
         <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17999"/>
-        <nd ref="-1434"/>
-        <nd ref="-1436"/>
-        <nd ref="-4670"/>
-        <nd ref="-1438"/>
-        <nd ref="-1440"/>
-        <nd ref="-1442"/>
-        <nd ref="-4671"/>
-        <nd ref="-1444"/>
-        <nd ref="-1446"/>
-        <nd ref="-1448"/>
-        <nd ref="-1450"/>
-        <nd ref="-4672"/>
-        <nd ref="-1452"/>
-        <nd ref="-4674"/>
-        <nd ref="-1454"/>
-        <nd ref="-1456"/>
-        <nd ref="-22748"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20856"/>
-        <nd ref="-1424"/>
-        <nd ref="-4657"/>
-        <nd ref="-1426"/>
-        <nd ref="-4658"/>
-        <nd ref="-1428"/>
-        <nd ref="-4659"/>
-        <nd ref="-1430"/>
-        <nd ref="-4660"/>
-        <nd ref="-1432"/>
-        <nd ref="-20268"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16259,6 +15472,11 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24649"/>
+        <nd ref="-4838"/>
+        <nd ref="-113"/>
+        <nd ref="-4840"/>
+        <nd ref="-115"/>
         <nd ref="-32730"/>
         <nd ref="-117"/>
         <nd ref="-119"/>
@@ -16271,19 +15489,16 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24649"/>
-        <nd ref="-4838"/>
-        <nd ref="-113"/>
-        <nd ref="-4840"/>
-        <nd ref="-115"/>
-        <nd ref="-32730"/>
-        <tag k="alt_name" v="E Executive Ave NW"/>
-        <tag k="name" v="EAST EXECUTIVE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23446"/>
+        <nd ref="-2676"/>
+        <nd ref="-6829"/>
+        <nd ref="-2677"/>
+        <nd ref="-6831"/>
+        <nd ref="-2678"/>
+        <nd ref="-2679"/>
+        <nd ref="-6833"/>
+        <nd ref="-2680"/>
         <nd ref="-23369"/>
         <nd ref="-3463"/>
         <nd ref="-3464"/>
@@ -16298,19 +15513,47 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36361"/>
-        <nd ref="-74"/>
-        <nd ref="-5513"/>
-        <nd ref="-73"/>
-        <nd ref="-72"/>
-        <nd ref="-32708"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21715"/>
+        <nd ref="-295"/>
+        <nd ref="-296"/>
+        <nd ref="-297"/>
+        <nd ref="-5275"/>
+        <nd ref="-298"/>
+        <nd ref="-5277"/>
+        <nd ref="-299"/>
+        <nd ref="-300"/>
+        <nd ref="-5279"/>
+        <nd ref="-301"/>
+        <nd ref="-5281"/>
+        <nd ref="-302"/>
+        <nd ref="-5283"/>
+        <nd ref="-303"/>
+        <nd ref="-304"/>
+        <nd ref="-305"/>
+        <nd ref="-5285"/>
+        <nd ref="-306"/>
+        <nd ref="-5287"/>
+        <nd ref="-307"/>
+        <nd ref="-308"/>
+        <nd ref="-309"/>
+        <nd ref="-310"/>
+        <nd ref="-5289"/>
+        <nd ref="-311"/>
+        <nd ref="-312"/>
+        <nd ref="-5291"/>
+        <nd ref="-313"/>
+        <nd ref="-314"/>
+        <nd ref="-5293"/>
+        <nd ref="-315"/>
+        <nd ref="-5295"/>
+        <nd ref="-316"/>
+        <nd ref="-317"/>
+        <nd ref="-5297"/>
+        <nd ref="-318"/>
+        <nd ref="-319"/>
+        <nd ref="-5299"/>
+        <nd ref="-320"/>
         <nd ref="-21605"/>
         <nd ref="-5303"/>
         <nd ref="-3979"/>
@@ -16354,92 +15597,55 @@
         <nd ref="-5331"/>
         <nd ref="-4004"/>
         <nd ref="-21477"/>
+        <nd ref="-321"/>
+        <nd ref="-322"/>
+        <nd ref="-5334"/>
+        <nd ref="-323"/>
+        <nd ref="-5335"/>
+        <nd ref="-324"/>
+        <nd ref="-5336"/>
+        <nd ref="-325"/>
+        <nd ref="-5337"/>
+        <nd ref="-326"/>
+        <nd ref="-5338"/>
+        <nd ref="-327"/>
+        <nd ref="-328"/>
+        <nd ref="-329"/>
+        <nd ref="-26842"/>
         <tag k="alt_name" v="23rd St NW"/>
         <tag k="name" v="23RD ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36361"/>
+        <nd ref="-74"/>
+        <nd ref="-5513"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
         <nd ref="-32708"/>
         <nd ref="-5511"/>
         <nd ref="-71"/>
         <nd ref="-70"/>
         <nd ref="-32709"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32709"/>
         <nd ref="-68"/>
         <nd ref="-66"/>
         <nd ref="-64"/>
-        <nd ref="-31694"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28789"/>
-        <nd ref="-3917"/>
-        <nd ref="-5212"/>
-        <nd ref="-3919"/>
-        <nd ref="-3921"/>
-        <nd ref="-5214"/>
-        <nd ref="-3923"/>
-        <nd ref="-3925"/>
-        <nd ref="-5216"/>
-        <nd ref="-3927"/>
-        <nd ref="-5218"/>
-        <nd ref="-3929"/>
-        <nd ref="-28868"/>
-        <nd ref="-5222"/>
-        <nd ref="-3933"/>
-        <nd ref="-35901"/>
-        <nd ref="-3937"/>
-        <nd ref="-5226"/>
-        <nd ref="-3939"/>
-        <nd ref="-29235"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-31694"/>
         <nd ref="-62"/>
         <nd ref="-60"/>
         <nd ref="-59"/>
         <nd ref="-31492"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31492"/>
         <nd ref="-58"/>
         <nd ref="-57"/>
         <nd ref="-56"/>
         <nd ref="-31493"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1223"/>
+        <nd ref="-1221"/>
+        <nd ref="-1219"/>
         <nd ref="-31958"/>
         <nd ref="-55"/>
         <nd ref="-54"/>
-        <nd ref="-31959"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-31959"/>
         <nd ref="-52"/>
         <nd ref="-51"/>
@@ -16450,37 +15656,17 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17889"/>
-        <nd ref="-5895"/>
-        <nd ref="-1228"/>
-        <nd ref="-1230"/>
-        <nd ref="-5896"/>
-        <nd ref="-1232"/>
-        <nd ref="-5897"/>
-        <nd ref="-1234"/>
-        <nd ref="-23996"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18245"/>
-        <nd ref="-3846"/>
-        <nd ref="-3848"/>
-        <nd ref="-7348"/>
-        <nd ref="-3850"/>
-        <nd ref="-7349"/>
-        <nd ref="-3853"/>
-        <nd ref="-3856"/>
-        <nd ref="-18228"/>
-        <tag k="alt_name" v="16th St NW"/>
-        <tag k="name" v="16TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17717"/>
+        <nd ref="-1203"/>
+        <nd ref="-4663"/>
+        <nd ref="-1204"/>
+        <nd ref="-4664"/>
+        <nd ref="-1205"/>
+        <nd ref="-4665"/>
+        <nd ref="-1206"/>
+        <nd ref="-1208"/>
+        <nd ref="-1210"/>
         <nd ref="-17861"/>
         <nd ref="-4666"/>
         <nd ref="-1214"/>
@@ -16491,41 +15677,25 @@
         <nd ref="-1220"/>
         <nd ref="-1222"/>
         <nd ref="-17999"/>
+        <nd ref="-1434"/>
+        <nd ref="-1436"/>
+        <nd ref="-4670"/>
+        <nd ref="-1438"/>
+        <nd ref="-1440"/>
+        <nd ref="-1442"/>
+        <nd ref="-4671"/>
+        <nd ref="-1444"/>
+        <nd ref="-1446"/>
+        <nd ref="-1448"/>
+        <nd ref="-1450"/>
+        <nd ref="-4672"/>
+        <nd ref="-1452"/>
+        <nd ref="-4674"/>
+        <nd ref="-1454"/>
+        <nd ref="-1456"/>
+        <nd ref="-22748"/>
         <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-30938"/>
-        <nd ref="-24"/>
-        <nd ref="-22"/>
-        <nd ref="-5482"/>
-        <nd ref="-20"/>
-        <nd ref="-5481"/>
-        <nd ref="-18"/>
-        <nd ref="-16"/>
-        <nd ref="-14"/>
-        <nd ref="-12"/>
-        <nd ref="-5480"/>
-        <nd ref="-11"/>
-        <nd ref="-5479"/>
-        <nd ref="-10"/>
-        <nd ref="-5478"/>
-        <nd ref="-9"/>
-        <nd ref="-5477"/>
-        <nd ref="-8"/>
-        <nd ref="-7"/>
-        <nd ref="-6"/>
-        <nd ref="-5476"/>
-        <nd ref="-5"/>
-        <nd ref="-5475"/>
-        <nd ref="-4"/>
-        <nd ref="-3"/>
-        <nd ref="-2"/>
-        <nd ref="-34278"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 1;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16543,60 +15713,11 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17717"/>
-        <nd ref="-1203"/>
-        <nd ref="-4663"/>
-        <nd ref="-1204"/>
-        <nd ref="-4664"/>
-        <nd ref="-1205"/>
-        <nd ref="-4665"/>
-        <nd ref="-1206"/>
-        <nd ref="-1208"/>
-        <nd ref="-1210"/>
-        <nd ref="-17861"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20268"/>
-        <nd ref="-1199"/>
-        <nd ref="-1200"/>
-        <nd ref="-4662"/>
-        <nd ref="-1201"/>
-        <nd ref="-17717"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23687"/>
-        <nd ref="-1192"/>
-        <nd ref="-1193"/>
-        <nd ref="-4655"/>
-        <nd ref="-1194"/>
-        <nd ref="-1195"/>
-        <nd ref="-4656"/>
-        <nd ref="-1196"/>
-        <nd ref="-20856"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23686"/>
-        <nd ref="-1190"/>
-        <nd ref="-23687"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35691"/>
+        <nd ref="-3815"/>
+        <nd ref="-7237"/>
+        <nd ref="-3814"/>
         <nd ref="-36914"/>
         <nd ref="-7239"/>
         <nd ref="-7240"/>
@@ -16641,9 +15762,16 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22300"/>
         <nd ref="-22540"/>
-        <tag k="alt_name" v="14th St SW;US Hwy 1"/>
+        <nd ref="-22300"/>
+        <nd ref="-2520"/>
+        <nd ref="-7342"/>
+        <nd ref="-7343"/>
+        <nd ref="-2521"/>
+        <nd ref="-7344"/>
+        <nd ref="-2522"/>
+        <nd ref="-22285"/>
+        <tag k="alt_name" v="14TH ST NW;14th St NW;14th St SW;US Hwy 1"/>
         <tag k="name" v="14TH ST SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
@@ -16663,19 +15791,6 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22540"/>
-        <nd ref="-3438"/>
-        <nd ref="-6153"/>
-        <nd ref="-6155"/>
-        <nd ref="-3440"/>
-        <nd ref="-3442"/>
-        <nd ref="-25764"/>
-        <tag k="alt_name" v="Jefferson Dr SW"/>
-        <tag k="name" v="JEFFERSON DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-32225"/>
         <nd ref="-6120"/>
         <nd ref="-3421"/>
@@ -16705,12 +15820,49 @@
         <nd ref="-6149"/>
         <nd ref="-3436"/>
         <nd ref="-22540"/>
+        <nd ref="-3438"/>
+        <nd ref="-6153"/>
+        <nd ref="-6155"/>
+        <nd ref="-3440"/>
+        <nd ref="-3442"/>
+        <nd ref="-25764"/>
         <tag k="alt_name" v="Jefferson Dr SW"/>
         <tag k="name" v="JEFFERSON DR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37317"/>
+        <nd ref="-896"/>
+        <nd ref="-897"/>
+        <nd ref="-5459"/>
+        <nd ref="-898"/>
+        <nd ref="-899"/>
+        <nd ref="-900"/>
+        <nd ref="-901"/>
+        <nd ref="-5460"/>
+        <nd ref="-902"/>
+        <nd ref="-34559"/>
+        <nd ref="-903"/>
+        <nd ref="-904"/>
+        <nd ref="-905"/>
+        <nd ref="-906"/>
+        <nd ref="-34501"/>
+        <nd ref="-907"/>
+        <nd ref="-908"/>
+        <nd ref="-909"/>
+        <nd ref="-910"/>
+        <nd ref="-911"/>
+        <nd ref="-912"/>
+        <nd ref="-913"/>
+        <nd ref="-914"/>
+        <nd ref="-915"/>
+        <nd ref="-916"/>
+        <nd ref="-917"/>
+        <nd ref="-918"/>
+        <nd ref="-919"/>
+        <nd ref="-921"/>
+        <nd ref="-923"/>
         <nd ref="-29235"/>
         <nd ref="-3120"/>
         <nd ref="-3121"/>
@@ -16732,7 +15884,32 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22921"/>
+        <nd ref="-888"/>
+        <nd ref="-889"/>
+        <nd ref="-5442"/>
+        <nd ref="-5443"/>
+        <nd ref="-890"/>
+        <nd ref="-5444"/>
+        <nd ref="-891"/>
+        <nd ref="-892"/>
+        <nd ref="-5445"/>
+        <nd ref="-5446"/>
+        <nd ref="-893"/>
+        <nd ref="-5447"/>
+        <nd ref="-894"/>
+        <nd ref="-31505"/>
+        <nd ref="-5449"/>
+        <nd ref="-3105"/>
+        <nd ref="-5450"/>
+        <nd ref="-3106"/>
+        <nd ref="-5451"/>
+        <nd ref="-3107"/>
+        <nd ref="-3108"/>
+        <nd ref="-5452"/>
+        <nd ref="-3109"/>
+        <nd ref="-3110"/>
         <nd ref="-25611"/>
         <nd ref="-3111"/>
         <nd ref="-3112"/>
@@ -16747,24 +15924,6 @@
         <nd ref="-3118"/>
         <nd ref="-3119"/>
         <nd ref="-37316"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31505"/>
-        <nd ref="-5449"/>
-        <nd ref="-3105"/>
-        <nd ref="-5450"/>
-        <nd ref="-3106"/>
-        <nd ref="-5451"/>
-        <nd ref="-3107"/>
-        <nd ref="-3108"/>
-        <nd ref="-5452"/>
-        <nd ref="-3109"/>
-        <nd ref="-3110"/>
-        <nd ref="-25611"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
@@ -16788,41 +15947,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23467"/>
-        <nd ref="-3095"/>
-        <nd ref="-6813"/>
-        <nd ref="-3096"/>
-        <nd ref="-3097"/>
-        <nd ref="-6815"/>
-        <nd ref="-3098"/>
-        <nd ref="-6817"/>
-        <nd ref="-31568"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23349"/>
-        <nd ref="-6798"/>
-        <nd ref="-3088"/>
-        <nd ref="-6801"/>
-        <nd ref="-3089"/>
-        <nd ref="-3090"/>
-        <nd ref="-3091"/>
-        <nd ref="-6804"/>
-        <nd ref="-3092"/>
-        <nd ref="-6807"/>
-        <nd ref="-3093"/>
-        <nd ref="-3094"/>
-        <nd ref="-6809"/>
-        <nd ref="-23467"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36327"/>
         <nd ref="-4180"/>
@@ -16835,30 +15959,13 @@
         <nd ref="-4184"/>
         <nd ref="-6656"/>
         <nd ref="-37361"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
+        <nd ref="-6658"/>
+        <nd ref="-741"/>
+        <nd ref="-6660"/>
+        <nd ref="-742"/>
+        <nd ref="-34914"/>
+        <tag k="alt_name" v="Independence Ave SW;OHIO DR SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26769"/>
-        <nd ref="-3079"/>
-        <nd ref="-6786"/>
-        <nd ref="-3080"/>
-        <nd ref="-3081"/>
-        <nd ref="-6788"/>
-        <nd ref="-3082"/>
-        <nd ref="-6790"/>
-        <nd ref="-3083"/>
-        <nd ref="-3084"/>
-        <nd ref="-6792"/>
-        <nd ref="-3085"/>
-        <nd ref="-6795"/>
-        <nd ref="-3086"/>
-        <nd ref="-3087"/>
-        <nd ref="-23349"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16871,79 +15978,53 @@
         <nd ref="-6768"/>
         <nd ref="-3078"/>
         <nd ref="-26806"/>
+        <nd ref="-877"/>
+        <nd ref="-6772"/>
+        <nd ref="-878"/>
+        <nd ref="-879"/>
+        <nd ref="-6774"/>
+        <nd ref="-880"/>
+        <nd ref="-6776"/>
+        <nd ref="-881"/>
+        <nd ref="-882"/>
+        <nd ref="-26807"/>
         <tag k="alt_name" v="E St NW;Ellipse Rd NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24649"/>
-        <nd ref="-3064"/>
-        <nd ref="-6751"/>
-        <nd ref="-3065"/>
-        <nd ref="-6754"/>
-        <nd ref="-3066"/>
-        <nd ref="-3067"/>
-        <nd ref="-6757"/>
-        <nd ref="-3068"/>
-        <nd ref="-3069"/>
-        <nd ref="-6760"/>
-        <nd ref="-3070"/>
-        <nd ref="-3071"/>
-        <nd ref="-6762"/>
-        <nd ref="-3072"/>
-        <nd ref="-3073"/>
-        <nd ref="-3074"/>
-        <nd ref="-26315"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18123"/>
-        <nd ref="-2134"/>
-        <nd ref="-4708"/>
-        <nd ref="-2135"/>
-        <nd ref="-2136"/>
-        <nd ref="-19555"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17999"/>
-        <nd ref="-2126"/>
-        <nd ref="-2128"/>
-        <nd ref="-4706"/>
-        <nd ref="-2130"/>
-        <nd ref="-2132"/>
-        <nd ref="-18123"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18228"/>
-        <nd ref="-2114"/>
-        <nd ref="-2116"/>
-        <nd ref="-4696"/>
-        <nd ref="-2118"/>
-        <nd ref="-4698"/>
-        <nd ref="-2120"/>
-        <nd ref="-4700"/>
-        <nd ref="-2122"/>
-        <nd ref="-4702"/>
-        <nd ref="-2124"/>
-        <nd ref="-17889"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21247"/>
+        <nd ref="-2075"/>
+        <nd ref="-4676"/>
+        <nd ref="-2076"/>
+        <nd ref="-2078"/>
+        <nd ref="-4677"/>
+        <nd ref="-4678"/>
+        <nd ref="-2080"/>
+        <nd ref="-2082"/>
+        <nd ref="-4679"/>
+        <nd ref="-4680"/>
+        <nd ref="-2084"/>
+        <nd ref="-25955"/>
+        <nd ref="-2501"/>
+        <nd ref="-4681"/>
+        <nd ref="-2502"/>
+        <nd ref="-2503"/>
+        <nd ref="-2504"/>
+        <nd ref="-4682"/>
+        <nd ref="-2505"/>
+        <nd ref="-2506"/>
+        <nd ref="-2507"/>
+        <nd ref="-4683"/>
+        <nd ref="-21165"/>
+        <nd ref="-2086"/>
+        <nd ref="-2088"/>
+        <nd ref="-4684"/>
+        <nd ref="-2090"/>
+        <nd ref="-4685"/>
+        <nd ref="-4686"/>
+        <nd ref="-2092"/>
         <nd ref="-20961"/>
         <nd ref="-2094"/>
         <nd ref="-2096"/>
@@ -16963,130 +16044,51 @@
         <nd ref="-2110"/>
         <nd ref="-2112"/>
         <nd ref="-18228"/>
+        <nd ref="-2114"/>
+        <nd ref="-2116"/>
+        <nd ref="-4696"/>
+        <nd ref="-2118"/>
+        <nd ref="-4698"/>
+        <nd ref="-2120"/>
+        <nd ref="-4700"/>
+        <nd ref="-2122"/>
+        <nd ref="-4702"/>
+        <nd ref="-2124"/>
+        <nd ref="-17889"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21165"/>
-        <nd ref="-2086"/>
-        <nd ref="-2088"/>
-        <nd ref="-4684"/>
-        <nd ref="-2090"/>
-        <nd ref="-4685"/>
-        <nd ref="-4686"/>
-        <nd ref="-2092"/>
-        <nd ref="-20961"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21247"/>
-        <nd ref="-2075"/>
-        <nd ref="-4676"/>
-        <nd ref="-2076"/>
-        <nd ref="-2078"/>
-        <nd ref="-4677"/>
-        <nd ref="-4678"/>
-        <nd ref="-2080"/>
-        <nd ref="-2082"/>
-        <nd ref="-4679"/>
-        <nd ref="-4680"/>
-        <nd ref="-2084"/>
-        <nd ref="-25955"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24271"/>
-        <nd ref="-247"/>
-        <nd ref="-5939"/>
-        <nd ref="-248"/>
-        <nd ref="-249"/>
-        <nd ref="-5940"/>
-        <nd ref="-250"/>
-        <nd ref="-5941"/>
-        <nd ref="-251"/>
-        <nd ref="-5942"/>
-        <nd ref="-252"/>
-        <nd ref="-253"/>
-        <nd ref="-5943"/>
-        <nd ref="-254"/>
-        <nd ref="-255"/>
-        <nd ref="-5944"/>
-        <nd ref="-256"/>
-        <nd ref="-5945"/>
-        <nd ref="-24202"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18123"/>
-        <nd ref="-3795"/>
-        <nd ref="-5404"/>
-        <nd ref="-3797"/>
-        <nd ref="-3799"/>
-        <nd ref="-5406"/>
-        <nd ref="-3801"/>
-        <nd ref="-3803"/>
-        <nd ref="-24045"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25938"/>
-        <nd ref="-3783"/>
-        <nd ref="-3785"/>
-        <nd ref="-5398"/>
-        <nd ref="-3787"/>
-        <nd ref="-5400"/>
-        <nd ref="-3789"/>
-        <nd ref="-3791"/>
-        <nd ref="-18123"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25773"/>
-        <nd ref="-5394"/>
-        <nd ref="-3775"/>
-        <nd ref="-3777"/>
-        <nd ref="-3779"/>
-        <nd ref="-25938"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20283"/>
-        <nd ref="-5372"/>
-        <nd ref="-3762"/>
-        <nd ref="-5373"/>
-        <nd ref="-3763"/>
-        <nd ref="-5374"/>
-        <nd ref="-3765"/>
-        <nd ref="-5376"/>
-        <nd ref="-3767"/>
-        <nd ref="-3769"/>
-        <nd ref="-20219"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31958"/>
+        <nd ref="-24154"/>
+        <nd ref="-3735"/>
+        <nd ref="-5357"/>
+        <nd ref="-3736"/>
+        <nd ref="-3737"/>
+        <nd ref="-5358"/>
+        <nd ref="-3738"/>
+        <nd ref="-23369"/>
+        <nd ref="-3740"/>
+        <nd ref="-5360"/>
+        <nd ref="-3741"/>
+        <nd ref="-5361"/>
+        <nd ref="-3742"/>
+        <nd ref="-3743"/>
+        <nd ref="-23388"/>
+        <nd ref="-3745"/>
+        <nd ref="-5363"/>
+        <nd ref="-3746"/>
+        <nd ref="-5364"/>
+        <nd ref="-3747"/>
+        <nd ref="-3748"/>
+        <nd ref="-23349"/>
+        <nd ref="-5366"/>
+        <nd ref="-3750"/>
+        <nd ref="-5367"/>
+        <nd ref="-3751"/>
+        <nd ref="-3752"/>
         <nd ref="-22758"/>
         <nd ref="-5369"/>
         <nd ref="-3754"/>
@@ -17098,47 +16100,55 @@
         <nd ref="-3759"/>
         <nd ref="-3760"/>
         <nd ref="-20283"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23349"/>
-        <nd ref="-5366"/>
-        <nd ref="-3750"/>
-        <nd ref="-5367"/>
-        <nd ref="-3751"/>
-        <nd ref="-3752"/>
-        <nd ref="-22758"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23388"/>
-        <nd ref="-3745"/>
-        <nd ref="-5363"/>
-        <nd ref="-3746"/>
-        <nd ref="-5364"/>
-        <nd ref="-3747"/>
-        <nd ref="-3748"/>
-        <nd ref="-23349"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23369"/>
-        <nd ref="-3740"/>
-        <nd ref="-5360"/>
-        <nd ref="-3741"/>
-        <nd ref="-5361"/>
-        <nd ref="-3742"/>
-        <nd ref="-3743"/>
-        <nd ref="-23388"/>
+        <nd ref="-5372"/>
+        <nd ref="-3762"/>
+        <nd ref="-5373"/>
+        <nd ref="-3763"/>
+        <nd ref="-5374"/>
+        <nd ref="-3765"/>
+        <nd ref="-5376"/>
+        <nd ref="-3767"/>
+        <nd ref="-3769"/>
+        <nd ref="-20219"/>
+        <nd ref="-5380"/>
+        <nd ref="-144"/>
+        <nd ref="-5382"/>
+        <nd ref="-145"/>
+        <nd ref="-5384"/>
+        <nd ref="-146"/>
+        <nd ref="-5386"/>
+        <nd ref="-5388"/>
+        <nd ref="-147"/>
+        <nd ref="-5390"/>
+        <nd ref="-148"/>
+        <nd ref="-25773"/>
+        <nd ref="-5394"/>
+        <nd ref="-3775"/>
+        <nd ref="-3777"/>
+        <nd ref="-3779"/>
+        <nd ref="-25938"/>
+        <nd ref="-3783"/>
+        <nd ref="-3785"/>
+        <nd ref="-5398"/>
+        <nd ref="-3787"/>
+        <nd ref="-5400"/>
+        <nd ref="-3789"/>
+        <nd ref="-3791"/>
+        <nd ref="-18123"/>
+        <nd ref="-3795"/>
+        <nd ref="-5404"/>
+        <nd ref="-3797"/>
+        <nd ref="-3799"/>
+        <nd ref="-5406"/>
+        <nd ref="-3801"/>
+        <nd ref="-3803"/>
+        <nd ref="-24045"/>
+        <nd ref="-5410"/>
+        <nd ref="-149"/>
+        <nd ref="-150"/>
+        <nd ref="-5412"/>
+        <nd ref="-151"/>
+        <nd ref="-24046"/>
         <tag k="alt_name" v="18th St NW"/>
         <tag k="name" v="18TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -17153,97 +16163,42 @@
         <nd ref="-1038"/>
         <nd ref="-4727"/>
         <nd ref="-32921"/>
+        <nd ref="-35726"/>
         <tag k="alt_name" v="26th St NW"/>
         <tag k="name" v="26TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24154"/>
-        <nd ref="-3735"/>
-        <nd ref="-5357"/>
-        <nd ref="-3736"/>
-        <nd ref="-3737"/>
-        <nd ref="-5358"/>
-        <nd ref="-3738"/>
-        <nd ref="-23369"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31958"/>
-        <nd ref="-24154"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21809"/>
-        <nd ref="-6508"/>
-        <nd ref="-2431"/>
-        <nd ref="-2432"/>
-        <nd ref="-2433"/>
-        <nd ref="-6511"/>
-        <nd ref="-6514"/>
-        <nd ref="-2434"/>
-        <nd ref="-2435"/>
-        <nd ref="-6517"/>
-        <nd ref="-2436"/>
-        <nd ref="-2437"/>
-        <nd ref="-6521"/>
-        <nd ref="-2438"/>
-        <nd ref="-6525"/>
-        <nd ref="-2439"/>
-        <nd ref="-6529"/>
-        <nd ref="-2440"/>
-        <nd ref="-6533"/>
-        <nd ref="-6536"/>
-        <nd ref="-2441"/>
-        <nd ref="-2442"/>
-        <nd ref="-2443"/>
-        <nd ref="-6539"/>
-        <nd ref="-2444"/>
-        <nd ref="-2445"/>
-        <nd ref="-27699"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21605"/>
-        <nd ref="-2412"/>
-        <nd ref="-2414"/>
-        <nd ref="-6477"/>
-        <nd ref="-2416"/>
-        <nd ref="-6480"/>
-        <nd ref="-2418"/>
-        <nd ref="-6483"/>
-        <nd ref="-2420"/>
-        <nd ref="-6486"/>
-        <nd ref="-2422"/>
-        <nd ref="-2423"/>
-        <nd ref="-2424"/>
-        <nd ref="-6489"/>
-        <nd ref="-2425"/>
-        <nd ref="-6493"/>
-        <nd ref="-2426"/>
-        <nd ref="-6497"/>
-        <nd ref="-2427"/>
-        <nd ref="-2428"/>
-        <nd ref="-2429"/>
-        <nd ref="-6501"/>
-        <nd ref="-2430"/>
-        <nd ref="-21809"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28676"/>
+        <nd ref="-2681"/>
+        <nd ref="-6849"/>
+        <nd ref="-2682"/>
+        <nd ref="-6850"/>
+        <nd ref="-2683"/>
+        <nd ref="-6851"/>
+        <nd ref="-2684"/>
+        <nd ref="-6852"/>
+        <nd ref="-6853"/>
+        <nd ref="-2685"/>
+        <nd ref="-28677"/>
+        <nd ref="-2686"/>
+        <nd ref="-6854"/>
+        <nd ref="-2687"/>
+        <nd ref="-2688"/>
+        <nd ref="-6855"/>
+        <nd ref="-2689"/>
+        <nd ref="-2690"/>
+        <nd ref="-28586"/>
+        <nd ref="-2691"/>
+        <nd ref="-6857"/>
+        <nd ref="-2692"/>
+        <nd ref="-2693"/>
+        <nd ref="-6858"/>
+        <nd ref="-2694"/>
+        <nd ref="-2695"/>
+        <nd ref="-2696"/>
+        <nd ref="-2697"/>
         <nd ref="-28495"/>
         <nd ref="-2698"/>
         <nd ref="-6860"/>
@@ -17256,38 +16211,6 @@
         <nd ref="-6863"/>
         <nd ref="-2703"/>
         <nd ref="-28607"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28586"/>
-        <nd ref="-2691"/>
-        <nd ref="-6857"/>
-        <nd ref="-2692"/>
-        <nd ref="-2693"/>
-        <nd ref="-6858"/>
-        <nd ref="-2694"/>
-        <nd ref="-2695"/>
-        <nd ref="-2696"/>
-        <nd ref="-2697"/>
-        <nd ref="-28495"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28677"/>
-        <nd ref="-2686"/>
-        <nd ref="-6854"/>
-        <nd ref="-2687"/>
-        <nd ref="-2688"/>
-        <nd ref="-6855"/>
-        <nd ref="-2689"/>
-        <nd ref="-2690"/>
-        <nd ref="-28586"/>
         <tag k="alt_name" v="C St NW"/>
         <tag k="name" v="C ST NW"/>
         <tag k="highway" v="road"/>
@@ -17307,22 +16230,6 @@
         <nd ref="-23388"/>
         <tag k="alt_name" v="D St NW"/>
         <tag k="name" v="D ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23446"/>
-        <nd ref="-2676"/>
-        <nd ref="-6829"/>
-        <nd ref="-2677"/>
-        <nd ref="-6831"/>
-        <nd ref="-2678"/>
-        <nd ref="-2679"/>
-        <nd ref="-6833"/>
-        <nd ref="-2680"/>
-        <nd ref="-23369"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -17351,7 +16258,19 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24099"/>
+        <nd ref="-2244"/>
+        <nd ref="-2246"/>
+        <nd ref="-2248"/>
+        <nd ref="-20879"/>
+        <nd ref="-2250"/>
+        <nd ref="-2251"/>
+        <nd ref="-2252"/>
+        <nd ref="-2253"/>
+        <nd ref="-16443"/>
+        <nd ref="-2255"/>
+        <nd ref="-2256"/>
         <nd ref="-16702"/>
         <nd ref="-2258"/>
         <nd ref="-6902"/>
@@ -17365,95 +16284,14 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16443"/>
-        <nd ref="-2255"/>
-        <nd ref="-2256"/>
-        <nd ref="-16702"/>
-        <tag k="alt_name" v="15th St NW;Pennsylvania Ave NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20879"/>
-        <nd ref="-2250"/>
-        <nd ref="-2251"/>
-        <nd ref="-2252"/>
-        <nd ref="-2253"/>
-        <nd ref="-16443"/>
-        <tag k="alt_name" v="15th St NW;Pennsylvania Ave NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31439"/>
-        <nd ref="-2384"/>
-        <nd ref="-5900"/>
-        <nd ref="-2385"/>
-        <nd ref="-5901"/>
-        <nd ref="-2386"/>
-        <nd ref="-5902"/>
-        <nd ref="-2387"/>
-        <nd ref="-2388"/>
-        <nd ref="-31397"/>
-        <tag k="alt_name" v="C St SW"/>
-        <tag k="name" v="C ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24099"/>
-        <nd ref="-2244"/>
-        <nd ref="-2246"/>
-        <nd ref="-2248"/>
-        <nd ref="-20879"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24433"/>
-        <nd ref="-137"/>
-        <nd ref="-4633"/>
-        <nd ref="-138"/>
-        <nd ref="-139"/>
-        <nd ref="-140"/>
-        <nd ref="-4634"/>
-        <nd ref="-141"/>
-        <nd ref="-27725"/>
-        <tag k="alt_name" v="New Hampshire Ave NW"/>
-        <tag k="name" v="NEW HAMPSHIRE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31439"/>
-        <nd ref="-3831"/>
-        <nd ref="-6304"/>
-        <nd ref="-3833"/>
-        <nd ref="-6305"/>
-        <nd ref="-3835"/>
-        <nd ref="-3837"/>
-        <nd ref="-3839"/>
-        <nd ref="-3841"/>
-        <nd ref="-3843"/>
-        <nd ref="-6306"/>
-        <nd ref="-3845"/>
-        <nd ref="-3847"/>
-        <nd ref="-6307"/>
-        <nd ref="-3849"/>
-        <nd ref="-3852"/>
-        <nd ref="-6308"/>
-        <nd ref="-31431"/>
-        <tag k="alt_name" v="12th St SW"/>
-        <tag k="name" v="12TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27002"/>
+        <nd ref="-1047"/>
+        <nd ref="-1048"/>
+        <nd ref="-6872"/>
+        <nd ref="-6873"/>
+        <nd ref="-1049"/>
+        <nd ref="-1050"/>
         <nd ref="-27003"/>
         <nd ref="-2198"/>
         <nd ref="-2199"/>
@@ -17508,16 +16346,30 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27699"/>
-        <nd ref="-135"/>
-        <nd ref="-24202"/>
-        <tag k="alt_name" v="New Hampshire Ave NW"/>
-        <tag k="name" v="NEW HAMPSHIRE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25965"/>
+        <nd ref="-3702"/>
+        <nd ref="-3703"/>
+        <nd ref="-3704"/>
+        <nd ref="-4642"/>
+        <nd ref="-3706"/>
+        <nd ref="-3708"/>
+        <nd ref="-4643"/>
+        <nd ref="-3710"/>
+        <nd ref="-31881"/>
+        <nd ref="-3714"/>
+        <nd ref="-3716"/>
+        <nd ref="-3718"/>
+        <nd ref="-3720"/>
+        <nd ref="-23446"/>
+        <nd ref="-3723"/>
+        <nd ref="-4644"/>
+        <nd ref="-3724"/>
+        <nd ref="-4645"/>
+        <nd ref="-4646"/>
+        <nd ref="-3725"/>
+        <nd ref="-3726"/>
+        <nd ref="-3727"/>
         <nd ref="-23447"/>
         <nd ref="-3729"/>
         <nd ref="-4647"/>
@@ -17527,6 +16379,40 @@
         <nd ref="-3732"/>
         <nd ref="-4649"/>
         <nd ref="-26769"/>
+        <nd ref="-3469"/>
+        <nd ref="-4650"/>
+        <nd ref="-3470"/>
+        <nd ref="-4651"/>
+        <nd ref="-3471"/>
+        <nd ref="-3472"/>
+        <nd ref="-4652"/>
+        <nd ref="-3473"/>
+        <nd ref="-23686"/>
+        <nd ref="-1190"/>
+        <nd ref="-23687"/>
+        <nd ref="-1192"/>
+        <nd ref="-1193"/>
+        <nd ref="-4655"/>
+        <nd ref="-1194"/>
+        <nd ref="-1195"/>
+        <nd ref="-4656"/>
+        <nd ref="-1196"/>
+        <nd ref="-20856"/>
+        <nd ref="-1424"/>
+        <nd ref="-4657"/>
+        <nd ref="-1426"/>
+        <nd ref="-4658"/>
+        <nd ref="-1428"/>
+        <nd ref="-4659"/>
+        <nd ref="-1430"/>
+        <nd ref="-4660"/>
+        <nd ref="-1432"/>
+        <nd ref="-20268"/>
+        <nd ref="-1199"/>
+        <nd ref="-1200"/>
+        <nd ref="-4662"/>
+        <nd ref="-1201"/>
+        <nd ref="-17717"/>
         <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -17555,507 +16441,41 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23446"/>
-        <nd ref="-3723"/>
-        <nd ref="-4644"/>
-        <nd ref="-3724"/>
-        <nd ref="-4645"/>
-        <nd ref="-4646"/>
-        <nd ref="-3725"/>
-        <nd ref="-3726"/>
-        <nd ref="-3727"/>
-        <nd ref="-23447"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25763"/>
-        <nd ref="-4991"/>
-        <nd ref="-3822"/>
-        <nd ref="-4993"/>
-        <nd ref="-3823"/>
-        <nd ref="-4995"/>
-        <nd ref="-3824"/>
-        <nd ref="-4997"/>
-        <nd ref="-3825"/>
-        <nd ref="-3826"/>
-        <nd ref="-4999"/>
-        <nd ref="-3827"/>
-        <nd ref="-3828"/>
-        <nd ref="-3829"/>
-        <nd ref="-5001"/>
-        <nd ref="-25764"/>
-        <tag k="alt_name" v="15th St SW;Raoul Wallenberg Pl SW"/>
-        <tag k="name" v="15TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31881"/>
-        <nd ref="-3714"/>
-        <nd ref="-3716"/>
-        <nd ref="-3718"/>
-        <nd ref="-3720"/>
-        <nd ref="-23446"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25965"/>
-        <nd ref="-3702"/>
-        <nd ref="-3703"/>
-        <nd ref="-3704"/>
-        <nd ref="-4642"/>
-        <nd ref="-3706"/>
-        <nd ref="-3708"/>
-        <nd ref="-4643"/>
-        <nd ref="-3710"/>
-        <nd ref="-31881"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22515"/>
-        <nd ref="-853"/>
-        <nd ref="-854"/>
-        <nd ref="-5413"/>
-        <nd ref="-855"/>
-        <nd ref="-856"/>
-        <nd ref="-857"/>
-        <nd ref="-858"/>
-        <nd ref="-5415"/>
-        <nd ref="-859"/>
-        <nd ref="-5417"/>
-        <nd ref="-860"/>
-        <nd ref="-5419"/>
-        <nd ref="-861"/>
-        <nd ref="-862"/>
-        <nd ref="-863"/>
-        <nd ref="-36915"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35691"/>
-        <nd ref="-3815"/>
-        <nd ref="-7237"/>
-        <nd ref="-3814"/>
-        <nd ref="-36914"/>
-        <tag k="alt_name" v="14th St SW;US Hwy 1"/>
-        <tag k="name" v="14TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25554"/>
-        <nd ref="-2245"/>
-        <nd ref="-24935"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25227"/>
-        <nd ref="-2241"/>
-        <nd ref="-25277"/>
-        <nd ref="-25553"/>
-        <nd ref="-2243"/>
-        <nd ref="-25554"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37316"/>
         <nd ref="-6208"/>
         <nd ref="-2237"/>
         <nd ref="-6210"/>
         <nd ref="-2239"/>
         <nd ref="-25227"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23884"/>
-        <nd ref="-37298"/>
-        <nd ref="-2231"/>
-        <nd ref="-2233"/>
-        <nd ref="-37241"/>
-        <nd ref="-37316"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25437"/>
-        <nd ref="-23884"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23852"/>
-        <nd ref="-6198"/>
-        <nd ref="-2225"/>
-        <nd ref="-6200"/>
-        <nd ref="-2227"/>
-        <nd ref="-6202"/>
-        <nd ref="-2229"/>
-        <nd ref="-23818"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23851"/>
-        <nd ref="-6196"/>
-        <nd ref="-2221"/>
-        <nd ref="-23852"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24154"/>
-        <nd ref="-6190"/>
-        <nd ref="-2213"/>
-        <nd ref="-6192"/>
-        <nd ref="-2215"/>
-        <nd ref="-6194"/>
-        <nd ref="-2217"/>
-        <nd ref="-2219"/>
-        <nd ref="-23851"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35221"/>
-        <nd ref="-2138"/>
-        <nd ref="-2139"/>
-        <nd ref="-5986"/>
-        <nd ref="-2140"/>
-        <nd ref="-2141"/>
-        <nd ref="-16502"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22921"/>
-        <nd ref="-888"/>
-        <nd ref="-889"/>
-        <nd ref="-5442"/>
-        <nd ref="-5443"/>
-        <nd ref="-890"/>
-        <nd ref="-5444"/>
-        <nd ref="-891"/>
-        <nd ref="-892"/>
-        <nd ref="-5445"/>
-        <nd ref="-5446"/>
-        <nd ref="-893"/>
-        <nd ref="-5447"/>
-        <nd ref="-894"/>
-        <nd ref="-31505"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29305"/>
-        <nd ref="-5059"/>
-        <nd ref="-2289"/>
-        <nd ref="-34119"/>
-        <nd ref="-2291"/>
-        <nd ref="-37167"/>
-        <nd ref="-36185"/>
-        <nd ref="-2297"/>
-        <nd ref="-36230"/>
-        <nd ref="-2299"/>
-        <nd ref="-36800"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37329"/>
-        <nd ref="-3408"/>
-        <nd ref="-3409"/>
-        <nd ref="-4954"/>
-        <nd ref="-3410"/>
-        <nd ref="-3411"/>
-        <nd ref="-4955"/>
-        <nd ref="-3412"/>
-        <nd ref="-3413"/>
-        <nd ref="-4956"/>
-        <nd ref="-3414"/>
-        <nd ref="-3415"/>
-        <nd ref="-3416"/>
-        <nd ref="-3417"/>
-        <nd ref="-4957"/>
-        <nd ref="-3418"/>
-        <nd ref="-3419"/>
-        <nd ref="-35778"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20879"/>
-        <nd ref="-7172"/>
-        <nd ref="-32730"/>
-        <tag k="alt_name" v="Alexander Hamilton Pl NW"/>
-        <tag k="name" v="ALEXANDER HAMILTON PL NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24202"/>
-        <nd ref="-2172"/>
-        <nd ref="-5946"/>
-        <nd ref="-5947"/>
-        <nd ref="-2173"/>
-        <nd ref="-2174"/>
-        <nd ref="-25814"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25523"/>
-        <nd ref="-2148"/>
-        <nd ref="-2149"/>
-        <nd ref="-2150"/>
-        <nd ref="-5925"/>
-        <nd ref="-2151"/>
-        <nd ref="-2152"/>
-        <nd ref="-5926"/>
-        <nd ref="-2153"/>
-        <nd ref="-2154"/>
-        <nd ref="-5927"/>
-        <nd ref="-2155"/>
-        <nd ref="-5928"/>
-        <nd ref="-2156"/>
-        <nd ref="-2157"/>
-        <nd ref="-5929"/>
-        <nd ref="-2158"/>
-        <nd ref="-5930"/>
-        <nd ref="-2159"/>
-        <nd ref="-5931"/>
-        <nd ref="-5932"/>
-        <nd ref="-2160"/>
-        <nd ref="-2161"/>
-        <nd ref="-5933"/>
-        <nd ref="-2162"/>
-        <nd ref="-5934"/>
-        <nd ref="-2163"/>
-        <nd ref="-2164"/>
-        <nd ref="-2165"/>
-        <nd ref="-5935"/>
-        <nd ref="-2166"/>
-        <nd ref="-5936"/>
-        <nd ref="-5937"/>
-        <nd ref="-2167"/>
-        <nd ref="-2168"/>
-        <nd ref="-2169"/>
-        <nd ref="-5938"/>
-        <nd ref="-2170"/>
-        <nd ref="-2171"/>
-        <nd ref="-21477"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17025"/>
-        <nd ref="-7170"/>
-        <nd ref="-3673"/>
-        <nd ref="-3674"/>
-        <nd ref="-3675"/>
-        <nd ref="-7171"/>
-        <nd ref="-20925"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23996"/>
-        <nd ref="-4022"/>
-        <nd ref="-22748"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23981"/>
-        <nd ref="-4018"/>
-        <nd ref="-5783"/>
-        <nd ref="-4019"/>
-        <nd ref="-5784"/>
-        <nd ref="-4020"/>
-        <nd ref="-5785"/>
-        <nd ref="-4021"/>
-        <nd ref="-23996"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22753"/>
-        <nd ref="-4014"/>
-        <nd ref="-5779"/>
-        <nd ref="-4015"/>
-        <nd ref="-5780"/>
-        <nd ref="-4016"/>
-        <nd ref="-5781"/>
-        <nd ref="-4017"/>
-        <nd ref="-23981"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22730"/>
-        <nd ref="-5776"/>
-        <nd ref="-4012"/>
-        <nd ref="-5777"/>
-        <nd ref="-4013"/>
-        <nd ref="-22753"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23985"/>
-        <nd ref="-4009"/>
-        <nd ref="-5774"/>
-        <nd ref="-4010"/>
-        <nd ref="-5775"/>
-        <nd ref="-4011"/>
-        <nd ref="-22730"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23687"/>
-        <nd ref="-2057"/>
-        <nd ref="-2058"/>
-        <nd ref="-7433"/>
-        <nd ref="-2059"/>
-        <nd ref="-2060"/>
-        <nd ref="-7434"/>
-        <nd ref="-2062"/>
-        <nd ref="-23651"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26769"/>
-        <nd ref="-3469"/>
-        <nd ref="-4650"/>
-        <nd ref="-3470"/>
-        <nd ref="-4651"/>
-        <nd ref="-3471"/>
-        <nd ref="-3472"/>
-        <nd ref="-4652"/>
-        <nd ref="-3473"/>
-        <nd ref="-23686"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2241"/>
+        <nd ref="-25277"/>
+        <nd ref="-25553"/>
+        <nd ref="-2243"/>
+        <nd ref="-25554"/>
+        <nd ref="-2245"/>
+        <nd ref="-24935"/>
+        <nd ref="-6214"/>
+        <nd ref="-81"/>
         <nd ref="-35347"/>
         <nd ref="-6216"/>
         <nd ref="-737"/>
         <nd ref="-37024"/>
         <nd ref="-37308"/>
         <nd ref="-27277"/>
+        <nd ref="-6218"/>
+        <nd ref="-83"/>
+        <nd ref="-6220"/>
+        <nd ref="-85"/>
+        <nd ref="-6222"/>
+        <nd ref="-87"/>
+        <nd ref="-27278"/>
         <tag k="alt_name" v="Virginia Ave NW"/>
         <tag k="name" v="VIRGINIA AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20925"/>
-        <nd ref="-7166"/>
-        <nd ref="-3962"/>
-        <nd ref="-3964"/>
-        <nd ref="-7167"/>
-        <nd ref="-3966"/>
-        <nd ref="-3968"/>
-        <nd ref="-7168"/>
-        <nd ref="-3970"/>
-        <nd ref="-3972"/>
-        <nd ref="-7169"/>
-        <nd ref="-18244"/>
-        <tag k="alt_name" v="Madison Pl NW"/>
-        <tag k="name" v="MADISON PL NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25379"/>
-        <nd ref="-839"/>
-        <nd ref="-5154"/>
-        <nd ref="-840"/>
-        <nd ref="-841"/>
-        <nd ref="-5157"/>
-        <nd ref="-842"/>
-        <nd ref="-5160"/>
-        <nd ref="-843"/>
-        <nd ref="-5163"/>
-        <nd ref="-844"/>
-        <nd ref="-5166"/>
-        <nd ref="-845"/>
-        <nd ref="-5169"/>
-        <nd ref="-846"/>
-        <nd ref="-847"/>
-        <nd ref="-5172"/>
-        <nd ref="-848"/>
-        <nd ref="-849"/>
-        <nd ref="-5175"/>
-        <nd ref="-850"/>
-        <nd ref="-25380"/>
-        <tag k="alt_name" v="25th St NW;Whitehurst Fwy Rmp"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-31959"/>
         <nd ref="-701"/>
         <nd ref="-6176"/>
@@ -18086,12 +16506,101 @@
         <nd ref="-735"/>
         <nd ref="-6188"/>
         <nd ref="-24154"/>
+        <nd ref="-6190"/>
+        <nd ref="-2213"/>
+        <nd ref="-6192"/>
+        <nd ref="-2215"/>
+        <nd ref="-6194"/>
+        <nd ref="-2217"/>
+        <nd ref="-2219"/>
+        <nd ref="-23851"/>
+        <nd ref="-6196"/>
+        <nd ref="-2221"/>
+        <nd ref="-23852"/>
+        <nd ref="-6198"/>
+        <nd ref="-2225"/>
+        <nd ref="-6200"/>
+        <nd ref="-2227"/>
+        <nd ref="-6202"/>
+        <nd ref="-2229"/>
+        <nd ref="-23818"/>
+        <nd ref="-6204"/>
+        <nd ref="-999"/>
+        <nd ref="-6206"/>
+        <nd ref="-1000"/>
+        <nd ref="-25437"/>
+        <nd ref="-23884"/>
+        <nd ref="-37298"/>
+        <nd ref="-2231"/>
+        <nd ref="-2233"/>
+        <nd ref="-37241"/>
+        <nd ref="-37316"/>
         <tag k="alt_name" v="Virginia Ave NW"/>
         <tag k="name" v="VIRGINIA AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20879"/>
+        <nd ref="-7172"/>
+        <nd ref="-32730"/>
+        <tag k="alt_name" v="Alexander Hamilton Pl NW"/>
+        <tag k="name" v="ALEXANDER HAMILTON PL NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17025"/>
+        <nd ref="-7170"/>
+        <nd ref="-3673"/>
+        <nd ref="-3674"/>
+        <nd ref="-3675"/>
+        <nd ref="-7171"/>
+        <nd ref="-20925"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22730"/>
+        <nd ref="-5776"/>
+        <nd ref="-4012"/>
+        <nd ref="-5777"/>
+        <nd ref="-4013"/>
+        <nd ref="-22753"/>
+        <nd ref="-4014"/>
+        <nd ref="-5779"/>
+        <nd ref="-4015"/>
+        <nd ref="-5780"/>
+        <nd ref="-4016"/>
+        <nd ref="-5781"/>
+        <nd ref="-4017"/>
+        <nd ref="-23981"/>
+        <tag k="alt_name" v="K St NW;US Hwy 29"/>
+        <tag k="name" v="K ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20925"/>
+        <nd ref="-7166"/>
+        <nd ref="-3962"/>
+        <nd ref="-3964"/>
+        <nd ref="-7167"/>
+        <nd ref="-3966"/>
+        <nd ref="-3968"/>
+        <nd ref="-7168"/>
+        <nd ref="-3970"/>
+        <nd ref="-3972"/>
+        <nd ref="-7169"/>
+        <nd ref="-18244"/>
+        <tag k="alt_name" v="Madison Pl NW"/>
+        <tag k="name" v="MADISON PL NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35347"/>
         <nd ref="-827"/>
         <nd ref="-5127"/>
@@ -18113,6 +16622,27 @@
         <nd ref="-5148"/>
         <nd ref="-837"/>
         <nd ref="-25379"/>
+        <nd ref="-839"/>
+        <nd ref="-5154"/>
+        <nd ref="-840"/>
+        <nd ref="-841"/>
+        <nd ref="-5157"/>
+        <nd ref="-842"/>
+        <nd ref="-5160"/>
+        <nd ref="-843"/>
+        <nd ref="-5163"/>
+        <nd ref="-844"/>
+        <nd ref="-5166"/>
+        <nd ref="-845"/>
+        <nd ref="-5169"/>
+        <nd ref="-846"/>
+        <nd ref="-847"/>
+        <nd ref="-5172"/>
+        <nd ref="-848"/>
+        <nd ref="-849"/>
+        <nd ref="-5175"/>
+        <nd ref="-850"/>
+        <nd ref="-25380"/>
         <tag k="alt_name" v="25th St NW;Whitehurst Fwy Rmp"/>
         <tag k="name" v="25TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -18157,28 +16687,36 @@
         <nd ref="-5054"/>
         <nd ref="-3234"/>
         <nd ref="-33960"/>
+        <nd ref="-5057"/>
+        <nd ref="-5060"/>
+        <nd ref="-5063"/>
+        <nd ref="-5066"/>
+        <nd ref="-5069"/>
+        <nd ref="-5072"/>
+        <nd ref="-5075"/>
+        <nd ref="-5078"/>
+        <nd ref="-5081"/>
+        <nd ref="-5083"/>
+        <nd ref="-5086"/>
+        <nd ref="-5089"/>
+        <nd ref="-5092"/>
+        <nd ref="-5095"/>
+        <nd ref="-5098"/>
+        <nd ref="-5100"/>
+        <nd ref="-5102"/>
+        <nd ref="-5104"/>
+        <nd ref="-5106"/>
+        <nd ref="-5108"/>
+        <nd ref="-5110"/>
+        <nd ref="-5113"/>
+        <nd ref="-5116"/>
+        <nd ref="-5119"/>
+        <nd ref="-5122"/>
+        <nd ref="-5125"/>
+        <nd ref="-5128"/>
+        <nd ref="-27996"/>
         <tag k="alt_name" v="Lincoln Memorial Cir"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27725"/>
-        <nd ref="-961"/>
-        <nd ref="-4383"/>
-        <nd ref="-962"/>
-        <nd ref="-4384"/>
-        <nd ref="-963"/>
-        <nd ref="-4385"/>
-        <nd ref="-964"/>
-        <nd ref="-965"/>
-        <nd ref="-4386"/>
-        <nd ref="-966"/>
-        <nd ref="-967"/>
-        <nd ref="-4387"/>
-        <nd ref="-26842"/>
-        <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -18199,6 +16737,18 @@
         <nd ref="-960"/>
         <nd ref="-4365"/>
         <nd ref="-34114"/>
+        <nd ref="-1865"/>
+        <nd ref="-4367"/>
+        <nd ref="-1866"/>
+        <nd ref="-4368"/>
+        <nd ref="-1867"/>
+        <nd ref="-4369"/>
+        <nd ref="-1868"/>
+        <nd ref="-4370"/>
+        <nd ref="-1869"/>
+        <nd ref="-4371"/>
+        <nd ref="-1870"/>
+        <nd ref="-33002"/>
         <tag k="alt_name" v="Washington Cir NW"/>
         <tag k="name" v="WASHINGTON CIR NW"/>
         <tag k="highway" v="road"/>
@@ -18274,164 +16824,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18244"/>
-        <nd ref="-3446"/>
-        <nd ref="-3447"/>
-        <nd ref="-6349"/>
-        <nd ref="-3448"/>
-        <nd ref="-6351"/>
-        <nd ref="-3449"/>
-        <nd ref="-3450"/>
-        <nd ref="-3451"/>
-        <nd ref="-18245"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31505"/>
-        <nd ref="-3373"/>
-        <nd ref="-4421"/>
-        <nd ref="-3374"/>
-        <nd ref="-3375"/>
-        <nd ref="-3376"/>
-        <nd ref="-3377"/>
-        <nd ref="-4422"/>
-        <nd ref="-3378"/>
-        <nd ref="-3379"/>
-        <nd ref="-4423"/>
-        <nd ref="-3380"/>
-        <nd ref="-20065"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35035"/>
-        <nd ref="-1735"/>
-        <nd ref="-6950"/>
-        <nd ref="-1733"/>
-        <nd ref="-1731"/>
-        <nd ref="-1729"/>
-        <nd ref="-6951"/>
-        <nd ref="-1727"/>
-        <nd ref="-1725"/>
-        <nd ref="-6952"/>
-        <nd ref="-1723"/>
-        <nd ref="-1721"/>
-        <nd ref="-6953"/>
-        <nd ref="-1719"/>
-        <nd ref="-6955"/>
-        <nd ref="-1717"/>
-        <nd ref="-6957"/>
-        <nd ref="-1715"/>
-        <nd ref="-6959"/>
-        <nd ref="-1713"/>
-        <nd ref="-33250"/>
-        <nd ref="-1709"/>
-        <nd ref="-6963"/>
-        <nd ref="-1707"/>
-        <nd ref="-1705"/>
-        <nd ref="-1703"/>
-        <nd ref="-6965"/>
-        <nd ref="-1701"/>
-        <nd ref="-1699"/>
-        <nd ref="-6967"/>
-        <nd ref="-1697"/>
-        <nd ref="-1695"/>
-        <nd ref="-6968"/>
-        <nd ref="-1693"/>
-        <nd ref="-6969"/>
-        <nd ref="-1691"/>
-        <nd ref="-6970"/>
-        <nd ref="-1689"/>
-        <nd ref="-6971"/>
-        <nd ref="-1687"/>
-        <nd ref="-6972"/>
-        <nd ref="-1685"/>
-        <nd ref="-6973"/>
-        <nd ref="-1683"/>
-        <nd ref="-6974"/>
-        <nd ref="-1681"/>
-        <nd ref="-1679"/>
-        <nd ref="-6975"/>
-        <nd ref="-1677"/>
-        <nd ref="-1675"/>
-        <nd ref="-6977"/>
-        <nd ref="-1673"/>
-        <nd ref="-6979"/>
-        <nd ref="-6981"/>
-        <nd ref="-1671"/>
-        <nd ref="-1669"/>
-        <nd ref="-6983"/>
-        <nd ref="-1667"/>
-        <nd ref="-6985"/>
-        <nd ref="-1665"/>
-        <nd ref="-1663"/>
-        <nd ref="-1661"/>
-        <nd ref="-6987"/>
-        <nd ref="-1659"/>
-        <nd ref="-1657"/>
-        <nd ref="-6989"/>
-        <nd ref="-6991"/>
-        <nd ref="-36988"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22748"/>
-        <nd ref="-2726"/>
-        <nd ref="-2728"/>
-        <nd ref="-2730"/>
-        <nd ref="-5788"/>
-        <nd ref="-2732"/>
-        <nd ref="-5789"/>
-        <nd ref="-2734"/>
-        <nd ref="-2736"/>
-        <nd ref="-2738"/>
-        <nd ref="-24045"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24988"/>
-        <nd ref="-540"/>
-        <nd ref="-542"/>
-        <nd ref="-6278"/>
-        <nd ref="-544"/>
-        <nd ref="-546"/>
-        <nd ref="-549"/>
-        <nd ref="-552"/>
-        <nd ref="-554"/>
-        <nd ref="-556"/>
-        <nd ref="-558"/>
-        <nd ref="-6279"/>
-        <nd ref="-560"/>
-        <nd ref="-562"/>
-        <nd ref="-6280"/>
-        <nd ref="-564"/>
-        <nd ref="-566"/>
-        <nd ref="-568"/>
-        <nd ref="-6281"/>
-        <nd ref="-570"/>
-        <nd ref="-6282"/>
-        <nd ref="-572"/>
-        <nd ref="-6283"/>
-        <nd ref="-574"/>
-        <nd ref="-6284"/>
-        <nd ref="-24935"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24192"/>
         <nd ref="-2721"/>
@@ -18444,58 +16836,14 @@
         <nd ref="-2725"/>
         <nd ref="-5772"/>
         <nd ref="-23985"/>
+        <nd ref="-4009"/>
+        <nd ref="-5774"/>
+        <nd ref="-4010"/>
+        <nd ref="-5775"/>
+        <nd ref="-4011"/>
+        <nd ref="-22730"/>
         <tag k="alt_name" v="K St NW;US Hwy 29"/>
         <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31493"/>
-        <nd ref="-1223"/>
-        <nd ref="-1221"/>
-        <nd ref="-1219"/>
-        <nd ref="-31958"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21350"/>
-        <nd ref="-496"/>
-        <nd ref="-498"/>
-        <nd ref="-500"/>
-        <nd ref="-502"/>
-        <nd ref="-504"/>
-        <nd ref="-506"/>
-        <nd ref="-6254"/>
-        <nd ref="-508"/>
-        <nd ref="-510"/>
-        <nd ref="-6256"/>
-        <nd ref="-512"/>
-        <nd ref="-514"/>
-        <nd ref="-516"/>
-        <nd ref="-6257"/>
-        <nd ref="-518"/>
-        <nd ref="-520"/>
-        <nd ref="-6258"/>
-        <nd ref="-522"/>
-        <nd ref="-524"/>
-        <nd ref="-6259"/>
-        <nd ref="-526"/>
-        <nd ref="-6260"/>
-        <nd ref="-528"/>
-        <nd ref="-6261"/>
-        <nd ref="-530"/>
-        <nd ref="-532"/>
-        <nd ref="-534"/>
-        <nd ref="-6262"/>
-        <nd ref="-536"/>
-        <nd ref="-6263"/>
-        <nd ref="-538"/>
-        <nd ref="-21715"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -18519,6 +16867,21 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20268"/>
+        <nd ref="-3884"/>
+        <nd ref="-6225"/>
+        <nd ref="-6226"/>
+        <nd ref="-3885"/>
+        <nd ref="-3886"/>
+        <nd ref="-6227"/>
+        <nd ref="-6228"/>
+        <nd ref="-3887"/>
+        <nd ref="-3888"/>
+        <nd ref="-6229"/>
+        <nd ref="-3889"/>
+        <nd ref="-3890"/>
+        <nd ref="-6231"/>
+        <nd ref="-3891"/>
         <nd ref="-20219"/>
         <nd ref="-486"/>
         <nd ref="-488"/>
@@ -18528,6 +16891,24 @@
         <nd ref="-6235"/>
         <nd ref="-494"/>
         <nd ref="-20086"/>
+        <nd ref="-3892"/>
+        <nd ref="-6237"/>
+        <nd ref="-3893"/>
+        <nd ref="-6239"/>
+        <nd ref="-3894"/>
+        <nd ref="-3895"/>
+        <nd ref="-6241"/>
+        <nd ref="-3896"/>
+        <nd ref="-19895"/>
+        <nd ref="-3897"/>
+        <nd ref="-3898"/>
+        <nd ref="-6243"/>
+        <nd ref="-3899"/>
+        <nd ref="-3900"/>
+        <nd ref="-3901"/>
+        <nd ref="-3902"/>
+        <nd ref="-3903"/>
+        <nd ref="-19701"/>
         <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>

--- a/test-files/cmd/glacial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest/output.osm
+++ b/test-files/cmd/glacial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest/output.osm
@@ -575,14 +575,14 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="2"/>
     </way>
-    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="31"/>
         <nd ref="17"/>
         <nd ref="37"/>
+        <nd ref="21"/>
         <tag k="note" v="2"/>
-        <tag k="hoot:id" v="3"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -600,6 +600,9 @@
         <nd ref="2"/>
         <nd ref="18"/>
         <nd ref="32"/>
+        <nd ref="14"/>
+        <nd ref="35"/>
+        <nd ref="21"/>
         <tag k="note" v="0"/>
         <tag k="hoot:id" v="5"/>
         <tag k="hoot:status" v="3"/>
@@ -759,29 +762,10 @@
         <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="20" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="32"/>
-        <nd ref="14"/>
-        <tag k="note" v="0"/>
-        <tag k="hoot:id" v="20"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="20"/>
-    </way>
-    <way visible="true" id="21" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="14"/>
-        <nd ref="35"/>
         <nd ref="21"/>
         <nd ref="10"/>
         <nd ref="5"/>
         <nd ref="25"/>
-        <nd ref="193"/>
-        <tag k="note" v="0"/>
-        <tag k="hoot:id" v="21"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="21"/>
-    </way>
-    <way visible="true" id="22" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="193"/>
         <nd ref="9"/>
         <nd ref="30"/>
@@ -803,18 +787,9 @@
         <nd ref="15"/>
         <nd ref="36"/>
         <tag k="note" v="0"/>
-        <tag k="hoot:id" v="22"/>
+        <tag k="hoot:id" v="20"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="22"/>
-    </way>
-    <way visible="true" id="23" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="37"/>
-        <nd ref="21"/>
-        <tag k="note" v="2"/>
-        <tag k="hoot:id" v="23"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="23"/>
+        <tag k="hoot:id" v="20"/>
     </way>
 </osm>

--- a/test-files/cmd/glacial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest2/output.osm
+++ b/test-files/cmd/glacial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest2/output.osm
@@ -20522,9 +20522,39 @@
         <nd ref="2355"/>
         <nd ref="2354"/>
         <nd ref="4919"/>
+        <nd ref="2353"/>
+        <nd ref="2352"/>
+        <nd ref="2351"/>
+        <nd ref="2350"/>
+        <nd ref="2349"/>
+        <nd ref="2348"/>
+        <nd ref="2347"/>
+        <nd ref="2346"/>
+        <nd ref="2345"/>
+        <nd ref="2344"/>
+        <nd ref="2343"/>
+        <nd ref="2342"/>
+        <nd ref="2341"/>
+        <nd ref="2340"/>
+        <nd ref="2339"/>
+        <nd ref="2338"/>
+        <nd ref="2337"/>
+        <nd ref="2336"/>
+        <nd ref="2335"/>
+        <nd ref="2334"/>
+        <nd ref="2333"/>
+        <nd ref="2332"/>
+        <nd ref="2331"/>
+        <nd ref="2330"/>
+        <nd ref="2329"/>
+        <nd ref="2328"/>
+        <nd ref="2327"/>
+        <nd ref="2326"/>
+        <nd ref="2325"/>
+        <nd ref="1829"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="58"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="alt_name" v="Lincoln Memorial Cir"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
         <tag k="highway" v="road"/>
@@ -21530,7 +21560,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="116"/>
     </way>
-    <way visible="true" id="117" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="117" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="3673"/>
         <nd ref="4181"/>
         <nd ref="4182"/>
@@ -21539,11 +21569,9 @@
         <nd ref="4185"/>
         <nd ref="741"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="117"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="117"/>
     </way>
     <way visible="true" id="118" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -23090,11 +23118,44 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="205"/>
     </way>
-    <way visible="true" id="206" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
-        <nd ref="4923"/>
+    <way visible="true" id="206" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="258"/>
+        <nd ref="2777"/>
+        <nd ref="2777"/>
+        <nd ref="2778"/>
+        <nd ref="2779"/>
+        <nd ref="2780"/>
+        <nd ref="2781"/>
+        <nd ref="2782"/>
+        <nd ref="2783"/>
+        <nd ref="2784"/>
+        <nd ref="2784"/>
+        <nd ref="2785"/>
+        <nd ref="2785"/>
+        <nd ref="2786"/>
+        <nd ref="2788"/>
+        <nd ref="2791"/>
+        <nd ref="2794"/>
+        <nd ref="2797"/>
+        <nd ref="2800"/>
+        <nd ref="2803"/>
+        <nd ref="2806"/>
+        <nd ref="2809"/>
+        <nd ref="2812"/>
+        <nd ref="2815"/>
+        <nd ref="2818"/>
+        <nd ref="2821"/>
+        <nd ref="2824"/>
+        <nd ref="2824"/>
+        <nd ref="2827"/>
+        <nd ref="2830"/>
+        <nd ref="2833"/>
+        <nd ref="2836"/>
+        <nd ref="2836"/>
         <nd ref="2839"/>
         <nd ref="2842"/>
         <nd ref="2845"/>
+        <nd ref="2848"/>
         <nd ref="2848"/>
         <nd ref="2852"/>
         <nd ref="2856"/>
@@ -23109,12 +23170,11 @@
         <nd ref="2892"/>
         <nd ref="2896"/>
         <nd ref="2899"/>
+        <nd ref="2899"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="206"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="206"/>
     </way>
     <way visible="true" id="207" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -23802,6 +23862,45 @@
         <nd ref="754"/>
         <nd ref="755"/>
         <nd ref="4926"/>
+        <nd ref="756"/>
+        <nd ref="757"/>
+        <nd ref="758"/>
+        <nd ref="759"/>
+        <nd ref="760"/>
+        <nd ref="761"/>
+        <nd ref="762"/>
+        <nd ref="763"/>
+        <nd ref="764"/>
+        <nd ref="765"/>
+        <nd ref="766"/>
+        <nd ref="767"/>
+        <nd ref="769"/>
+        <nd ref="771"/>
+        <nd ref="773"/>
+        <nd ref="774"/>
+        <nd ref="775"/>
+        <nd ref="776"/>
+        <nd ref="777"/>
+        <nd ref="778"/>
+        <nd ref="779"/>
+        <nd ref="780"/>
+        <nd ref="781"/>
+        <nd ref="782"/>
+        <nd ref="783"/>
+        <nd ref="784"/>
+        <nd ref="785"/>
+        <nd ref="786"/>
+        <nd ref="787"/>
+        <nd ref="788"/>
+        <nd ref="789"/>
+        <nd ref="790"/>
+        <nd ref="791"/>
+        <nd ref="792"/>
+        <nd ref="793"/>
+        <nd ref="794"/>
+        <nd ref="795"/>
+        <nd ref="796"/>
+        <nd ref="3383"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="235"/>
         <tag k="hoot:status" v="3"/>
@@ -24308,8 +24407,12 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="266"/>
     </way>
-    <way visible="true" id="267" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
-        <nd ref="4921"/>
+    <way visible="true" id="267" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="3408"/>
+        <nd ref="1530"/>
+        <nd ref="1532"/>
+        <nd ref="1534"/>
+        <nd ref="1536"/>
         <nd ref="1538"/>
         <nd ref="1540"/>
         <nd ref="1542"/>
@@ -24321,6 +24424,7 @@
         <nd ref="1554"/>
         <nd ref="1556"/>
         <nd ref="1558"/>
+        <nd ref="1560"/>
         <nd ref="1560"/>
         <nd ref="1562"/>
         <nd ref="1564"/>
@@ -24337,12 +24441,92 @@
         <nd ref="1586"/>
         <nd ref="1588"/>
         <nd ref="1590"/>
-        <nd ref="4920"/>
+        <nd ref="1592"/>
+        <nd ref="1594"/>
+        <nd ref="1596"/>
+        <nd ref="1598"/>
+        <nd ref="1599"/>
+        <nd ref="1600"/>
+        <nd ref="1601"/>
+        <nd ref="1601"/>
+        <nd ref="1602"/>
+        <nd ref="1603"/>
+        <nd ref="1604"/>
+        <nd ref="1605"/>
+        <nd ref="1606"/>
+        <nd ref="1607"/>
+        <nd ref="101"/>
+        <nd ref="1608"/>
+        <nd ref="1609"/>
+        <nd ref="1610"/>
+        <nd ref="380"/>
+        <nd ref="1611"/>
+        <nd ref="1612"/>
+        <nd ref="1613"/>
+        <nd ref="1614"/>
+        <nd ref="1615"/>
+        <nd ref="1616"/>
+        <nd ref="1617"/>
+        <nd ref="1618"/>
+        <nd ref="1619"/>
+        <nd ref="1620"/>
+        <nd ref="1313"/>
+        <nd ref="1621"/>
+        <nd ref="1622"/>
+        <nd ref="1623"/>
+        <nd ref="1624"/>
+        <nd ref="1625"/>
+        <nd ref="1626"/>
+        <nd ref="1627"/>
+        <nd ref="1628"/>
+        <nd ref="1629"/>
+        <nd ref="1630"/>
+        <nd ref="1631"/>
+        <nd ref="1632"/>
+        <nd ref="1633"/>
+        <nd ref="1634"/>
+        <nd ref="1635"/>
+        <nd ref="1636"/>
+        <nd ref="1637"/>
+        <nd ref="1638"/>
+        <nd ref="1639"/>
+        <nd ref="1640"/>
+        <nd ref="1641"/>
+        <nd ref="1642"/>
+        <nd ref="1643"/>
+        <nd ref="1644"/>
+        <nd ref="1645"/>
+        <nd ref="1646"/>
+        <nd ref="1647"/>
+        <nd ref="1648"/>
+        <nd ref="1648"/>
+        <nd ref="1649"/>
+        <nd ref="1650"/>
+        <nd ref="1651"/>
+        <nd ref="1652"/>
+        <nd ref="1653"/>
+        <nd ref="1654"/>
+        <nd ref="1655"/>
+        <nd ref="1656"/>
+        <nd ref="1657"/>
+        <nd ref="1659"/>
+        <nd ref="1661"/>
+        <nd ref="1663"/>
+        <nd ref="1665"/>
+        <nd ref="1667"/>
+        <nd ref="1669"/>
+        <nd ref="1671"/>
+        <nd ref="1673"/>
+        <nd ref="1675"/>
+        <nd ref="1677"/>
+        <nd ref="1679"/>
+        <nd ref="1679"/>
+        <nd ref="1681"/>
+        <nd ref="460"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="267"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="267"/>
     </way>
     <way visible="true" id="268" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -25782,7 +25966,53 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="337"/>
     </way>
-    <way visible="true" id="338" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="338" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="2448"/>
+        <nd ref="2787"/>
+        <nd ref="2789"/>
+        <nd ref="2792"/>
+        <nd ref="2795"/>
+        <nd ref="2798"/>
+        <nd ref="2801"/>
+        <nd ref="2804"/>
+        <nd ref="2804"/>
+        <nd ref="2807"/>
+        <nd ref="2810"/>
+        <nd ref="2813"/>
+        <nd ref="2816"/>
+        <nd ref="2819"/>
+        <nd ref="2822"/>
+        <nd ref="2825"/>
+        <nd ref="2828"/>
+        <nd ref="2831"/>
+        <nd ref="2831"/>
+        <nd ref="2834"/>
+        <nd ref="2837"/>
+        <nd ref="2840"/>
+        <nd ref="2843"/>
+        <nd ref="2846"/>
+        <nd ref="2849"/>
+        <nd ref="258"/>
+        <tag k="accuracy" v="5"/>
+        <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="338"/>
+    </way>
+    <way visible="true" id="339" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="3475"/>
+        <nd ref="1094"/>
+        <nd ref="1096"/>
+        <nd ref="1098"/>
+        <nd ref="1100"/>
+        <nd ref="1068"/>
+        <tag k="accuracy" v="5"/>
+        <tag k="name" v="STATE PL NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="339"/>
+    </way>
+    <way visible="true" id="340" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
         <nd ref="2448"/>
         <nd ref="2787"/>
         <nd ref="2789"/>
@@ -25807,28 +26037,50 @@
         <nd ref="2846"/>
         <nd ref="2849"/>
         <nd ref="258"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="338"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="338"/>
-    </way>
-    <way visible="true" id="339" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
-        <nd ref="3475"/>
-        <nd ref="1094"/>
-        <nd ref="1096"/>
-        <nd ref="1098"/>
-        <nd ref="1100"/>
-        <nd ref="1068"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="name" v="STATE PL NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="339"/>
-    </way>
-    <way visible="true" id="340" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+        <nd ref="2777"/>
+        <nd ref="2778"/>
+        <nd ref="2779"/>
+        <nd ref="2780"/>
+        <nd ref="2781"/>
+        <nd ref="2782"/>
+        <nd ref="2783"/>
+        <nd ref="2784"/>
+        <nd ref="2785"/>
+        <nd ref="2786"/>
+        <nd ref="2788"/>
+        <nd ref="2791"/>
+        <nd ref="2794"/>
+        <nd ref="2797"/>
+        <nd ref="2800"/>
+        <nd ref="2803"/>
+        <nd ref="2806"/>
+        <nd ref="2809"/>
+        <nd ref="2812"/>
+        <nd ref="2815"/>
+        <nd ref="2818"/>
+        <nd ref="2821"/>
+        <nd ref="2824"/>
+        <nd ref="2827"/>
+        <nd ref="2830"/>
+        <nd ref="2833"/>
+        <nd ref="2836"/>
+        <nd ref="4923"/>
+        <nd ref="2839"/>
+        <nd ref="2842"/>
+        <nd ref="2845"/>
+        <nd ref="2848"/>
+        <nd ref="2852"/>
+        <nd ref="2856"/>
+        <nd ref="2860"/>
+        <nd ref="2864"/>
+        <nd ref="2868"/>
+        <nd ref="2872"/>
+        <nd ref="2876"/>
+        <nd ref="2880"/>
+        <nd ref="2884"/>
+        <nd ref="2888"/>
+        <nd ref="2892"/>
+        <nd ref="2896"/>
         <nd ref="2899"/>
         <nd ref="2853"/>
         <nd ref="2857"/>
@@ -26585,9 +26837,38 @@
         <nd ref="4427"/>
         <nd ref="4426"/>
         <nd ref="4921"/>
+        <nd ref="1538"/>
+        <nd ref="1540"/>
+        <nd ref="1542"/>
+        <nd ref="1544"/>
+        <nd ref="1546"/>
+        <nd ref="1548"/>
+        <nd ref="1550"/>
+        <nd ref="1552"/>
+        <nd ref="1554"/>
+        <nd ref="1556"/>
+        <nd ref="1558"/>
+        <nd ref="1560"/>
+        <nd ref="1562"/>
+        <nd ref="1564"/>
+        <nd ref="1566"/>
+        <nd ref="1568"/>
+        <nd ref="1570"/>
+        <nd ref="1572"/>
+        <nd ref="1574"/>
+        <nd ref="1576"/>
+        <nd ref="1578"/>
+        <nd ref="1580"/>
+        <nd ref="1582"/>
+        <nd ref="1584"/>
+        <nd ref="1586"/>
+        <nd ref="1588"/>
+        <nd ref="1590"/>
+        <nd ref="4920"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="376"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="road"/>
         <tag k="hoot:id" v="376"/>
     </way>
@@ -26833,23 +27114,23 @@
         <nd ref="4890"/>
         <nd ref="4891"/>
         <nd ref="3673"/>
+        <nd ref="4181"/>
+        <nd ref="4182"/>
+        <nd ref="4183"/>
+        <nd ref="4184"/>
+        <nd ref="4185"/>
+        <nd ref="741"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="395"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
         <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:id" v="395"/>
     </way>
     <way visible="true" id="396" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4915"/>
-        <nd ref="2116"/>
-        <nd ref="2118"/>
-        <nd ref="2120"/>
-        <nd ref="2122"/>
-        <nd ref="2124"/>
-        <nd ref="2126"/>
-        <nd ref="2128"/>
-        <nd ref="4916"/>
+        <nd ref="4917"/>
+        <nd ref="741"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="396"/>
         <tag k="hoot:status" v="3"/>
@@ -26858,39 +27139,16 @@
         <tag k="hoot:id" v="396"/>
     </way>
     <way visible="true" id="397" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4916"/>
-        <nd ref="2130"/>
-        <nd ref="2132"/>
-        <nd ref="2134"/>
-        <nd ref="4917"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="397"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="397"/>
-    </way>
-    <way visible="true" id="398" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4917"/>
-        <nd ref="741"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="398"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="398"/>
-    </way>
-    <way visible="true" id="399" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4698"/>
         <nd ref="4699"/>
         <nd ref="4918"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="399"/>
+        <tag k="hoot:id" v="397"/>
         <tag k="hoot:status" v="2"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="399"/>
+        <tag k="hoot:id" v="397"/>
     </way>
-    <way visible="true" id="400" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="398" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="3421"/>
         <nd ref="3609"/>
         <nd ref="3612"/>
@@ -26900,13 +27158,13 @@
         <nd ref="3624"/>
         <nd ref="4918"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="400"/>
+        <tag k="hoot:id" v="398"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="OHIO DR NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="400"/>
+        <tag k="hoot:id" v="398"/>
     </way>
-    <way visible="true" id="401" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="399" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4922"/>
         <nd ref="4557"/>
         <nd ref="4556"/>
@@ -26914,51 +27172,13 @@
         <nd ref="4554"/>
         <nd ref="4919"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="401"/>
+        <tag k="hoot:id" v="399"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Lincoln Memorial Cir"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="401"/>
+        <tag k="hoot:id" v="399"/>
     </way>
-    <way visible="true" id="402" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4919"/>
-        <nd ref="2353"/>
-        <nd ref="2352"/>
-        <nd ref="2351"/>
-        <nd ref="2350"/>
-        <nd ref="2349"/>
-        <nd ref="2348"/>
-        <nd ref="2347"/>
-        <nd ref="2346"/>
-        <nd ref="2345"/>
-        <nd ref="2344"/>
-        <nd ref="2343"/>
-        <nd ref="2342"/>
-        <nd ref="2341"/>
-        <nd ref="2340"/>
-        <nd ref="2339"/>
-        <nd ref="2338"/>
-        <nd ref="2337"/>
-        <nd ref="2336"/>
-        <nd ref="2335"/>
-        <nd ref="2334"/>
-        <nd ref="2333"/>
-        <nd ref="2332"/>
-        <nd ref="2331"/>
-        <nd ref="2330"/>
-        <nd ref="2329"/>
-        <nd ref="2328"/>
-        <nd ref="2327"/>
-        <nd ref="2326"/>
-        <nd ref="2325"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="402"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="402"/>
-    </way>
-    <way visible="true" id="403" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="400" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4920"/>
         <nd ref="1592"/>
         <nd ref="1594"/>
@@ -27040,13 +27260,13 @@
         <nd ref="1681"/>
         <nd ref="460"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="403"/>
+        <tag k="hoot:id" v="400"/>
         <tag k="hoot:status" v="1"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
-        <tag k="hoot:id" v="403"/>
+        <tag k="hoot:id" v="400"/>
     </way>
-    <way visible="true" id="404" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="401" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="3408"/>
         <nd ref="1530"/>
         <nd ref="1532"/>
@@ -27054,13 +27274,27 @@
         <nd ref="1536"/>
         <nd ref="4921"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="404"/>
+        <tag k="hoot:id" v="401"/>
         <tag k="hoot:status" v="1"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
-        <tag k="hoot:id" v="404"/>
+        <tag k="hoot:id" v="401"/>
     </way>
-    <way visible="true" id="405" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="402" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+        <nd ref="2274"/>
+        <nd ref="2275"/>
+        <nd ref="2276"/>
+        <nd ref="2277"/>
+        <nd ref="4922"/>
+        <tag k="accuracy" v="5"/>
+        <tag k="hoot:id" v="402"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="alt_name" v="Lincoln Memorial Cir"/>
+        <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="402"/>
+    </way>
+    <way visible="true" id="403" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4914"/>
         <nd ref="3325"/>
         <nd ref="3326"/>
@@ -27113,14 +27347,14 @@
         <nd ref="3372"/>
         <nd ref="3671"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="405"/>
+        <tag k="hoot:id" v="403"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Rock Crk and Potomac Pkwy NW"/>
         <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="405"/>
+        <tag k="hoot:id" v="403"/>
     </way>
-    <way visible="true" id="406" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="404" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="3236"/>
         <nd ref="4538"/>
         <nd ref="4537"/>
@@ -27151,114 +27385,43 @@
         <nd ref="4512"/>
         <nd ref="2448"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="406"/>
+        <tag k="hoot:id" v="404"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Lincoln Memorial Cir"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="406"/>
+        <tag k="hoot:id" v="404"/>
     </way>
-    <way visible="true" id="407" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="2274"/>
-        <nd ref="2275"/>
-        <nd ref="2276"/>
-        <nd ref="2277"/>
-        <nd ref="4922"/>
+    <way visible="true" id="405" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+        <nd ref="3236"/>
+        <nd ref="3490"/>
+        <nd ref="3491"/>
+        <nd ref="3492"/>
+        <nd ref="4925"/>
+        <nd ref="3493"/>
+        <nd ref="3494"/>
+        <nd ref="3495"/>
+        <nd ref="3496"/>
+        <nd ref="3497"/>
+        <nd ref="3498"/>
+        <nd ref="3499"/>
+        <nd ref="3500"/>
+        <nd ref="3501"/>
+        <nd ref="3502"/>
+        <nd ref="3503"/>
+        <nd ref="3504"/>
+        <nd ref="3505"/>
+        <nd ref="3506"/>
+        <nd ref="3507"/>
+        <nd ref="4924"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="407"/>
+        <tag k="hoot:id" v="405"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
+        <tag k="alt_name" v="Daniel French Dr SW"/>
+        <tag k="name" v="DANIEL C FRENCH DR SW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="407"/>
+        <tag k="hoot:id" v="405"/>
     </way>
-    <way visible="true" id="408" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4926"/>
-        <nd ref="756"/>
-        <nd ref="757"/>
-        <nd ref="758"/>
-        <nd ref="759"/>
-        <nd ref="760"/>
-        <nd ref="761"/>
-        <nd ref="762"/>
-        <nd ref="763"/>
-        <nd ref="764"/>
-        <nd ref="765"/>
-        <nd ref="766"/>
-        <nd ref="767"/>
-        <nd ref="769"/>
-        <nd ref="771"/>
-        <nd ref="773"/>
-        <nd ref="774"/>
-        <nd ref="775"/>
-        <nd ref="776"/>
-        <nd ref="777"/>
-        <nd ref="778"/>
-        <nd ref="779"/>
-        <nd ref="780"/>
-        <nd ref="781"/>
-        <nd ref="782"/>
-        <nd ref="783"/>
-        <nd ref="784"/>
-        <nd ref="785"/>
-        <nd ref="786"/>
-        <nd ref="787"/>
-        <nd ref="788"/>
-        <nd ref="789"/>
-        <nd ref="790"/>
-        <nd ref="791"/>
-        <nd ref="792"/>
-        <nd ref="793"/>
-        <nd ref="794"/>
-        <nd ref="795"/>
-        <nd ref="796"/>
-        <nd ref="3383"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="408"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Ohio Dr SW"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="408"/>
-    </way>
-    <way visible="true" id="409" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="258"/>
-        <nd ref="2777"/>
-        <nd ref="2778"/>
-        <nd ref="2779"/>
-        <nd ref="2780"/>
-        <nd ref="2781"/>
-        <nd ref="2782"/>
-        <nd ref="2783"/>
-        <nd ref="2784"/>
-        <nd ref="2785"/>
-        <nd ref="2786"/>
-        <nd ref="2788"/>
-        <nd ref="2791"/>
-        <nd ref="2794"/>
-        <nd ref="2797"/>
-        <nd ref="2800"/>
-        <nd ref="2803"/>
-        <nd ref="2806"/>
-        <nd ref="2809"/>
-        <nd ref="2812"/>
-        <nd ref="2815"/>
-        <nd ref="2818"/>
-        <nd ref="2821"/>
-        <nd ref="2824"/>
-        <nd ref="2827"/>
-        <nd ref="2830"/>
-        <nd ref="2833"/>
-        <nd ref="2836"/>
-        <nd ref="4923"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="409"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="409"/>
-    </way>
-    <way visible="true" id="410" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="406" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4922"/>
         <nd ref="4635"/>
         <nd ref="4634"/>
@@ -27298,39 +27461,27 @@
         <nd ref="4601"/>
         <nd ref="4600"/>
         <nd ref="3408"/>
+        <nd ref="3409"/>
+        <nd ref="3410"/>
+        <nd ref="3411"/>
+        <nd ref="3412"/>
+        <nd ref="3413"/>
+        <nd ref="3414"/>
+        <nd ref="3415"/>
+        <nd ref="3416"/>
+        <nd ref="3417"/>
+        <nd ref="3418"/>
+        <nd ref="3419"/>
+        <nd ref="3420"/>
+        <nd ref="3421"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="410"/>
+        <tag k="hoot:id" v="406"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="410"/>
+        <tag k="hoot:id" v="406"/>
     </way>
-    <way visible="true" id="411" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4925"/>
-        <nd ref="3493"/>
-        <nd ref="3494"/>
-        <nd ref="3495"/>
-        <nd ref="3496"/>
-        <nd ref="3497"/>
-        <nd ref="3498"/>
-        <nd ref="3499"/>
-        <nd ref="3500"/>
-        <nd ref="3501"/>
-        <nd ref="3502"/>
-        <nd ref="3503"/>
-        <nd ref="3504"/>
-        <nd ref="3505"/>
-        <nd ref="3506"/>
-        <nd ref="3507"/>
-        <nd ref="4924"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="411"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Daniel French Dr SW"/>
-        <tag k="name" v="DANIEL C FRENCH DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="411"/>
-    </way>
-    <way visible="true" id="412" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="407" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4927"/>
         <nd ref="4406"/>
         <nd ref="4343"/>
@@ -27358,51 +27509,27 @@
         <nd ref="4911"/>
         <nd ref="4912"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="412"/>
+        <tag k="hoot:id" v="407"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="412"/>
+        <tag k="hoot:id" v="407"/>
     </way>
-    <way visible="true" id="413" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="3236"/>
-        <nd ref="3490"/>
-        <nd ref="3491"/>
-        <nd ref="3492"/>
-        <nd ref="4925"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="413"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Daniel French Dr SW"/>
-        <tag k="name" v="DANIEL C FRENCH DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="413"/>
-    </way>
-    <way visible="true" id="414" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="408" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+        <nd ref="741"/>
         <nd ref="4928"/>
         <nd ref="742"/>
         <nd ref="743"/>
         <nd ref="4927"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="414"/>
+        <tag k="hoot:id" v="408"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Independence Ave SW"/>
         <tag k="name" v="OHIO DR SW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="414"/>
+        <tag k="hoot:id" v="408"/>
     </way>
-    <way visible="true" id="415" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="741"/>
-        <nd ref="4928"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="415"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="415"/>
-    </way>
-    <way visible="true" id="416" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="409" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="259"/>
         <nd ref="4721"/>
         <nd ref="4722"/>
@@ -27489,20 +27616,41 @@
         <nd ref="4803"/>
         <nd ref="4804"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="416"/>
+        <tag k="hoot:id" v="409"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="23rd St NW"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="416"/>
+        <tag k="hoot:id" v="409"/>
     </way>
-    <way visible="true" id="417" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="410" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="3421"/>
         <nd ref="4913"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="417"/>
+        <tag k="hoot:id" v="410"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
-        <tag k="hoot:id" v="417"/>
+        <tag k="hoot:id" v="410"/>
+    </way>
+    <way visible="true" id="411" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+        <nd ref="4915"/>
+        <nd ref="2116"/>
+        <nd ref="2118"/>
+        <nd ref="2120"/>
+        <nd ref="2122"/>
+        <nd ref="2124"/>
+        <nd ref="2126"/>
+        <nd ref="2128"/>
+        <nd ref="4916"/>
+        <nd ref="2130"/>
+        <nd ref="2132"/>
+        <nd ref="2134"/>
+        <nd ref="4917"/>
+        <tag k="accuracy" v="5"/>
+        <tag k="hoot:id" v="411"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="OHIO DR SW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="411"/>
     </way>
 </osm>

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest.sh.stdout
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbAllDataTypesConflateTest.sh.stdout
@@ -36,12 +36,12 @@ STEP 11b: Writing a XML changeset file that is the difference between the croppe
 STEP 12: Executing the SQL changeset on the osm api db...
 
 Changeset(s) Created: 1
-Changeset Details: min_lat=38.8467218, max_lat=38.9109693, min_lon=-104.8997532, max_lon=-104.7145693, num_changes=13
+Changeset Details: min_lat=38.8467218, max_lat=38.9109693, min_lon=-104.8997532, max_lon=-104.7145693, num_changes=9
 Node(s) Created: 5
 Node(s) Modified: 2
 Node(s) Deleted: 0
-Way(s) Created: 4
-Way(s) Modified: 2
+Way(s) Created: 1
+Way(s) Modified: 1
 Way(s) Deleted: 0
 Relation(s) Created: 0
 Relation(s) Modified: 0
@@ -52,6 +52,6 @@ STEP 14: Reading the entire contents of the osm api db, for the SQL changeset wo
 
 STEP 15: Cleaning up database...
 
-15:23:07.573 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 239
-15:23:07.926 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 240
-15:23:08.283 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 241
+20:40:48.790 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 335
+20:40:49.166 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 336
+20:40:49.519 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 337

--- a/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest2.sh.stdout
+++ b/test-files/cmd/glacial/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest2.sh.stdout
@@ -36,12 +36,12 @@ STEP 11b: Writing a XML changeset file that is the difference between the croppe
 STEP 12: Executing the SQL changeset on the osm api db...
 
 Changeset(s) Created: 1
-Changeset Details: min_lat=38.8864325, max_lat=38.901987, min_lon=-77.0532279, max_lon=-77.0319859, num_changes=427
+Changeset Details: min_lat=38.8864325, max_lat=38.901987, min_lon=-77.0532279, max_lon=-77.0319859, num_changes=417
 Node(s) Created: 378
 Node(s) Modified: 0
 Node(s) Deleted: 0
-Way(s) Created: 30
-Way(s) Modified: 19
+Way(s) Created: 24
+Way(s) Modified: 15
 Way(s) Deleted: 0
 Relation(s) Created: 0
 Relation(s) Modified: 0
@@ -52,6 +52,6 @@ STEP 14: Reading the entire contents of the osm api db, for the SQL changeset wo
 
 STEP 15: Cleaning up database...
 
-19:00:24.338 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 401
-19:00:24.586 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 402
-19:00:24.834 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 403
+21:03:09.015 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 341
+21:03:09.355 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 342
+21:03:09.737 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 343

--- a/test-files/cmd/slow/ConflateAverageTest/output.osm
+++ b/test-files/cmd/slow/ConflateAverageTest/output.osm
@@ -7093,16 +7093,6 @@
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920850456051070" lon="-77.0283330394810974"/>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920852684038323" lon="-77.0281791552407498"/>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920854311751967" lon="-77.0281004185644349"/>
-    <way visible="true" id="-36604" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38602"/>
-        <nd ref="-2807"/>
-        <nd ref="-38603"/>
-        <nd ref="-38284"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-36602" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36542"/>
         <nd ref="-2801"/>
@@ -7112,44 +7102,10 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-36599" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25231"/>
-        <nd ref="-6168"/>
-        <nd ref="-6169"/>
-        <nd ref="-38602"/>
-        <tag k="name" v="Pennsylvania Ave NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36592" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38594"/>
-        <nd ref="-4891"/>
-        <nd ref="-4894"/>
-        <nd ref="-38595"/>
-        <nd ref="-4897"/>
-        <nd ref="-3324"/>
-        <nd ref="-38309"/>
-        <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-36590" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-29343"/>
         <nd ref="-38594"/>
         <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36587" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38421"/>
-        <nd ref="-4874"/>
-        <nd ref="-4876"/>
-        <nd ref="-4878"/>
-        <nd ref="-4880"/>
-        <nd ref="-4882"/>
-        <nd ref="-4885"/>
-        <nd ref="-4888"/>
-        <nd ref="-38594"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -7190,23 +7146,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-36463" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38531"/>
-        <nd ref="-6199"/>
-        <nd ref="-38532"/>
-        <nd ref="-260"/>
-        <nd ref="-5188"/>
-        <nd ref="-261"/>
-        <nd ref="-262"/>
-        <nd ref="-263"/>
-        <nd ref="-5191"/>
-        <nd ref="-264"/>
-        <nd ref="-29743"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-36461" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35484"/>
         <nd ref="-259"/>
@@ -7240,15 +7179,6 @@
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36433" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38512"/>
-        <nd ref="-4953"/>
-        <nd ref="-1529"/>
-        <nd ref="-38513"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-36432" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38512"/>
@@ -7292,6 +7222,9 @@
     <way visible="true" id="-36412" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38415"/>
         <nd ref="-38500"/>
+        <nd ref="-895"/>
+        <nd ref="-38501"/>
+        <tag k="alt_name" v="E ST NW"/>
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -7348,36 +7281,6 @@
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36049" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38332"/>
-        <nd ref="-7373"/>
-        <nd ref="-38241"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-36047" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38331"/>
-        <nd ref="-976"/>
-        <nd ref="-975"/>
-        <nd ref="-7367"/>
-        <nd ref="-974"/>
-        <nd ref="-7368"/>
-        <nd ref="-7369"/>
-        <nd ref="-973"/>
-        <nd ref="-972"/>
-        <nd ref="-971"/>
-        <nd ref="-970"/>
-        <nd ref="-969"/>
-        <nd ref="-7370"/>
-        <nd ref="-968"/>
-        <nd ref="-7371"/>
-        <nd ref="-38332"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-36046" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38331"/>
@@ -7442,6 +7345,23 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-35901" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38331"/>
+        <nd ref="-976"/>
+        <nd ref="-975"/>
+        <nd ref="-7367"/>
+        <nd ref="-974"/>
+        <nd ref="-7368"/>
+        <nd ref="-7369"/>
+        <nd ref="-973"/>
+        <nd ref="-972"/>
+        <nd ref="-971"/>
+        <nd ref="-970"/>
+        <nd ref="-969"/>
+        <nd ref="-7370"/>
+        <nd ref="-968"/>
+        <nd ref="-7371"/>
+        <nd ref="-38332"/>
+        <nd ref="-7373"/>
         <nd ref="-38241"/>
         <nd ref="-4076"/>
         <nd ref="-4075"/>
@@ -7515,85 +7435,6 @@
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-35770" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38138"/>
-        <nd ref="-7064"/>
-        <nd ref="-38471"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-35734" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38217"/>
-        <nd ref="-700"/>
-        <nd ref="-699"/>
-        <nd ref="-7385"/>
-        <nd ref="-698"/>
-        <nd ref="-697"/>
-        <nd ref="-696"/>
-        <nd ref="-7387"/>
-        <nd ref="-695"/>
-        <nd ref="-694"/>
-        <nd ref="-693"/>
-        <nd ref="-692"/>
-        <nd ref="-691"/>
-        <nd ref="-7389"/>
-        <nd ref="-690"/>
-        <nd ref="-689"/>
-        <nd ref="-688"/>
-        <nd ref="-7391"/>
-        <nd ref="-687"/>
-        <nd ref="-686"/>
-        <nd ref="-7393"/>
-        <nd ref="-685"/>
-        <nd ref="-7395"/>
-        <nd ref="-684"/>
-        <nd ref="-7397"/>
-        <nd ref="-683"/>
-        <nd ref="-682"/>
-        <nd ref="-681"/>
-        <nd ref="-680"/>
-        <nd ref="-679"/>
-        <nd ref="-7399"/>
-        <nd ref="-7401"/>
-        <nd ref="-678"/>
-        <nd ref="-677"/>
-        <nd ref="-676"/>
-        <nd ref="-7403"/>
-        <nd ref="-675"/>
-        <nd ref="-674"/>
-        <nd ref="-7405"/>
-        <nd ref="-673"/>
-        <nd ref="-7407"/>
-        <nd ref="-672"/>
-        <nd ref="-7409"/>
-        <nd ref="-671"/>
-        <nd ref="-7411"/>
-        <nd ref="-670"/>
-        <nd ref="-669"/>
-        <nd ref="-667"/>
-        <nd ref="-7412"/>
-        <nd ref="-665"/>
-        <nd ref="-663"/>
-        <nd ref="-661"/>
-        <nd ref="-7413"/>
-        <nd ref="-7414"/>
-        <nd ref="-659"/>
-        <nd ref="-7415"/>
-        <nd ref="-657"/>
-        <nd ref="-7416"/>
-        <nd ref="-655"/>
-        <nd ref="-7417"/>
-        <nd ref="-653"/>
-        <nd ref="-7418"/>
-        <nd ref="-651"/>
-        <nd ref="-38211"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-35679" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38469"/>
         <nd ref="-38468"/>
@@ -7606,6 +7447,29 @@
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-35602" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38027"/>
+        <nd ref="-5589"/>
+        <nd ref="-5591"/>
+        <nd ref="-5593"/>
+        <nd ref="-5595"/>
+        <nd ref="-5597"/>
+        <nd ref="-5599"/>
+        <nd ref="-5601"/>
+        <nd ref="-5603"/>
+        <nd ref="-5605"/>
+        <nd ref="-5607"/>
+        <nd ref="-5609"/>
+        <nd ref="-5611"/>
+        <nd ref="-5613"/>
+        <nd ref="-5615"/>
+        <nd ref="-5617"/>
+        <nd ref="-5619"/>
+        <nd ref="-5621"/>
+        <nd ref="-6285"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-35601" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38049"/>
@@ -7678,21 +7542,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-35486" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37964"/>
-        <nd ref="-539"/>
-        <nd ref="-541"/>
-        <nd ref="-543"/>
-        <nd ref="-545"/>
-        <nd ref="-547"/>
-        <nd ref="-4533"/>
-        <nd ref="-550"/>
-        <nd ref="-4535"/>
-        <nd ref="-37965"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-35436" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37848"/>
         <nd ref="-1316"/>
@@ -7729,34 +7578,7 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-35231" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38353"/>
-        <nd ref="-4789"/>
-        <nd ref="-1303"/>
-        <nd ref="-1304"/>
-        <nd ref="-1305"/>
-        <nd ref="-1306"/>
-        <nd ref="-4790"/>
-        <nd ref="-1307"/>
-        <nd ref="-37817"/>
-        <nd ref="-4792"/>
-        <nd ref="-1308"/>
-        <nd ref="-4793"/>
-        <nd ref="-1309"/>
-        <nd ref="-1310"/>
-        <nd ref="-1311"/>
-        <nd ref="-7497"/>
-        <nd ref="-37847"/>
-        <nd ref="-1313"/>
-        <nd ref="-1314"/>
-        <nd ref="-4794"/>
-        <nd ref="-37848"/>
-        <tag k="alt_name" v="US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-35082" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-35081" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37656"/>
         <nd ref="-1255"/>
         <nd ref="-4766"/>
@@ -7820,18 +7642,31 @@
         <nd ref="-1297"/>
         <nd ref="-1298"/>
         <nd ref="-37723"/>
-        <tag k="alt_name" v="US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-35081" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37723"/>
         <nd ref="-1299"/>
         <nd ref="-1300"/>
         <nd ref="-1301"/>
         <nd ref="-4788"/>
         <nd ref="-38353"/>
+        <nd ref="-4789"/>
+        <nd ref="-1303"/>
+        <nd ref="-1304"/>
+        <nd ref="-1305"/>
+        <nd ref="-1306"/>
+        <nd ref="-4790"/>
+        <nd ref="-1307"/>
+        <nd ref="-37817"/>
+        <nd ref="-4792"/>
+        <nd ref="-1308"/>
+        <nd ref="-4793"/>
+        <nd ref="-1309"/>
+        <nd ref="-1310"/>
+        <nd ref="-1311"/>
+        <nd ref="-7497"/>
+        <nd ref="-37847"/>
+        <nd ref="-1313"/>
+        <nd ref="-1314"/>
+        <nd ref="-4794"/>
+        <nd ref="-37848"/>
         <tag k="alt_name" v="US Hwy 50"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
@@ -8006,19 +7841,6 @@
         <nd ref="-2131"/>
         <nd ref="-2129"/>
         <nd ref="-37165"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-34414" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38581"/>
-        <nd ref="-38582"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-34358" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37165"/>
         <nd ref="-5379"/>
         <nd ref="-2127"/>
         <nd ref="-2125"/>
@@ -8044,25 +7866,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-34318" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38278"/>
-        <nd ref="-3626"/>
-        <nd ref="-5852"/>
-        <nd ref="-3623"/>
-        <nd ref="-3620"/>
-        <nd ref="-5855"/>
-        <nd ref="-3617"/>
-        <nd ref="-3614"/>
-        <nd ref="-5858"/>
-        <nd ref="-5862"/>
-        <nd ref="-3611"/>
-        <nd ref="-5866"/>
-        <nd ref="-3608"/>
-        <nd ref="-37100"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-34171" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37534"/>
         <nd ref="-2759"/>
@@ -8079,7 +7882,34 @@
         <nd ref="-2753"/>
         <nd ref="-2752"/>
         <nd ref="-37010"/>
-        <tag k="alt_name" v="25th St NW"/>
+        <nd ref="-2750"/>
+        <nd ref="-6699"/>
+        <nd ref="-2749"/>
+        <nd ref="-2748"/>
+        <nd ref="-6700"/>
+        <nd ref="-2747"/>
+        <nd ref="-6701"/>
+        <nd ref="-2746"/>
+        <nd ref="-2745"/>
+        <nd ref="-6702"/>
+        <nd ref="-2744"/>
+        <nd ref="-2743"/>
+        <nd ref="-2742"/>
+        <nd ref="-6703"/>
+        <nd ref="-2741"/>
+        <nd ref="-2740"/>
+        <nd ref="-6704"/>
+        <nd ref="-2739"/>
+        <nd ref="-6705"/>
+        <nd ref="-2737"/>
+        <nd ref="-2735"/>
+        <nd ref="-6706"/>
+        <nd ref="-2733"/>
+        <nd ref="-2731"/>
+        <nd ref="-6707"/>
+        <nd ref="-2729"/>
+        <nd ref="-34073"/>
+        <tag k="alt_name" v="25th St NW;New Hampshire Ave NW"/>
         <tag k="name" v="25TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
@@ -8167,62 +7997,20 @@
         <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-33529" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36586"/>
-        <nd ref="-1537"/>
-        <nd ref="-5846"/>
-        <nd ref="-1539"/>
-        <nd ref="-1541"/>
-        <nd ref="-5847"/>
-        <nd ref="-1543"/>
-        <nd ref="-1545"/>
-        <nd ref="-5848"/>
-        <nd ref="-1547"/>
-        <nd ref="-5850"/>
-        <nd ref="-1549"/>
-        <nd ref="-1551"/>
-        <nd ref="-5853"/>
-        <nd ref="-1553"/>
-        <nd ref="-1555"/>
-        <nd ref="-5856"/>
-        <nd ref="-1557"/>
-        <nd ref="-1559"/>
-        <nd ref="-5859"/>
-        <nd ref="-1561"/>
-        <nd ref="-1563"/>
-        <nd ref="-1565"/>
-        <nd ref="-5863"/>
-        <nd ref="-1567"/>
-        <nd ref="-5867"/>
-        <nd ref="-1569"/>
-        <nd ref="-1571"/>
-        <nd ref="-1573"/>
-        <nd ref="-5870"/>
-        <nd ref="-1575"/>
-        <nd ref="-1577"/>
-        <nd ref="-5873"/>
-        <nd ref="-5876"/>
-        <nd ref="-1579"/>
-        <nd ref="-1581"/>
-        <nd ref="-1583"/>
-        <nd ref="-5879"/>
-        <nd ref="-1585"/>
-        <nd ref="-1587"/>
-        <nd ref="-1589"/>
-        <nd ref="-37583"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-33472" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36553"/>
-        <nd ref="-36987"/>
-        <tag k="alt_name" v="D St SW"/>
-        <tag k="name" v="D ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-33471" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32230"/>
+        <nd ref="-3481"/>
+        <nd ref="-3482"/>
+        <nd ref="-3483"/>
+        <nd ref="-6800"/>
+        <nd ref="-6803"/>
+        <nd ref="-3484"/>
+        <nd ref="-3485"/>
+        <nd ref="-3486"/>
+        <nd ref="-3487"/>
+        <nd ref="-6806"/>
+        <nd ref="-3488"/>
+        <nd ref="-36553"/>
         <nd ref="-36987"/>
         <nd ref="-38346"/>
         <tag k="alt_name" v="D St SW"/>
@@ -8242,22 +8030,6 @@
         <nd ref="-36542"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-33393" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38591"/>
-        <nd ref="-2771"/>
-        <nd ref="-36504"/>
-        <nd ref="-2772"/>
-        <nd ref="-5759"/>
-        <nd ref="-2773"/>
-        <nd ref="-2774"/>
-        <nd ref="-5760"/>
-        <nd ref="-2775"/>
-        <nd ref="-37483"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -8287,107 +8059,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-33267" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38438"/>
-        <nd ref="-3642"/>
-        <nd ref="-6672"/>
-        <nd ref="-6674"/>
-        <nd ref="-3639"/>
-        <nd ref="-3636"/>
-        <nd ref="-3633"/>
-        <nd ref="-3630"/>
-        <nd ref="-6676"/>
-        <nd ref="-3627"/>
-        <nd ref="-3624"/>
-        <nd ref="-3621"/>
-        <nd ref="-3618"/>
-        <nd ref="-3615"/>
-        <nd ref="-3612"/>
-        <nd ref="-3609"/>
-        <nd ref="-3606"/>
-        <nd ref="-3604"/>
-        <nd ref="-3602"/>
-        <nd ref="-3600"/>
-        <nd ref="-3598"/>
-        <nd ref="-3596"/>
-        <nd ref="-6678"/>
-        <nd ref="-3594"/>
-        <nd ref="-36398"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-33266" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38438"/>
-        <nd ref="-38461"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-33214" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36398"/>
-        <nd ref="-3592"/>
-        <nd ref="-3590"/>
-        <nd ref="-3588"/>
-        <nd ref="-3586"/>
-        <nd ref="-3584"/>
-        <nd ref="-3582"/>
-        <nd ref="-6680"/>
-        <nd ref="-3580"/>
-        <nd ref="-3578"/>
-        <nd ref="-3576"/>
-        <nd ref="-3574"/>
-        <nd ref="-6682"/>
-        <nd ref="-3572"/>
-        <nd ref="-3570"/>
-        <nd ref="-3568"/>
-        <nd ref="-3566"/>
-        <nd ref="-3564"/>
-        <nd ref="-3562"/>
-        <nd ref="-3560"/>
-        <nd ref="-3558"/>
-        <nd ref="-3557"/>
-        <nd ref="-3556"/>
-        <nd ref="-3555"/>
-        <nd ref="-3554"/>
-        <nd ref="-3553"/>
-        <nd ref="-6684"/>
-        <nd ref="-3552"/>
-        <nd ref="-3551"/>
-        <nd ref="-6686"/>
-        <nd ref="-3550"/>
-        <nd ref="-3549"/>
-        <nd ref="-6687"/>
-        <nd ref="-3548"/>
-        <nd ref="-3547"/>
-        <nd ref="-6688"/>
-        <nd ref="-3546"/>
-        <nd ref="-6689"/>
-        <nd ref="-3545"/>
-        <nd ref="-6690"/>
-        <nd ref="-3544"/>
-        <nd ref="-3543"/>
-        <nd ref="-3542"/>
-        <nd ref="-6691"/>
-        <nd ref="-3541"/>
-        <nd ref="-3540"/>
-        <nd ref="-6692"/>
-        <nd ref="-3539"/>
-        <nd ref="-6693"/>
-        <nd ref="-3538"/>
-        <nd ref="-3537"/>
-        <nd ref="-3536"/>
-        <nd ref="-3535"/>
-        <nd ref="-3534"/>
-        <nd ref="-6694"/>
-        <nd ref="-3533"/>
-        <nd ref="-36354"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-33212" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36263"/>
         <nd ref="-3527"/>
@@ -8400,6 +8071,83 @@
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
+    </way>
+    <way visible="true" id="-33189" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36325"/>
+        <nd ref="-3509"/>
+        <nd ref="-3508"/>
+        <nd ref="-36326"/>
+        <nd ref="-1735"/>
+        <nd ref="-6950"/>
+        <nd ref="-1733"/>
+        <nd ref="-1731"/>
+        <nd ref="-6951"/>
+        <nd ref="-1729"/>
+        <nd ref="-1727"/>
+        <nd ref="-1725"/>
+        <nd ref="-6952"/>
+        <nd ref="-1723"/>
+        <nd ref="-6953"/>
+        <nd ref="-1721"/>
+        <nd ref="-1719"/>
+        <nd ref="-6955"/>
+        <nd ref="-6957"/>
+        <nd ref="-1717"/>
+        <nd ref="-6959"/>
+        <nd ref="-1715"/>
+        <nd ref="-1713"/>
+        <nd ref="-32874"/>
+        <nd ref="-1709"/>
+        <nd ref="-6963"/>
+        <nd ref="-1707"/>
+        <nd ref="-1705"/>
+        <nd ref="-1703"/>
+        <nd ref="-6965"/>
+        <nd ref="-1701"/>
+        <nd ref="-1699"/>
+        <nd ref="-6967"/>
+        <nd ref="-1697"/>
+        <nd ref="-6968"/>
+        <nd ref="-1695"/>
+        <nd ref="-1693"/>
+        <nd ref="-6969"/>
+        <nd ref="-1691"/>
+        <nd ref="-6970"/>
+        <nd ref="-6971"/>
+        <nd ref="-1689"/>
+        <nd ref="-1687"/>
+        <nd ref="-6972"/>
+        <nd ref="-1685"/>
+        <nd ref="-6973"/>
+        <nd ref="-6974"/>
+        <nd ref="-1683"/>
+        <nd ref="-1681"/>
+        <nd ref="-1679"/>
+        <nd ref="-6975"/>
+        <nd ref="-1677"/>
+        <nd ref="-1675"/>
+        <nd ref="-6977"/>
+        <nd ref="-6979"/>
+        <nd ref="-1673"/>
+        <nd ref="-6981"/>
+        <nd ref="-1671"/>
+        <nd ref="-6983"/>
+        <nd ref="-1669"/>
+        <nd ref="-1667"/>
+        <nd ref="-6985"/>
+        <nd ref="-1665"/>
+        <nd ref="-1663"/>
+        <nd ref="-1661"/>
+        <nd ref="-6987"/>
+        <nd ref="-1659"/>
+        <nd ref="-6989"/>
+        <nd ref="-1657"/>
+        <nd ref="-6991"/>
+        <nd ref="-32914"/>
+        <tag k="alt_name" v="Independence Ave SW"/>
+        <tag k="name" v="INDEPENDENCE AVE SW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-33188" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36325"/>
@@ -8439,6 +8187,17 @@
     <way visible="true" id="-33007" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36190"/>
         <nd ref="-36191"/>
+        <nd ref="-3207"/>
+        <nd ref="-3209"/>
+        <nd ref="-3211"/>
+        <nd ref="-35811"/>
+        <nd ref="-6089"/>
+        <nd ref="-3213"/>
+        <nd ref="-6091"/>
+        <nd ref="-3215"/>
+        <nd ref="-3217"/>
+        <nd ref="-6093"/>
+        <nd ref="-35758"/>
         <tag k="alt_name" v="22nd St NW"/>
         <tag k="name" v="22ND ST NW"/>
         <tag k="highway" v="road"/>
@@ -8451,18 +8210,6 @@
         <tag k="name" v="22ND ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-32934" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38581"/>
-        <nd ref="-741"/>
-        <nd ref="-6658"/>
-        <nd ref="-742"/>
-        <nd ref="-6660"/>
-        <nd ref="-36148"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="OHIO DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-32844" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36087"/>
@@ -8577,97 +8324,51 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-32462" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36191"/>
-        <nd ref="-3207"/>
-        <nd ref="-3209"/>
-        <nd ref="-3211"/>
-        <nd ref="-35811"/>
-        <nd ref="-6089"/>
-        <nd ref="-3213"/>
-        <nd ref="-6091"/>
-        <nd ref="-3215"/>
-        <nd ref="-3217"/>
-        <nd ref="-6093"/>
-        <nd ref="-35758"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-32094" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37930"/>
-        <nd ref="-5219"/>
-        <nd ref="-983"/>
-        <nd ref="-984"/>
-        <nd ref="-5221"/>
-        <nd ref="-985"/>
-        <nd ref="-5223"/>
-        <nd ref="-986"/>
-        <nd ref="-987"/>
-        <nd ref="-5225"/>
-        <nd ref="-5227"/>
-        <nd ref="-988"/>
-        <nd ref="-989"/>
-        <nd ref="-5229"/>
-        <nd ref="-990"/>
-        <nd ref="-5231"/>
-        <nd ref="-991"/>
-        <nd ref="-5233"/>
-        <nd ref="-992"/>
-        <nd ref="-5235"/>
-        <nd ref="-5237"/>
-        <nd ref="-993"/>
-        <nd ref="-994"/>
-        <nd ref="-5239"/>
-        <nd ref="-995"/>
-        <nd ref="-996"/>
-        <nd ref="-997"/>
-        <nd ref="-5241"/>
-        <nd ref="-5243"/>
-        <nd ref="-998"/>
-        <nd ref="-5245"/>
         <nd ref="-35445"/>
+        <nd ref="-5245"/>
+        <nd ref="-998"/>
+        <nd ref="-5243"/>
+        <nd ref="-5241"/>
+        <nd ref="-997"/>
+        <nd ref="-996"/>
+        <nd ref="-995"/>
+        <nd ref="-5239"/>
+        <nd ref="-994"/>
+        <nd ref="-993"/>
+        <nd ref="-5237"/>
+        <nd ref="-5235"/>
+        <nd ref="-992"/>
+        <nd ref="-5233"/>
+        <nd ref="-991"/>
+        <nd ref="-5231"/>
+        <nd ref="-990"/>
+        <nd ref="-5229"/>
+        <nd ref="-989"/>
+        <nd ref="-988"/>
+        <nd ref="-5227"/>
+        <nd ref="-5225"/>
+        <nd ref="-987"/>
+        <nd ref="-986"/>
+        <nd ref="-5223"/>
+        <nd ref="-985"/>
+        <nd ref="-5221"/>
+        <nd ref="-984"/>
+        <nd ref="-983"/>
+        <nd ref="-5219"/>
+        <nd ref="-37930"/>
+        <nd ref="-982"/>
+        <nd ref="-7358"/>
+        <nd ref="-981"/>
+        <nd ref="-7360"/>
+        <nd ref="-980"/>
+        <nd ref="-7362"/>
+        <nd ref="-979"/>
+        <nd ref="-38167"/>
+        <nd ref="-38469"/>
+        <tag k="alt_name" v="I- 66"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32036" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38501"/>
-        <nd ref="-896"/>
-        <nd ref="-897"/>
-        <nd ref="-5459"/>
-        <nd ref="-898"/>
-        <nd ref="-899"/>
-        <nd ref="-900"/>
-        <nd ref="-901"/>
-        <nd ref="-5460"/>
-        <nd ref="-902"/>
-        <nd ref="-35393"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-32034" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38500"/>
-        <nd ref="-895"/>
-        <nd ref="-38501"/>
-        <tag k="alt_name" v="Virginia Avenue North W"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-31965" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35393"/>
-        <nd ref="-903"/>
-        <nd ref="-904"/>
-        <nd ref="-905"/>
-        <nd ref="-906"/>
-        <nd ref="-35332"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-31914" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -8685,66 +8386,6 @@
         <nd ref="-38062"/>
         <nd ref="-35287"/>
         <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-31817" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-30016"/>
-        <nd ref="-1518"/>
-        <nd ref="-1519"/>
-        <nd ref="-1520"/>
-        <nd ref="-35204"/>
-        <nd ref="-1521"/>
-        <nd ref="-1522"/>
-        <nd ref="-4734"/>
-        <nd ref="-1523"/>
-        <nd ref="-4736"/>
-        <nd ref="-1524"/>
-        <nd ref="-4737"/>
-        <nd ref="-1525"/>
-        <nd ref="-4738"/>
-        <nd ref="-1526"/>
-        <nd ref="-4739"/>
-        <nd ref="-1527"/>
-        <nd ref="-1528"/>
-        <nd ref="-4740"/>
-        <nd ref="-4741"/>
-        <nd ref="-1530"/>
-        <nd ref="-1532"/>
-        <nd ref="-4742"/>
-        <nd ref="-1534"/>
-        <nd ref="-4743"/>
-        <nd ref="-1536"/>
-        <nd ref="-4744"/>
-        <nd ref="-1538"/>
-        <nd ref="-4745"/>
-        <nd ref="-4746"/>
-        <nd ref="-1540"/>
-        <nd ref="-1542"/>
-        <nd ref="-4747"/>
-        <nd ref="-4748"/>
-        <nd ref="-1544"/>
-        <nd ref="-4749"/>
-        <nd ref="-1546"/>
-        <nd ref="-1548"/>
-        <nd ref="-4750"/>
-        <nd ref="-1550"/>
-        <nd ref="-4751"/>
-        <nd ref="-1552"/>
-        <nd ref="-1554"/>
-        <nd ref="-4752"/>
-        <nd ref="-4753"/>
-        <nd ref="-1556"/>
-        <nd ref="-1558"/>
-        <nd ref="-4755"/>
-        <nd ref="-1560"/>
-        <nd ref="-4757"/>
-        <nd ref="-38291"/>
-        <nd ref="-1562"/>
-        <nd ref="-1564"/>
-        <nd ref="-1566"/>
-        <nd ref="-31249"/>
-        <tag k="name" v="E ST EXPY NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -8838,6 +8479,11 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-31383" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34762"/>
+        <nd ref="-3489"/>
+        <nd ref="-7324"/>
+        <nd ref="-3490"/>
+        <nd ref="-3491"/>
         <nd ref="-34832"/>
         <nd ref="-7325"/>
         <nd ref="-3492"/>
@@ -8861,18 +8507,6 @@
         <nd ref="-3505"/>
         <nd ref="-3506"/>
         <nd ref="-37562"/>
-        <tag k="alt_name" v="Daniel French Dr SW"/>
-        <tag k="name" v="DANIEL C FRENCH DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-31307" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34762"/>
-        <nd ref="-3489"/>
-        <nd ref="-7324"/>
-        <nd ref="-3490"/>
-        <nd ref="-3491"/>
-        <nd ref="-34832"/>
         <tag k="alt_name" v="Daniel French Dr SW"/>
         <tag k="name" v="DANIEL C FRENCH DR SW"/>
         <tag k="highway" v="road"/>
@@ -8902,10 +8536,6 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-30704" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34380"/>
-        <nd ref="-1851"/>
-        <nd ref="-1852"/>
-        <nd ref="-4397"/>
         <nd ref="-36208"/>
         <nd ref="-1853"/>
         <nd ref="-1854"/>
@@ -8929,58 +8559,6 @@
         <nd ref="-34275"/>
         <tag k="alt_name" v="Washington Cir NW"/>
         <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30591" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34560"/>
-        <nd ref="-1865"/>
-        <nd ref="-4367"/>
-        <nd ref="-4368"/>
-        <nd ref="-1866"/>
-        <nd ref="-1867"/>
-        <nd ref="-4369"/>
-        <nd ref="-4370"/>
-        <nd ref="-1868"/>
-        <nd ref="-4371"/>
-        <nd ref="-1869"/>
-        <nd ref="-34430"/>
-        <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30466" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37010"/>
-        <nd ref="-2750"/>
-        <nd ref="-6699"/>
-        <nd ref="-2749"/>
-        <nd ref="-2748"/>
-        <nd ref="-6700"/>
-        <nd ref="-2747"/>
-        <nd ref="-6701"/>
-        <nd ref="-2746"/>
-        <nd ref="-2745"/>
-        <nd ref="-6702"/>
-        <nd ref="-2744"/>
-        <nd ref="-2743"/>
-        <nd ref="-2742"/>
-        <nd ref="-6703"/>
-        <nd ref="-2741"/>
-        <nd ref="-2740"/>
-        <nd ref="-6704"/>
-        <nd ref="-2739"/>
-        <nd ref="-6705"/>
-        <nd ref="-2737"/>
-        <nd ref="-2735"/>
-        <nd ref="-6706"/>
-        <nd ref="-2733"/>
-        <nd ref="-2731"/>
-        <nd ref="-6707"/>
-        <nd ref="-2729"/>
-        <nd ref="-34073"/>
-        <tag k="alt_name" v="25th St NW;New Hampshire Ave NW"/>
-        <tag k="name" v="25TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -9036,23 +8614,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-30330" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34007"/>
-        <nd ref="-2587"/>
-        <nd ref="-6914"/>
-        <nd ref="-2588"/>
-        <nd ref="-6916"/>
-        <nd ref="-2589"/>
-        <nd ref="-6918"/>
-        <nd ref="-6920"/>
-        <nd ref="-2590"/>
-        <nd ref="-34008"/>
-        <tag k="alt_name" v="South Pl NW"/>
-        <tag k="name" v="SOUTH EXECUTIVE AVE NW"/>
-        <tag k="foot" v="designated"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-30307" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-33975"/>
         <nd ref="-2559"/>
@@ -9081,14 +8642,26 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-30265" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33947"/>
-        <nd ref="-37046"/>
-        <tag k="name" v="26th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-30154" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-30152" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37464"/>
+        <nd ref="-2365"/>
+        <nd ref="-5034"/>
+        <nd ref="-2364"/>
+        <nd ref="-5032"/>
+        <nd ref="-2363"/>
+        <nd ref="-2362"/>
+        <nd ref="-2361"/>
+        <nd ref="-5030"/>
+        <nd ref="-2360"/>
+        <nd ref="-2359"/>
+        <nd ref="-5028"/>
+        <nd ref="-2358"/>
+        <nd ref="-5025"/>
+        <nd ref="-2357"/>
+        <nd ref="-2356"/>
+        <nd ref="-2355"/>
+        <nd ref="-2354"/>
+        <nd ref="-2353"/>
         <nd ref="-37463"/>
         <nd ref="-2352"/>
         <nd ref="-4828"/>
@@ -9131,31 +8704,6 @@
         <nd ref="-2325"/>
         <nd ref="-4841"/>
         <nd ref="-33846"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30152" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37463"/>
-        <nd ref="-2353"/>
-        <nd ref="-2354"/>
-        <nd ref="-2355"/>
-        <nd ref="-2356"/>
-        <nd ref="-2357"/>
-        <nd ref="-5025"/>
-        <nd ref="-2358"/>
-        <nd ref="-5028"/>
-        <nd ref="-2359"/>
-        <nd ref="-2360"/>
-        <nd ref="-5030"/>
-        <nd ref="-2361"/>
-        <nd ref="-2362"/>
-        <nd ref="-2363"/>
-        <nd ref="-5032"/>
-        <nd ref="-2364"/>
-        <nd ref="-5034"/>
-        <nd ref="-2365"/>
-        <nd ref="-37464"/>
         <tag k="alt_name" v="Lincoln Memorial Cir"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
         <tag k="highway" v="road"/>
@@ -9227,6 +8775,67 @@
         <nd ref="-2275"/>
         <nd ref="-2274"/>
         <nd ref="-38421"/>
+        <nd ref="-4874"/>
+        <nd ref="-4876"/>
+        <nd ref="-4878"/>
+        <nd ref="-4880"/>
+        <nd ref="-4882"/>
+        <nd ref="-4885"/>
+        <nd ref="-4888"/>
+        <nd ref="-38594"/>
+        <nd ref="-4891"/>
+        <nd ref="-4894"/>
+        <nd ref="-38595"/>
+        <nd ref="-4897"/>
+        <nd ref="-3324"/>
+        <nd ref="-38309"/>
+        <nd ref="-4900"/>
+        <nd ref="-4903"/>
+        <nd ref="-4907"/>
+        <nd ref="-4910"/>
+        <nd ref="-4913"/>
+        <nd ref="-4916"/>
+        <nd ref="-4919"/>
+        <nd ref="-4921"/>
+        <nd ref="-4923"/>
+        <nd ref="-4925"/>
+        <nd ref="-4927"/>
+        <nd ref="-29252"/>
+        <nd ref="-4931"/>
+        <nd ref="-4933"/>
+        <nd ref="-4935"/>
+        <nd ref="-4937"/>
+        <nd ref="-4939"/>
+        <nd ref="-4941"/>
+        <nd ref="-4943"/>
+        <nd ref="-4945"/>
+        <nd ref="-4947"/>
+        <nd ref="-4949"/>
+        <nd ref="-4950"/>
+        <nd ref="-4951"/>
+        <nd ref="-4952"/>
+        <nd ref="-38512"/>
+        <nd ref="-4953"/>
+        <nd ref="-1529"/>
+        <nd ref="-38513"/>
+        <nd ref="-3408"/>
+        <nd ref="-3409"/>
+        <nd ref="-4954"/>
+        <nd ref="-3410"/>
+        <nd ref="-3411"/>
+        <nd ref="-4955"/>
+        <nd ref="-3412"/>
+        <nd ref="-3413"/>
+        <nd ref="-4956"/>
+        <nd ref="-3414"/>
+        <nd ref="-3415"/>
+        <nd ref="-3416"/>
+        <nd ref="-3417"/>
+        <nd ref="-4957"/>
+        <nd ref="-3418"/>
+        <nd ref="-3419"/>
+        <nd ref="-37100"/>
+        <tag k="alt_name" v="INTERSTATE 66  BN;OHIO DR NW;ROCK CREEK &amp; POTOMAC PKWY NW"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
@@ -9371,108 +8980,121 @@
         <nd ref="-1849"/>
         <nd ref="-1850"/>
         <nd ref="-34380"/>
+        <nd ref="-1851"/>
+        <nd ref="-1852"/>
+        <nd ref="-4397"/>
+        <nd ref="-36208"/>
         <tag k="alt_name" v="Washington Cir NW"/>
         <tag k="name" v="WASHINGTON CIR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-29002" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32874"/>
-        <nd ref="-2040"/>
-        <nd ref="-4877"/>
-        <nd ref="-2038"/>
-        <nd ref="-4879"/>
-        <nd ref="-2036"/>
-        <nd ref="-4881"/>
-        <nd ref="-2034"/>
-        <nd ref="-4883"/>
-        <nd ref="-2032"/>
-        <nd ref="-2030"/>
-        <nd ref="-4886"/>
-        <nd ref="-2028"/>
-        <nd ref="-2026"/>
-        <nd ref="-4889"/>
-        <nd ref="-4892"/>
-        <nd ref="-2024"/>
-        <nd ref="-2022"/>
-        <nd ref="-4895"/>
-        <nd ref="-2020"/>
-        <nd ref="-4898"/>
-        <nd ref="-2018"/>
-        <nd ref="-4901"/>
-        <nd ref="-4904"/>
-        <nd ref="-2016"/>
-        <nd ref="-2014"/>
-        <nd ref="-2012"/>
-        <nd ref="-4908"/>
-        <nd ref="-2010"/>
-        <nd ref="-4911"/>
-        <nd ref="-2008"/>
-        <nd ref="-2006"/>
-        <nd ref="-4914"/>
-        <nd ref="-2004"/>
-        <nd ref="-2002"/>
-        <nd ref="-4917"/>
-        <nd ref="-2000"/>
-        <nd ref="-4920"/>
-        <nd ref="-1998"/>
-        <nd ref="-1996"/>
-        <nd ref="-1994"/>
-        <nd ref="-4922"/>
-        <nd ref="-1992"/>
-        <nd ref="-4924"/>
-        <nd ref="-1990"/>
-        <nd ref="-4926"/>
-        <nd ref="-1988"/>
-        <nd ref="-1986"/>
-        <nd ref="-4928"/>
-        <nd ref="-1984"/>
-        <nd ref="-1982"/>
-        <nd ref="-4930"/>
-        <nd ref="-1980"/>
-        <nd ref="-1978"/>
-        <nd ref="-4932"/>
-        <nd ref="-1976"/>
-        <nd ref="-1974"/>
-        <nd ref="-4934"/>
-        <nd ref="-1972"/>
-        <nd ref="-1970"/>
-        <nd ref="-4936"/>
-        <nd ref="-1969"/>
-        <nd ref="-4938"/>
-        <nd ref="-1968"/>
-        <nd ref="-1967"/>
-        <nd ref="-4940"/>
-        <nd ref="-1966"/>
-        <nd ref="-34059"/>
-        <tag k="alt_name" v="Maine Ave SW"/>
-        <tag k="name" v="MAINE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-29000" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34059"/>
-        <nd ref="-1965"/>
-        <nd ref="-1964"/>
-        <nd ref="-1963"/>
-        <nd ref="-4944"/>
-        <nd ref="-1962"/>
-        <nd ref="-1961"/>
-        <nd ref="-1960"/>
-        <nd ref="-4946"/>
-        <nd ref="-1959"/>
-        <nd ref="-1958"/>
-        <nd ref="-1957"/>
-        <nd ref="-4948"/>
-        <nd ref="-1956"/>
-        <nd ref="-1955"/>
-        <nd ref="-37456"/>
-        <tag k="alt_name" v="Maine Ave SW"/>
-        <tag k="name" v="MAINE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-28931" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38193"/>
+        <nd ref="-1718"/>
+        <nd ref="-1720"/>
+        <nd ref="-6312"/>
+        <nd ref="-1722"/>
+        <nd ref="-1724"/>
+        <nd ref="-1726"/>
+        <nd ref="-6314"/>
+        <nd ref="-1728"/>
+        <nd ref="-6316"/>
+        <nd ref="-1730"/>
+        <nd ref="-1732"/>
+        <nd ref="-1734"/>
+        <nd ref="-6318"/>
+        <nd ref="-1736"/>
+        <nd ref="-6320"/>
+        <nd ref="-6322"/>
+        <nd ref="-1737"/>
+        <nd ref="-1738"/>
+        <nd ref="-1739"/>
+        <nd ref="-6324"/>
+        <nd ref="-37848"/>
+        <nd ref="-1740"/>
+        <nd ref="-1741"/>
+        <nd ref="-6326"/>
+        <nd ref="-1742"/>
+        <nd ref="-6328"/>
+        <nd ref="-1743"/>
+        <nd ref="-6330"/>
+        <nd ref="-6332"/>
+        <nd ref="-1744"/>
+        <nd ref="-1745"/>
+        <nd ref="-6334"/>
+        <nd ref="-6336"/>
+        <nd ref="-1746"/>
+        <nd ref="-1747"/>
+        <nd ref="-6338"/>
+        <nd ref="-1748"/>
+        <nd ref="-6340"/>
+        <nd ref="-1749"/>
+        <nd ref="-1750"/>
+        <nd ref="-1751"/>
+        <nd ref="-6342"/>
+        <nd ref="-6344"/>
+        <nd ref="-1752"/>
+        <nd ref="-1753"/>
+        <nd ref="-1754"/>
+        <nd ref="-1755"/>
+        <nd ref="-6346"/>
+        <nd ref="-1756"/>
+        <nd ref="-6348"/>
+        <nd ref="-1757"/>
+        <nd ref="-1758"/>
+        <nd ref="-6350"/>
+        <nd ref="-1759"/>
+        <nd ref="-1760"/>
+        <nd ref="-6352"/>
+        <nd ref="-1761"/>
+        <nd ref="-1762"/>
+        <nd ref="-6354"/>
+        <nd ref="-1763"/>
+        <nd ref="-6356"/>
+        <nd ref="-1764"/>
+        <nd ref="-1765"/>
+        <nd ref="-1766"/>
+        <nd ref="-6358"/>
+        <nd ref="-6360"/>
+        <nd ref="-1767"/>
+        <nd ref="-1768"/>
+        <nd ref="-6362"/>
+        <nd ref="-1769"/>
+        <nd ref="-6364"/>
+        <nd ref="-1770"/>
+        <nd ref="-1771"/>
+        <nd ref="-6366"/>
+        <nd ref="-1772"/>
+        <nd ref="-6368"/>
+        <nd ref="-1773"/>
+        <nd ref="-6370"/>
+        <nd ref="-1774"/>
+        <nd ref="-1775"/>
+        <nd ref="-6372"/>
+        <nd ref="-1776"/>
+        <nd ref="-1777"/>
+        <nd ref="-1778"/>
+        <nd ref="-6374"/>
+        <nd ref="-1779"/>
+        <nd ref="-6376"/>
+        <nd ref="-1780"/>
+        <nd ref="-6378"/>
+        <nd ref="-1781"/>
+        <nd ref="-1782"/>
+        <nd ref="-31249"/>
+        <nd ref="-1783"/>
+        <nd ref="-5801"/>
+        <nd ref="-1784"/>
+        <nd ref="-5802"/>
+        <nd ref="-1785"/>
+        <nd ref="-1786"/>
+        <nd ref="-5803"/>
+        <nd ref="-1787"/>
+        <nd ref="-5804"/>
+        <nd ref="-1788"/>
+        <nd ref="-1789"/>
+        <nd ref="-5805"/>
         <nd ref="-32654"/>
         <nd ref="-5640"/>
         <nd ref="-1790"/>
@@ -9556,21 +9178,6 @@
         <nd ref="-37"/>
         <nd ref="-36"/>
         <nd ref="-32577"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-28834" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32576"/>
-        <nd ref="-48"/>
-        <nd ref="-32710"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-28629" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32577"/>
         <nd ref="-35"/>
         <nd ref="-34"/>
         <nd ref="-33"/>
@@ -9585,6 +9192,14 @@
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-28834" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32576"/>
+        <nd ref="-48"/>
+        <nd ref="-32710"/>
+        <tag k="name" v="CONSTITUTION AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-28627" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-32022"/>
@@ -9609,6 +9224,15 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-28481" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32319"/>
+        <nd ref="-2384"/>
+        <nd ref="-5900"/>
+        <nd ref="-2385"/>
+        <nd ref="-2386"/>
+        <nd ref="-5901"/>
+        <nd ref="-5902"/>
+        <nd ref="-2387"/>
+        <nd ref="-2388"/>
         <nd ref="-32283"/>
         <nd ref="-13"/>
         <nd ref="-15"/>
@@ -9618,13 +9242,6 @@
         <nd ref="-23"/>
         <nd ref="-25"/>
         <nd ref="-36697"/>
-        <tag k="alt_name" v="C St SW"/>
-        <tag k="name" v="C ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-28480" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36697"/>
         <nd ref="-27"/>
         <nd ref="-38347"/>
         <tag k="alt_name" v="C St SW"/>
@@ -9632,26 +9249,42 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-28330" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32230"/>
-        <nd ref="-3481"/>
-        <nd ref="-3482"/>
-        <nd ref="-3483"/>
-        <nd ref="-6800"/>
-        <nd ref="-6803"/>
-        <nd ref="-3484"/>
-        <nd ref="-3485"/>
-        <nd ref="-3486"/>
-        <nd ref="-3487"/>
-        <nd ref="-6806"/>
-        <nd ref="-3488"/>
-        <nd ref="-36553"/>
-        <tag k="alt_name" v="D St SW"/>
-        <tag k="name" v="D ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-27852" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31739"/>
+        <nd ref="-2955"/>
+        <nd ref="-2956"/>
+        <nd ref="-2957"/>
+        <nd ref="-6597"/>
+        <nd ref="-2958"/>
+        <nd ref="-6599"/>
+        <nd ref="-2959"/>
+        <nd ref="-2960"/>
+        <nd ref="-2961"/>
+        <nd ref="-2962"/>
+        <nd ref="-6601"/>
+        <nd ref="-2963"/>
+        <nd ref="-2964"/>
+        <nd ref="-2966"/>
+        <nd ref="-2968"/>
+        <nd ref="-2970"/>
+        <nd ref="-2972"/>
+        <nd ref="-2974"/>
+        <nd ref="-6603"/>
+        <nd ref="-2976"/>
+        <nd ref="-2978"/>
+        <nd ref="-6604"/>
+        <nd ref="-2979"/>
+        <nd ref="-6605"/>
+        <nd ref="-2980"/>
+        <nd ref="-2981"/>
+        <nd ref="-2982"/>
+        <nd ref="-6606"/>
+        <nd ref="-2983"/>
+        <nd ref="-6607"/>
+        <nd ref="-2984"/>
+        <nd ref="-2985"/>
+        <nd ref="-2986"/>
+        <nd ref="-2987"/>
         <nd ref="-31804"/>
         <nd ref="-6609"/>
         <nd ref="-2988"/>
@@ -9748,89 +9381,18 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-27851" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38461"/>
-        <nd ref="-38462"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-27782" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31739"/>
-        <nd ref="-2955"/>
-        <nd ref="-2956"/>
-        <nd ref="-2957"/>
-        <nd ref="-6597"/>
-        <nd ref="-2958"/>
-        <nd ref="-6599"/>
-        <nd ref="-2959"/>
-        <nd ref="-2960"/>
-        <nd ref="-2961"/>
-        <nd ref="-2962"/>
-        <nd ref="-6601"/>
-        <nd ref="-2963"/>
-        <nd ref="-2964"/>
-        <nd ref="-2966"/>
-        <nd ref="-2968"/>
-        <nd ref="-2970"/>
-        <nd ref="-2972"/>
-        <nd ref="-2974"/>
-        <nd ref="-6603"/>
-        <nd ref="-2976"/>
-        <nd ref="-2978"/>
-        <nd ref="-6604"/>
-        <nd ref="-2979"/>
-        <nd ref="-6605"/>
-        <nd ref="-2980"/>
-        <nd ref="-2981"/>
-        <nd ref="-2982"/>
-        <nd ref="-6606"/>
-        <nd ref="-2983"/>
-        <nd ref="-6607"/>
-        <nd ref="-2984"/>
-        <nd ref="-2985"/>
-        <nd ref="-2986"/>
-        <nd ref="-2987"/>
-        <nd ref="-31804"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-27714" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31669"/>
-        <nd ref="-2933"/>
-        <nd ref="-2935"/>
-        <nd ref="-6585"/>
-        <nd ref="-2937"/>
-        <nd ref="-2939"/>
-        <nd ref="-6587"/>
-        <nd ref="-2941"/>
-        <nd ref="-2943"/>
-        <nd ref="-6589"/>
-        <nd ref="-2945"/>
-        <nd ref="-2947"/>
-        <nd ref="-6591"/>
-        <nd ref="-2949"/>
-        <nd ref="-6593"/>
-        <nd ref="-2950"/>
-        <nd ref="-6595"/>
-        <nd ref="-2951"/>
-        <nd ref="-2952"/>
-        <nd ref="-2953"/>
-        <nd ref="-2954"/>
-        <nd ref="-31739"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-27396" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-27588" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-33403"/>
         <nd ref="-1704"/>
         <nd ref="-1706"/>
         <nd ref="-1708"/>
         <nd ref="-6844"/>
+        <nd ref="-37226"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-27396" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37226"/>
         <nd ref="-1710"/>
         <nd ref="-6846"/>
@@ -9906,11 +9468,16 @@
         <nd ref="-1419"/>
         <nd ref="-7212"/>
         <nd ref="-32654"/>
-        <tag k="name" v="E ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-27072" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-4352"/>
+        <nd ref="-1421"/>
+        <nd ref="-1422"/>
+        <nd ref="-4353"/>
+        <nd ref="-1423"/>
+        <nd ref="-4354"/>
+        <nd ref="-1425"/>
+        <nd ref="-1427"/>
+        <nd ref="-4355"/>
+        <nd ref="-1429"/>
         <nd ref="-31250"/>
         <nd ref="-1433"/>
         <nd ref="-5677"/>
@@ -9953,7 +9520,7 @@
         <nd ref="-32547"/>
         <tag k="name" v="E ST EXPY NW"/>
         <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-27071" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38211"/>
@@ -9999,6 +9566,21 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-26477" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38501"/>
+        <nd ref="-896"/>
+        <nd ref="-897"/>
+        <nd ref="-5459"/>
+        <nd ref="-898"/>
+        <nd ref="-899"/>
+        <nd ref="-900"/>
+        <nd ref="-901"/>
+        <nd ref="-5460"/>
+        <nd ref="-902"/>
+        <nd ref="-35393"/>
+        <nd ref="-903"/>
+        <nd ref="-904"/>
+        <nd ref="-905"/>
+        <nd ref="-906"/>
         <nd ref="-35332"/>
         <nd ref="-907"/>
         <nd ref="-908"/>
@@ -10016,6 +9598,21 @@
         <nd ref="-921"/>
         <nd ref="-923"/>
         <nd ref="-30396"/>
+        <nd ref="-3120"/>
+        <nd ref="-3121"/>
+        <nd ref="-5463"/>
+        <nd ref="-5464"/>
+        <nd ref="-3122"/>
+        <nd ref="-3123"/>
+        <nd ref="-3124"/>
+        <nd ref="-5465"/>
+        <nd ref="-3125"/>
+        <nd ref="-3126"/>
+        <nd ref="-5466"/>
+        <nd ref="-5467"/>
+        <nd ref="-3127"/>
+        <nd ref="-3128"/>
+        <nd ref="-30331"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
@@ -10064,24 +9661,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-25939" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29827"/>
-        <nd ref="-2681"/>
-        <nd ref="-6849"/>
-        <nd ref="-2682"/>
-        <nd ref="-6850"/>
-        <nd ref="-2683"/>
-        <nd ref="-6851"/>
-        <nd ref="-2684"/>
-        <nd ref="-6852"/>
-        <nd ref="-6853"/>
-        <nd ref="-2685"/>
-        <nd ref="-29828"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-25937" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24788"/>
         <nd ref="-29827"/>
@@ -10090,6 +9669,13 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-25698" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32502"/>
+        <nd ref="-3237"/>
+        <nd ref="-7066"/>
+        <nd ref="-3238"/>
+        <nd ref="-7067"/>
+        <nd ref="-3239"/>
+        <nd ref="-3240"/>
         <nd ref="-29730"/>
         <nd ref="-7068"/>
         <nd ref="-3242"/>
@@ -10119,6 +9705,39 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-25206" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28984"/>
+        <nd ref="-2786"/>
+        <nd ref="-2788"/>
+        <nd ref="-4958"/>
+        <nd ref="-2791"/>
+        <nd ref="-4959"/>
+        <nd ref="-2794"/>
+        <nd ref="-2797"/>
+        <nd ref="-2800"/>
+        <nd ref="-2803"/>
+        <nd ref="-4960"/>
+        <nd ref="-4961"/>
+        <nd ref="-2806"/>
+        <nd ref="-4962"/>
+        <nd ref="-2809"/>
+        <nd ref="-2812"/>
+        <nd ref="-2815"/>
+        <nd ref="-4963"/>
+        <nd ref="-2818"/>
+        <nd ref="-2821"/>
+        <nd ref="-4964"/>
+        <nd ref="-2824"/>
+        <nd ref="-4965"/>
+        <nd ref="-2827"/>
+        <nd ref="-2830"/>
+        <nd ref="-2833"/>
+        <nd ref="-4966"/>
+        <nd ref="-2836"/>
+        <nd ref="-2839"/>
+        <nd ref="-2842"/>
+        <nd ref="-4967"/>
+        <nd ref="-2845"/>
+        <nd ref="-2848"/>
         <nd ref="-29148"/>
         <nd ref="-2776"/>
         <nd ref="-2777"/>
@@ -10159,13 +9778,6 @@
         <nd ref="-4979"/>
         <nd ref="-2832"/>
         <nd ref="-2835"/>
-        <nd ref="-29252"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-25205" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-29252"/>
         <nd ref="-2838"/>
         <nd ref="-4980"/>
@@ -10226,7 +9838,80 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-24571" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-24569" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28750"/>
+        <nd ref="-6466"/>
+        <nd ref="-6469"/>
+        <nd ref="-4128"/>
+        <nd ref="-4129"/>
+        <nd ref="-6472"/>
+        <nd ref="-6475"/>
+        <nd ref="-4130"/>
+        <nd ref="-6478"/>
+        <nd ref="-6481"/>
+        <nd ref="-4131"/>
+        <nd ref="-4132"/>
+        <nd ref="-6484"/>
+        <nd ref="-4133"/>
+        <nd ref="-6487"/>
+        <nd ref="-6491"/>
+        <nd ref="-4134"/>
+        <nd ref="-4135"/>
+        <nd ref="-4136"/>
+        <nd ref="-4137"/>
+        <nd ref="-4138"/>
+        <nd ref="-6495"/>
+        <nd ref="-4139"/>
+        <nd ref="-4140"/>
+        <nd ref="-6499"/>
+        <nd ref="-4141"/>
+        <nd ref="-4142"/>
+        <nd ref="-6503"/>
+        <nd ref="-4143"/>
+        <nd ref="-4144"/>
+        <nd ref="-4145"/>
+        <nd ref="-6506"/>
+        <nd ref="-4146"/>
+        <nd ref="-4147"/>
+        <nd ref="-6509"/>
+        <nd ref="-4148"/>
+        <nd ref="-4149"/>
+        <nd ref="-6512"/>
+        <nd ref="-4150"/>
+        <nd ref="-4151"/>
+        <nd ref="-6515"/>
+        <nd ref="-4152"/>
+        <nd ref="-4153"/>
+        <nd ref="-6518"/>
+        <nd ref="-4154"/>
+        <nd ref="-6522"/>
+        <nd ref="-4155"/>
+        <nd ref="-6526"/>
+        <nd ref="-6530"/>
+        <nd ref="-4156"/>
+        <nd ref="-6534"/>
+        <nd ref="-4157"/>
+        <nd ref="-4158"/>
+        <nd ref="-4159"/>
+        <nd ref="-6537"/>
+        <nd ref="-6540"/>
+        <nd ref="-4160"/>
+        <nd ref="-4161"/>
+        <nd ref="-6543"/>
+        <nd ref="-4162"/>
+        <nd ref="-4163"/>
+        <nd ref="-6546"/>
+        <nd ref="-4164"/>
+        <nd ref="-6549"/>
+        <nd ref="-4165"/>
+        <nd ref="-6552"/>
+        <nd ref="-4166"/>
+        <nd ref="-4167"/>
+        <nd ref="-4168"/>
+        <nd ref="-6555"/>
+        <nd ref="-4169"/>
+        <nd ref="-6558"/>
+        <nd ref="-30465"/>
         <nd ref="-28622"/>
         <nd ref="-4171"/>
         <nd ref="-6567"/>
@@ -10236,43 +9921,35 @@
         <nd ref="-6570"/>
         <nd ref="-4175"/>
         <nd ref="-28538"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-24569" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-30465"/>
-        <nd ref="-28622"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-24455" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28538"/>
         <nd ref="-4176"/>
         <nd ref="-4177"/>
         <nd ref="-6576"/>
         <nd ref="-4178"/>
         <nd ref="-6579"/>
         <nd ref="-31669"/>
+        <nd ref="-2933"/>
+        <nd ref="-2935"/>
+        <nd ref="-6585"/>
+        <nd ref="-2937"/>
+        <nd ref="-2939"/>
+        <nd ref="-6587"/>
+        <nd ref="-2941"/>
+        <nd ref="-2943"/>
+        <nd ref="-6589"/>
+        <nd ref="-2945"/>
+        <nd ref="-2947"/>
+        <nd ref="-6591"/>
+        <nd ref="-2949"/>
+        <nd ref="-6593"/>
+        <nd ref="-2950"/>
+        <nd ref="-6595"/>
+        <nd ref="-2951"/>
+        <nd ref="-2952"/>
+        <nd ref="-2953"/>
+        <nd ref="-2954"/>
+        <nd ref="-31739"/>
         <tag k="alt_name" v="Independence Ave SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23997" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27971"/>
-        <nd ref="-1047"/>
-        <nd ref="-1048"/>
-        <nd ref="-6872"/>
-        <nd ref="-6873"/>
-        <nd ref="-1049"/>
-        <nd ref="-1050"/>
-        <nd ref="-27972"/>
-        <tag k="alt_name" v="15th St NW;Raoul Wallenberg Pl SW"/>
-        <tag k="name" v="15TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -10286,58 +9963,6 @@
         <tag k="name" v="15TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-23962" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27935"/>
-        <nd ref="-877"/>
-        <nd ref="-6772"/>
-        <nd ref="-878"/>
-        <nd ref="-879"/>
-        <nd ref="-6774"/>
-        <nd ref="-880"/>
-        <nd ref="-881"/>
-        <nd ref="-6776"/>
-        <nd ref="-882"/>
-        <nd ref="-27936"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23910" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38523"/>
-        <nd ref="-887"/>
-        <nd ref="-27898"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23568" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38138"/>
-        <nd ref="-3192"/>
-        <nd ref="-3194"/>
-        <nd ref="-6087"/>
-        <nd ref="-3196"/>
-        <nd ref="-3197"/>
-        <nd ref="-3199"/>
-        <nd ref="-3201"/>
-        <nd ref="-27557"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23552" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27547"/>
-        <nd ref="-2262"/>
-        <nd ref="-2263"/>
-        <nd ref="-2264"/>
-        <nd ref="-27548"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-23551" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27548"/>
@@ -10415,7 +10040,7 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-23419" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-23246" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27498"/>
         <nd ref="-6044"/>
         <nd ref="-592"/>
@@ -10447,42 +10072,6 @@
         <nd ref="-606"/>
         <nd ref="-6070"/>
         <nd ref="-607"/>
-        <nd ref="-27447"/>
-        <tag k="alt_name" v="Ellipse Rd NW"/>
-        <tag k="name" v="ELLIPSE RD NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23248" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27357"/>
-        <nd ref="-7282"/>
-        <nd ref="-4239"/>
-        <nd ref="-4240"/>
-        <nd ref="-7283"/>
-        <nd ref="-4241"/>
-        <nd ref="-7284"/>
-        <nd ref="-4242"/>
-        <nd ref="-7285"/>
-        <nd ref="-4243"/>
-        <nd ref="-4244"/>
-        <nd ref="-7286"/>
-        <nd ref="-7287"/>
-        <nd ref="-4245"/>
-        <nd ref="-7288"/>
-        <nd ref="-4246"/>
-        <nd ref="-7289"/>
-        <nd ref="-4247"/>
-        <nd ref="-7290"/>
-        <nd ref="-4248"/>
-        <nd ref="-4249"/>
-        <nd ref="-4251"/>
-        <nd ref="-27297"/>
-        <tag k="alt_name" v="Ellipse Rd NW"/>
-        <tag k="name" v="ELLIPSE RD NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23246" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27447"/>
         <nd ref="-6074"/>
         <nd ref="-4207"/>
@@ -10521,6 +10110,28 @@
         <nd ref="-4237"/>
         <nd ref="-4238"/>
         <nd ref="-27357"/>
+        <nd ref="-7282"/>
+        <nd ref="-4239"/>
+        <nd ref="-4240"/>
+        <nd ref="-7283"/>
+        <nd ref="-4241"/>
+        <nd ref="-7284"/>
+        <nd ref="-4242"/>
+        <nd ref="-7285"/>
+        <nd ref="-4243"/>
+        <nd ref="-4244"/>
+        <nd ref="-7286"/>
+        <nd ref="-7287"/>
+        <nd ref="-4245"/>
+        <nd ref="-7288"/>
+        <nd ref="-4246"/>
+        <nd ref="-7289"/>
+        <nd ref="-4247"/>
+        <nd ref="-7290"/>
+        <nd ref="-4248"/>
+        <nd ref="-4249"/>
+        <nd ref="-4251"/>
+        <nd ref="-27297"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="highway" v="road"/>
@@ -10559,6 +10170,18 @@
         <nd ref="-2551"/>
         <nd ref="-2552"/>
         <nd ref="-27221"/>
+        <nd ref="-2554"/>
+        <nd ref="-6003"/>
+        <nd ref="-2555"/>
+        <nd ref="-6006"/>
+        <nd ref="-2556"/>
+        <nd ref="-2557"/>
+        <nd ref="-25027"/>
+        <nd ref="-2144"/>
+        <nd ref="-2145"/>
+        <nd ref="-2146"/>
+        <nd ref="-2147"/>
+        <nd ref="-25028"/>
         <tag k="alt_name" v="14th St NW"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -10573,6 +10196,86 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-23131" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17012"/>
+        <nd ref="-3437"/>
+        <nd ref="-3439"/>
+        <nd ref="-6311"/>
+        <nd ref="-3441"/>
+        <nd ref="-3443"/>
+        <nd ref="-3444"/>
+        <nd ref="-6313"/>
+        <nd ref="-6315"/>
+        <nd ref="-3445"/>
+        <nd ref="-23321"/>
+        <nd ref="-2608"/>
+        <nd ref="-6319"/>
+        <nd ref="-6321"/>
+        <nd ref="-2609"/>
+        <nd ref="-2610"/>
+        <nd ref="-6323"/>
+        <nd ref="-6325"/>
+        <nd ref="-2611"/>
+        <nd ref="-23310"/>
+        <nd ref="-6329"/>
+        <nd ref="-2613"/>
+        <nd ref="-6331"/>
+        <nd ref="-2614"/>
+        <nd ref="-2615"/>
+        <nd ref="-6333"/>
+        <nd ref="-2616"/>
+        <nd ref="-6335"/>
+        <nd ref="-2617"/>
+        <nd ref="-6337"/>
+        <nd ref="-2618"/>
+        <nd ref="-17333"/>
+        <nd ref="-2619"/>
+        <nd ref="-2620"/>
+        <nd ref="-6341"/>
+        <nd ref="-2622"/>
+        <nd ref="-2624"/>
+        <nd ref="-27547"/>
+        <nd ref="-2626"/>
+        <nd ref="-2628"/>
+        <nd ref="-2630"/>
+        <nd ref="-6345"/>
+        <nd ref="-2632"/>
+        <nd ref="-20272"/>
+        <nd ref="-3446"/>
+        <nd ref="-3447"/>
+        <nd ref="-3448"/>
+        <nd ref="-6349"/>
+        <nd ref="-6351"/>
+        <nd ref="-3449"/>
+        <nd ref="-3450"/>
+        <nd ref="-3451"/>
+        <nd ref="-20273"/>
+        <nd ref="-2636"/>
+        <nd ref="-2638"/>
+        <nd ref="-2640"/>
+        <nd ref="-2642"/>
+        <nd ref="-20270"/>
+        <nd ref="-6357"/>
+        <nd ref="-2646"/>
+        <nd ref="-2648"/>
+        <nd ref="-6359"/>
+        <nd ref="-2650"/>
+        <nd ref="-2652"/>
+        <nd ref="-18486"/>
+        <nd ref="-3705"/>
+        <nd ref="-6363"/>
+        <nd ref="-3707"/>
+        <nd ref="-3709"/>
+        <nd ref="-6365"/>
+        <nd ref="-3711"/>
+        <nd ref="-6367"/>
+        <nd ref="-3713"/>
+        <nd ref="-3715"/>
+        <nd ref="-6369"/>
+        <nd ref="-3717"/>
+        <nd ref="-6371"/>
+        <nd ref="-3719"/>
+        <nd ref="-3721"/>
+        <nd ref="-6373"/>
         <nd ref="-27199"/>
         <nd ref="-3452"/>
         <nd ref="-6375"/>
@@ -10591,15 +10294,9 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-22955" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-22954" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27005"/>
         <nd ref="-2421"/>
-        <nd ref="-27109"/>
-        <tag k="name" v="17TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-22954" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27109"/>
         <nd ref="-31669"/>
         <tag k="name" v="17TH ST SW"/>
@@ -10626,7 +10323,63 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-22687" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-22686" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26245"/>
+        <nd ref="-2914"/>
+        <nd ref="-2915"/>
+        <nd ref="-2916"/>
+        <nd ref="-6103"/>
+        <nd ref="-6104"/>
+        <nd ref="-2917"/>
+        <nd ref="-6105"/>
+        <nd ref="-2918"/>
+        <nd ref="-2919"/>
+        <nd ref="-6106"/>
+        <nd ref="-2920"/>
+        <nd ref="-6107"/>
+        <nd ref="-6108"/>
+        <nd ref="-2921"/>
+        <nd ref="-6109"/>
+        <nd ref="-2922"/>
+        <nd ref="-2923"/>
+        <nd ref="-6110"/>
+        <nd ref="-6111"/>
+        <nd ref="-2924"/>
+        <nd ref="-2925"/>
+        <nd ref="-6112"/>
+        <nd ref="-2926"/>
+        <nd ref="-26194"/>
+        <nd ref="-1010"/>
+        <nd ref="-1011"/>
+        <nd ref="-1012"/>
+        <nd ref="-6114"/>
+        <nd ref="-1013"/>
+        <nd ref="-6115"/>
+        <nd ref="-1014"/>
+        <nd ref="-1015"/>
+        <nd ref="-1016"/>
+        <nd ref="-6116"/>
+        <nd ref="-1017"/>
+        <nd ref="-6117"/>
+        <nd ref="-6118"/>
+        <nd ref="-1018"/>
+        <nd ref="-1019"/>
+        <nd ref="-6121"/>
+        <nd ref="-6124"/>
+        <nd ref="-1020"/>
+        <nd ref="-6127"/>
+        <nd ref="-1021"/>
+        <nd ref="-1022"/>
+        <nd ref="-6130"/>
+        <nd ref="-6133"/>
+        <nd ref="-1023"/>
+        <nd ref="-1024"/>
+        <nd ref="-6136"/>
+        <nd ref="-1025"/>
+        <nd ref="-6139"/>
+        <nd ref="-1026"/>
+        <nd ref="-6142"/>
+        <nd ref="-1027"/>
         <nd ref="-26744"/>
         <nd ref="-6148"/>
         <nd ref="-2929"/>
@@ -10636,13 +10389,6 @@
         <nd ref="-6152"/>
         <nd ref="-2932"/>
         <nd ref="-2934"/>
-        <nd ref="-26823"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-22686" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26823"/>
         <nd ref="-6156"/>
         <nd ref="-2936"/>
@@ -10655,18 +10401,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-22671" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26733"/>
-        <nd ref="-3177"/>
-        <nd ref="-3179"/>
-        <nd ref="-6430"/>
-        <nd ref="-3181"/>
-        <nd ref="-26734"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-22670" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26734"/>
         <nd ref="-3183"/>
@@ -10675,23 +10409,22 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-22641" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26710"/>
-        <nd ref="-6442"/>
-        <nd ref="-3185"/>
-        <nd ref="-6445"/>
-        <nd ref="-3187"/>
-        <nd ref="-3189"/>
-        <nd ref="-3191"/>
-        <nd ref="-3193"/>
-        <nd ref="-3195"/>
-        <nd ref="-26711"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-22610" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18362"/>
+        <nd ref="-2866"/>
+        <nd ref="-4447"/>
+        <nd ref="-2870"/>
+        <nd ref="-2874"/>
+        <nd ref="-4448"/>
+        <nd ref="-2878"/>
+        <nd ref="-4449"/>
+        <nd ref="-2882"/>
+        <nd ref="-26669"/>
+        <nd ref="-4450"/>
+        <nd ref="-2886"/>
+        <nd ref="-2890"/>
+        <nd ref="-4451"/>
+        <nd ref="-2894"/>
         <nd ref="-36693"/>
         <nd ref="-3676"/>
         <nd ref="-4452"/>
@@ -10706,6 +10439,19 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-22508" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27982"/>
+        <nd ref="-4383"/>
+        <nd ref="-961"/>
+        <nd ref="-962"/>
+        <nd ref="-4384"/>
+        <nd ref="-4385"/>
+        <nd ref="-963"/>
+        <nd ref="-964"/>
+        <nd ref="-4386"/>
+        <nd ref="-965"/>
+        <nd ref="-966"/>
+        <nd ref="-967"/>
+        <nd ref="-4387"/>
         <nd ref="-26596"/>
         <nd ref="-1834"/>
         <nd ref="-4388"/>
@@ -10728,60 +10474,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-22269" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34038"/>
-        <nd ref="-2367"/>
-        <nd ref="-5709"/>
-        <nd ref="-2368"/>
-        <nd ref="-5710"/>
-        <nd ref="-5711"/>
-        <nd ref="-2369"/>
-        <nd ref="-2370"/>
-        <nd ref="-5712"/>
-        <nd ref="-2371"/>
-        <nd ref="-5713"/>
-        <nd ref="-2372"/>
-        <nd ref="-2373"/>
-        <nd ref="-5714"/>
-        <nd ref="-5715"/>
-        <nd ref="-2374"/>
-        <nd ref="-2375"/>
-        <nd ref="-26395"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-21833" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25947"/>
-        <nd ref="-5908"/>
-        <nd ref="-234"/>
-        <nd ref="-235"/>
-        <nd ref="-236"/>
-        <nd ref="-5910"/>
-        <nd ref="-237"/>
-        <nd ref="-5912"/>
-        <nd ref="-238"/>
-        <nd ref="-5914"/>
-        <nd ref="-239"/>
-        <nd ref="-5916"/>
-        <nd ref="-240"/>
-        <nd ref="-241"/>
-        <nd ref="-5918"/>
-        <nd ref="-5920"/>
-        <nd ref="-242"/>
-        <nd ref="-243"/>
-        <nd ref="-244"/>
-        <nd ref="-245"/>
-        <nd ref="-5922"/>
-        <nd ref="-5923"/>
-        <nd ref="-246"/>
-        <nd ref="-25948"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-21831" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19888"/>
         <nd ref="-232"/>
@@ -10790,29 +10482,6 @@
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-21741" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25859"/>
-        <nd ref="-869"/>
-        <nd ref="-6727"/>
-        <nd ref="-870"/>
-        <nd ref="-871"/>
-        <nd ref="-6730"/>
-        <nd ref="-6733"/>
-        <nd ref="-872"/>
-        <nd ref="-6736"/>
-        <nd ref="-873"/>
-        <nd ref="-6739"/>
-        <nd ref="-874"/>
-        <nd ref="-875"/>
-        <nd ref="-6742"/>
-        <nd ref="-876"/>
-        <nd ref="-6745"/>
-        <nd ref="-25860"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-21739" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25255"/>
@@ -10847,6 +10516,8 @@
         <nd ref="-2189"/>
         <nd ref="-2190"/>
         <nd ref="-25681"/>
+        <nd ref="-5954"/>
+        <nd ref="-5955"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
@@ -10873,6 +10544,15 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-21436" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25386"/>
+        <nd ref="-5751"/>
+        <nd ref="-2378"/>
+        <nd ref="-2379"/>
+        <nd ref="-2380"/>
+        <nd ref="-5752"/>
+        <nd ref="-2381"/>
+        <nd ref="-5753"/>
+        <nd ref="-2382"/>
         <nd ref="-25562"/>
         <nd ref="-2763"/>
         <nd ref="-2764"/>
@@ -10890,23 +10570,20 @@
     <way visible="true" id="-21172" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16353"/>
         <nd ref="-25295"/>
+        <nd ref="-2063"/>
+        <nd ref="-5980"/>
+        <nd ref="-5982"/>
+        <nd ref="-2064"/>
+        <nd ref="-2065"/>
+        <nd ref="-25296"/>
+        <nd ref="-2533"/>
+        <nd ref="-2534"/>
+        <nd ref="-2535"/>
+        <nd ref="-38284"/>
+        <tag k="alt_name" v="14TH ST NW"/>
         <tag k="name" v="14th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-18860" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36692"/>
-        <nd ref="-6400"/>
-        <nd ref="-2658"/>
-        <nd ref="-2660"/>
-        <nd ref="-2662"/>
-        <nd ref="-2664"/>
-        <nd ref="-2666"/>
-        <nd ref="-23437"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-18858" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36692"/>
@@ -10924,6 +10601,21 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-17514" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26433"/>
+        <nd ref="-4991"/>
+        <nd ref="-3822"/>
+        <nd ref="-3823"/>
+        <nd ref="-4993"/>
+        <nd ref="-4995"/>
+        <nd ref="-3824"/>
+        <nd ref="-3825"/>
+        <nd ref="-4997"/>
+        <nd ref="-3826"/>
+        <nd ref="-4999"/>
+        <nd ref="-3827"/>
+        <nd ref="-3828"/>
+        <nd ref="-3829"/>
+        <nd ref="-5001"/>
         <nd ref="-26434"/>
         <nd ref="-2390"/>
         <nd ref="-2391"/>
@@ -10984,22 +10676,6 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-1121" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37930"/>
-        <nd ref="-982"/>
-        <nd ref="-7358"/>
-        <nd ref="-981"/>
-        <nd ref="-7360"/>
-        <nd ref="-980"/>
-        <nd ref="-7362"/>
-        <nd ref="-979"/>
-        <nd ref="-38167"/>
-        <nd ref="-38469"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-1112" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38492"/>
         <nd ref="-5094"/>
@@ -11039,6 +10715,15 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-1054" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37965"/>
+        <nd ref="-4535"/>
+        <nd ref="-550"/>
+        <nd ref="-4533"/>
+        <nd ref="-547"/>
+        <nd ref="-545"/>
+        <nd ref="-543"/>
+        <nd ref="-541"/>
+        <nd ref="-539"/>
         <nd ref="-37964"/>
         <nd ref="-537"/>
         <nd ref="-535"/>
@@ -11120,6 +10805,171 @@
         <nd ref="-4539"/>
         <nd ref="-465"/>
         <nd ref="-38396"/>
+        <nd ref="-464"/>
+        <nd ref="-463"/>
+        <nd ref="-4541"/>
+        <nd ref="-462"/>
+        <nd ref="-38291"/>
+        <nd ref="-461"/>
+        <nd ref="-460"/>
+        <nd ref="-38292"/>
+        <nd ref="-458"/>
+        <nd ref="-4543"/>
+        <nd ref="-457"/>
+        <nd ref="-456"/>
+        <nd ref="-4544"/>
+        <nd ref="-455"/>
+        <nd ref="-4545"/>
+        <nd ref="-454"/>
+        <nd ref="-4546"/>
+        <nd ref="-453"/>
+        <nd ref="-4547"/>
+        <nd ref="-452"/>
+        <nd ref="-451"/>
+        <nd ref="-450"/>
+        <nd ref="-4548"/>
+        <nd ref="-4549"/>
+        <nd ref="-449"/>
+        <nd ref="-448"/>
+        <nd ref="-4550"/>
+        <nd ref="-447"/>
+        <nd ref="-4551"/>
+        <nd ref="-446"/>
+        <nd ref="-445"/>
+        <nd ref="-444"/>
+        <nd ref="-4552"/>
+        <nd ref="-443"/>
+        <nd ref="-442"/>
+        <nd ref="-4553"/>
+        <nd ref="-441"/>
+        <nd ref="-440"/>
+        <nd ref="-439"/>
+        <nd ref="-4554"/>
+        <nd ref="-438"/>
+        <nd ref="-437"/>
+        <nd ref="-436"/>
+        <nd ref="-4555"/>
+        <nd ref="-435"/>
+        <nd ref="-434"/>
+        <nd ref="-4556"/>
+        <nd ref="-433"/>
+        <nd ref="-432"/>
+        <nd ref="-4557"/>
+        <nd ref="-431"/>
+        <nd ref="-4558"/>
+        <nd ref="-430"/>
+        <nd ref="-4559"/>
+        <nd ref="-429"/>
+        <nd ref="-428"/>
+        <nd ref="-4560"/>
+        <nd ref="-4561"/>
+        <nd ref="-427"/>
+        <nd ref="-426"/>
+        <nd ref="-425"/>
+        <nd ref="-38353"/>
+        <nd ref="-424"/>
+        <nd ref="-38354"/>
+        <nd ref="-423"/>
+        <nd ref="-4564"/>
+        <nd ref="-422"/>
+        <nd ref="-421"/>
+        <nd ref="-420"/>
+        <nd ref="-4565"/>
+        <nd ref="-419"/>
+        <nd ref="-418"/>
+        <nd ref="-4566"/>
+        <nd ref="-416"/>
+        <nd ref="-414"/>
+        <nd ref="-4567"/>
+        <nd ref="-412"/>
+        <nd ref="-4568"/>
+        <nd ref="-410"/>
+        <nd ref="-408"/>
+        <nd ref="-407"/>
+        <nd ref="-4569"/>
+        <nd ref="-406"/>
+        <nd ref="-405"/>
+        <nd ref="-4570"/>
+        <nd ref="-404"/>
+        <nd ref="-403"/>
+        <nd ref="-4571"/>
+        <nd ref="-402"/>
+        <nd ref="-4572"/>
+        <nd ref="-401"/>
+        <nd ref="-4573"/>
+        <nd ref="-400"/>
+        <nd ref="-399"/>
+        <nd ref="-398"/>
+        <nd ref="-397"/>
+        <nd ref="-4574"/>
+        <nd ref="-396"/>
+        <nd ref="-4575"/>
+        <nd ref="-395"/>
+        <nd ref="-394"/>
+        <nd ref="-393"/>
+        <nd ref="-392"/>
+        <nd ref="-4576"/>
+        <nd ref="-390"/>
+        <nd ref="-388"/>
+        <nd ref="-386"/>
+        <nd ref="-4577"/>
+        <nd ref="-384"/>
+        <nd ref="-4578"/>
+        <nd ref="-382"/>
+        <nd ref="-381"/>
+        <nd ref="-380"/>
+        <nd ref="-38192"/>
+        <nd ref="-378"/>
+        <nd ref="-4579"/>
+        <nd ref="-377"/>
+        <nd ref="-4580"/>
+        <nd ref="-376"/>
+        <nd ref="-375"/>
+        <nd ref="-38193"/>
+        <nd ref="-373"/>
+        <nd ref="-372"/>
+        <nd ref="-371"/>
+        <nd ref="-4582"/>
+        <nd ref="-370"/>
+        <nd ref="-369"/>
+        <nd ref="-4583"/>
+        <nd ref="-368"/>
+        <nd ref="-367"/>
+        <nd ref="-4584"/>
+        <nd ref="-366"/>
+        <nd ref="-4585"/>
+        <nd ref="-365"/>
+        <nd ref="-364"/>
+        <nd ref="-4586"/>
+        <nd ref="-363"/>
+        <nd ref="-4587"/>
+        <nd ref="-362"/>
+        <nd ref="-361"/>
+        <nd ref="-4588"/>
+        <nd ref="-360"/>
+        <nd ref="-359"/>
+        <nd ref="-358"/>
+        <nd ref="-4589"/>
+        <nd ref="-357"/>
+        <nd ref="-356"/>
+        <nd ref="-355"/>
+        <nd ref="-4590"/>
+        <nd ref="-354"/>
+        <nd ref="-4591"/>
+        <nd ref="-353"/>
+        <nd ref="-352"/>
+        <nd ref="-4592"/>
+        <nd ref="-351"/>
+        <nd ref="-350"/>
+        <nd ref="-4593"/>
+        <nd ref="-349"/>
+        <nd ref="-348"/>
+        <nd ref="-347"/>
+        <nd ref="-346"/>
+        <nd ref="-345"/>
+        <nd ref="-4594"/>
+        <nd ref="-344"/>
+        <nd ref="-38258"/>
         <tag k="alt_name" v="I- 66"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
@@ -11180,26 +11030,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-1018" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38590"/>
-        <nd ref="-2299"/>
-        <nd ref="-38591"/>
-        <nd ref="-2301"/>
-        <nd ref="-4347"/>
-        <nd ref="-2303"/>
-        <nd ref="-4348"/>
-        <nd ref="-4349"/>
-        <nd ref="-2305"/>
-        <nd ref="-2307"/>
-        <nd ref="-2309"/>
-        <nd ref="-38062"/>
-        <nd ref="-4350"/>
-        <nd ref="-37046"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-1014" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30465"/>
         <nd ref="-2056"/>
@@ -11230,85 +11060,92 @@
         <nd ref="-2042"/>
         <nd ref="-4875"/>
         <nd ref="-32874"/>
+        <nd ref="-2040"/>
+        <nd ref="-4877"/>
+        <nd ref="-2038"/>
+        <nd ref="-4879"/>
+        <nd ref="-2036"/>
+        <nd ref="-4881"/>
+        <nd ref="-2034"/>
+        <nd ref="-4883"/>
+        <nd ref="-2032"/>
+        <nd ref="-2030"/>
+        <nd ref="-4886"/>
+        <nd ref="-2028"/>
+        <nd ref="-2026"/>
+        <nd ref="-4889"/>
+        <nd ref="-4892"/>
+        <nd ref="-2024"/>
+        <nd ref="-2022"/>
+        <nd ref="-4895"/>
+        <nd ref="-2020"/>
+        <nd ref="-4898"/>
+        <nd ref="-2018"/>
+        <nd ref="-4901"/>
+        <nd ref="-4904"/>
+        <nd ref="-2016"/>
+        <nd ref="-2014"/>
+        <nd ref="-2012"/>
+        <nd ref="-4908"/>
+        <nd ref="-2010"/>
+        <nd ref="-4911"/>
+        <nd ref="-2008"/>
+        <nd ref="-2006"/>
+        <nd ref="-4914"/>
+        <nd ref="-2004"/>
+        <nd ref="-2002"/>
+        <nd ref="-4917"/>
+        <nd ref="-2000"/>
+        <nd ref="-4920"/>
+        <nd ref="-1998"/>
+        <nd ref="-1996"/>
+        <nd ref="-1994"/>
+        <nd ref="-4922"/>
+        <nd ref="-1992"/>
+        <nd ref="-4924"/>
+        <nd ref="-1990"/>
+        <nd ref="-4926"/>
+        <nd ref="-1988"/>
+        <nd ref="-1986"/>
+        <nd ref="-4928"/>
+        <nd ref="-1984"/>
+        <nd ref="-1982"/>
+        <nd ref="-4930"/>
+        <nd ref="-1980"/>
+        <nd ref="-1978"/>
+        <nd ref="-4932"/>
+        <nd ref="-1976"/>
+        <nd ref="-1974"/>
+        <nd ref="-4934"/>
+        <nd ref="-1972"/>
+        <nd ref="-1970"/>
+        <nd ref="-4936"/>
+        <nd ref="-1969"/>
+        <nd ref="-4938"/>
+        <nd ref="-1968"/>
+        <nd ref="-1967"/>
+        <nd ref="-4940"/>
+        <nd ref="-1966"/>
+        <nd ref="-34059"/>
+        <nd ref="-1965"/>
+        <nd ref="-1964"/>
+        <nd ref="-1963"/>
+        <nd ref="-4944"/>
+        <nd ref="-1962"/>
+        <nd ref="-1961"/>
+        <nd ref="-1960"/>
+        <nd ref="-4946"/>
+        <nd ref="-1959"/>
+        <nd ref="-1958"/>
+        <nd ref="-1957"/>
+        <nd ref="-4948"/>
+        <nd ref="-1956"/>
+        <nd ref="-1955"/>
+        <nd ref="-37456"/>
+        <nd ref="-1951"/>
+        <nd ref="-37457"/>
         <tag k="alt_name" v="Maine Ave SW"/>
         <tag k="name" v="MAINE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-1013" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36325"/>
-        <nd ref="-3509"/>
-        <nd ref="-3508"/>
-        <nd ref="-36326"/>
-        <nd ref="-1735"/>
-        <nd ref="-6950"/>
-        <nd ref="-1733"/>
-        <nd ref="-1731"/>
-        <nd ref="-6951"/>
-        <nd ref="-1729"/>
-        <nd ref="-1727"/>
-        <nd ref="-1725"/>
-        <nd ref="-6952"/>
-        <nd ref="-1723"/>
-        <nd ref="-6953"/>
-        <nd ref="-1721"/>
-        <nd ref="-1719"/>
-        <nd ref="-6955"/>
-        <nd ref="-6957"/>
-        <nd ref="-1717"/>
-        <nd ref="-6959"/>
-        <nd ref="-1715"/>
-        <nd ref="-1713"/>
-        <nd ref="-32874"/>
-        <nd ref="-1709"/>
-        <nd ref="-6963"/>
-        <nd ref="-1707"/>
-        <nd ref="-1705"/>
-        <nd ref="-1703"/>
-        <nd ref="-6965"/>
-        <nd ref="-1701"/>
-        <nd ref="-1699"/>
-        <nd ref="-6967"/>
-        <nd ref="-1697"/>
-        <nd ref="-6968"/>
-        <nd ref="-1695"/>
-        <nd ref="-1693"/>
-        <nd ref="-6969"/>
-        <nd ref="-1691"/>
-        <nd ref="-6970"/>
-        <nd ref="-6971"/>
-        <nd ref="-1689"/>
-        <nd ref="-1687"/>
-        <nd ref="-6972"/>
-        <nd ref="-1685"/>
-        <nd ref="-6973"/>
-        <nd ref="-6974"/>
-        <nd ref="-1683"/>
-        <nd ref="-1681"/>
-        <nd ref="-1679"/>
-        <nd ref="-6975"/>
-        <nd ref="-1677"/>
-        <nd ref="-1675"/>
-        <nd ref="-6977"/>
-        <nd ref="-6979"/>
-        <nd ref="-1673"/>
-        <nd ref="-6981"/>
-        <nd ref="-1671"/>
-        <nd ref="-6983"/>
-        <nd ref="-1669"/>
-        <nd ref="-1667"/>
-        <nd ref="-6985"/>
-        <nd ref="-1665"/>
-        <nd ref="-1663"/>
-        <nd ref="-1661"/>
-        <nd ref="-6987"/>
-        <nd ref="-1659"/>
-        <nd ref="-6989"/>
-        <nd ref="-1657"/>
-        <nd ref="-6991"/>
-        <nd ref="-32914"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -11316,9 +11153,6 @@
         <nd ref="-36148"/>
         <nd ref="-6662"/>
         <nd ref="-38582"/>
-        <nd ref="-6666"/>
-        <nd ref="-6668"/>
-        <nd ref="-38438"/>
         <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -11328,15 +11162,12 @@
         <nd ref="-4731"/>
         <nd ref="-5080"/>
         <nd ref="-37033"/>
+        <nd ref="-4733"/>
+        <nd ref="-4735"/>
+        <nd ref="-1041"/>
+        <nd ref="-37034"/>
+        <tag k="alt_name" v="26TH ST NW"/>
         <tag k="name" v="26th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-951" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25681"/>
-        <nd ref="-5954"/>
-        <nd ref="-5955"/>
-        <tag k="name" v="I St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -11387,26 +11218,61 @@
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-934" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31249"/>
-        <nd ref="-1783"/>
-        <nd ref="-5801"/>
-        <nd ref="-1784"/>
-        <nd ref="-5802"/>
-        <nd ref="-1785"/>
-        <nd ref="-1786"/>
-        <nd ref="-5803"/>
-        <nd ref="-1787"/>
-        <nd ref="-5804"/>
-        <nd ref="-1788"/>
-        <nd ref="-1789"/>
-        <nd ref="-5805"/>
-        <nd ref="-32654"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-933" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30016"/>
+        <nd ref="-1518"/>
+        <nd ref="-1519"/>
+        <nd ref="-1520"/>
+        <nd ref="-35204"/>
+        <nd ref="-1521"/>
+        <nd ref="-1522"/>
+        <nd ref="-4734"/>
+        <nd ref="-1523"/>
+        <nd ref="-4736"/>
+        <nd ref="-1524"/>
+        <nd ref="-4737"/>
+        <nd ref="-1525"/>
+        <nd ref="-4738"/>
+        <nd ref="-1526"/>
+        <nd ref="-4739"/>
+        <nd ref="-1527"/>
+        <nd ref="-1528"/>
+        <nd ref="-4740"/>
+        <nd ref="-4741"/>
+        <nd ref="-1530"/>
+        <nd ref="-1532"/>
+        <nd ref="-4742"/>
+        <nd ref="-1534"/>
+        <nd ref="-4743"/>
+        <nd ref="-1536"/>
+        <nd ref="-4744"/>
+        <nd ref="-1538"/>
+        <nd ref="-4745"/>
+        <nd ref="-4746"/>
+        <nd ref="-1540"/>
+        <nd ref="-1542"/>
+        <nd ref="-4747"/>
+        <nd ref="-4748"/>
+        <nd ref="-1544"/>
+        <nd ref="-4749"/>
+        <nd ref="-1546"/>
+        <nd ref="-1548"/>
+        <nd ref="-4750"/>
+        <nd ref="-1550"/>
+        <nd ref="-4751"/>
+        <nd ref="-1552"/>
+        <nd ref="-1554"/>
+        <nd ref="-4752"/>
+        <nd ref="-4753"/>
+        <nd ref="-1556"/>
+        <nd ref="-1558"/>
+        <nd ref="-4755"/>
+        <nd ref="-1560"/>
+        <nd ref="-4757"/>
+        <nd ref="-38291"/>
+        <nd ref="-1562"/>
+        <nd ref="-1564"/>
+        <nd ref="-1566"/>
         <nd ref="-31249"/>
         <nd ref="-5505"/>
         <nd ref="-1570"/>
@@ -11415,6 +11281,96 @@
         <tag k="name" v="E ST EXPY NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-901" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38582"/>
+        <nd ref="-6666"/>
+        <nd ref="-6668"/>
+        <nd ref="-38438"/>
+        <nd ref="-3642"/>
+        <nd ref="-6672"/>
+        <nd ref="-6674"/>
+        <nd ref="-3639"/>
+        <nd ref="-3636"/>
+        <nd ref="-3633"/>
+        <nd ref="-3630"/>
+        <nd ref="-6676"/>
+        <nd ref="-3627"/>
+        <nd ref="-3624"/>
+        <nd ref="-3621"/>
+        <nd ref="-3618"/>
+        <nd ref="-3615"/>
+        <nd ref="-3612"/>
+        <nd ref="-3609"/>
+        <nd ref="-3606"/>
+        <nd ref="-3604"/>
+        <nd ref="-3602"/>
+        <nd ref="-3600"/>
+        <nd ref="-3598"/>
+        <nd ref="-3596"/>
+        <nd ref="-6678"/>
+        <nd ref="-3594"/>
+        <nd ref="-36398"/>
+        <nd ref="-3592"/>
+        <nd ref="-3590"/>
+        <nd ref="-3588"/>
+        <nd ref="-3586"/>
+        <nd ref="-3584"/>
+        <nd ref="-3582"/>
+        <nd ref="-6680"/>
+        <nd ref="-3580"/>
+        <nd ref="-3578"/>
+        <nd ref="-3576"/>
+        <nd ref="-3574"/>
+        <nd ref="-6682"/>
+        <nd ref="-3572"/>
+        <nd ref="-3570"/>
+        <nd ref="-3568"/>
+        <nd ref="-3566"/>
+        <nd ref="-3564"/>
+        <nd ref="-3562"/>
+        <nd ref="-3560"/>
+        <nd ref="-3558"/>
+        <nd ref="-3557"/>
+        <nd ref="-3556"/>
+        <nd ref="-3555"/>
+        <nd ref="-3554"/>
+        <nd ref="-3553"/>
+        <nd ref="-6684"/>
+        <nd ref="-3552"/>
+        <nd ref="-3551"/>
+        <nd ref="-6686"/>
+        <nd ref="-3550"/>
+        <nd ref="-3549"/>
+        <nd ref="-6687"/>
+        <nd ref="-3548"/>
+        <nd ref="-3547"/>
+        <nd ref="-6688"/>
+        <nd ref="-3546"/>
+        <nd ref="-6689"/>
+        <nd ref="-3545"/>
+        <nd ref="-6690"/>
+        <nd ref="-3544"/>
+        <nd ref="-3543"/>
+        <nd ref="-3542"/>
+        <nd ref="-6691"/>
+        <nd ref="-3541"/>
+        <nd ref="-3540"/>
+        <nd ref="-6692"/>
+        <nd ref="-3539"/>
+        <nd ref="-6693"/>
+        <nd ref="-3538"/>
+        <nd ref="-3537"/>
+        <nd ref="-3536"/>
+        <nd ref="-3535"/>
+        <nd ref="-3534"/>
+        <nd ref="-6694"/>
+        <nd ref="-3533"/>
+        <nd ref="-36354"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
+        <tag k="name" v="Independence Ave SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-891" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38462"/>
@@ -11448,152 +11404,6 @@
         <tag k="name" v="E ST EXPY NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-863" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32654"/>
-        <nd ref="-4352"/>
-        <nd ref="-1421"/>
-        <nd ref="-1422"/>
-        <nd ref="-4353"/>
-        <nd ref="-1423"/>
-        <nd ref="-4354"/>
-        <nd ref="-1425"/>
-        <nd ref="-1427"/>
-        <nd ref="-4355"/>
-        <nd ref="-1429"/>
-        <nd ref="-31250"/>
-        <tag k="name" v="E ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-853" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38193"/>
-        <nd ref="-1718"/>
-        <nd ref="-1720"/>
-        <nd ref="-6312"/>
-        <nd ref="-1722"/>
-        <nd ref="-1724"/>
-        <nd ref="-1726"/>
-        <nd ref="-6314"/>
-        <nd ref="-1728"/>
-        <nd ref="-6316"/>
-        <nd ref="-1730"/>
-        <nd ref="-1732"/>
-        <nd ref="-1734"/>
-        <nd ref="-6318"/>
-        <nd ref="-1736"/>
-        <nd ref="-6320"/>
-        <nd ref="-6322"/>
-        <nd ref="-1737"/>
-        <nd ref="-1738"/>
-        <nd ref="-1739"/>
-        <nd ref="-6324"/>
-        <nd ref="-37848"/>
-        <nd ref="-1740"/>
-        <nd ref="-1741"/>
-        <nd ref="-6326"/>
-        <nd ref="-1742"/>
-        <nd ref="-6328"/>
-        <nd ref="-1743"/>
-        <nd ref="-6330"/>
-        <nd ref="-6332"/>
-        <nd ref="-1744"/>
-        <nd ref="-1745"/>
-        <nd ref="-6334"/>
-        <nd ref="-6336"/>
-        <nd ref="-1746"/>
-        <nd ref="-1747"/>
-        <nd ref="-6338"/>
-        <nd ref="-1748"/>
-        <nd ref="-6340"/>
-        <nd ref="-1749"/>
-        <nd ref="-1750"/>
-        <nd ref="-1751"/>
-        <nd ref="-6342"/>
-        <nd ref="-6344"/>
-        <nd ref="-1752"/>
-        <nd ref="-1753"/>
-        <nd ref="-1754"/>
-        <nd ref="-1755"/>
-        <nd ref="-6346"/>
-        <nd ref="-1756"/>
-        <nd ref="-6348"/>
-        <nd ref="-1757"/>
-        <nd ref="-1758"/>
-        <nd ref="-6350"/>
-        <nd ref="-1759"/>
-        <nd ref="-1760"/>
-        <nd ref="-6352"/>
-        <nd ref="-1761"/>
-        <nd ref="-1762"/>
-        <nd ref="-6354"/>
-        <nd ref="-1763"/>
-        <nd ref="-6356"/>
-        <nd ref="-1764"/>
-        <nd ref="-1765"/>
-        <nd ref="-1766"/>
-        <nd ref="-6358"/>
-        <nd ref="-6360"/>
-        <nd ref="-1767"/>
-        <nd ref="-1768"/>
-        <nd ref="-6362"/>
-        <nd ref="-1769"/>
-        <nd ref="-6364"/>
-        <nd ref="-1770"/>
-        <nd ref="-1771"/>
-        <nd ref="-6366"/>
-        <nd ref="-1772"/>
-        <nd ref="-6368"/>
-        <nd ref="-1773"/>
-        <nd ref="-6370"/>
-        <nd ref="-1774"/>
-        <nd ref="-1775"/>
-        <nd ref="-6372"/>
-        <nd ref="-1776"/>
-        <nd ref="-1777"/>
-        <nd ref="-1778"/>
-        <nd ref="-6374"/>
-        <nd ref="-1779"/>
-        <nd ref="-6376"/>
-        <nd ref="-1780"/>
-        <nd ref="-6378"/>
-        <nd ref="-1781"/>
-        <nd ref="-1782"/>
-        <nd ref="-31249"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-849" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38309"/>
-        <nd ref="-4900"/>
-        <nd ref="-4903"/>
-        <nd ref="-4907"/>
-        <nd ref="-4910"/>
-        <nd ref="-4913"/>
-        <nd ref="-4916"/>
-        <nd ref="-4919"/>
-        <nd ref="-4921"/>
-        <nd ref="-4923"/>
-        <nd ref="-4925"/>
-        <nd ref="-4927"/>
-        <nd ref="-29252"/>
-        <nd ref="-4931"/>
-        <nd ref="-4933"/>
-        <nd ref="-4935"/>
-        <nd ref="-4937"/>
-        <nd ref="-4939"/>
-        <nd ref="-4941"/>
-        <nd ref="-4943"/>
-        <nd ref="-4945"/>
-        <nd ref="-4947"/>
-        <nd ref="-4949"/>
-        <nd ref="-4950"/>
-        <nd ref="-4951"/>
-        <nd ref="-4952"/>
-        <nd ref="-38512"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-816" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30331"/>
@@ -11709,41 +11519,32 @@
     <way visible="true" id="-694" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-20544"/>
         <nd ref="-25386"/>
+        <nd ref="-247"/>
+        <nd ref="-248"/>
+        <nd ref="-5939"/>
+        <nd ref="-249"/>
+        <nd ref="-5940"/>
+        <nd ref="-250"/>
+        <nd ref="-5941"/>
+        <nd ref="-251"/>
+        <nd ref="-5942"/>
+        <nd ref="-252"/>
+        <nd ref="-253"/>
+        <nd ref="-5943"/>
+        <nd ref="-254"/>
+        <nd ref="-255"/>
+        <nd ref="-5944"/>
+        <nd ref="-256"/>
+        <nd ref="-5945"/>
+        <nd ref="-25315"/>
+        <nd ref="-2172"/>
+        <nd ref="-5946"/>
+        <nd ref="-5947"/>
+        <nd ref="-2173"/>
+        <nd ref="-2174"/>
+        <nd ref="-26744"/>
+        <tag k="alt_name" v="I ST NW"/>
         <tag k="name" v="I St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-656" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34762"/>
-        <nd ref="-5057"/>
-        <nd ref="-5060"/>
-        <nd ref="-5063"/>
-        <nd ref="-5066"/>
-        <nd ref="-5069"/>
-        <nd ref="-5072"/>
-        <nd ref="-5075"/>
-        <nd ref="-5078"/>
-        <nd ref="-5081"/>
-        <nd ref="-5083"/>
-        <nd ref="-5086"/>
-        <nd ref="-5089"/>
-        <nd ref="-5092"/>
-        <nd ref="-5095"/>
-        <nd ref="-5098"/>
-        <nd ref="-5100"/>
-        <nd ref="-5102"/>
-        <nd ref="-5104"/>
-        <nd ref="-5106"/>
-        <nd ref="-5108"/>
-        <nd ref="-5110"/>
-        <nd ref="-5113"/>
-        <nd ref="-5116"/>
-        <nd ref="-5119"/>
-        <nd ref="-5122"/>
-        <nd ref="-5125"/>
-        <nd ref="-5128"/>
-        <nd ref="-28984"/>
-        <tag k="name" v="Lincoln Memorial Cir"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -11887,28 +11688,13 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-650" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38027"/>
-        <nd ref="-5589"/>
-        <nd ref="-5591"/>
-        <nd ref="-5593"/>
-        <nd ref="-5595"/>
-        <nd ref="-5597"/>
-        <nd ref="-5599"/>
-        <nd ref="-5601"/>
-        <nd ref="-5603"/>
-        <nd ref="-5605"/>
-        <nd ref="-5607"/>
-        <nd ref="-5609"/>
-        <nd ref="-5611"/>
-        <nd ref="-5613"/>
-        <nd ref="-5615"/>
-        <nd ref="-5617"/>
-        <nd ref="-5619"/>
-        <nd ref="-5621"/>
         <nd ref="-6285"/>
         <nd ref="-5623"/>
         <nd ref="-5625"/>
         <nd ref="-38438"/>
+        <nd ref="-38461"/>
+        <nd ref="-38462"/>
+        <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -11962,13 +11748,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-610" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7020"/>
-        <nd ref="-5989"/>
-        <tag k="name" v="14th St SW"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
     <way visible="true" id="-608" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35558"/>
         <nd ref="-7058"/>
@@ -11981,13 +11760,6 @@
         <nd ref="-7006"/>
         <tag k="name" v="US Hwy 29"/>
         <tag k="highway" v="secondary"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-606" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38359"/>
-        <nd ref="-38468"/>
-        <tag k="name" v="Virginia Avenue North W"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-600" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -12007,6 +11779,48 @@
         <nd ref="-5844"/>
         <nd ref="-5845"/>
         <nd ref="-36586"/>
+        <nd ref="-1537"/>
+        <nd ref="-5846"/>
+        <nd ref="-1539"/>
+        <nd ref="-1541"/>
+        <nd ref="-5847"/>
+        <nd ref="-1543"/>
+        <nd ref="-1545"/>
+        <nd ref="-5848"/>
+        <nd ref="-1547"/>
+        <nd ref="-5850"/>
+        <nd ref="-1549"/>
+        <nd ref="-1551"/>
+        <nd ref="-5853"/>
+        <nd ref="-1553"/>
+        <nd ref="-1555"/>
+        <nd ref="-5856"/>
+        <nd ref="-1557"/>
+        <nd ref="-1559"/>
+        <nd ref="-5859"/>
+        <nd ref="-1561"/>
+        <nd ref="-1563"/>
+        <nd ref="-1565"/>
+        <nd ref="-5863"/>
+        <nd ref="-1567"/>
+        <nd ref="-5867"/>
+        <nd ref="-1569"/>
+        <nd ref="-1571"/>
+        <nd ref="-1573"/>
+        <nd ref="-5870"/>
+        <nd ref="-1575"/>
+        <nd ref="-1577"/>
+        <nd ref="-5873"/>
+        <nd ref="-5876"/>
+        <nd ref="-1579"/>
+        <nd ref="-1581"/>
+        <nd ref="-1583"/>
+        <nd ref="-5879"/>
+        <nd ref="-1585"/>
+        <nd ref="-1587"/>
+        <nd ref="-1589"/>
+        <nd ref="-37583"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -12119,6 +11933,7 @@
         <nd ref="-6396"/>
         <nd ref="-6399"/>
         <nd ref="-38359"/>
+        <nd ref="-38468"/>
         <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="Virginia Avenue North W"/>
         <tag k="highway" v="unclassified"/>
@@ -12167,6 +11982,9 @@
         <nd ref="-4626"/>
         <nd ref="-4627"/>
         <nd ref="-28822"/>
+        <nd ref="-135"/>
+        <nd ref="-25315"/>
+        <tag k="alt_name" v="NEW HAMPSHIRE AVE NW"/>
         <tag k="name" v="New Hampshire Ave NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12412,6 +12230,24 @@
         <nd ref="-5706"/>
         <nd ref="-5707"/>
         <nd ref="-34038"/>
+        <nd ref="-2367"/>
+        <nd ref="-5709"/>
+        <nd ref="-2368"/>
+        <nd ref="-5710"/>
+        <nd ref="-5711"/>
+        <nd ref="-2369"/>
+        <nd ref="-2370"/>
+        <nd ref="-5712"/>
+        <nd ref="-2371"/>
+        <nd ref="-5713"/>
+        <nd ref="-2372"/>
+        <nd ref="-2373"/>
+        <nd ref="-5714"/>
+        <nd ref="-5715"/>
+        <nd ref="-2374"/>
+        <nd ref="-2375"/>
+        <nd ref="-26395"/>
+        <tag k="alt_name" v="24TH ST NW"/>
         <tag k="name" v="24th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12428,6 +12264,7 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-510" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-7020"/>
         <nd ref="-5989"/>
         <nd ref="-36987"/>
         <nd ref="-36697"/>
@@ -12474,6 +12311,27 @@
     <way visible="true" id="-504" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4408"/>
         <nd ref="-24823"/>
+        <nd ref="-4410"/>
+        <nd ref="-4266"/>
+        <nd ref="-4268"/>
+        <nd ref="-4270"/>
+        <nd ref="-4411"/>
+        <nd ref="-4272"/>
+        <nd ref="-4412"/>
+        <nd ref="-4413"/>
+        <nd ref="-4274"/>
+        <nd ref="-4276"/>
+        <nd ref="-4414"/>
+        <nd ref="-4415"/>
+        <nd ref="-4277"/>
+        <nd ref="-4278"/>
+        <nd ref="-4416"/>
+        <nd ref="-4417"/>
+        <nd ref="-4279"/>
+        <nd ref="-4280"/>
+        <nd ref="-4418"/>
+        <nd ref="-31995"/>
+        <tag k="alt_name" v="20TH ST NW"/>
         <tag k="name" v="20th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12583,6 +12441,8 @@
         <nd ref="-7312"/>
         <nd ref="-7313"/>
         <nd ref="-38581"/>
+        <nd ref="-38582"/>
+        <tag k="name" v="OHIO DR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -12612,6 +12472,23 @@
     <way visible="true" id="-470" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7051"/>
         <nd ref="-23490"/>
+        <nd ref="-853"/>
+        <nd ref="-854"/>
+        <nd ref="-5413"/>
+        <nd ref="-855"/>
+        <nd ref="-856"/>
+        <nd ref="-857"/>
+        <nd ref="-858"/>
+        <nd ref="-5415"/>
+        <nd ref="-859"/>
+        <nd ref="-5417"/>
+        <nd ref="-860"/>
+        <nd ref="-5419"/>
+        <nd ref="-861"/>
+        <nd ref="-862"/>
+        <nd ref="-863"/>
+        <nd ref="-28749"/>
+        <tag k="alt_name" v="INDEPENDENCE AVE SW"/>
         <tag k="name" v="Independence Ave SW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12623,8 +12500,35 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-462" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32023"/>
+        <nd ref="-24"/>
+        <nd ref="-5482"/>
+        <nd ref="-22"/>
+        <nd ref="-20"/>
+        <nd ref="-5481"/>
+        <nd ref="-18"/>
+        <nd ref="-16"/>
+        <nd ref="-14"/>
+        <nd ref="-5480"/>
+        <nd ref="-12"/>
+        <nd ref="-11"/>
+        <nd ref="-5479"/>
+        <nd ref="-5478"/>
+        <nd ref="-10"/>
+        <nd ref="-9"/>
+        <nd ref="-5477"/>
+        <nd ref="-8"/>
+        <nd ref="-7"/>
+        <nd ref="-6"/>
+        <nd ref="-5476"/>
+        <nd ref="-5"/>
+        <nd ref="-5475"/>
+        <nd ref="-4"/>
+        <nd ref="-3"/>
+        <nd ref="-2"/>
         <nd ref="-35558"/>
         <nd ref="-7059"/>
+        <tag k="alt_name" v="CONSTITUTION AVE NW;Constitution Ave NW;US Hwy 1"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="secondary"/>
         <tag k="error:circular" v="5"/>
@@ -12749,6 +12653,20 @@
     <way visible="true" id="-423" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4338"/>
         <nd ref="-38278"/>
+        <nd ref="-3626"/>
+        <nd ref="-5852"/>
+        <nd ref="-3623"/>
+        <nd ref="-3620"/>
+        <nd ref="-5855"/>
+        <nd ref="-3617"/>
+        <nd ref="-3614"/>
+        <nd ref="-5858"/>
+        <nd ref="-5862"/>
+        <nd ref="-3611"/>
+        <nd ref="-5866"/>
+        <nd ref="-3608"/>
+        <nd ref="-37100"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
@@ -12756,6 +12674,13 @@
         <nd ref="-26823"/>
         <nd ref="-5888"/>
         <nd ref="-33926"/>
+        <nd ref="-5889"/>
+        <nd ref="-335"/>
+        <nd ref="-336"/>
+        <nd ref="-5890"/>
+        <nd ref="-337"/>
+        <nd ref="-33972"/>
+        <tag k="alt_name" v="QUEEN ANNES LN NW"/>
         <tag k="name" v="Queen Annes Ln NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
@@ -12874,6 +12799,16 @@
         <nd ref="-6910"/>
         <nd ref="-6912"/>
         <nd ref="-34007"/>
+        <nd ref="-2587"/>
+        <nd ref="-6914"/>
+        <nd ref="-2588"/>
+        <nd ref="-6916"/>
+        <nd ref="-2589"/>
+        <nd ref="-6918"/>
+        <nd ref="-6920"/>
+        <nd ref="-2590"/>
+        <nd ref="-34008"/>
+        <tag k="alt_name" v="SOUTH EXECUTIVE AVE NW"/>
         <tag k="name" v="South Pl NW"/>
         <tag k="foot" v="designated"/>
         <tag k="highway" v="path"/>
@@ -12927,70 +12862,18 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-374" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26194"/>
-        <nd ref="-1010"/>
-        <nd ref="-1011"/>
-        <nd ref="-1012"/>
-        <nd ref="-6114"/>
-        <nd ref="-1013"/>
-        <nd ref="-6115"/>
-        <nd ref="-1014"/>
-        <nd ref="-1015"/>
-        <nd ref="-1016"/>
-        <nd ref="-6116"/>
-        <nd ref="-1017"/>
-        <nd ref="-6117"/>
-        <nd ref="-6118"/>
-        <nd ref="-1018"/>
-        <nd ref="-1019"/>
-        <nd ref="-6121"/>
-        <nd ref="-6124"/>
-        <nd ref="-1020"/>
-        <nd ref="-6127"/>
-        <nd ref="-1021"/>
-        <nd ref="-1022"/>
-        <nd ref="-6130"/>
-        <nd ref="-6133"/>
-        <nd ref="-1023"/>
-        <nd ref="-1024"/>
-        <nd ref="-6136"/>
-        <nd ref="-1025"/>
-        <nd ref="-6139"/>
-        <nd ref="-1026"/>
-        <nd ref="-6142"/>
-        <nd ref="-1027"/>
-        <nd ref="-26744"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-373" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19605"/>
-        <nd ref="-3302"/>
-        <nd ref="-3303"/>
-        <nd ref="-3304"/>
-        <nd ref="-3305"/>
-        <nd ref="-3306"/>
-        <nd ref="-3307"/>
-        <nd ref="-3308"/>
-        <nd ref="-3309"/>
-        <nd ref="-3310"/>
-        <nd ref="-3311"/>
-        <nd ref="-3312"/>
-        <nd ref="-3313"/>
-        <nd ref="-3314"/>
-        <nd ref="-3315"/>
-        <nd ref="-3316"/>
-        <nd ref="-3317"/>
-        <nd ref="-35878"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-372" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26301"/>
+        <nd ref="-3251"/>
+        <nd ref="-3252"/>
+        <nd ref="-7076"/>
+        <nd ref="-3253"/>
+        <nd ref="-7078"/>
+        <nd ref="-36024"/>
+        <nd ref="-3255"/>
+        <nd ref="-35704"/>
+        <nd ref="-7080"/>
+        <nd ref="-3257"/>
         <nd ref="-26444"/>
         <nd ref="-3296"/>
         <nd ref="-7082"/>
@@ -13005,25 +12888,17 @@
         <nd ref="-3301"/>
         <nd ref="-7092"/>
         <nd ref="-22093"/>
+        <nd ref="-7094"/>
+        <nd ref="-3260"/>
+        <nd ref="-3261"/>
+        <nd ref="-7096"/>
+        <nd ref="-3262"/>
+        <nd ref="-3263"/>
+        <nd ref="-7098"/>
+        <nd ref="-3264"/>
+        <nd ref="-22060"/>
         <tag k="alt_name" v="21st St NW"/>
         <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-371" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20068"/>
-        <nd ref="-3291"/>
-        <nd ref="-3292"/>
-        <nd ref="-4433"/>
-        <nd ref="-3293"/>
-        <nd ref="-4434"/>
-        <nd ref="-3294"/>
-        <nd ref="-4435"/>
-        <nd ref="-4436"/>
-        <nd ref="-3295"/>
-        <nd ref="-19785"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -13048,6 +12923,63 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-369" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22971"/>
+        <nd ref="-608"/>
+        <nd ref="-609"/>
+        <nd ref="-610"/>
+        <nd ref="-5807"/>
+        <nd ref="-5808"/>
+        <nd ref="-611"/>
+        <nd ref="-612"/>
+        <nd ref="-613"/>
+        <nd ref="-614"/>
+        <nd ref="-21544"/>
+        <nd ref="-1105"/>
+        <nd ref="-5809"/>
+        <nd ref="-1106"/>
+        <nd ref="-5810"/>
+        <nd ref="-1107"/>
+        <nd ref="-5811"/>
+        <nd ref="-5812"/>
+        <nd ref="-1108"/>
+        <nd ref="-1109"/>
+        <nd ref="-21902"/>
+        <nd ref="-1110"/>
+        <nd ref="-5814"/>
+        <nd ref="-1111"/>
+        <nd ref="-1112"/>
+        <nd ref="-5815"/>
+        <nd ref="-1113"/>
+        <nd ref="-1114"/>
+        <nd ref="-21940"/>
+        <nd ref="-1115"/>
+        <nd ref="-1116"/>
+        <nd ref="-5817"/>
+        <nd ref="-5818"/>
+        <nd ref="-5819"/>
+        <nd ref="-1117"/>
+        <nd ref="-1118"/>
+        <nd ref="-1119"/>
+        <nd ref="-22093"/>
+        <nd ref="-5821"/>
+        <nd ref="-615"/>
+        <nd ref="-616"/>
+        <nd ref="-5822"/>
+        <nd ref="-617"/>
+        <nd ref="-618"/>
+        <nd ref="-5823"/>
+        <nd ref="-619"/>
+        <nd ref="-620"/>
+        <nd ref="-5824"/>
+        <nd ref="-621"/>
+        <nd ref="-622"/>
+        <nd ref="-5825"/>
+        <nd ref="-623"/>
+        <nd ref="-624"/>
+        <nd ref="-625"/>
+        <nd ref="-626"/>
+        <nd ref="-627"/>
+        <nd ref="-5826"/>
         <nd ref="-22783"/>
         <nd ref="-1120"/>
         <nd ref="-1121"/>
@@ -13098,97 +13030,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-368" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21940"/>
-        <nd ref="-1115"/>
-        <nd ref="-1116"/>
-        <nd ref="-5817"/>
-        <nd ref="-5818"/>
-        <nd ref="-5819"/>
-        <nd ref="-1117"/>
-        <nd ref="-1118"/>
-        <nd ref="-1119"/>
-        <nd ref="-22093"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-366" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21902"/>
-        <nd ref="-1110"/>
-        <nd ref="-5814"/>
-        <nd ref="-1111"/>
-        <nd ref="-1112"/>
-        <nd ref="-5815"/>
-        <nd ref="-1113"/>
-        <nd ref="-1114"/>
-        <nd ref="-21940"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-365" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26245"/>
-        <nd ref="-2914"/>
-        <nd ref="-2915"/>
-        <nd ref="-2916"/>
-        <nd ref="-6103"/>
-        <nd ref="-6104"/>
-        <nd ref="-2917"/>
-        <nd ref="-6105"/>
-        <nd ref="-2918"/>
-        <nd ref="-2919"/>
-        <nd ref="-6106"/>
-        <nd ref="-2920"/>
-        <nd ref="-6107"/>
-        <nd ref="-6108"/>
-        <nd ref="-2921"/>
-        <nd ref="-6109"/>
-        <nd ref="-2922"/>
-        <nd ref="-2923"/>
-        <nd ref="-6110"/>
-        <nd ref="-6111"/>
-        <nd ref="-2924"/>
-        <nd ref="-2925"/>
-        <nd ref="-6112"/>
-        <nd ref="-2926"/>
-        <nd ref="-26194"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-364" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21544"/>
-        <nd ref="-1105"/>
-        <nd ref="-5809"/>
-        <nd ref="-1106"/>
-        <nd ref="-5810"/>
-        <nd ref="-1107"/>
-        <nd ref="-5811"/>
-        <nd ref="-5812"/>
-        <nd ref="-1108"/>
-        <nd ref="-1109"/>
-        <nd ref="-21902"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-362" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16908"/>
-        <nd ref="-1102"/>
-        <nd ref="-7250"/>
-        <nd ref="-1103"/>
-        <nd ref="-1104"/>
-        <nd ref="-16992"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-360" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16841"/>
         <nd ref="-1092"/>
@@ -13203,113 +13044,13 @@
         <nd ref="-7249"/>
         <nd ref="-1101"/>
         <nd ref="-16908"/>
+        <nd ref="-1102"/>
+        <nd ref="-7250"/>
+        <nd ref="-1103"/>
+        <nd ref="-1104"/>
+        <nd ref="-16992"/>
         <tag k="alt_name" v="F St NW"/>
         <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-358" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19888"/>
-        <nd ref="-3278"/>
-        <nd ref="-7112"/>
-        <nd ref="-3279"/>
-        <nd ref="-7113"/>
-        <nd ref="-3280"/>
-        <nd ref="-19605"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-357" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26733"/>
-        <nd ref="-3272"/>
-        <nd ref="-7107"/>
-        <nd ref="-3273"/>
-        <nd ref="-3274"/>
-        <nd ref="-7108"/>
-        <nd ref="-3275"/>
-        <nd ref="-7109"/>
-        <nd ref="-7110"/>
-        <nd ref="-3276"/>
-        <nd ref="-19888"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-356" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22060"/>
-        <nd ref="-3266"/>
-        <nd ref="-3267"/>
-        <nd ref="-7102"/>
-        <nd ref="-7104"/>
-        <nd ref="-3268"/>
-        <nd ref="-3269"/>
-        <nd ref="-7105"/>
-        <nd ref="-3270"/>
-        <nd ref="-7106"/>
-        <nd ref="-26733"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-355" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22093"/>
-        <nd ref="-7094"/>
-        <nd ref="-3260"/>
-        <nd ref="-3261"/>
-        <nd ref="-7096"/>
-        <nd ref="-3262"/>
-        <nd ref="-3263"/>
-        <nd ref="-7098"/>
-        <nd ref="-3264"/>
-        <nd ref="-22060"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-354" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26301"/>
-        <nd ref="-3251"/>
-        <nd ref="-3252"/>
-        <nd ref="-7076"/>
-        <nd ref="-3253"/>
-        <nd ref="-7078"/>
-        <nd ref="-36024"/>
-        <nd ref="-3255"/>
-        <nd ref="-35704"/>
-        <nd ref="-7080"/>
-        <nd ref="-3257"/>
-        <nd ref="-26444"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-353" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22314"/>
-        <nd ref="-1347"/>
-        <nd ref="-6741"/>
-        <nd ref="-1348"/>
-        <nd ref="-6744"/>
-        <nd ref="-1349"/>
-        <nd ref="-6747"/>
-        <nd ref="-1350"/>
-        <nd ref="-1351"/>
-        <nd ref="-6750"/>
-        <nd ref="-1352"/>
-        <nd ref="-6753"/>
-        <nd ref="-1353"/>
-        <nd ref="-6756"/>
-        <nd ref="-1354"/>
-        <nd ref="-1355"/>
-        <nd ref="-6759"/>
-        <nd ref="-27972"/>
-        <tag k="alt_name" v="Madison Dr NW"/>
-        <tag k="name" v="MADISON DR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -13339,32 +13080,25 @@
         <nd ref="-1346"/>
         <nd ref="-6738"/>
         <nd ref="-22314"/>
+        <nd ref="-1347"/>
+        <nd ref="-6741"/>
+        <nd ref="-1348"/>
+        <nd ref="-6744"/>
+        <nd ref="-1349"/>
+        <nd ref="-6747"/>
+        <nd ref="-1350"/>
+        <nd ref="-1351"/>
+        <nd ref="-6750"/>
+        <nd ref="-1352"/>
+        <nd ref="-6753"/>
+        <nd ref="-1353"/>
+        <nd ref="-6756"/>
+        <nd ref="-1354"/>
+        <nd ref="-1355"/>
+        <nd ref="-6759"/>
+        <nd ref="-27972"/>
         <tag k="alt_name" v="Madison Dr NW"/>
         <tag k="name" v="MADISON DR NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-350" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32502"/>
-        <nd ref="-3237"/>
-        <nd ref="-7066"/>
-        <nd ref="-3238"/>
-        <nd ref="-7067"/>
-        <nd ref="-3239"/>
-        <nd ref="-3240"/>
-        <nd ref="-29730"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-347" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34013"/>
-        <nd ref="-6214"/>
-        <nd ref="-81"/>
-        <nd ref="-36776"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -13381,15 +13115,15 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-345" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25231"/>
-        <nd ref="-25296"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-343" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20273"/>
+        <nd ref="-3846"/>
+        <nd ref="-3848"/>
+        <nd ref="-7348"/>
+        <nd ref="-3850"/>
+        <nd ref="-7349"/>
+        <nd ref="-3853"/>
+        <nd ref="-3856"/>
         <nd ref="-20255"/>
         <nd ref="-7351"/>
         <nd ref="-383"/>
@@ -13397,173 +13131,15 @@
         <nd ref="-387"/>
         <nd ref="-389"/>
         <nd ref="-23418"/>
+        <nd ref="-715"/>
+        <nd ref="-718"/>
+        <nd ref="-721"/>
+        <nd ref="-7352"/>
+        <nd ref="-724"/>
+        <nd ref="-23419"/>
         <tag k="alt_name" v="16th St NW"/>
         <tag k="name" v="16TH ST NW"/>
         <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-342" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38292"/>
-        <nd ref="-458"/>
-        <nd ref="-4543"/>
-        <nd ref="-457"/>
-        <nd ref="-456"/>
-        <nd ref="-4544"/>
-        <nd ref="-455"/>
-        <nd ref="-4545"/>
-        <nd ref="-454"/>
-        <nd ref="-4546"/>
-        <nd ref="-453"/>
-        <nd ref="-4547"/>
-        <nd ref="-452"/>
-        <nd ref="-451"/>
-        <nd ref="-450"/>
-        <nd ref="-4548"/>
-        <nd ref="-4549"/>
-        <nd ref="-449"/>
-        <nd ref="-448"/>
-        <nd ref="-4550"/>
-        <nd ref="-447"/>
-        <nd ref="-4551"/>
-        <nd ref="-446"/>
-        <nd ref="-445"/>
-        <nd ref="-444"/>
-        <nd ref="-4552"/>
-        <nd ref="-443"/>
-        <nd ref="-442"/>
-        <nd ref="-4553"/>
-        <nd ref="-441"/>
-        <nd ref="-440"/>
-        <nd ref="-439"/>
-        <nd ref="-4554"/>
-        <nd ref="-438"/>
-        <nd ref="-437"/>
-        <nd ref="-436"/>
-        <nd ref="-4555"/>
-        <nd ref="-435"/>
-        <nd ref="-434"/>
-        <nd ref="-4556"/>
-        <nd ref="-433"/>
-        <nd ref="-432"/>
-        <nd ref="-4557"/>
-        <nd ref="-431"/>
-        <nd ref="-4558"/>
-        <nd ref="-430"/>
-        <nd ref="-4559"/>
-        <nd ref="-429"/>
-        <nd ref="-428"/>
-        <nd ref="-4560"/>
-        <nd ref="-4561"/>
-        <nd ref="-427"/>
-        <nd ref="-426"/>
-        <nd ref="-425"/>
-        <nd ref="-38353"/>
-        <nd ref="-424"/>
-        <nd ref="-38354"/>
-        <nd ref="-423"/>
-        <nd ref="-4564"/>
-        <nd ref="-422"/>
-        <nd ref="-421"/>
-        <nd ref="-420"/>
-        <nd ref="-4565"/>
-        <nd ref="-419"/>
-        <nd ref="-418"/>
-        <nd ref="-4566"/>
-        <nd ref="-416"/>
-        <nd ref="-414"/>
-        <nd ref="-4567"/>
-        <nd ref="-412"/>
-        <nd ref="-4568"/>
-        <nd ref="-410"/>
-        <nd ref="-408"/>
-        <nd ref="-407"/>
-        <nd ref="-4569"/>
-        <nd ref="-406"/>
-        <nd ref="-405"/>
-        <nd ref="-4570"/>
-        <nd ref="-404"/>
-        <nd ref="-403"/>
-        <nd ref="-4571"/>
-        <nd ref="-402"/>
-        <nd ref="-4572"/>
-        <nd ref="-401"/>
-        <nd ref="-4573"/>
-        <nd ref="-400"/>
-        <nd ref="-399"/>
-        <nd ref="-398"/>
-        <nd ref="-397"/>
-        <nd ref="-4574"/>
-        <nd ref="-396"/>
-        <nd ref="-4575"/>
-        <nd ref="-395"/>
-        <nd ref="-394"/>
-        <nd ref="-393"/>
-        <nd ref="-392"/>
-        <nd ref="-4576"/>
-        <nd ref="-390"/>
-        <nd ref="-388"/>
-        <nd ref="-386"/>
-        <nd ref="-4577"/>
-        <nd ref="-384"/>
-        <nd ref="-4578"/>
-        <nd ref="-382"/>
-        <nd ref="-381"/>
-        <nd ref="-380"/>
-        <nd ref="-38192"/>
-        <nd ref="-378"/>
-        <nd ref="-4579"/>
-        <nd ref="-377"/>
-        <nd ref="-4580"/>
-        <nd ref="-376"/>
-        <nd ref="-375"/>
-        <nd ref="-38193"/>
-        <nd ref="-373"/>
-        <nd ref="-372"/>
-        <nd ref="-371"/>
-        <nd ref="-4582"/>
-        <nd ref="-370"/>
-        <nd ref="-369"/>
-        <nd ref="-4583"/>
-        <nd ref="-368"/>
-        <nd ref="-367"/>
-        <nd ref="-4584"/>
-        <nd ref="-366"/>
-        <nd ref="-4585"/>
-        <nd ref="-365"/>
-        <nd ref="-364"/>
-        <nd ref="-4586"/>
-        <nd ref="-363"/>
-        <nd ref="-4587"/>
-        <nd ref="-362"/>
-        <nd ref="-361"/>
-        <nd ref="-4588"/>
-        <nd ref="-360"/>
-        <nd ref="-359"/>
-        <nd ref="-358"/>
-        <nd ref="-4589"/>
-        <nd ref="-357"/>
-        <nd ref="-356"/>
-        <nd ref="-355"/>
-        <nd ref="-4590"/>
-        <nd ref="-354"/>
-        <nd ref="-4591"/>
-        <nd ref="-353"/>
-        <nd ref="-352"/>
-        <nd ref="-4592"/>
-        <nd ref="-351"/>
-        <nd ref="-350"/>
-        <nd ref="-4593"/>
-        <nd ref="-349"/>
-        <nd ref="-348"/>
-        <nd ref="-347"/>
-        <nd ref="-346"/>
-        <nd ref="-345"/>
-        <nd ref="-4594"/>
-        <nd ref="-344"/>
-        <nd ref="-38258"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-340" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -13583,6 +13159,13 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-338" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34008"/>
+        <nd ref="-1087"/>
+        <nd ref="-6490"/>
+        <nd ref="-6494"/>
+        <nd ref="-1089"/>
+        <nd ref="-6498"/>
+        <nd ref="-1091"/>
         <nd ref="-24644"/>
         <nd ref="-1093"/>
         <nd ref="-6502"/>
@@ -13596,62 +13179,703 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-337" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28984"/>
-        <nd ref="-2786"/>
-        <nd ref="-2788"/>
-        <nd ref="-4958"/>
-        <nd ref="-2791"/>
-        <nd ref="-4959"/>
-        <nd ref="-2794"/>
-        <nd ref="-2797"/>
-        <nd ref="-2800"/>
-        <nd ref="-2803"/>
-        <nd ref="-4960"/>
-        <nd ref="-4961"/>
-        <nd ref="-2806"/>
-        <nd ref="-4962"/>
-        <nd ref="-2809"/>
-        <nd ref="-2812"/>
-        <nd ref="-2815"/>
-        <nd ref="-4963"/>
-        <nd ref="-2818"/>
-        <nd ref="-2821"/>
-        <nd ref="-4964"/>
-        <nd ref="-2824"/>
-        <nd ref="-4965"/>
-        <nd ref="-2827"/>
-        <nd ref="-2830"/>
-        <nd ref="-2833"/>
-        <nd ref="-4966"/>
-        <nd ref="-2836"/>
-        <nd ref="-2839"/>
-        <nd ref="-2842"/>
-        <nd ref="-4967"/>
-        <nd ref="-2845"/>
-        <nd ref="-2848"/>
-        <nd ref="-29148"/>
-        <tag k="alt_name" v="Lincoln Memorial Cir"/>
-        <tag k="name" v="LINCOLN MEMORIAL CIR NW"/>
+    <way visible="true" id="-332" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25231"/>
+        <nd ref="-25296"/>
+        <nd ref="-228"/>
+        <nd ref="-6715"/>
+        <nd ref="-229"/>
+        <nd ref="-6718"/>
+        <nd ref="-230"/>
+        <nd ref="-231"/>
+        <nd ref="-25255"/>
+        <tag k="alt_name" v="E St NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-336" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34008"/>
-        <nd ref="-1087"/>
-        <nd ref="-6490"/>
-        <nd ref="-6494"/>
-        <nd ref="-1089"/>
-        <nd ref="-6498"/>
-        <nd ref="-1091"/>
-        <nd ref="-24644"/>
-        <tag k="alt_name" v="State Pl NW"/>
-        <tag k="name" v="STATE PL NW"/>
+    <way visible="true" id="-320" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22661"/>
+        <nd ref="-2862"/>
+        <nd ref="-4445"/>
+        <nd ref="-18362"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-319" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19396"/>
+        <nd ref="-1149"/>
+        <nd ref="-1150"/>
+        <nd ref="-1151"/>
+        <nd ref="-19698"/>
+        <nd ref="-2509"/>
+        <nd ref="-4710"/>
+        <nd ref="-2510"/>
+        <nd ref="-19605"/>
+        <tag k="alt_name" v="I St NW"/>
+        <tag k="name" v="I ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-318" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22747"/>
+        <nd ref="-2834"/>
+        <nd ref="-2837"/>
+        <nd ref="-7231"/>
+        <nd ref="-2840"/>
+        <nd ref="-7232"/>
+        <nd ref="-7233"/>
+        <nd ref="-2843"/>
+        <nd ref="-2846"/>
+        <nd ref="-2850"/>
+        <nd ref="-2854"/>
+        <nd ref="-22661"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
         <tag k="foot" v="designated"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-335" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-317" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23366"/>
+        <nd ref="-224"/>
+        <nd ref="-6166"/>
+        <nd ref="-225"/>
+        <nd ref="-226"/>
+        <nd ref="-6167"/>
+        <nd ref="-25231"/>
+        <nd ref="-6168"/>
+        <nd ref="-6169"/>
+        <nd ref="-38602"/>
+        <nd ref="-2807"/>
+        <nd ref="-38603"/>
+        <nd ref="-38284"/>
+        <nd ref="-2810"/>
+        <nd ref="-6170"/>
+        <nd ref="-2813"/>
+        <nd ref="-6171"/>
+        <nd ref="-2816"/>
+        <nd ref="-6172"/>
+        <nd ref="-6173"/>
+        <nd ref="-2819"/>
+        <nd ref="-6174"/>
+        <nd ref="-2822"/>
+        <nd ref="-6175"/>
+        <nd ref="-2825"/>
+        <nd ref="-2828"/>
+        <nd ref="-22701"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
+        <tag k="name" v="PENNSYLVANIA AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-310" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38531"/>
+        <nd ref="-6199"/>
+        <nd ref="-38532"/>
+        <nd ref="-260"/>
+        <nd ref="-5188"/>
+        <nd ref="-261"/>
+        <nd ref="-262"/>
+        <nd ref="-263"/>
+        <nd ref="-5191"/>
+        <nd ref="-264"/>
+        <nd ref="-29743"/>
+        <nd ref="-266"/>
+        <nd ref="-267"/>
+        <nd ref="-268"/>
+        <nd ref="-5197"/>
+        <nd ref="-269"/>
+        <nd ref="-5200"/>
+        <nd ref="-270"/>
+        <nd ref="-271"/>
+        <nd ref="-5203"/>
+        <nd ref="-272"/>
+        <nd ref="-273"/>
+        <nd ref="-5206"/>
+        <nd ref="-274"/>
+        <nd ref="-29923"/>
+        <nd ref="-3917"/>
+        <nd ref="-5212"/>
+        <nd ref="-3919"/>
+        <nd ref="-3921"/>
+        <nd ref="-5214"/>
+        <nd ref="-3923"/>
+        <nd ref="-3925"/>
+        <nd ref="-5216"/>
+        <nd ref="-3927"/>
+        <nd ref="-5218"/>
+        <nd ref="-3929"/>
+        <nd ref="-30016"/>
+        <nd ref="-5222"/>
+        <nd ref="-3933"/>
+        <nd ref="-37242"/>
+        <nd ref="-3937"/>
+        <nd ref="-3939"/>
+        <nd ref="-5226"/>
+        <nd ref="-30396"/>
+        <tag k="alt_name" v="23rd St NW"/>
+        <tag k="name" v="23RD ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-309" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26395"/>
+        <nd ref="-2459"/>
+        <nd ref="-5717"/>
+        <nd ref="-5718"/>
+        <nd ref="-2460"/>
+        <nd ref="-5719"/>
+        <nd ref="-2461"/>
+        <nd ref="-5720"/>
+        <nd ref="-2462"/>
+        <nd ref="-2463"/>
+        <nd ref="-5721"/>
+        <nd ref="-2464"/>
+        <nd ref="-2465"/>
+        <nd ref="-5722"/>
+        <nd ref="-5723"/>
+        <nd ref="-2466"/>
+        <nd ref="-2467"/>
+        <nd ref="-5724"/>
+        <nd ref="-5725"/>
+        <nd ref="-2468"/>
+        <nd ref="-2469"/>
+        <nd ref="-5726"/>
+        <nd ref="-2470"/>
+        <nd ref="-5727"/>
+        <nd ref="-2471"/>
+        <nd ref="-5728"/>
+        <nd ref="-2472"/>
+        <nd ref="-2473"/>
+        <nd ref="-5729"/>
+        <nd ref="-2474"/>
+        <nd ref="-5730"/>
+        <nd ref="-2475"/>
+        <nd ref="-2476"/>
+        <nd ref="-5731"/>
+        <nd ref="-2477"/>
+        <nd ref="-2478"/>
+        <nd ref="-2479"/>
+        <nd ref="-2480"/>
+        <nd ref="-5732"/>
+        <nd ref="-20863"/>
+        <nd ref="-5733"/>
+        <nd ref="-2482"/>
+        <nd ref="-2483"/>
+        <nd ref="-5734"/>
+        <nd ref="-2484"/>
+        <nd ref="-5735"/>
+        <nd ref="-2485"/>
+        <nd ref="-2486"/>
+        <nd ref="-5736"/>
+        <nd ref="-2487"/>
+        <nd ref="-5737"/>
+        <nd ref="-2488"/>
+        <nd ref="-5738"/>
+        <nd ref="-2489"/>
+        <nd ref="-5739"/>
+        <nd ref="-2490"/>
+        <nd ref="-5740"/>
+        <nd ref="-2491"/>
+        <nd ref="-5741"/>
+        <nd ref="-2492"/>
+        <nd ref="-5743"/>
+        <nd ref="-2493"/>
+        <nd ref="-2494"/>
+        <nd ref="-5745"/>
+        <nd ref="-2495"/>
+        <nd ref="-2496"/>
+        <nd ref="-5747"/>
+        <nd ref="-2497"/>
+        <nd ref="-2498"/>
+        <nd ref="-2499"/>
+        <nd ref="-2500"/>
+        <nd ref="-5749"/>
+        <nd ref="-25386"/>
+        <tag k="alt_name" v="24th St NW"/>
+        <tag k="name" v="24TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-307" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29148"/>
+        <nd ref="-35484"/>
+        <tag k="alt_name" v="23rd St NW"/>
+        <tag k="name" v="23RD ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-306" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24645"/>
+        <nd ref="-2057"/>
+        <nd ref="-2058"/>
+        <nd ref="-7433"/>
+        <nd ref="-2059"/>
+        <nd ref="-2060"/>
+        <nd ref="-7434"/>
+        <nd ref="-2062"/>
+        <nd ref="-24603"/>
+        <nd ref="-1069"/>
+        <nd ref="-1071"/>
+        <nd ref="-1073"/>
+        <nd ref="-1075"/>
+        <nd ref="-7436"/>
+        <nd ref="-1077"/>
+        <nd ref="-23622"/>
+        <tag k="alt_name" v="New York Ave NW"/>
+        <tag k="name" v="NEW YORK AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-304" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23326"/>
+        <nd ref="-1059"/>
+        <nd ref="-1061"/>
+        <nd ref="-6932"/>
+        <nd ref="-6933"/>
+        <nd ref="-1063"/>
+        <nd ref="-23310"/>
+        <nd ref="-1178"/>
+        <nd ref="-6935"/>
+        <nd ref="-1179"/>
+        <nd ref="-17332"/>
+        <nd ref="-1065"/>
+        <nd ref="-6939"/>
+        <nd ref="-17468"/>
+        <tag k="alt_name" v="New York Ave NW"/>
+        <tag k="name" v="NEW YORK AVE NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-303" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23366"/>
+        <nd ref="-1248"/>
+        <nd ref="-7115"/>
+        <nd ref="-1250"/>
+        <nd ref="-36541"/>
+        <tag k="alt_name" v="13th St NW"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-301" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23418"/>
+        <nd ref="-4018"/>
+        <nd ref="-5783"/>
+        <nd ref="-4019"/>
+        <nd ref="-5784"/>
+        <nd ref="-4020"/>
+        <nd ref="-5785"/>
+        <nd ref="-4021"/>
+        <nd ref="-23409"/>
+        <nd ref="-4022"/>
+        <nd ref="-23414"/>
+        <nd ref="-2726"/>
+        <nd ref="-2728"/>
+        <nd ref="-2730"/>
+        <nd ref="-5788"/>
+        <nd ref="-2732"/>
+        <nd ref="-5789"/>
+        <nd ref="-2734"/>
+        <nd ref="-2736"/>
+        <nd ref="-2738"/>
+        <nd ref="-23618"/>
+        <nd ref="-3318"/>
+        <nd ref="-3319"/>
+        <nd ref="-3320"/>
+        <nd ref="-5790"/>
+        <nd ref="-3321"/>
+        <nd ref="-3322"/>
+        <nd ref="-3323"/>
+        <nd ref="-23613"/>
+        <nd ref="-5792"/>
+        <nd ref="-1180"/>
+        <nd ref="-1181"/>
+        <nd ref="-5793"/>
+        <nd ref="-1182"/>
+        <nd ref="-5794"/>
+        <nd ref="-1183"/>
+        <nd ref="-5795"/>
+        <nd ref="-1184"/>
+        <nd ref="-25023"/>
+        <nd ref="-1185"/>
+        <nd ref="-5797"/>
+        <nd ref="-5798"/>
+        <nd ref="-1186"/>
+        <nd ref="-1187"/>
+        <nd ref="-1188"/>
+        <nd ref="-5799"/>
+        <nd ref="-35878"/>
+        <nd ref="-5059"/>
+        <nd ref="-2289"/>
+        <nd ref="-36191"/>
+        <nd ref="-2291"/>
+        <nd ref="-36208"/>
+        <nd ref="-36231"/>
+        <nd ref="-38590"/>
+        <nd ref="-2299"/>
+        <nd ref="-38591"/>
+        <nd ref="-2301"/>
+        <nd ref="-4347"/>
+        <nd ref="-2303"/>
+        <nd ref="-4348"/>
+        <nd ref="-4349"/>
+        <nd ref="-2305"/>
+        <nd ref="-2307"/>
+        <nd ref="-2309"/>
+        <nd ref="-38062"/>
+        <nd ref="-4350"/>
+        <nd ref="-37046"/>
+        <tag k="alt_name" v="K St NW;US Hwy 29"/>
+        <tag k="name" v="K ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-300" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23006"/>
+        <nd ref="-1029"/>
+        <nd ref="-1030"/>
+        <nd ref="-4688"/>
+        <nd ref="-1031"/>
+        <nd ref="-4690"/>
+        <nd ref="-1032"/>
+        <nd ref="-23432"/>
+        <nd ref="-1034"/>
+        <nd ref="-23433"/>
+        <tag k="alt_name" v="15th St NW"/>
+        <tag k="name" v="15TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-297" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35558"/>
+        <nd ref="-5742"/>
+        <nd ref="-2604"/>
+        <nd ref="-2605"/>
+        <nd ref="-5744"/>
+        <nd ref="-5746"/>
+        <nd ref="-2606"/>
+        <nd ref="-5748"/>
+        <nd ref="-2607"/>
+        <nd ref="-16344"/>
+        <tag k="alt_name" v="12th St NW"/>
+        <tag k="name" v="12TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-296" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36541"/>
+        <nd ref="-7117"/>
+        <nd ref="-2621"/>
+        <nd ref="-2623"/>
+        <nd ref="-7118"/>
+        <nd ref="-2625"/>
+        <nd ref="-7119"/>
+        <nd ref="-2627"/>
+        <nd ref="-16841"/>
+        <nd ref="-2631"/>
+        <nd ref="-7121"/>
+        <nd ref="-2633"/>
+        <nd ref="-2635"/>
+        <nd ref="-17034"/>
+        <nd ref="-2639"/>
+        <nd ref="-2641"/>
+        <nd ref="-7125"/>
+        <nd ref="-7127"/>
+        <nd ref="-2643"/>
+        <nd ref="-2645"/>
+        <nd ref="-7129"/>
+        <nd ref="-2647"/>
+        <nd ref="-2649"/>
+        <nd ref="-23321"/>
+        <nd ref="-2653"/>
+        <nd ref="-2655"/>
+        <nd ref="-7131"/>
+        <nd ref="-2657"/>
+        <nd ref="-23326"/>
+        <nd ref="-7133"/>
+        <nd ref="-1256"/>
+        <nd ref="-7135"/>
+        <nd ref="-1258"/>
+        <nd ref="-7137"/>
+        <nd ref="-1260"/>
+        <nd ref="-1262"/>
+        <nd ref="-23292"/>
+        <nd ref="-7141"/>
+        <nd ref="-2659"/>
+        <nd ref="-2661"/>
+        <nd ref="-2663"/>
+        <nd ref="-2665"/>
+        <nd ref="-25669"/>
+        <nd ref="-2669"/>
+        <nd ref="-7145"/>
+        <nd ref="-2671"/>
+        <nd ref="-23423"/>
+        <tag k="alt_name" v="13th St NW"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-295" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35557"/>
+        <nd ref="-35558"/>
+        <tag k="alt_name" v="12th St NW"/>
+        <tag k="name" v="12TH ST EXPY NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-293" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22060"/>
+        <nd ref="-3266"/>
+        <nd ref="-3267"/>
+        <nd ref="-7102"/>
+        <nd ref="-7104"/>
+        <nd ref="-3268"/>
+        <nd ref="-3269"/>
+        <nd ref="-7105"/>
+        <nd ref="-3270"/>
+        <nd ref="-7106"/>
+        <nd ref="-26733"/>
+        <nd ref="-3272"/>
+        <nd ref="-7107"/>
+        <nd ref="-3273"/>
+        <nd ref="-3274"/>
+        <nd ref="-7108"/>
+        <nd ref="-3275"/>
+        <nd ref="-7109"/>
+        <nd ref="-7110"/>
+        <nd ref="-3276"/>
+        <nd ref="-19888"/>
+        <nd ref="-3278"/>
+        <nd ref="-7112"/>
+        <nd ref="-3279"/>
+        <nd ref="-7113"/>
+        <nd ref="-3280"/>
+        <nd ref="-19605"/>
+        <nd ref="-3302"/>
+        <nd ref="-3303"/>
+        <nd ref="-3304"/>
+        <nd ref="-3305"/>
+        <nd ref="-3306"/>
+        <nd ref="-3307"/>
+        <nd ref="-3308"/>
+        <nd ref="-3309"/>
+        <nd ref="-3310"/>
+        <nd ref="-3311"/>
+        <nd ref="-3312"/>
+        <nd ref="-3313"/>
+        <nd ref="-3314"/>
+        <nd ref="-3315"/>
+        <nd ref="-3316"/>
+        <nd ref="-3317"/>
+        <nd ref="-35878"/>
+        <nd ref="-3283"/>
+        <nd ref="-3284"/>
+        <nd ref="-3285"/>
+        <nd ref="-3286"/>
+        <nd ref="-3287"/>
+        <nd ref="-3288"/>
+        <nd ref="-3289"/>
+        <nd ref="-24994"/>
+        <tag k="alt_name" v="21st St NW"/>
+        <tag k="name" v="21ST ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-289" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34560"/>
+        <nd ref="-332"/>
+        <nd ref="-333"/>
+        <nd ref="-7055"/>
+        <nd ref="-34561"/>
+        <tag k="alt_name" v="23rd St NW"/>
+        <tag k="name" v="23RD ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-286" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38591"/>
+        <nd ref="-2771"/>
+        <nd ref="-36504"/>
+        <nd ref="-2772"/>
+        <nd ref="-5759"/>
+        <nd ref="-2773"/>
+        <nd ref="-2774"/>
+        <nd ref="-5760"/>
+        <nd ref="-2775"/>
+        <nd ref="-37483"/>
+        <nd ref="-769"/>
+        <nd ref="-771"/>
+        <nd ref="-35690"/>
+        <tag k="alt_name" v="24th St NW"/>
+        <tag k="name" v="24TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-285" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21940"/>
+        <nd ref="-4287"/>
+        <nd ref="-4424"/>
+        <nd ref="-4288"/>
+        <nd ref="-4289"/>
+        <nd ref="-4425"/>
+        <nd ref="-4290"/>
+        <nd ref="-4426"/>
+        <nd ref="-4291"/>
+        <nd ref="-4292"/>
+        <nd ref="-4427"/>
+        <nd ref="-4293"/>
+        <nd ref="-21918"/>
+        <nd ref="-4295"/>
+        <nd ref="-4429"/>
+        <nd ref="-4296"/>
+        <nd ref="-4298"/>
+        <nd ref="-4430"/>
+        <nd ref="-4300"/>
+        <nd ref="-4431"/>
+        <nd ref="-4302"/>
+        <nd ref="-4304"/>
+        <nd ref="-4432"/>
+        <nd ref="-20068"/>
+        <nd ref="-3291"/>
+        <nd ref="-3292"/>
+        <nd ref="-4433"/>
+        <nd ref="-3293"/>
+        <nd ref="-4434"/>
+        <nd ref="-3294"/>
+        <nd ref="-4435"/>
+        <nd ref="-4436"/>
+        <nd ref="-3295"/>
+        <nd ref="-19785"/>
+        <nd ref="-1153"/>
+        <nd ref="-1154"/>
+        <nd ref="-4438"/>
+        <nd ref="-1155"/>
+        <nd ref="-19698"/>
+        <nd ref="-1157"/>
+        <nd ref="-1158"/>
+        <nd ref="-1159"/>
+        <nd ref="-1160"/>
+        <nd ref="-4440"/>
+        <nd ref="-1161"/>
+        <nd ref="-1162"/>
+        <nd ref="-1163"/>
+        <nd ref="-1164"/>
+        <nd ref="-1165"/>
+        <nd ref="-4441"/>
+        <nd ref="-1166"/>
+        <nd ref="-4442"/>
+        <nd ref="-1167"/>
+        <nd ref="-1168"/>
+        <nd ref="-4443"/>
+        <nd ref="-1169"/>
+        <nd ref="-1170"/>
+        <nd ref="-25023"/>
+        <nd ref="-1172"/>
+        <nd ref="-1173"/>
+        <nd ref="-1174"/>
+        <nd ref="-1175"/>
+        <nd ref="-4444"/>
+        <nd ref="-1176"/>
+        <nd ref="-1177"/>
+        <nd ref="-25024"/>
+        <tag k="alt_name" v="20th St NW"/>
+        <tag k="name" v="20TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-282" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18515"/>
+        <nd ref="-5895"/>
+        <nd ref="-1228"/>
+        <nd ref="-1230"/>
+        <nd ref="-1232"/>
+        <nd ref="-5896"/>
+        <nd ref="-5897"/>
+        <nd ref="-1234"/>
+        <nd ref="-23409"/>
+        <nd ref="-1238"/>
+        <nd ref="-1240"/>
+        <nd ref="-1242"/>
+        <nd ref="-5898"/>
+        <nd ref="-23410"/>
+        <tag k="alt_name" v="17th St NW"/>
+        <tag k="name" v="17TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="3.53553"/>
+    </way>
+    <way visible="true" id="-279" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27780"/>
+        <nd ref="-3131"/>
+        <nd ref="-5964"/>
+        <nd ref="-3132"/>
+        <nd ref="-3133"/>
+        <nd ref="-3134"/>
+        <nd ref="-5965"/>
+        <nd ref="-5966"/>
+        <nd ref="-3135"/>
+        <nd ref="-3136"/>
+        <nd ref="-3137"/>
+        <nd ref="-5967"/>
+        <nd ref="-3138"/>
+        <nd ref="-5968"/>
+        <nd ref="-3139"/>
+        <nd ref="-3140"/>
+        <nd ref="-5969"/>
+        <nd ref="-3141"/>
+        <nd ref="-3142"/>
+        <nd ref="-3143"/>
+        <nd ref="-5970"/>
+        <nd ref="-3144"/>
+        <nd ref="-3145"/>
+        <nd ref="-3146"/>
+        <nd ref="-3147"/>
+        <nd ref="-3148"/>
+        <nd ref="-3149"/>
+        <nd ref="-5971"/>
+        <nd ref="-3150"/>
+        <nd ref="-3151"/>
+        <nd ref="-5972"/>
+        <nd ref="-3152"/>
+        <nd ref="-22783"/>
+        <nd ref="-163"/>
+        <nd ref="-5973"/>
+        <nd ref="-5974"/>
+        <nd ref="-164"/>
+        <nd ref="-165"/>
+        <nd ref="-166"/>
+        <nd ref="-167"/>
+        <nd ref="-168"/>
+        <nd ref="-5975"/>
+        <nd ref="-169"/>
+        <nd ref="-170"/>
+        <nd ref="-5977"/>
+        <nd ref="-171"/>
+        <nd ref="-5979"/>
+        <nd ref="-172"/>
+        <nd ref="-173"/>
+        <nd ref="-174"/>
+        <nd ref="-5981"/>
+        <nd ref="-5983"/>
+        <nd ref="-175"/>
+        <nd ref="-5985"/>
+        <nd ref="-176"/>
+        <nd ref="-177"/>
+        <nd ref="-178"/>
+        <nd ref="-5987"/>
+        <nd ref="-179"/>
+        <nd ref="-180"/>
+        <nd ref="-5990"/>
+        <nd ref="-181"/>
+        <nd ref="-182"/>
+        <nd ref="-5993"/>
+        <nd ref="-183"/>
+        <nd ref="-5996"/>
+        <nd ref="-184"/>
+        <nd ref="-185"/>
         <nd ref="-22143"/>
         <nd ref="-6002"/>
         <nd ref="-3155"/>
@@ -13700,757 +13924,6 @@
         <nd ref="-6037"/>
         <nd ref="-3186"/>
         <nd ref="-26711"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-334" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27780"/>
-        <nd ref="-3131"/>
-        <nd ref="-5964"/>
-        <nd ref="-3132"/>
-        <nd ref="-3133"/>
-        <nd ref="-3134"/>
-        <nd ref="-5965"/>
-        <nd ref="-5966"/>
-        <nd ref="-3135"/>
-        <nd ref="-3136"/>
-        <nd ref="-3137"/>
-        <nd ref="-5967"/>
-        <nd ref="-3138"/>
-        <nd ref="-5968"/>
-        <nd ref="-3139"/>
-        <nd ref="-3140"/>
-        <nd ref="-5969"/>
-        <nd ref="-3141"/>
-        <nd ref="-3142"/>
-        <nd ref="-3143"/>
-        <nd ref="-5970"/>
-        <nd ref="-3144"/>
-        <nd ref="-3145"/>
-        <nd ref="-3146"/>
-        <nd ref="-3147"/>
-        <nd ref="-3148"/>
-        <nd ref="-3149"/>
-        <nd ref="-5971"/>
-        <nd ref="-3150"/>
-        <nd ref="-3151"/>
-        <nd ref="-5972"/>
-        <nd ref="-3152"/>
-        <nd ref="-22783"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-333" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25023"/>
-        <nd ref="-1185"/>
-        <nd ref="-5797"/>
-        <nd ref="-5798"/>
-        <nd ref="-1186"/>
-        <nd ref="-1187"/>
-        <nd ref="-1188"/>
-        <nd ref="-5799"/>
-        <nd ref="-35878"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-332" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25296"/>
-        <nd ref="-228"/>
-        <nd ref="-6715"/>
-        <nd ref="-229"/>
-        <nd ref="-6718"/>
-        <nd ref="-230"/>
-        <nd ref="-231"/>
-        <nd ref="-25255"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-331" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23613"/>
-        <nd ref="-5792"/>
-        <nd ref="-1180"/>
-        <nd ref="-1181"/>
-        <nd ref="-5793"/>
-        <nd ref="-1182"/>
-        <nd ref="-5794"/>
-        <nd ref="-1183"/>
-        <nd ref="-5795"/>
-        <nd ref="-1184"/>
-        <nd ref="-25023"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-330" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23366"/>
-        <nd ref="-224"/>
-        <nd ref="-6166"/>
-        <nd ref="-225"/>
-        <nd ref="-226"/>
-        <nd ref="-6167"/>
-        <nd ref="-25231"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-327" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20068"/>
-        <nd ref="-3000"/>
-        <nd ref="-6418"/>
-        <nd ref="-6421"/>
-        <nd ref="-3002"/>
-        <nd ref="-3004"/>
-        <nd ref="-6424"/>
-        <nd ref="-3006"/>
-        <nd ref="-3008"/>
-        <nd ref="-3010"/>
-        <nd ref="-3012"/>
-        <nd ref="-26733"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-325" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33926"/>
-        <nd ref="-5889"/>
-        <nd ref="-335"/>
-        <nd ref="-336"/>
-        <nd ref="-5890"/>
-        <nd ref="-337"/>
-        <nd ref="-33972"/>
-        <tag k="alt_name" v="Queen Annes Ln NW"/>
-        <tag k="name" v="QUEEN ANNES LN NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-322" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26669"/>
-        <nd ref="-4450"/>
-        <nd ref="-2886"/>
-        <nd ref="-2890"/>
-        <nd ref="-4451"/>
-        <nd ref="-2894"/>
-        <nd ref="-36693"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-321" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18362"/>
-        <nd ref="-2866"/>
-        <nd ref="-4447"/>
-        <nd ref="-2870"/>
-        <nd ref="-2874"/>
-        <nd ref="-4448"/>
-        <nd ref="-2878"/>
-        <nd ref="-4449"/>
-        <nd ref="-2882"/>
-        <nd ref="-26669"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-320" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22661"/>
-        <nd ref="-2862"/>
-        <nd ref="-4445"/>
-        <nd ref="-18362"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-319" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19396"/>
-        <nd ref="-1149"/>
-        <nd ref="-1150"/>
-        <nd ref="-1151"/>
-        <nd ref="-19698"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-318" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22747"/>
-        <nd ref="-2834"/>
-        <nd ref="-2837"/>
-        <nd ref="-7231"/>
-        <nd ref="-2840"/>
-        <nd ref="-7232"/>
-        <nd ref="-7233"/>
-        <nd ref="-2843"/>
-        <nd ref="-2846"/>
-        <nd ref="-2850"/>
-        <nd ref="-2854"/>
-        <nd ref="-22661"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="foot" v="designated"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-317" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38284"/>
-        <nd ref="-2810"/>
-        <nd ref="-6170"/>
-        <nd ref="-2813"/>
-        <nd ref="-6171"/>
-        <nd ref="-2816"/>
-        <nd ref="-6172"/>
-        <nd ref="-6173"/>
-        <nd ref="-2819"/>
-        <nd ref="-6174"/>
-        <nd ref="-2822"/>
-        <nd ref="-6175"/>
-        <nd ref="-2825"/>
-        <nd ref="-2828"/>
-        <nd ref="-22701"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-316" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24823"/>
-        <nd ref="-999"/>
-        <nd ref="-6204"/>
-        <nd ref="-1000"/>
-        <nd ref="-6206"/>
-        <nd ref="-26301"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-315" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20544"/>
-        <nd ref="-321"/>
-        <nd ref="-322"/>
-        <nd ref="-5334"/>
-        <nd ref="-323"/>
-        <nd ref="-324"/>
-        <nd ref="-5335"/>
-        <nd ref="-325"/>
-        <nd ref="-5336"/>
-        <nd ref="-5337"/>
-        <nd ref="-326"/>
-        <nd ref="-327"/>
-        <nd ref="-5338"/>
-        <nd ref="-328"/>
-        <nd ref="-329"/>
-        <nd ref="-26596"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-313" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22575"/>
-        <nd ref="-295"/>
-        <nd ref="-296"/>
-        <nd ref="-297"/>
-        <nd ref="-298"/>
-        <nd ref="-5275"/>
-        <nd ref="-299"/>
-        <nd ref="-5277"/>
-        <nd ref="-300"/>
-        <nd ref="-301"/>
-        <nd ref="-5279"/>
-        <nd ref="-302"/>
-        <nd ref="-5281"/>
-        <nd ref="-5283"/>
-        <nd ref="-303"/>
-        <nd ref="-304"/>
-        <nd ref="-305"/>
-        <nd ref="-306"/>
-        <nd ref="-5285"/>
-        <nd ref="-307"/>
-        <nd ref="-5287"/>
-        <nd ref="-308"/>
-        <nd ref="-309"/>
-        <nd ref="-310"/>
-        <nd ref="-5289"/>
-        <nd ref="-311"/>
-        <nd ref="-312"/>
-        <nd ref="-313"/>
-        <nd ref="-5291"/>
-        <nd ref="-314"/>
-        <nd ref="-5293"/>
-        <nd ref="-315"/>
-        <nd ref="-5295"/>
-        <nd ref="-316"/>
-        <nd ref="-317"/>
-        <nd ref="-5297"/>
-        <nd ref="-318"/>
-        <nd ref="-319"/>
-        <nd ref="-320"/>
-        <nd ref="-5299"/>
-        <nd ref="-20610"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-311" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20863"/>
-        <nd ref="-5733"/>
-        <nd ref="-2482"/>
-        <nd ref="-2483"/>
-        <nd ref="-5734"/>
-        <nd ref="-2484"/>
-        <nd ref="-5735"/>
-        <nd ref="-2485"/>
-        <nd ref="-2486"/>
-        <nd ref="-5736"/>
-        <nd ref="-2487"/>
-        <nd ref="-5737"/>
-        <nd ref="-2488"/>
-        <nd ref="-5738"/>
-        <nd ref="-2489"/>
-        <nd ref="-5739"/>
-        <nd ref="-2490"/>
-        <nd ref="-5740"/>
-        <nd ref="-2491"/>
-        <nd ref="-5741"/>
-        <nd ref="-2492"/>
-        <nd ref="-5743"/>
-        <nd ref="-2493"/>
-        <nd ref="-2494"/>
-        <nd ref="-5745"/>
-        <nd ref="-2495"/>
-        <nd ref="-2496"/>
-        <nd ref="-5747"/>
-        <nd ref="-2497"/>
-        <nd ref="-2498"/>
-        <nd ref="-2499"/>
-        <nd ref="-2500"/>
-        <nd ref="-5749"/>
-        <nd ref="-25386"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-310" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29743"/>
-        <nd ref="-266"/>
-        <nd ref="-267"/>
-        <nd ref="-268"/>
-        <nd ref="-5197"/>
-        <nd ref="-269"/>
-        <nd ref="-5200"/>
-        <nd ref="-270"/>
-        <nd ref="-271"/>
-        <nd ref="-5203"/>
-        <nd ref="-272"/>
-        <nd ref="-273"/>
-        <nd ref="-5206"/>
-        <nd ref="-274"/>
-        <nd ref="-29923"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-309" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26395"/>
-        <nd ref="-2459"/>
-        <nd ref="-5717"/>
-        <nd ref="-5718"/>
-        <nd ref="-2460"/>
-        <nd ref="-5719"/>
-        <nd ref="-2461"/>
-        <nd ref="-5720"/>
-        <nd ref="-2462"/>
-        <nd ref="-2463"/>
-        <nd ref="-5721"/>
-        <nd ref="-2464"/>
-        <nd ref="-2465"/>
-        <nd ref="-5722"/>
-        <nd ref="-5723"/>
-        <nd ref="-2466"/>
-        <nd ref="-2467"/>
-        <nd ref="-5724"/>
-        <nd ref="-5725"/>
-        <nd ref="-2468"/>
-        <nd ref="-2469"/>
-        <nd ref="-5726"/>
-        <nd ref="-2470"/>
-        <nd ref="-5727"/>
-        <nd ref="-2471"/>
-        <nd ref="-5728"/>
-        <nd ref="-2472"/>
-        <nd ref="-2473"/>
-        <nd ref="-5729"/>
-        <nd ref="-2474"/>
-        <nd ref="-5730"/>
-        <nd ref="-2475"/>
-        <nd ref="-2476"/>
-        <nd ref="-5731"/>
-        <nd ref="-2477"/>
-        <nd ref="-2478"/>
-        <nd ref="-2479"/>
-        <nd ref="-2480"/>
-        <nd ref="-5732"/>
-        <nd ref="-20863"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-307" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29148"/>
-        <nd ref="-35484"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-306" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24603"/>
-        <nd ref="-1069"/>
-        <nd ref="-1071"/>
-        <nd ref="-1073"/>
-        <nd ref="-1075"/>
-        <nd ref="-7436"/>
-        <nd ref="-1077"/>
-        <nd ref="-23622"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-305" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23326"/>
-        <nd ref="-7133"/>
-        <nd ref="-1256"/>
-        <nd ref="-7135"/>
-        <nd ref="-1258"/>
-        <nd ref="-7137"/>
-        <nd ref="-1260"/>
-        <nd ref="-1262"/>
-        <nd ref="-23292"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-304" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17332"/>
-        <nd ref="-1065"/>
-        <nd ref="-6939"/>
-        <nd ref="-17468"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-303" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23366"/>
-        <nd ref="-1248"/>
-        <nd ref="-7115"/>
-        <nd ref="-1250"/>
-        <nd ref="-36541"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-302" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23326"/>
-        <nd ref="-1059"/>
-        <nd ref="-1061"/>
-        <nd ref="-6932"/>
-        <nd ref="-6933"/>
-        <nd ref="-1063"/>
-        <nd ref="-23310"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-301" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23618"/>
-        <nd ref="-3318"/>
-        <nd ref="-3319"/>
-        <nd ref="-3320"/>
-        <nd ref="-5790"/>
-        <nd ref="-3321"/>
-        <nd ref="-3322"/>
-        <nd ref="-3323"/>
-        <nd ref="-23613"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-300" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23432"/>
-        <nd ref="-1034"/>
-        <nd ref="-23433"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-299" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25023"/>
-        <nd ref="-1172"/>
-        <nd ref="-1173"/>
-        <nd ref="-1174"/>
-        <nd ref="-1175"/>
-        <nd ref="-4444"/>
-        <nd ref="-1176"/>
-        <nd ref="-1177"/>
-        <nd ref="-25024"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-298" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25027"/>
-        <nd ref="-2144"/>
-        <nd ref="-2145"/>
-        <nd ref="-2146"/>
-        <nd ref="-2147"/>
-        <nd ref="-25028"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-297" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35558"/>
-        <nd ref="-5742"/>
-        <nd ref="-2604"/>
-        <nd ref="-2605"/>
-        <nd ref="-5744"/>
-        <nd ref="-5746"/>
-        <nd ref="-2606"/>
-        <nd ref="-5748"/>
-        <nd ref="-2607"/>
-        <nd ref="-16344"/>
-        <tag k="alt_name" v="12th St NW"/>
-        <tag k="name" v="12TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-296" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25669"/>
-        <nd ref="-2669"/>
-        <nd ref="-7145"/>
-        <nd ref="-2671"/>
-        <nd ref="-23423"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-295" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35557"/>
-        <nd ref="-35558"/>
-        <tag k="alt_name" v="12th St NW"/>
-        <tag k="name" v="12TH ST EXPY NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-293" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35878"/>
-        <nd ref="-3283"/>
-        <nd ref="-3284"/>
-        <nd ref="-3285"/>
-        <nd ref="-3286"/>
-        <nd ref="-3287"/>
-        <nd ref="-3288"/>
-        <nd ref="-3289"/>
-        <nd ref="-24994"/>
-        <tag k="alt_name" v="21st St NW"/>
-        <tag k="name" v="21ST ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-292" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23613"/>
-        <nd ref="-4203"/>
-        <nd ref="-4204"/>
-        <nd ref="-7163"/>
-        <nd ref="-4205"/>
-        <nd ref="-4206"/>
-        <nd ref="-7165"/>
-        <nd ref="-23614"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-291" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23618"/>
-        <nd ref="-5410"/>
-        <nd ref="-149"/>
-        <nd ref="-150"/>
-        <nd ref="-5412"/>
-        <nd ref="-151"/>
-        <nd ref="-23619"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-290" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25386"/>
-        <nd ref="-5751"/>
-        <nd ref="-2378"/>
-        <nd ref="-2379"/>
-        <nd ref="-2380"/>
-        <nd ref="-5752"/>
-        <nd ref="-2381"/>
-        <nd ref="-5753"/>
-        <nd ref="-2382"/>
-        <nd ref="-25562"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-289" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34560"/>
-        <nd ref="-332"/>
-        <nd ref="-333"/>
-        <nd ref="-7055"/>
-        <nd ref="-34561"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-287" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23418"/>
-        <nd ref="-715"/>
-        <nd ref="-718"/>
-        <nd ref="-721"/>
-        <nd ref="-7352"/>
-        <nd ref="-724"/>
-        <nd ref="-23419"/>
-        <tag k="alt_name" v="16th St NW"/>
-        <tag k="name" v="16TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-286" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37483"/>
-        <nd ref="-769"/>
-        <nd ref="-771"/>
-        <nd ref="-35690"/>
-        <tag k="alt_name" v="24th St NW"/>
-        <tag k="name" v="24TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-285" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19698"/>
-        <nd ref="-1157"/>
-        <nd ref="-1158"/>
-        <nd ref="-1159"/>
-        <nd ref="-1160"/>
-        <nd ref="-4440"/>
-        <nd ref="-1161"/>
-        <nd ref="-1162"/>
-        <nd ref="-1163"/>
-        <nd ref="-1164"/>
-        <nd ref="-1165"/>
-        <nd ref="-4441"/>
-        <nd ref="-1166"/>
-        <nd ref="-4442"/>
-        <nd ref="-1167"/>
-        <nd ref="-1168"/>
-        <nd ref="-4443"/>
-        <nd ref="-1169"/>
-        <nd ref="-1170"/>
-        <nd ref="-25023"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-284" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37033"/>
-        <nd ref="-4733"/>
-        <nd ref="-4735"/>
-        <nd ref="-1041"/>
-        <nd ref="-37034"/>
-        <tag k="alt_name" v="26th St NW"/>
-        <tag k="name" v="26TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-283" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19785"/>
-        <nd ref="-1153"/>
-        <nd ref="-1154"/>
-        <nd ref="-4438"/>
-        <nd ref="-1155"/>
-        <nd ref="-19698"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-282" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23409"/>
-        <nd ref="-1238"/>
-        <nd ref="-1240"/>
-        <nd ref="-1242"/>
-        <nd ref="-5898"/>
-        <nd ref="-23410"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-281" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25948"/>
-        <nd ref="-211"/>
-        <nd ref="-212"/>
-        <nd ref="-6073"/>
-        <nd ref="-213"/>
-        <nd ref="-6075"/>
-        <nd ref="-214"/>
-        <nd ref="-6077"/>
-        <nd ref="-215"/>
-        <nd ref="-6079"/>
-        <nd ref="-216"/>
-        <nd ref="-217"/>
-        <nd ref="-6081"/>
-        <nd ref="-218"/>
-        <nd ref="-6083"/>
-        <nd ref="-219"/>
-        <nd ref="-220"/>
-        <nd ref="-6085"/>
-        <nd ref="-221"/>
-        <nd ref="-222"/>
-        <nd ref="-38138"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-279" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26711"/>
         <nd ref="-6039"/>
         <nd ref="-186"/>
         <nd ref="-187"/>
@@ -14493,72 +13966,89 @@
         <nd ref="-209"/>
         <nd ref="-6071"/>
         <nd ref="-25948"/>
-        <tag k="alt_name" v="22nd St NW"/>
-        <tag k="name" v="22ND ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-278" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17012"/>
-        <nd ref="-3437"/>
-        <nd ref="-3439"/>
-        <nd ref="-6311"/>
-        <nd ref="-3441"/>
-        <nd ref="-3443"/>
-        <nd ref="-3444"/>
-        <nd ref="-6313"/>
-        <nd ref="-6315"/>
-        <nd ref="-3445"/>
-        <nd ref="-23321"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-277" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22783"/>
-        <nd ref="-163"/>
-        <nd ref="-5973"/>
-        <nd ref="-5974"/>
-        <nd ref="-164"/>
-        <nd ref="-165"/>
-        <nd ref="-166"/>
-        <nd ref="-167"/>
-        <nd ref="-168"/>
-        <nd ref="-5975"/>
-        <nd ref="-169"/>
-        <nd ref="-170"/>
-        <nd ref="-5977"/>
-        <nd ref="-171"/>
-        <nd ref="-5979"/>
-        <nd ref="-172"/>
-        <nd ref="-173"/>
-        <nd ref="-174"/>
-        <nd ref="-5981"/>
-        <nd ref="-5983"/>
-        <nd ref="-175"/>
-        <nd ref="-5985"/>
-        <nd ref="-176"/>
-        <nd ref="-177"/>
-        <nd ref="-178"/>
-        <nd ref="-5987"/>
-        <nd ref="-179"/>
-        <nd ref="-180"/>
-        <nd ref="-5990"/>
-        <nd ref="-181"/>
-        <nd ref="-182"/>
-        <nd ref="-5993"/>
-        <nd ref="-183"/>
-        <nd ref="-5996"/>
-        <nd ref="-184"/>
-        <nd ref="-185"/>
-        <nd ref="-22143"/>
+        <nd ref="-211"/>
+        <nd ref="-212"/>
+        <nd ref="-6073"/>
+        <nd ref="-213"/>
+        <nd ref="-6075"/>
+        <nd ref="-214"/>
+        <nd ref="-6077"/>
+        <nd ref="-215"/>
+        <nd ref="-6079"/>
+        <nd ref="-216"/>
+        <nd ref="-217"/>
+        <nd ref="-6081"/>
+        <nd ref="-218"/>
+        <nd ref="-6083"/>
+        <nd ref="-219"/>
+        <nd ref="-220"/>
+        <nd ref="-6085"/>
+        <nd ref="-221"/>
+        <nd ref="-222"/>
+        <nd ref="-38138"/>
+        <nd ref="-3192"/>
+        <nd ref="-3194"/>
+        <nd ref="-6087"/>
+        <nd ref="-3196"/>
+        <nd ref="-3197"/>
+        <nd ref="-3199"/>
+        <nd ref="-3201"/>
+        <nd ref="-27557"/>
         <tag k="alt_name" v="22nd St NW"/>
         <tag k="name" v="22ND ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-276" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22060"/>
+        <nd ref="-3904"/>
+        <nd ref="-3905"/>
+        <nd ref="-6245"/>
+        <nd ref="-3906"/>
+        <nd ref="-6247"/>
+        <nd ref="-3907"/>
+        <nd ref="-3908"/>
+        <nd ref="-3909"/>
+        <nd ref="-6249"/>
+        <nd ref="-3910"/>
+        <nd ref="-6250"/>
+        <nd ref="-3911"/>
+        <nd ref="-3912"/>
+        <nd ref="-6252"/>
+        <nd ref="-3913"/>
+        <nd ref="-3914"/>
+        <nd ref="-22143"/>
+        <nd ref="-496"/>
+        <nd ref="-498"/>
+        <nd ref="-500"/>
+        <nd ref="-502"/>
+        <nd ref="-504"/>
+        <nd ref="-506"/>
+        <nd ref="-6254"/>
+        <nd ref="-508"/>
+        <nd ref="-510"/>
+        <nd ref="-6256"/>
+        <nd ref="-512"/>
+        <nd ref="-514"/>
+        <nd ref="-516"/>
+        <nd ref="-6257"/>
+        <nd ref="-518"/>
+        <nd ref="-520"/>
+        <nd ref="-6258"/>
+        <nd ref="-522"/>
+        <nd ref="-6259"/>
+        <nd ref="-524"/>
+        <nd ref="-526"/>
+        <nd ref="-6260"/>
+        <nd ref="-528"/>
+        <nd ref="-6261"/>
+        <nd ref="-530"/>
+        <nd ref="-532"/>
+        <nd ref="-534"/>
+        <nd ref="-6262"/>
+        <nd ref="-536"/>
+        <nd ref="-6263"/>
+        <nd ref="-538"/>
         <nd ref="-22575"/>
         <nd ref="-3916"/>
         <nd ref="-6264"/>
@@ -14598,6 +14088,31 @@
         <nd ref="-6277"/>
         <nd ref="-3960"/>
         <nd ref="-26395"/>
+        <nd ref="-540"/>
+        <nd ref="-542"/>
+        <nd ref="-6278"/>
+        <nd ref="-544"/>
+        <nd ref="-546"/>
+        <nd ref="-549"/>
+        <nd ref="-552"/>
+        <nd ref="-554"/>
+        <nd ref="-556"/>
+        <nd ref="-6279"/>
+        <nd ref="-558"/>
+        <nd ref="-560"/>
+        <nd ref="-562"/>
+        <nd ref="-6280"/>
+        <nd ref="-564"/>
+        <nd ref="-566"/>
+        <nd ref="-568"/>
+        <nd ref="-6281"/>
+        <nd ref="-6282"/>
+        <nd ref="-570"/>
+        <nd ref="-572"/>
+        <nd ref="-6283"/>
+        <nd ref="-574"/>
+        <nd ref="-6284"/>
+        <nd ref="-34013"/>
         <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>
@@ -14632,30 +14147,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-273" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22060"/>
-        <nd ref="-3904"/>
-        <nd ref="-3905"/>
-        <nd ref="-6245"/>
-        <nd ref="-3906"/>
-        <nd ref="-6247"/>
-        <nd ref="-3907"/>
-        <nd ref="-3908"/>
-        <nd ref="-3909"/>
-        <nd ref="-6249"/>
-        <nd ref="-3910"/>
-        <nd ref="-6250"/>
-        <nd ref="-3911"/>
-        <nd ref="-3912"/>
-        <nd ref="-6252"/>
-        <nd ref="-3913"/>
-        <nd ref="-3914"/>
-        <nd ref="-22143"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-272" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16815"/>
         <nd ref="-7241"/>
@@ -14670,38 +14161,6 @@
         <nd ref="-16841"/>
         <tag k="alt_name" v="F St NW"/>
         <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-271" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21918"/>
-        <nd ref="-3897"/>
-        <nd ref="-6243"/>
-        <nd ref="-3898"/>
-        <nd ref="-3899"/>
-        <nd ref="-3900"/>
-        <nd ref="-3901"/>
-        <nd ref="-3902"/>
-        <nd ref="-3903"/>
-        <nd ref="-22060"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21456"/>
-        <nd ref="-3892"/>
-        <nd ref="-3893"/>
-        <nd ref="-6237"/>
-        <nd ref="-6239"/>
-        <nd ref="-3894"/>
-        <nd ref="-6241"/>
-        <nd ref="-3895"/>
-        <nd ref="-3896"/>
-        <nd ref="-21918"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -14744,28 +14203,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21390"/>
-        <nd ref="-3884"/>
-        <nd ref="-6225"/>
-        <nd ref="-3885"/>
-        <nd ref="-6226"/>
-        <nd ref="-3886"/>
-        <nd ref="-6227"/>
-        <nd ref="-6228"/>
-        <nd ref="-3887"/>
-        <nd ref="-3888"/>
-        <nd ref="-6229"/>
-        <nd ref="-3889"/>
-        <nd ref="-3890"/>
-        <nd ref="-6231"/>
-        <nd ref="-3891"/>
-        <nd ref="-21313"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38461"/>
         <nd ref="-3671"/>
@@ -14787,7 +14224,18 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-17034"/>
+        <nd ref="-3864"/>
+        <nd ref="-3866"/>
+        <nd ref="-3868"/>
+        <nd ref="-6941"/>
+        <nd ref="-3870"/>
+        <nd ref="-6942"/>
+        <nd ref="-3872"/>
+        <nd ref="-3874"/>
+        <nd ref="-3876"/>
+        <nd ref="-6943"/>
         <nd ref="-17040"/>
         <nd ref="-3878"/>
         <nd ref="-6944"/>
@@ -14802,60 +14250,12 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28352"/>
-        <nd ref="-83"/>
-        <nd ref="-6218"/>
-        <nd ref="-6220"/>
-        <nd ref="-85"/>
-        <nd ref="-6222"/>
-        <nd ref="-87"/>
-        <nd ref="-28353"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17034"/>
-        <nd ref="-3864"/>
-        <nd ref="-3866"/>
-        <nd ref="-3868"/>
-        <nd ref="-6941"/>
-        <nd ref="-3870"/>
-        <nd ref="-6942"/>
-        <nd ref="-3872"/>
-        <nd ref="-3874"/>
-        <nd ref="-3876"/>
-        <nd ref="-6943"/>
-        <nd ref="-17040"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3671"/>
         <nd ref="-37562"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31943"/>
-        <nd ref="-409"/>
-        <nd ref="-411"/>
-        <nd ref="-4504"/>
-        <nd ref="-413"/>
-        <nd ref="-415"/>
-        <nd ref="-4505"/>
-        <nd ref="-4506"/>
-        <nd ref="-417"/>
-        <nd ref="-31944"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16797"/>
@@ -14911,6 +14311,13 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36692"/>
+        <nd ref="-6400"/>
+        <nd ref="-2658"/>
+        <nd ref="-2660"/>
+        <nd ref="-2662"/>
+        <nd ref="-2664"/>
+        <nd ref="-2666"/>
         <nd ref="-23437"/>
         <nd ref="-2668"/>
         <nd ref="-2670"/>
@@ -14922,6 +14329,22 @@
         <nd ref="-6412"/>
         <nd ref="-2675"/>
         <nd ref="-20068"/>
+        <nd ref="-3000"/>
+        <nd ref="-6418"/>
+        <nd ref="-6421"/>
+        <nd ref="-3002"/>
+        <nd ref="-3004"/>
+        <nd ref="-6424"/>
+        <nd ref="-3006"/>
+        <nd ref="-3008"/>
+        <nd ref="-3010"/>
+        <nd ref="-3012"/>
+        <nd ref="-26733"/>
+        <nd ref="-3177"/>
+        <nd ref="-3179"/>
+        <nd ref="-6430"/>
+        <nd ref="-3181"/>
+        <nd ref="-26734"/>
         <tag k="alt_name" v="H St NW"/>
         <tag k="name" v="H ST NW"/>
         <tag k="highway" v="road"/>
@@ -14947,97 +14370,11 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20270"/>
-        <nd ref="-6357"/>
-        <nd ref="-2646"/>
-        <nd ref="-2648"/>
-        <nd ref="-6359"/>
-        <nd ref="-2650"/>
-        <nd ref="-2652"/>
-        <nd ref="-18486"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18983"/>
-        <nd ref="-4457"/>
-        <nd ref="-338"/>
-        <nd ref="-4458"/>
-        <nd ref="-339"/>
-        <nd ref="-340"/>
-        <nd ref="-341"/>
-        <nd ref="-4459"/>
-        <nd ref="-19785"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-23325"/>
         <nd ref="-23326"/>
         <tag k="alt_name" v="New York Ave NW"/>
         <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20273"/>
-        <nd ref="-2636"/>
-        <nd ref="-2638"/>
-        <nd ref="-2640"/>
-        <nd ref="-2642"/>
-        <nd ref="-20270"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27547"/>
-        <nd ref="-2626"/>
-        <nd ref="-2628"/>
-        <nd ref="-2630"/>
-        <nd ref="-6345"/>
-        <nd ref="-2632"/>
-        <nd ref="-20272"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17333"/>
-        <nd ref="-2619"/>
-        <nd ref="-2620"/>
-        <nd ref="-6341"/>
-        <nd ref="-2622"/>
-        <nd ref="-2624"/>
-        <nd ref="-27547"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23310"/>
-        <nd ref="-6329"/>
-        <nd ref="-2613"/>
-        <nd ref="-6331"/>
-        <nd ref="-2614"/>
-        <nd ref="-2615"/>
-        <nd ref="-6333"/>
-        <nd ref="-2616"/>
-        <nd ref="-6335"/>
-        <nd ref="-2617"/>
-        <nd ref="-6337"/>
-        <nd ref="-2618"/>
-        <nd ref="-17333"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -15089,6 +14426,15 @@
         <nd ref="-4503"/>
         <nd ref="-666"/>
         <nd ref="-31943"/>
+        <nd ref="-409"/>
+        <nd ref="-411"/>
+        <nd ref="-4504"/>
+        <nd ref="-413"/>
+        <nd ref="-415"/>
+        <nd ref="-4505"/>
+        <nd ref="-4506"/>
+        <nd ref="-417"/>
+        <nd ref="-31944"/>
         <tag k="alt_name" v="F St NW"/>
         <tag k="name" v="F ST NW"/>
         <tag k="highway" v="road"/>
@@ -15100,49 +14446,6 @@
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23321"/>
-        <nd ref="-2608"/>
-        <nd ref="-6319"/>
-        <nd ref="-6321"/>
-        <nd ref="-2609"/>
-        <nd ref="-2610"/>
-        <nd ref="-6323"/>
-        <nd ref="-6325"/>
-        <nd ref="-2611"/>
-        <nd ref="-23310"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22093"/>
-        <nd ref="-5821"/>
-        <nd ref="-615"/>
-        <nd ref="-616"/>
-        <nd ref="-5822"/>
-        <nd ref="-617"/>
-        <nd ref="-618"/>
-        <nd ref="-5823"/>
-        <nd ref="-619"/>
-        <nd ref="-620"/>
-        <nd ref="-5824"/>
-        <nd ref="-621"/>
-        <nd ref="-622"/>
-        <nd ref="-5825"/>
-        <nd ref="-623"/>
-        <nd ref="-624"/>
-        <nd ref="-625"/>
-        <nd ref="-626"/>
-        <nd ref="-627"/>
-        <nd ref="-5826"/>
-        <nd ref="-22783"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-23414"/>
@@ -15177,23 +14480,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22971"/>
-        <nd ref="-608"/>
-        <nd ref="-609"/>
-        <nd ref="-610"/>
-        <nd ref="-5807"/>
-        <nd ref="-5808"/>
-        <nd ref="-611"/>
-        <nd ref="-612"/>
-        <nd ref="-613"/>
-        <nd ref="-614"/>
-        <nd ref="-21544"/>
-        <tag k="alt_name" v="F St NW"/>
-        <tag k="name" v="F ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37624"/>
         <nd ref="-3818"/>
@@ -15224,6 +14510,69 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38217"/>
+        <nd ref="-700"/>
+        <nd ref="-699"/>
+        <nd ref="-7385"/>
+        <nd ref="-698"/>
+        <nd ref="-697"/>
+        <nd ref="-696"/>
+        <nd ref="-7387"/>
+        <nd ref="-695"/>
+        <nd ref="-694"/>
+        <nd ref="-693"/>
+        <nd ref="-692"/>
+        <nd ref="-691"/>
+        <nd ref="-7389"/>
+        <nd ref="-690"/>
+        <nd ref="-689"/>
+        <nd ref="-688"/>
+        <nd ref="-7391"/>
+        <nd ref="-687"/>
+        <nd ref="-686"/>
+        <nd ref="-7393"/>
+        <nd ref="-685"/>
+        <nd ref="-7395"/>
+        <nd ref="-684"/>
+        <nd ref="-7397"/>
+        <nd ref="-683"/>
+        <nd ref="-682"/>
+        <nd ref="-681"/>
+        <nd ref="-680"/>
+        <nd ref="-679"/>
+        <nd ref="-7399"/>
+        <nd ref="-7401"/>
+        <nd ref="-678"/>
+        <nd ref="-677"/>
+        <nd ref="-676"/>
+        <nd ref="-7403"/>
+        <nd ref="-675"/>
+        <nd ref="-674"/>
+        <nd ref="-7405"/>
+        <nd ref="-673"/>
+        <nd ref="-7407"/>
+        <nd ref="-672"/>
+        <nd ref="-7409"/>
+        <nd ref="-671"/>
+        <nd ref="-7411"/>
+        <nd ref="-670"/>
+        <nd ref="-669"/>
+        <nd ref="-667"/>
+        <nd ref="-7412"/>
+        <nd ref="-665"/>
+        <nd ref="-663"/>
+        <nd ref="-661"/>
+        <nd ref="-7413"/>
+        <nd ref="-7414"/>
+        <nd ref="-659"/>
+        <nd ref="-7415"/>
+        <nd ref="-657"/>
+        <nd ref="-7416"/>
+        <nd ref="-655"/>
+        <nd ref="-7417"/>
+        <nd ref="-653"/>
+        <nd ref="-7418"/>
+        <nd ref="-651"/>
         <nd ref="-38211"/>
         <nd ref="-4040"/>
         <nd ref="-4039"/>
@@ -15243,40 +14592,6 @@
         <tag k="alt_name" v="I- 66"/>
         <tag k="name" v="INTERSTATE 66  BN"/>
         <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38396"/>
-        <nd ref="-464"/>
-        <nd ref="-463"/>
-        <nd ref="-4541"/>
-        <nd ref="-462"/>
-        <nd ref="-38291"/>
-        <nd ref="-461"/>
-        <nd ref="-460"/>
-        <nd ref="-38292"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21313"/>
-        <nd ref="-144"/>
-        <nd ref="-5380"/>
-        <nd ref="-5382"/>
-        <nd ref="-145"/>
-        <nd ref="-146"/>
-        <nd ref="-5384"/>
-        <nd ref="-5386"/>
-        <nd ref="-5388"/>
-        <nd ref="-147"/>
-        <nd ref="-5390"/>
-        <nd ref="-148"/>
-        <nd ref="-26669"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -15380,16 +14695,24 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37456"/>
-        <nd ref="-1951"/>
-        <nd ref="-37457"/>
-        <tag k="alt_name" v="Maine Ave SW"/>
-        <tag k="name" v="MAINE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32319"/>
+        <nd ref="-3831"/>
+        <nd ref="-6304"/>
+        <nd ref="-3833"/>
+        <nd ref="-6305"/>
+        <nd ref="-3835"/>
+        <nd ref="-3837"/>
+        <nd ref="-3839"/>
+        <nd ref="-3841"/>
+        <nd ref="-3843"/>
+        <nd ref="-6306"/>
+        <nd ref="-3845"/>
+        <nd ref="-3847"/>
+        <nd ref="-6307"/>
+        <nd ref="-3849"/>
+        <nd ref="-3852"/>
+        <nd ref="-6308"/>
         <nd ref="-32273"/>
         <nd ref="-3858"/>
         <nd ref="-3861"/>
@@ -15407,15 +14730,6 @@
         <nd ref="-32274"/>
         <tag k="alt_name" v="12th St SW"/>
         <tag k="name" v="12TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33171"/>
-        <nd ref="-76"/>
-        <nd ref="-33172"/>
-        <tag k="alt_name" v="Jefferson Dr SW"/>
-        <tag k="name" v="JEFFERSON DR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -15449,21 +14763,12 @@
         <nd ref="-6911"/>
         <nd ref="-1082"/>
         <nd ref="-27547"/>
+        <nd ref="-2262"/>
+        <nd ref="-2263"/>
+        <nd ref="-2264"/>
+        <nd ref="-27548"/>
         <tag k="alt_name" v="15th St NW"/>
         <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25295"/>
-        <nd ref="-2063"/>
-        <nd ref="-5980"/>
-        <nd ref="-5982"/>
-        <nd ref="-2064"/>
-        <nd ref="-2065"/>
-        <nd ref="-25296"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -15494,85 +14799,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23292"/>
-        <nd ref="-7141"/>
-        <nd ref="-2659"/>
-        <nd ref="-2661"/>
-        <nd ref="-2663"/>
-        <nd ref="-2665"/>
-        <nd ref="-25669"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21918"/>
-        <nd ref="-4295"/>
-        <nd ref="-4429"/>
-        <nd ref="-4296"/>
-        <nd ref="-4298"/>
-        <nd ref="-4430"/>
-        <nd ref="-4300"/>
-        <nd ref="-4431"/>
-        <nd ref="-4302"/>
-        <nd ref="-4304"/>
-        <nd ref="-4432"/>
-        <nd ref="-20068"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23321"/>
-        <nd ref="-2653"/>
-        <nd ref="-2655"/>
-        <nd ref="-7131"/>
-        <nd ref="-2657"/>
-        <nd ref="-23326"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21940"/>
-        <nd ref="-4287"/>
-        <nd ref="-4424"/>
-        <nd ref="-4288"/>
-        <nd ref="-4289"/>
-        <nd ref="-4425"/>
-        <nd ref="-4290"/>
-        <nd ref="-4426"/>
-        <nd ref="-4291"/>
-        <nd ref="-4292"/>
-        <nd ref="-4427"/>
-        <nd ref="-4293"/>
-        <nd ref="-21918"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17034"/>
-        <nd ref="-2639"/>
-        <nd ref="-2641"/>
-        <nd ref="-7125"/>
-        <nd ref="-7127"/>
-        <nd ref="-2643"/>
-        <nd ref="-2645"/>
-        <nd ref="-7129"/>
-        <nd ref="-2647"/>
-        <nd ref="-2649"/>
-        <nd ref="-23321"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-31995"/>
         <nd ref="-4282"/>
@@ -15583,45 +14809,18 @@
         <nd ref="-4285"/>
         <nd ref="-4286"/>
         <nd ref="-31969"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16841"/>
-        <nd ref="-2631"/>
-        <nd ref="-7121"/>
-        <nd ref="-2633"/>
-        <nd ref="-2635"/>
-        <nd ref="-17034"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24823"/>
-        <nd ref="-4410"/>
-        <nd ref="-4266"/>
-        <nd ref="-4268"/>
-        <nd ref="-4270"/>
-        <nd ref="-4411"/>
-        <nd ref="-4272"/>
-        <nd ref="-4412"/>
-        <nd ref="-4413"/>
-        <nd ref="-4274"/>
-        <nd ref="-4276"/>
-        <nd ref="-4414"/>
-        <nd ref="-4415"/>
-        <nd ref="-4277"/>
-        <nd ref="-4278"/>
-        <nd ref="-4416"/>
-        <nd ref="-4417"/>
-        <nd ref="-4279"/>
-        <nd ref="-4280"/>
-        <nd ref="-4418"/>
-        <nd ref="-31995"/>
+        <nd ref="-3373"/>
+        <nd ref="-4421"/>
+        <nd ref="-3374"/>
+        <nd ref="-3375"/>
+        <nd ref="-3376"/>
+        <nd ref="-3377"/>
+        <nd ref="-3378"/>
+        <nd ref="-4422"/>
+        <nd ref="-3379"/>
+        <nd ref="-3380"/>
+        <nd ref="-4423"/>
+        <nd ref="-21940"/>
         <tag k="alt_name" v="20th St NW"/>
         <tag k="name" v="20TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -15640,23 +14839,16 @@
         <nd ref="-4632"/>
         <nd ref="-4028"/>
         <nd ref="-25562"/>
+        <nd ref="-137"/>
+        <nd ref="-138"/>
+        <nd ref="-4633"/>
+        <nd ref="-139"/>
+        <nd ref="-140"/>
+        <nd ref="-4634"/>
+        <nd ref="-141"/>
+        <nd ref="-27982"/>
         <tag k="alt_name" v="New Hampshire Ave NW"/>
         <tag k="name" v="NEW HAMPSHIRE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36541"/>
-        <nd ref="-7117"/>
-        <nd ref="-2621"/>
-        <nd ref="-2623"/>
-        <nd ref="-7118"/>
-        <nd ref="-2625"/>
-        <nd ref="-7119"/>
-        <nd ref="-2627"/>
-        <nd ref="-16841"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -15699,62 +14891,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23310"/>
-        <nd ref="-1178"/>
-        <nd ref="-6935"/>
-        <nd ref="-1179"/>
-        <nd ref="-17332"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21456"/>
-        <nd ref="-4197"/>
-        <nd ref="-7154"/>
-        <nd ref="-4198"/>
-        <nd ref="-4199"/>
-        <nd ref="-7155"/>
-        <nd ref="-4200"/>
-        <nd ref="-4201"/>
-        <nd ref="-4202"/>
-        <nd ref="-23437"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24787"/>
-        <nd ref="-4185"/>
-        <nd ref="-7126"/>
-        <nd ref="-4186"/>
-        <nd ref="-7128"/>
-        <nd ref="-4187"/>
-        <nd ref="-7130"/>
-        <nd ref="-4188"/>
-        <nd ref="-7132"/>
-        <nd ref="-4189"/>
-        <nd ref="-7134"/>
-        <nd ref="-4190"/>
-        <nd ref="-4191"/>
-        <nd ref="-7136"/>
-        <nd ref="-4192"/>
-        <nd ref="-7138"/>
-        <nd ref="-4193"/>
-        <nd ref="-7140"/>
-        <nd ref="-4194"/>
-        <nd ref="-4195"/>
-        <nd ref="-7142"/>
-        <nd ref="-4196"/>
-        <nd ref="-24283"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-20272"/>
         <nd ref="-1944"/>
@@ -15787,43 +14923,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
     </way>
-    <way visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23006"/>
-        <nd ref="-1029"/>
-        <nd ref="-1030"/>
-        <nd ref="-4688"/>
-        <nd ref="-1031"/>
-        <nd ref="-4690"/>
-        <nd ref="-1032"/>
-        <nd ref="-23432"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18486"/>
-        <nd ref="-3705"/>
-        <nd ref="-6363"/>
-        <nd ref="-3707"/>
-        <nd ref="-3709"/>
-        <nd ref="-6365"/>
-        <nd ref="-3711"/>
-        <nd ref="-6367"/>
-        <nd ref="-3713"/>
-        <nd ref="-3715"/>
-        <nd ref="-6369"/>
-        <nd ref="-3717"/>
-        <nd ref="-6371"/>
-        <nd ref="-3719"/>
-        <nd ref="-3721"/>
-        <nd ref="-6373"/>
-        <nd ref="-27199"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19396"/>
         <nd ref="-4122"/>
@@ -15833,29 +14932,45 @@
         <nd ref="-4125"/>
         <nd ref="-4126"/>
         <nd ref="-23613"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18983"/>
-        <nd ref="-4115"/>
-        <nd ref="-4116"/>
-        <nd ref="-7158"/>
-        <nd ref="-4117"/>
-        <nd ref="-4118"/>
-        <nd ref="-7159"/>
-        <nd ref="-4119"/>
-        <nd ref="-7160"/>
-        <nd ref="-4120"/>
-        <nd ref="-19396"/>
+        <nd ref="-4203"/>
+        <nd ref="-4204"/>
+        <nd ref="-7163"/>
+        <nd ref="-4205"/>
+        <nd ref="-4206"/>
+        <nd ref="-7165"/>
+        <nd ref="-23614"/>
         <tag k="alt_name" v="19th St NW"/>
         <tag k="name" v="19TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20863"/>
+        <nd ref="-6508"/>
+        <nd ref="-2431"/>
+        <nd ref="-2432"/>
+        <nd ref="-2433"/>
+        <nd ref="-6511"/>
+        <nd ref="-6514"/>
+        <nd ref="-2434"/>
+        <nd ref="-6517"/>
+        <nd ref="-2435"/>
+        <nd ref="-2436"/>
+        <nd ref="-2437"/>
+        <nd ref="-6521"/>
+        <nd ref="-2438"/>
+        <nd ref="-6525"/>
+        <nd ref="-2439"/>
+        <nd ref="-6529"/>
+        <nd ref="-6533"/>
+        <nd ref="-2440"/>
+        <nd ref="-6536"/>
+        <nd ref="-2441"/>
+        <nd ref="-2442"/>
+        <nd ref="-6539"/>
+        <nd ref="-2443"/>
+        <nd ref="-2444"/>
+        <nd ref="-2445"/>
         <nd ref="-28822"/>
         <nd ref="-3792"/>
         <nd ref="-3794"/>
@@ -15894,12 +15009,31 @@
         <nd ref="-7157"/>
         <nd ref="-4113"/>
         <nd ref="-18983"/>
+        <nd ref="-4115"/>
+        <nd ref="-4116"/>
+        <nd ref="-7158"/>
+        <nd ref="-4117"/>
+        <nd ref="-4118"/>
+        <nd ref="-7159"/>
+        <nd ref="-4119"/>
+        <nd ref="-7160"/>
+        <nd ref="-4120"/>
+        <nd ref="-19396"/>
         <tag k="alt_name" v="19th St NW"/>
         <tag k="name" v="19TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26710"/>
+        <nd ref="-6442"/>
+        <nd ref="-3185"/>
+        <nd ref="-6445"/>
+        <nd ref="-3187"/>
+        <nd ref="-3189"/>
+        <nd ref="-3191"/>
+        <nd ref="-3193"/>
+        <nd ref="-3195"/>
         <nd ref="-26711"/>
         <nd ref="-6450"/>
         <nd ref="-3764"/>
@@ -15925,42 +15059,63 @@
         <nd ref="-6474"/>
         <nd ref="-3790"/>
         <nd ref="-20610"/>
+        <nd ref="-2412"/>
+        <nd ref="-6477"/>
+        <nd ref="-2414"/>
+        <nd ref="-2416"/>
+        <nd ref="-6480"/>
+        <nd ref="-2418"/>
+        <nd ref="-6483"/>
+        <nd ref="-2420"/>
+        <nd ref="-6486"/>
+        <nd ref="-2422"/>
+        <nd ref="-2423"/>
+        <nd ref="-2424"/>
+        <nd ref="-6489"/>
+        <nd ref="-2425"/>
+        <nd ref="-6493"/>
+        <nd ref="-2426"/>
+        <nd ref="-6497"/>
+        <nd ref="-2427"/>
+        <nd ref="-2428"/>
+        <nd ref="-6501"/>
+        <nd ref="-2429"/>
+        <nd ref="-2430"/>
+        <nd ref="-20863"/>
         <tag k="alt_name" v="H St NW"/>
         <tag k="name" v="H ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27221"/>
-        <nd ref="-2554"/>
-        <nd ref="-6003"/>
-        <nd ref="-2555"/>
-        <nd ref="-6006"/>
-        <nd ref="-2556"/>
-        <nd ref="-2557"/>
-        <nd ref="-25027"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21902"/>
-        <nd ref="-4102"/>
-        <nd ref="-4103"/>
-        <nd ref="-7151"/>
-        <nd ref="-4104"/>
-        <nd ref="-4105"/>
-        <nd ref="-4106"/>
-        <nd ref="-4107"/>
-        <nd ref="-7152"/>
-        <nd ref="-21456"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24787"/>
+        <nd ref="-4185"/>
+        <nd ref="-7126"/>
+        <nd ref="-4186"/>
+        <nd ref="-7128"/>
+        <nd ref="-4187"/>
+        <nd ref="-7130"/>
+        <nd ref="-4188"/>
+        <nd ref="-7132"/>
+        <nd ref="-4189"/>
+        <nd ref="-7134"/>
+        <nd ref="-4190"/>
+        <nd ref="-4191"/>
+        <nd ref="-7136"/>
+        <nd ref="-4192"/>
+        <nd ref="-7138"/>
+        <nd ref="-4193"/>
+        <nd ref="-7140"/>
+        <nd ref="-4194"/>
+        <nd ref="-4195"/>
+        <nd ref="-7142"/>
+        <nd ref="-4196"/>
+        <nd ref="-24283"/>
+        <nd ref="-4089"/>
+        <nd ref="-4090"/>
+        <nd ref="-7144"/>
+        <nd ref="-7146"/>
+        <nd ref="-4091"/>
         <nd ref="-23812"/>
         <nd ref="-4093"/>
         <nd ref="-7147"/>
@@ -15975,47 +15130,26 @@
         <nd ref="-4099"/>
         <nd ref="-4100"/>
         <nd ref="-21902"/>
+        <nd ref="-4102"/>
+        <nd ref="-4103"/>
+        <nd ref="-7151"/>
+        <nd ref="-4104"/>
+        <nd ref="-4105"/>
+        <nd ref="-4106"/>
+        <nd ref="-4107"/>
+        <nd ref="-7152"/>
+        <nd ref="-21456"/>
+        <nd ref="-4197"/>
+        <nd ref="-7154"/>
+        <nd ref="-4198"/>
+        <nd ref="-4199"/>
+        <nd ref="-7155"/>
+        <nd ref="-4200"/>
+        <nd ref="-4201"/>
+        <nd ref="-4202"/>
+        <nd ref="-23437"/>
         <tag k="alt_name" v="19th St NW"/>
         <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17332"/>
-        <nd ref="-2545"/>
-        <nd ref="-2546"/>
-        <nd ref="-2547"/>
-        <nd ref="-2548"/>
-        <nd ref="-17333"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24283"/>
-        <nd ref="-4089"/>
-        <nd ref="-4090"/>
-        <nd ref="-7144"/>
-        <nd ref="-7146"/>
-        <nd ref="-4091"/>
-        <nd ref="-23812"/>
-        <tag k="alt_name" v="19th St NW"/>
-        <tag k="name" v="19TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17040"/>
-        <nd ref="-2539"/>
-        <nd ref="-5994"/>
-        <nd ref="-2540"/>
-        <nd ref="-2541"/>
-        <nd ref="-2542"/>
-        <nd ref="-2543"/>
-        <nd ref="-17332"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16034,21 +15168,28 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38284"/>
+        <nd ref="-2138"/>
+        <nd ref="-2139"/>
+        <nd ref="-2140"/>
+        <nd ref="-5986"/>
+        <nd ref="-2141"/>
         <nd ref="-16908"/>
         <nd ref="-2536"/>
         <nd ref="-2537"/>
         <nd ref="-17040"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25296"/>
-        <nd ref="-2533"/>
-        <nd ref="-2534"/>
-        <nd ref="-2535"/>
-        <nd ref="-38284"/>
+        <nd ref="-2539"/>
+        <nd ref="-5994"/>
+        <nd ref="-2540"/>
+        <nd ref="-2541"/>
+        <nd ref="-2542"/>
+        <nd ref="-2543"/>
+        <nd ref="-17332"/>
+        <nd ref="-2545"/>
+        <nd ref="-2546"/>
+        <nd ref="-2547"/>
+        <nd ref="-2548"/>
+        <nd ref="-17333"/>
         <tag k="alt_name" v="14th St NW"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -16066,20 +15207,6 @@
         <nd ref="-7347"/>
         <nd ref="-2530"/>
         <nd ref="-32023"/>
-        <tag k="alt_name" v="14th St NW;US Hwy 1"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22331"/>
-        <nd ref="-2520"/>
-        <nd ref="-7342"/>
-        <nd ref="-7343"/>
-        <nd ref="-2521"/>
-        <nd ref="-2522"/>
-        <nd ref="-7344"/>
-        <nd ref="-22314"/>
         <tag k="alt_name" v="14th St NW;US Hwy 1"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -16105,61 +15232,36 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19698"/>
-        <nd ref="-2509"/>
-        <nd ref="-4710"/>
-        <nd ref="-2510"/>
-        <nd ref="-19605"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-18515"/>
         <nd ref="-4704"/>
         <nd ref="-2508"/>
         <nd ref="-18746"/>
+        <nd ref="-2126"/>
+        <nd ref="-2128"/>
+        <nd ref="-4706"/>
+        <nd ref="-2130"/>
+        <nd ref="-2132"/>
+        <nd ref="-18689"/>
+        <nd ref="-2134"/>
+        <nd ref="-4708"/>
+        <nd ref="-2135"/>
+        <nd ref="-2136"/>
+        <nd ref="-19396"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19605"/>
-        <nd ref="-4319"/>
-        <nd ref="-4320"/>
-        <nd ref="-4465"/>
-        <nd ref="-4466"/>
-        <nd ref="-4321"/>
-        <nd ref="-4322"/>
-        <nd ref="-4467"/>
-        <nd ref="-38138"/>
-        <tag k="alt_name" v="Pennsylvania Ave NW"/>
-        <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27221"/>
-        <nd ref="-2501"/>
-        <nd ref="-2502"/>
-        <nd ref="-4681"/>
-        <nd ref="-2503"/>
-        <nd ref="-2504"/>
-        <nd ref="-4682"/>
-        <nd ref="-2505"/>
-        <nd ref="-2506"/>
-        <nd ref="-2507"/>
-        <nd ref="-4683"/>
-        <nd ref="-23238"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18983"/>
+        <nd ref="-4457"/>
+        <nd ref="-338"/>
+        <nd ref="-4458"/>
+        <nd ref="-339"/>
+        <nd ref="-340"/>
+        <nd ref="-341"/>
+        <nd ref="-4459"/>
         <nd ref="-19785"/>
         <nd ref="-4312"/>
         <nd ref="-4460"/>
@@ -16173,49 +15275,18 @@
         <nd ref="-4318"/>
         <nd ref="-4463"/>
         <nd ref="-19605"/>
+        <nd ref="-4319"/>
+        <nd ref="-4320"/>
+        <nd ref="-4465"/>
+        <nd ref="-4466"/>
+        <nd ref="-4321"/>
+        <nd ref="-4322"/>
+        <nd ref="-4467"/>
+        <nd ref="-38138"/>
+        <nd ref="-7064"/>
+        <nd ref="-38471"/>
         <tag k="alt_name" v="Pennsylvania Ave NW"/>
         <tag k="name" v="PENNSYLVANIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18746"/>
-        <nd ref="-1434"/>
-        <nd ref="-1436"/>
-        <nd ref="-1438"/>
-        <nd ref="-4670"/>
-        <nd ref="-1440"/>
-        <nd ref="-1442"/>
-        <nd ref="-4671"/>
-        <nd ref="-1444"/>
-        <nd ref="-1446"/>
-        <nd ref="-1448"/>
-        <nd ref="-1450"/>
-        <nd ref="-4672"/>
-        <nd ref="-1452"/>
-        <nd ref="-4674"/>
-        <nd ref="-1454"/>
-        <nd ref="-1456"/>
-        <nd ref="-23414"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22971"/>
-        <nd ref="-1424"/>
-        <nd ref="-1426"/>
-        <nd ref="-4657"/>
-        <nd ref="-4658"/>
-        <nd ref="-1428"/>
-        <nd ref="-4659"/>
-        <nd ref="-1430"/>
-        <nd ref="-1432"/>
-        <nd ref="-4660"/>
-        <nd ref="-21390"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16246,6 +15317,11 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25860"/>
+        <nd ref="-113"/>
+        <nd ref="-4838"/>
+        <nd ref="-115"/>
+        <nd ref="-4840"/>
         <nd ref="-33975"/>
         <nd ref="-117"/>
         <nd ref="-119"/>
@@ -16258,19 +15334,16 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25860"/>
-        <nd ref="-113"/>
-        <nd ref="-4838"/>
-        <nd ref="-115"/>
-        <nd ref="-4840"/>
-        <nd ref="-33975"/>
-        <tag k="alt_name" v="E Executive Ave NW"/>
-        <tag k="name" v="EAST EXECUTIVE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24472"/>
+        <nd ref="-2676"/>
+        <nd ref="-6829"/>
+        <nd ref="-2677"/>
+        <nd ref="-6831"/>
+        <nd ref="-2678"/>
+        <nd ref="-2679"/>
+        <nd ref="-6833"/>
+        <nd ref="-2680"/>
         <nd ref="-24388"/>
         <nd ref="-3463"/>
         <nd ref="-3464"/>
@@ -16292,12 +15365,79 @@
         <nd ref="-73"/>
         <nd ref="-72"/>
         <nd ref="-33291"/>
+        <nd ref="-5511"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-33292"/>
+        <nd ref="-68"/>
+        <nd ref="-66"/>
+        <nd ref="-64"/>
+        <nd ref="-32502"/>
+        <nd ref="-62"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-32090"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
+        <nd ref="-32091"/>
+        <nd ref="-1223"/>
+        <nd ref="-1221"/>
+        <nd ref="-1219"/>
+        <nd ref="-33168"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
+        <nd ref="-33169"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-50"/>
+        <nd ref="-32710"/>
         <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22575"/>
+        <nd ref="-295"/>
+        <nd ref="-296"/>
+        <nd ref="-297"/>
+        <nd ref="-298"/>
+        <nd ref="-5275"/>
+        <nd ref="-299"/>
+        <nd ref="-5277"/>
+        <nd ref="-300"/>
+        <nd ref="-301"/>
+        <nd ref="-5279"/>
+        <nd ref="-302"/>
+        <nd ref="-5281"/>
+        <nd ref="-5283"/>
+        <nd ref="-303"/>
+        <nd ref="-304"/>
+        <nd ref="-305"/>
+        <nd ref="-306"/>
+        <nd ref="-5285"/>
+        <nd ref="-307"/>
+        <nd ref="-5287"/>
+        <nd ref="-308"/>
+        <nd ref="-309"/>
+        <nd ref="-310"/>
+        <nd ref="-5289"/>
+        <nd ref="-311"/>
+        <nd ref="-312"/>
+        <nd ref="-313"/>
+        <nd ref="-5291"/>
+        <nd ref="-314"/>
+        <nd ref="-5293"/>
+        <nd ref="-315"/>
+        <nd ref="-5295"/>
+        <nd ref="-316"/>
+        <nd ref="-317"/>
+        <nd ref="-5297"/>
+        <nd ref="-318"/>
+        <nd ref="-319"/>
+        <nd ref="-320"/>
+        <nd ref="-5299"/>
         <nd ref="-20610"/>
         <nd ref="-3979"/>
         <nd ref="-5303"/>
@@ -16341,178 +15481,23 @@
         <nd ref="-5331"/>
         <nd ref="-4004"/>
         <nd ref="-20544"/>
+        <nd ref="-321"/>
+        <nd ref="-322"/>
+        <nd ref="-5334"/>
+        <nd ref="-323"/>
+        <nd ref="-324"/>
+        <nd ref="-5335"/>
+        <nd ref="-325"/>
+        <nd ref="-5336"/>
+        <nd ref="-5337"/>
+        <nd ref="-326"/>
+        <nd ref="-327"/>
+        <nd ref="-5338"/>
+        <nd ref="-328"/>
+        <nd ref="-329"/>
+        <nd ref="-26596"/>
         <tag k="alt_name" v="23rd St NW"/>
         <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33291"/>
-        <nd ref="-5511"/>
-        <nd ref="-71"/>
-        <nd ref="-70"/>
-        <nd ref="-33292"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33292"/>
-        <nd ref="-68"/>
-        <nd ref="-66"/>
-        <nd ref="-64"/>
-        <nd ref="-32502"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29923"/>
-        <nd ref="-3917"/>
-        <nd ref="-5212"/>
-        <nd ref="-3919"/>
-        <nd ref="-3921"/>
-        <nd ref="-5214"/>
-        <nd ref="-3923"/>
-        <nd ref="-3925"/>
-        <nd ref="-5216"/>
-        <nd ref="-3927"/>
-        <nd ref="-5218"/>
-        <nd ref="-3929"/>
-        <nd ref="-30016"/>
-        <nd ref="-5222"/>
-        <nd ref="-3933"/>
-        <nd ref="-37242"/>
-        <nd ref="-3937"/>
-        <nd ref="-3939"/>
-        <nd ref="-5226"/>
-        <nd ref="-30396"/>
-        <tag k="alt_name" v="23rd St NW"/>
-        <tag k="name" v="23RD ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32502"/>
-        <nd ref="-62"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
-        <nd ref="-32090"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32090"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-32091"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33168"/>
-        <nd ref="-55"/>
-        <nd ref="-54"/>
-        <nd ref="-33169"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33169"/>
-        <nd ref="-52"/>
-        <nd ref="-51"/>
-        <nd ref="-50"/>
-        <nd ref="-32710"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18515"/>
-        <nd ref="-5895"/>
-        <nd ref="-1228"/>
-        <nd ref="-1230"/>
-        <nd ref="-1232"/>
-        <nd ref="-5896"/>
-        <nd ref="-5897"/>
-        <nd ref="-1234"/>
-        <nd ref="-23409"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20273"/>
-        <nd ref="-3846"/>
-        <nd ref="-3848"/>
-        <nd ref="-7348"/>
-        <nd ref="-3850"/>
-        <nd ref="-7349"/>
-        <nd ref="-3853"/>
-        <nd ref="-3856"/>
-        <nd ref="-20255"/>
-        <tag k="alt_name" v="16th St NW"/>
-        <tag k="name" v="16TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18486"/>
-        <nd ref="-4666"/>
-        <nd ref="-1214"/>
-        <nd ref="-4667"/>
-        <nd ref="-1216"/>
-        <nd ref="-4668"/>
-        <nd ref="-1218"/>
-        <nd ref="-1220"/>
-        <nd ref="-1222"/>
-        <nd ref="-18746"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32023"/>
-        <nd ref="-24"/>
-        <nd ref="-5482"/>
-        <nd ref="-22"/>
-        <nd ref="-20"/>
-        <nd ref="-5481"/>
-        <nd ref="-18"/>
-        <nd ref="-16"/>
-        <nd ref="-14"/>
-        <nd ref="-5480"/>
-        <nd ref="-12"/>
-        <nd ref="-11"/>
-        <nd ref="-5479"/>
-        <nd ref="-5478"/>
-        <nd ref="-10"/>
-        <nd ref="-9"/>
-        <nd ref="-5477"/>
-        <nd ref="-8"/>
-        <nd ref="-7"/>
-        <nd ref="-6"/>
-        <nd ref="-5476"/>
-        <nd ref="-5"/>
-        <nd ref="-5475"/>
-        <nd ref="-4"/>
-        <nd ref="-3"/>
-        <nd ref="-2"/>
-        <nd ref="-35558"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 1;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16527,59 +15512,6 @@
         <nd ref="-27447"/>
         <tag k="alt_name" v="16th St NW"/>
         <tag k="name" v="16TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18362"/>
-        <nd ref="-1203"/>
-        <nd ref="-4663"/>
-        <nd ref="-1204"/>
-        <nd ref="-4664"/>
-        <nd ref="-1205"/>
-        <nd ref="-1206"/>
-        <nd ref="-4665"/>
-        <nd ref="-1208"/>
-        <nd ref="-1210"/>
-        <nd ref="-18486"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21390"/>
-        <nd ref="-1199"/>
-        <nd ref="-1200"/>
-        <nd ref="-4662"/>
-        <nd ref="-1201"/>
-        <nd ref="-18362"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24645"/>
-        <nd ref="-1192"/>
-        <nd ref="-1193"/>
-        <nd ref="-4655"/>
-        <nd ref="-1194"/>
-        <nd ref="-1195"/>
-        <nd ref="-4656"/>
-        <nd ref="-1196"/>
-        <nd ref="-22971"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24644"/>
-        <nd ref="-1190"/>
-        <nd ref="-24645"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16625,9 +15557,16 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22331"/>
         <nd ref="-23553"/>
-        <tag k="alt_name" v="14th St SW;US Hwy 1"/>
+        <nd ref="-22331"/>
+        <nd ref="-2520"/>
+        <nd ref="-7342"/>
+        <nd ref="-7343"/>
+        <nd ref="-2521"/>
+        <nd ref="-2522"/>
+        <nd ref="-7344"/>
+        <nd ref="-22314"/>
+        <tag k="alt_name" v="14TH ST NW;14th St NW;14th St SW;US Hwy 1"/>
         <tag k="name" v="14TH ST SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
@@ -16646,20 +15585,9 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23553"/>
-        <nd ref="-3438"/>
-        <nd ref="-6153"/>
-        <nd ref="-6155"/>
-        <nd ref="-3440"/>
-        <nd ref="-3442"/>
-        <nd ref="-26434"/>
-        <tag k="alt_name" v="Jefferson Dr SW"/>
-        <tag k="name" v="JEFFERSON DR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33171"/>
+        <nd ref="-76"/>
         <nd ref="-33172"/>
         <nd ref="-3421"/>
         <nd ref="-6120"/>
@@ -16689,34 +15617,43 @@
         <nd ref="-3436"/>
         <nd ref="-6149"/>
         <nd ref="-23553"/>
+        <nd ref="-3438"/>
+        <nd ref="-6153"/>
+        <nd ref="-6155"/>
+        <nd ref="-3440"/>
+        <nd ref="-3442"/>
+        <nd ref="-26434"/>
         <tag k="alt_name" v="Jefferson Dr SW"/>
         <tag k="name" v="JEFFERSON DR SW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-30396"/>
-        <nd ref="-3120"/>
-        <nd ref="-3121"/>
-        <nd ref="-5463"/>
-        <nd ref="-5464"/>
-        <nd ref="-3122"/>
-        <nd ref="-3123"/>
-        <nd ref="-3124"/>
-        <nd ref="-5465"/>
-        <nd ref="-3125"/>
-        <nd ref="-3126"/>
-        <nd ref="-5466"/>
-        <nd ref="-5467"/>
-        <nd ref="-3127"/>
-        <nd ref="-3128"/>
-        <nd ref="-30331"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23812"/>
+        <nd ref="-888"/>
+        <nd ref="-889"/>
+        <nd ref="-5442"/>
+        <nd ref="-890"/>
+        <nd ref="-5443"/>
+        <nd ref="-5444"/>
+        <nd ref="-891"/>
+        <nd ref="-892"/>
+        <nd ref="-5445"/>
+        <nd ref="-5446"/>
+        <nd ref="-893"/>
+        <nd ref="-5447"/>
+        <nd ref="-894"/>
+        <nd ref="-31969"/>
+        <nd ref="-5449"/>
+        <nd ref="-3105"/>
+        <nd ref="-5450"/>
+        <nd ref="-3106"/>
+        <nd ref="-5451"/>
+        <nd ref="-3107"/>
+        <nd ref="-3108"/>
+        <nd ref="-5452"/>
+        <nd ref="-3109"/>
+        <nd ref="-3110"/>
         <nd ref="-26444"/>
         <nd ref="-3111"/>
         <nd ref="-3112"/>
@@ -16731,24 +15668,6 @@
         <nd ref="-3118"/>
         <nd ref="-3119"/>
         <nd ref="-38500"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31969"/>
-        <nd ref="-5449"/>
-        <nd ref="-3105"/>
-        <nd ref="-5450"/>
-        <nd ref="-3106"/>
-        <nd ref="-5451"/>
-        <nd ref="-3107"/>
-        <nd ref="-3108"/>
-        <nd ref="-5452"/>
-        <nd ref="-3109"/>
-        <nd ref="-3110"/>
-        <nd ref="-26444"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
@@ -16772,22 +15691,24 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24283"/>
-        <nd ref="-3095"/>
-        <nd ref="-6813"/>
-        <nd ref="-3096"/>
-        <nd ref="-3097"/>
-        <nd ref="-6815"/>
-        <nd ref="-3098"/>
-        <nd ref="-6817"/>
-        <nd ref="-31995"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38523"/>
+        <nd ref="-887"/>
+        <nd ref="-27898"/>
+        <nd ref="-3079"/>
+        <nd ref="-6786"/>
+        <nd ref="-3080"/>
+        <nd ref="-3081"/>
+        <nd ref="-6788"/>
+        <nd ref="-3082"/>
+        <nd ref="-3083"/>
+        <nd ref="-6790"/>
+        <nd ref="-3084"/>
+        <nd ref="-6792"/>
+        <nd ref="-3085"/>
+        <nd ref="-6795"/>
+        <nd ref="-3086"/>
+        <nd ref="-3087"/>
         <nd ref="-24367"/>
         <nd ref="-6798"/>
         <nd ref="-3088"/>
@@ -16802,6 +15723,14 @@
         <nd ref="-3094"/>
         <nd ref="-6809"/>
         <nd ref="-24283"/>
+        <nd ref="-3095"/>
+        <nd ref="-6813"/>
+        <nd ref="-3096"/>
+        <nd ref="-3097"/>
+        <nd ref="-6815"/>
+        <nd ref="-3098"/>
+        <nd ref="-6817"/>
+        <nd ref="-31995"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
@@ -16819,30 +15748,13 @@
         <nd ref="-4184"/>
         <nd ref="-6656"/>
         <nd ref="-38581"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
+        <nd ref="-741"/>
+        <nd ref="-6658"/>
+        <nd ref="-742"/>
+        <nd ref="-6660"/>
+        <nd ref="-36148"/>
+        <tag k="alt_name" v="Independence Ave SW;OHIO DR SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27898"/>
-        <nd ref="-3079"/>
-        <nd ref="-6786"/>
-        <nd ref="-3080"/>
-        <nd ref="-3081"/>
-        <nd ref="-6788"/>
-        <nd ref="-3082"/>
-        <nd ref="-3083"/>
-        <nd ref="-6790"/>
-        <nd ref="-3084"/>
-        <nd ref="-6792"/>
-        <nd ref="-3085"/>
-        <nd ref="-6795"/>
-        <nd ref="-3086"/>
-        <nd ref="-3087"/>
-        <nd ref="-24367"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -16855,91 +15767,38 @@
         <nd ref="-6768"/>
         <nd ref="-3078"/>
         <nd ref="-27935"/>
+        <nd ref="-877"/>
+        <nd ref="-6772"/>
+        <nd ref="-878"/>
+        <nd ref="-879"/>
+        <nd ref="-6774"/>
+        <nd ref="-880"/>
+        <nd ref="-881"/>
+        <nd ref="-6776"/>
+        <nd ref="-882"/>
+        <nd ref="-27936"/>
         <tag k="alt_name" v="E St NW;Ellipse Rd NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28750"/>
-        <nd ref="-6466"/>
-        <nd ref="-6469"/>
-        <nd ref="-4128"/>
-        <nd ref="-4129"/>
-        <nd ref="-6472"/>
-        <nd ref="-6475"/>
-        <nd ref="-4130"/>
-        <nd ref="-6478"/>
-        <nd ref="-6481"/>
-        <nd ref="-4131"/>
-        <nd ref="-4132"/>
-        <nd ref="-6484"/>
-        <nd ref="-4133"/>
-        <nd ref="-6487"/>
-        <nd ref="-6491"/>
-        <nd ref="-4134"/>
-        <nd ref="-4135"/>
-        <nd ref="-4136"/>
-        <nd ref="-4137"/>
-        <nd ref="-4138"/>
-        <nd ref="-6495"/>
-        <nd ref="-4139"/>
-        <nd ref="-4140"/>
-        <nd ref="-6499"/>
-        <nd ref="-4141"/>
-        <nd ref="-4142"/>
-        <nd ref="-6503"/>
-        <nd ref="-4143"/>
-        <nd ref="-4144"/>
-        <nd ref="-4145"/>
-        <nd ref="-6506"/>
-        <nd ref="-4146"/>
-        <nd ref="-4147"/>
-        <nd ref="-6509"/>
-        <nd ref="-4148"/>
-        <nd ref="-4149"/>
-        <nd ref="-6512"/>
-        <nd ref="-4150"/>
-        <nd ref="-4151"/>
-        <nd ref="-6515"/>
-        <nd ref="-4152"/>
-        <nd ref="-4153"/>
-        <nd ref="-6518"/>
-        <nd ref="-4154"/>
-        <nd ref="-6522"/>
-        <nd ref="-4155"/>
-        <nd ref="-6526"/>
-        <nd ref="-6530"/>
-        <nd ref="-4156"/>
-        <nd ref="-6534"/>
-        <nd ref="-4157"/>
-        <nd ref="-4158"/>
-        <nd ref="-4159"/>
-        <nd ref="-6537"/>
-        <nd ref="-6540"/>
-        <nd ref="-4160"/>
-        <nd ref="-4161"/>
-        <nd ref="-6543"/>
-        <nd ref="-4162"/>
-        <nd ref="-4163"/>
-        <nd ref="-6546"/>
-        <nd ref="-4164"/>
-        <nd ref="-6549"/>
-        <nd ref="-4165"/>
-        <nd ref="-6552"/>
-        <nd ref="-4166"/>
-        <nd ref="-4167"/>
-        <nd ref="-4168"/>
-        <nd ref="-6555"/>
-        <nd ref="-4169"/>
-        <nd ref="-6558"/>
-        <nd ref="-30465"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25859"/>
+        <nd ref="-869"/>
+        <nd ref="-6727"/>
+        <nd ref="-870"/>
+        <nd ref="-871"/>
+        <nd ref="-6730"/>
+        <nd ref="-6733"/>
+        <nd ref="-872"/>
+        <nd ref="-6736"/>
+        <nd ref="-873"/>
+        <nd ref="-6739"/>
+        <nd ref="-874"/>
+        <nd ref="-875"/>
+        <nd ref="-6742"/>
+        <nd ref="-876"/>
+        <nd ref="-6745"/>
         <nd ref="-25860"/>
         <nd ref="-3064"/>
         <nd ref="-3065"/>
@@ -16963,50 +15822,38 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18689"/>
-        <nd ref="-2134"/>
-        <nd ref="-4708"/>
-        <nd ref="-2135"/>
-        <nd ref="-2136"/>
-        <nd ref="-19396"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18746"/>
-        <nd ref="-2126"/>
-        <nd ref="-2128"/>
-        <nd ref="-4706"/>
-        <nd ref="-2130"/>
-        <nd ref="-2132"/>
-        <nd ref="-18689"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20255"/>
-        <nd ref="-2114"/>
-        <nd ref="-2116"/>
-        <nd ref="-4696"/>
-        <nd ref="-2118"/>
-        <nd ref="-4698"/>
-        <nd ref="-2120"/>
-        <nd ref="-2122"/>
-        <nd ref="-4700"/>
-        <nd ref="-4702"/>
-        <nd ref="-2124"/>
-        <nd ref="-18515"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23292"/>
+        <nd ref="-2075"/>
+        <nd ref="-4676"/>
+        <nd ref="-2076"/>
+        <nd ref="-2078"/>
+        <nd ref="-4677"/>
+        <nd ref="-2080"/>
+        <nd ref="-4678"/>
+        <nd ref="-2082"/>
+        <nd ref="-4679"/>
+        <nd ref="-2084"/>
+        <nd ref="-4680"/>
+        <nd ref="-27221"/>
+        <nd ref="-2501"/>
+        <nd ref="-2502"/>
+        <nd ref="-4681"/>
+        <nd ref="-2503"/>
+        <nd ref="-2504"/>
+        <nd ref="-4682"/>
+        <nd ref="-2505"/>
+        <nd ref="-2506"/>
+        <nd ref="-2507"/>
+        <nd ref="-4683"/>
+        <nd ref="-23238"/>
+        <nd ref="-2086"/>
+        <nd ref="-2088"/>
+        <nd ref="-4684"/>
+        <nd ref="-2090"/>
+        <nd ref="-4685"/>
+        <nd ref="-4686"/>
+        <nd ref="-2092"/>
         <nd ref="-23006"/>
         <nd ref="-2094"/>
         <nd ref="-2096"/>
@@ -17026,86 +15873,23 @@
         <nd ref="-4695"/>
         <nd ref="-2112"/>
         <nd ref="-20255"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23238"/>
-        <nd ref="-2086"/>
-        <nd ref="-2088"/>
-        <nd ref="-4684"/>
-        <nd ref="-2090"/>
-        <nd ref="-4685"/>
-        <nd ref="-4686"/>
-        <nd ref="-2092"/>
-        <nd ref="-23006"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23292"/>
-        <nd ref="-2075"/>
-        <nd ref="-4676"/>
-        <nd ref="-2076"/>
-        <nd ref="-2078"/>
-        <nd ref="-4677"/>
-        <nd ref="-2080"/>
-        <nd ref="-4678"/>
-        <nd ref="-2082"/>
-        <nd ref="-4679"/>
-        <nd ref="-2084"/>
-        <nd ref="-4680"/>
-        <nd ref="-27221"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25386"/>
-        <nd ref="-247"/>
-        <nd ref="-248"/>
-        <nd ref="-5939"/>
-        <nd ref="-249"/>
-        <nd ref="-5940"/>
-        <nd ref="-250"/>
-        <nd ref="-5941"/>
-        <nd ref="-251"/>
-        <nd ref="-5942"/>
-        <nd ref="-252"/>
-        <nd ref="-253"/>
-        <nd ref="-5943"/>
-        <nd ref="-254"/>
-        <nd ref="-255"/>
-        <nd ref="-5944"/>
-        <nd ref="-256"/>
-        <nd ref="-5945"/>
-        <nd ref="-25315"/>
+        <nd ref="-2114"/>
+        <nd ref="-2116"/>
+        <nd ref="-4696"/>
+        <nd ref="-2118"/>
+        <nd ref="-4698"/>
+        <nd ref="-2120"/>
+        <nd ref="-2122"/>
+        <nd ref="-4700"/>
+        <nd ref="-4702"/>
+        <nd ref="-2124"/>
+        <nd ref="-18515"/>
         <tag k="alt_name" v="I St NW"/>
         <tag k="name" v="I ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18689"/>
-        <nd ref="-3795"/>
-        <nd ref="-5404"/>
-        <nd ref="-3797"/>
-        <nd ref="-3799"/>
-        <nd ref="-5406"/>
-        <nd ref="-3801"/>
-        <nd ref="-3803"/>
-        <nd ref="-23618"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27199"/>
         <nd ref="-3783"/>
         <nd ref="-3785"/>
@@ -17115,41 +15899,54 @@
         <nd ref="-5400"/>
         <nd ref="-3791"/>
         <nd ref="-18689"/>
+        <nd ref="-3795"/>
+        <nd ref="-5404"/>
+        <nd ref="-3797"/>
+        <nd ref="-3799"/>
+        <nd ref="-5406"/>
+        <nd ref="-3801"/>
+        <nd ref="-3803"/>
+        <nd ref="-23618"/>
+        <nd ref="-5410"/>
+        <nd ref="-149"/>
+        <nd ref="-150"/>
+        <nd ref="-5412"/>
+        <nd ref="-151"/>
+        <nd ref="-23619"/>
         <tag k="alt_name" v="18th St NW"/>
         <tag k="name" v="18TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26669"/>
-        <nd ref="-5394"/>
-        <nd ref="-3775"/>
-        <nd ref="-3777"/>
-        <nd ref="-3779"/>
-        <nd ref="-27199"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21544"/>
-        <nd ref="-5372"/>
-        <nd ref="-3762"/>
-        <nd ref="-5373"/>
-        <nd ref="-3763"/>
-        <nd ref="-5374"/>
-        <nd ref="-3765"/>
-        <nd ref="-3767"/>
-        <nd ref="-5376"/>
-        <nd ref="-3769"/>
-        <nd ref="-21313"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33168"/>
+        <nd ref="-25041"/>
+        <nd ref="-3735"/>
+        <nd ref="-5357"/>
+        <nd ref="-3736"/>
+        <nd ref="-3737"/>
+        <nd ref="-3738"/>
+        <nd ref="-5358"/>
+        <nd ref="-24388"/>
+        <nd ref="-3740"/>
+        <nd ref="-3741"/>
+        <nd ref="-5360"/>
+        <nd ref="-5361"/>
+        <nd ref="-3742"/>
+        <nd ref="-3743"/>
+        <nd ref="-24409"/>
+        <nd ref="-3745"/>
+        <nd ref="-3746"/>
+        <nd ref="-5363"/>
+        <nd ref="-3747"/>
+        <nd ref="-5364"/>
+        <nd ref="-3748"/>
+        <nd ref="-24367"/>
+        <nd ref="-3750"/>
+        <nd ref="-5366"/>
+        <nd ref="-5367"/>
+        <nd ref="-3751"/>
+        <nd ref="-3752"/>
         <nd ref="-23622"/>
         <nd ref="-5369"/>
         <nd ref="-3754"/>
@@ -17161,47 +15958,33 @@
         <nd ref="-3759"/>
         <nd ref="-3760"/>
         <nd ref="-21544"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24367"/>
-        <nd ref="-3750"/>
-        <nd ref="-5366"/>
-        <nd ref="-5367"/>
-        <nd ref="-3751"/>
-        <nd ref="-3752"/>
-        <nd ref="-23622"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24409"/>
-        <nd ref="-3745"/>
-        <nd ref="-3746"/>
-        <nd ref="-5363"/>
-        <nd ref="-3747"/>
-        <nd ref="-5364"/>
-        <nd ref="-3748"/>
-        <nd ref="-24367"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24388"/>
-        <nd ref="-3740"/>
-        <nd ref="-3741"/>
-        <nd ref="-5360"/>
-        <nd ref="-5361"/>
-        <nd ref="-3742"/>
-        <nd ref="-3743"/>
-        <nd ref="-24409"/>
+        <nd ref="-5372"/>
+        <nd ref="-3762"/>
+        <nd ref="-5373"/>
+        <nd ref="-3763"/>
+        <nd ref="-5374"/>
+        <nd ref="-3765"/>
+        <nd ref="-3767"/>
+        <nd ref="-5376"/>
+        <nd ref="-3769"/>
+        <nd ref="-21313"/>
+        <nd ref="-144"/>
+        <nd ref="-5380"/>
+        <nd ref="-5382"/>
+        <nd ref="-145"/>
+        <nd ref="-146"/>
+        <nd ref="-5384"/>
+        <nd ref="-5386"/>
+        <nd ref="-5388"/>
+        <nd ref="-147"/>
+        <nd ref="-5390"/>
+        <nd ref="-148"/>
+        <nd ref="-26669"/>
+        <nd ref="-5394"/>
+        <nd ref="-3775"/>
+        <nd ref="-3777"/>
+        <nd ref="-3779"/>
+        <nd ref="-27199"/>
         <tag k="alt_name" v="18th St NW"/>
         <tag k="name" v="18TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -17216,97 +15999,42 @@
         <nd ref="-1038"/>
         <nd ref="-4727"/>
         <nd ref="-33947"/>
+        <nd ref="-37046"/>
         <tag k="alt_name" v="26th St NW"/>
         <tag k="name" v="26TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25041"/>
-        <nd ref="-3735"/>
-        <nd ref="-5357"/>
-        <nd ref="-3736"/>
-        <nd ref="-3737"/>
-        <nd ref="-3738"/>
-        <nd ref="-5358"/>
-        <nd ref="-24388"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33168"/>
-        <nd ref="-25041"/>
-        <tag k="alt_name" v="18th St NW"/>
-        <tag k="name" v="18TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20863"/>
-        <nd ref="-6508"/>
-        <nd ref="-2431"/>
-        <nd ref="-2432"/>
-        <nd ref="-2433"/>
-        <nd ref="-6511"/>
-        <nd ref="-6514"/>
-        <nd ref="-2434"/>
-        <nd ref="-6517"/>
-        <nd ref="-2435"/>
-        <nd ref="-2436"/>
-        <nd ref="-2437"/>
-        <nd ref="-6521"/>
-        <nd ref="-2438"/>
-        <nd ref="-6525"/>
-        <nd ref="-2439"/>
-        <nd ref="-6529"/>
-        <nd ref="-6533"/>
-        <nd ref="-2440"/>
-        <nd ref="-6536"/>
-        <nd ref="-2441"/>
-        <nd ref="-2442"/>
-        <nd ref="-6539"/>
-        <nd ref="-2443"/>
-        <nd ref="-2444"/>
-        <nd ref="-2445"/>
-        <nd ref="-28822"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20610"/>
-        <nd ref="-2412"/>
-        <nd ref="-6477"/>
-        <nd ref="-2414"/>
-        <nd ref="-2416"/>
-        <nd ref="-6480"/>
-        <nd ref="-2418"/>
-        <nd ref="-6483"/>
-        <nd ref="-2420"/>
-        <nd ref="-6486"/>
-        <nd ref="-2422"/>
-        <nd ref="-2423"/>
-        <nd ref="-2424"/>
-        <nd ref="-6489"/>
-        <nd ref="-2425"/>
-        <nd ref="-6493"/>
-        <nd ref="-2426"/>
-        <nd ref="-6497"/>
-        <nd ref="-2427"/>
-        <nd ref="-2428"/>
-        <nd ref="-6501"/>
-        <nd ref="-2429"/>
-        <nd ref="-2430"/>
-        <nd ref="-20863"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29827"/>
+        <nd ref="-2681"/>
+        <nd ref="-6849"/>
+        <nd ref="-2682"/>
+        <nd ref="-6850"/>
+        <nd ref="-2683"/>
+        <nd ref="-6851"/>
+        <nd ref="-2684"/>
+        <nd ref="-6852"/>
+        <nd ref="-6853"/>
+        <nd ref="-2685"/>
+        <nd ref="-29828"/>
+        <nd ref="-2686"/>
+        <nd ref="-6854"/>
+        <nd ref="-2687"/>
+        <nd ref="-2688"/>
+        <nd ref="-6855"/>
+        <nd ref="-2689"/>
+        <nd ref="-2690"/>
+        <nd ref="-29730"/>
+        <nd ref="-2691"/>
+        <nd ref="-6857"/>
+        <nd ref="-2692"/>
+        <nd ref="-2693"/>
+        <nd ref="-6858"/>
+        <nd ref="-2694"/>
+        <nd ref="-2695"/>
+        <nd ref="-2696"/>
+        <nd ref="-2697"/>
         <nd ref="-29609"/>
         <nd ref="-2698"/>
         <nd ref="-6860"/>
@@ -17319,38 +16047,6 @@
         <nd ref="-6863"/>
         <nd ref="-2703"/>
         <nd ref="-29743"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29730"/>
-        <nd ref="-2691"/>
-        <nd ref="-6857"/>
-        <nd ref="-2692"/>
-        <nd ref="-2693"/>
-        <nd ref="-6858"/>
-        <nd ref="-2694"/>
-        <nd ref="-2695"/>
-        <nd ref="-2696"/>
-        <nd ref="-2697"/>
-        <nd ref="-29609"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-29828"/>
-        <nd ref="-2686"/>
-        <nd ref="-6854"/>
-        <nd ref="-2687"/>
-        <nd ref="-2688"/>
-        <nd ref="-6855"/>
-        <nd ref="-2689"/>
-        <nd ref="-2690"/>
-        <nd ref="-29730"/>
         <tag k="alt_name" v="C St NW"/>
         <tag k="name" v="C ST NW"/>
         <tag k="highway" v="road"/>
@@ -17370,22 +16066,6 @@
         <nd ref="-24409"/>
         <tag k="alt_name" v="D St NW"/>
         <tag k="name" v="D ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24472"/>
-        <nd ref="-2676"/>
-        <nd ref="-6829"/>
-        <nd ref="-2677"/>
-        <nd ref="-6831"/>
-        <nd ref="-2678"/>
-        <nd ref="-2679"/>
-        <nd ref="-6833"/>
-        <nd ref="-2680"/>
-        <nd ref="-24388"/>
-        <tag k="alt_name" v="C St NW"/>
-        <tag k="name" v="C ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -17414,7 +16094,19 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25255"/>
+        <nd ref="-2244"/>
+        <nd ref="-2246"/>
+        <nd ref="-2248"/>
+        <nd ref="-22701"/>
+        <nd ref="-2250"/>
+        <nd ref="-2251"/>
+        <nd ref="-2252"/>
+        <nd ref="-2253"/>
+        <nd ref="-16992"/>
+        <nd ref="-2255"/>
+        <nd ref="-2256"/>
         <nd ref="-17114"/>
         <nd ref="-2258"/>
         <nd ref="-6902"/>
@@ -17428,95 +16120,14 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16992"/>
-        <nd ref="-2255"/>
-        <nd ref="-2256"/>
-        <nd ref="-17114"/>
-        <tag k="alt_name" v="15th St NW;Pennsylvania Ave NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22701"/>
-        <nd ref="-2250"/>
-        <nd ref="-2251"/>
-        <nd ref="-2252"/>
-        <nd ref="-2253"/>
-        <nd ref="-16992"/>
-        <tag k="alt_name" v="15th St NW;Pennsylvania Ave NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32319"/>
-        <nd ref="-2384"/>
-        <nd ref="-5900"/>
-        <nd ref="-2385"/>
-        <nd ref="-2386"/>
-        <nd ref="-5901"/>
-        <nd ref="-5902"/>
-        <nd ref="-2387"/>
-        <nd ref="-2388"/>
-        <nd ref="-32283"/>
-        <tag k="alt_name" v="C St SW"/>
-        <tag k="name" v="C ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25255"/>
-        <nd ref="-2244"/>
-        <nd ref="-2246"/>
-        <nd ref="-2248"/>
-        <nd ref="-22701"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="15TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25562"/>
-        <nd ref="-137"/>
-        <nd ref="-138"/>
-        <nd ref="-4633"/>
-        <nd ref="-139"/>
-        <nd ref="-140"/>
-        <nd ref="-4634"/>
-        <nd ref="-141"/>
-        <nd ref="-27982"/>
-        <tag k="alt_name" v="New Hampshire Ave NW"/>
-        <tag k="name" v="NEW HAMPSHIRE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32319"/>
-        <nd ref="-3831"/>
-        <nd ref="-6304"/>
-        <nd ref="-3833"/>
-        <nd ref="-6305"/>
-        <nd ref="-3835"/>
-        <nd ref="-3837"/>
-        <nd ref="-3839"/>
-        <nd ref="-3841"/>
-        <nd ref="-3843"/>
-        <nd ref="-6306"/>
-        <nd ref="-3845"/>
-        <nd ref="-3847"/>
-        <nd ref="-6307"/>
-        <nd ref="-3849"/>
-        <nd ref="-3852"/>
-        <nd ref="-6308"/>
-        <nd ref="-32273"/>
-        <tag k="alt_name" v="12th St SW"/>
-        <tag k="name" v="12TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27971"/>
+        <nd ref="-1047"/>
+        <nd ref="-1048"/>
+        <nd ref="-6872"/>
+        <nd ref="-6873"/>
+        <nd ref="-1049"/>
+        <nd ref="-1050"/>
         <nd ref="-27972"/>
         <nd ref="-2198"/>
         <nd ref="-2199"/>
@@ -17571,16 +16182,30 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28822"/>
-        <nd ref="-135"/>
-        <nd ref="-25315"/>
-        <tag k="alt_name" v="New Hampshire Ave NW"/>
-        <tag k="name" v="NEW HAMPSHIRE AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26880"/>
+        <nd ref="-3702"/>
+        <nd ref="-3703"/>
+        <nd ref="-3704"/>
+        <nd ref="-4642"/>
+        <nd ref="-3706"/>
+        <nd ref="-3708"/>
+        <nd ref="-3710"/>
+        <nd ref="-4643"/>
+        <nd ref="-32710"/>
+        <nd ref="-3714"/>
+        <nd ref="-3716"/>
+        <nd ref="-3718"/>
+        <nd ref="-3720"/>
+        <nd ref="-24472"/>
+        <nd ref="-3723"/>
+        <nd ref="-4644"/>
+        <nd ref="-3724"/>
+        <nd ref="-4645"/>
+        <nd ref="-4646"/>
+        <nd ref="-3725"/>
+        <nd ref="-3726"/>
+        <nd ref="-3727"/>
         <nd ref="-24473"/>
         <nd ref="-3729"/>
         <nd ref="-4647"/>
@@ -17590,6 +16215,76 @@
         <nd ref="-3732"/>
         <nd ref="-4649"/>
         <nd ref="-27898"/>
+        <nd ref="-3469"/>
+        <nd ref="-4650"/>
+        <nd ref="-3470"/>
+        <nd ref="-3471"/>
+        <nd ref="-4651"/>
+        <nd ref="-3472"/>
+        <nd ref="-4652"/>
+        <nd ref="-3473"/>
+        <nd ref="-24644"/>
+        <nd ref="-1190"/>
+        <nd ref="-24645"/>
+        <nd ref="-1192"/>
+        <nd ref="-1193"/>
+        <nd ref="-4655"/>
+        <nd ref="-1194"/>
+        <nd ref="-1195"/>
+        <nd ref="-4656"/>
+        <nd ref="-1196"/>
+        <nd ref="-22971"/>
+        <nd ref="-1424"/>
+        <nd ref="-1426"/>
+        <nd ref="-4657"/>
+        <nd ref="-4658"/>
+        <nd ref="-1428"/>
+        <nd ref="-4659"/>
+        <nd ref="-1430"/>
+        <nd ref="-1432"/>
+        <nd ref="-4660"/>
+        <nd ref="-21390"/>
+        <nd ref="-1199"/>
+        <nd ref="-1200"/>
+        <nd ref="-4662"/>
+        <nd ref="-1201"/>
+        <nd ref="-18362"/>
+        <nd ref="-1203"/>
+        <nd ref="-4663"/>
+        <nd ref="-1204"/>
+        <nd ref="-4664"/>
+        <nd ref="-1205"/>
+        <nd ref="-1206"/>
+        <nd ref="-4665"/>
+        <nd ref="-1208"/>
+        <nd ref="-1210"/>
+        <nd ref="-18486"/>
+        <nd ref="-4666"/>
+        <nd ref="-1214"/>
+        <nd ref="-4667"/>
+        <nd ref="-1216"/>
+        <nd ref="-4668"/>
+        <nd ref="-1218"/>
+        <nd ref="-1220"/>
+        <nd ref="-1222"/>
+        <nd ref="-18746"/>
+        <nd ref="-1434"/>
+        <nd ref="-1436"/>
+        <nd ref="-1438"/>
+        <nd ref="-4670"/>
+        <nd ref="-1440"/>
+        <nd ref="-1442"/>
+        <nd ref="-4671"/>
+        <nd ref="-1444"/>
+        <nd ref="-1446"/>
+        <nd ref="-1448"/>
+        <nd ref="-1450"/>
+        <nd ref="-4672"/>
+        <nd ref="-1452"/>
+        <nd ref="-4674"/>
+        <nd ref="-1454"/>
+        <nd ref="-1456"/>
+        <nd ref="-23414"/>
         <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -17618,72 +16313,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24472"/>
-        <nd ref="-3723"/>
-        <nd ref="-4644"/>
-        <nd ref="-3724"/>
-        <nd ref="-4645"/>
-        <nd ref="-4646"/>
-        <nd ref="-3725"/>
-        <nd ref="-3726"/>
-        <nd ref="-3727"/>
-        <nd ref="-24473"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26433"/>
-        <nd ref="-4991"/>
-        <nd ref="-3822"/>
-        <nd ref="-3823"/>
-        <nd ref="-4993"/>
-        <nd ref="-4995"/>
-        <nd ref="-3824"/>
-        <nd ref="-3825"/>
-        <nd ref="-4997"/>
-        <nd ref="-3826"/>
-        <nd ref="-4999"/>
-        <nd ref="-3827"/>
-        <nd ref="-3828"/>
-        <nd ref="-3829"/>
-        <nd ref="-5001"/>
-        <nd ref="-26434"/>
-        <tag k="alt_name" v="15th St SW;Raoul Wallenberg Pl SW"/>
-        <tag k="name" v="15TH ST SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32710"/>
-        <nd ref="-3714"/>
-        <nd ref="-3716"/>
-        <nd ref="-3718"/>
-        <nd ref="-3720"/>
-        <nd ref="-24472"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26880"/>
-        <nd ref="-3702"/>
-        <nd ref="-3703"/>
-        <nd ref="-3704"/>
-        <nd ref="-4642"/>
-        <nd ref="-3706"/>
-        <nd ref="-3708"/>
-        <nd ref="-3710"/>
-        <nd ref="-4643"/>
-        <nd ref="-32710"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-28749"/>
         <nd ref="-6448"/>
@@ -17694,29 +16323,6 @@
         <nd ref="-866"/>
         <nd ref="-6460"/>
         <nd ref="-28750"/>
-        <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="name" v="INDEPENDENCE AVE SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23490"/>
-        <nd ref="-853"/>
-        <nd ref="-854"/>
-        <nd ref="-5413"/>
-        <nd ref="-855"/>
-        <nd ref="-856"/>
-        <nd ref="-857"/>
-        <nd ref="-858"/>
-        <nd ref="-5415"/>
-        <nd ref="-859"/>
-        <nd ref="-5417"/>
-        <nd ref="-860"/>
-        <nd ref="-5419"/>
-        <nd ref="-861"/>
-        <nd ref="-862"/>
-        <nd ref="-863"/>
-        <nd ref="-28749"/>
         <tag k="alt_name" v="Independence Ave SW"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="highway" v="road"/>
@@ -17737,6 +16343,21 @@
         <nd ref="-34038"/>
         <nd ref="-2245"/>
         <nd ref="-34013"/>
+        <nd ref="-6214"/>
+        <nd ref="-81"/>
+        <nd ref="-36776"/>
+        <nd ref="-6216"/>
+        <nd ref="-737"/>
+        <nd ref="-38176"/>
+        <nd ref="-38469"/>
+        <nd ref="-28352"/>
+        <nd ref="-83"/>
+        <nd ref="-6218"/>
+        <nd ref="-6220"/>
+        <nd ref="-85"/>
+        <nd ref="-6222"/>
+        <nd ref="-87"/>
+        <nd ref="-28353"/>
         <tag k="alt_name" v="Virginia Ave NW"/>
         <tag k="name" v="VIRGINIA AVE NW"/>
         <tag k="highway" v="road"/>
@@ -17754,63 +16375,36 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38500"/>
-        <nd ref="-2237"/>
-        <nd ref="-6208"/>
-        <nd ref="-6210"/>
-        <nd ref="-2239"/>
-        <nd ref="-27780"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24887"/>
-        <nd ref="-38427"/>
-        <nd ref="-2231"/>
-        <nd ref="-2233"/>
-        <nd ref="-38414"/>
-        <nd ref="-38500"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26301"/>
-        <nd ref="-24887"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24788"/>
-        <nd ref="-6198"/>
-        <nd ref="-2225"/>
-        <nd ref="-2227"/>
-        <nd ref="-6200"/>
-        <nd ref="-2229"/>
-        <nd ref="-6202"/>
-        <nd ref="-24823"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24787"/>
-        <nd ref="-6196"/>
-        <nd ref="-2221"/>
-        <nd ref="-24788"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33169"/>
+        <nd ref="-701"/>
+        <nd ref="-6176"/>
+        <nd ref="-703"/>
+        <nd ref="-6177"/>
+        <nd ref="-705"/>
+        <nd ref="-6178"/>
+        <nd ref="-707"/>
+        <nd ref="-6179"/>
+        <nd ref="-709"/>
+        <nd ref="-6180"/>
+        <nd ref="-711"/>
+        <nd ref="-6181"/>
+        <nd ref="-713"/>
+        <nd ref="-6182"/>
+        <nd ref="-716"/>
+        <nd ref="-6183"/>
+        <nd ref="-719"/>
+        <nd ref="-6184"/>
+        <nd ref="-722"/>
+        <nd ref="-725"/>
+        <nd ref="-727"/>
+        <nd ref="-6185"/>
+        <nd ref="-729"/>
+        <nd ref="-731"/>
+        <nd ref="-6186"/>
+        <nd ref="-733"/>
+        <nd ref="-735"/>
+        <nd ref="-6188"/>
         <nd ref="-25041"/>
         <nd ref="-6190"/>
         <nd ref="-2213"/>
@@ -17820,79 +16414,34 @@
         <nd ref="-2217"/>
         <nd ref="-2219"/>
         <nd ref="-24787"/>
+        <nd ref="-6196"/>
+        <nd ref="-2221"/>
+        <nd ref="-24788"/>
+        <nd ref="-6198"/>
+        <nd ref="-2225"/>
+        <nd ref="-2227"/>
+        <nd ref="-6200"/>
+        <nd ref="-2229"/>
+        <nd ref="-6202"/>
+        <nd ref="-24823"/>
+        <nd ref="-999"/>
+        <nd ref="-6204"/>
+        <nd ref="-1000"/>
+        <nd ref="-6206"/>
+        <nd ref="-26301"/>
+        <nd ref="-24887"/>
+        <nd ref="-38427"/>
+        <nd ref="-2231"/>
+        <nd ref="-2233"/>
+        <nd ref="-38414"/>
+        <nd ref="-38500"/>
+        <nd ref="-2237"/>
+        <nd ref="-6208"/>
+        <nd ref="-6210"/>
+        <nd ref="-2239"/>
+        <nd ref="-27780"/>
         <tag k="alt_name" v="Virginia Ave NW"/>
         <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38284"/>
-        <nd ref="-2138"/>
-        <nd ref="-2139"/>
-        <nd ref="-2140"/>
-        <nd ref="-5986"/>
-        <nd ref="-2141"/>
-        <nd ref="-16908"/>
-        <tag k="alt_name" v="14th St NW"/>
-        <tag k="name" v="14TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23812"/>
-        <nd ref="-888"/>
-        <nd ref="-889"/>
-        <nd ref="-5442"/>
-        <nd ref="-890"/>
-        <nd ref="-5443"/>
-        <nd ref="-5444"/>
-        <nd ref="-891"/>
-        <nd ref="-892"/>
-        <nd ref="-5445"/>
-        <nd ref="-5446"/>
-        <nd ref="-893"/>
-        <nd ref="-5447"/>
-        <nd ref="-894"/>
-        <nd ref="-31969"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35878"/>
-        <nd ref="-5059"/>
-        <nd ref="-2289"/>
-        <nd ref="-36191"/>
-        <nd ref="-2291"/>
-        <nd ref="-36208"/>
-        <nd ref="-36231"/>
-        <nd ref="-38590"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-38513"/>
-        <nd ref="-3408"/>
-        <nd ref="-3409"/>
-        <nd ref="-4954"/>
-        <nd ref="-3410"/>
-        <nd ref="-3411"/>
-        <nd ref="-4955"/>
-        <nd ref="-3412"/>
-        <nd ref="-3413"/>
-        <nd ref="-4956"/>
-        <nd ref="-3414"/>
-        <nd ref="-3415"/>
-        <nd ref="-3416"/>
-        <nd ref="-3417"/>
-        <nd ref="-4957"/>
-        <nd ref="-3418"/>
-        <nd ref="-3419"/>
-        <nd ref="-37100"/>
-        <tag k="name" v="OHIO DR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -17905,20 +16454,30 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25315"/>
-        <nd ref="-2172"/>
-        <nd ref="-5946"/>
-        <nd ref="-5947"/>
-        <nd ref="-2173"/>
-        <nd ref="-2174"/>
-        <nd ref="-26744"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25947"/>
+        <nd ref="-5908"/>
+        <nd ref="-234"/>
+        <nd ref="-235"/>
+        <nd ref="-236"/>
+        <nd ref="-5910"/>
+        <nd ref="-237"/>
+        <nd ref="-5912"/>
+        <nd ref="-238"/>
+        <nd ref="-5914"/>
+        <nd ref="-239"/>
+        <nd ref="-5916"/>
+        <nd ref="-240"/>
+        <nd ref="-241"/>
+        <nd ref="-5918"/>
+        <nd ref="-5920"/>
+        <nd ref="-242"/>
+        <nd ref="-243"/>
+        <nd ref="-244"/>
+        <nd ref="-245"/>
+        <nd ref="-5922"/>
+        <nd ref="-5923"/>
+        <nd ref="-246"/>
         <nd ref="-25948"/>
         <nd ref="-2148"/>
         <nd ref="-2149"/>
@@ -17977,31 +16536,12 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23409"/>
-        <nd ref="-4022"/>
-        <nd ref="-23414"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23418"/>
-        <nd ref="-4018"/>
-        <nd ref="-5783"/>
-        <nd ref="-4019"/>
-        <nd ref="-5784"/>
-        <nd ref="-4020"/>
-        <nd ref="-5785"/>
-        <nd ref="-4021"/>
-        <nd ref="-23409"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23403"/>
+        <nd ref="-4012"/>
+        <nd ref="-5776"/>
+        <nd ref="-5777"/>
+        <nd ref="-4013"/>
         <nd ref="-23432"/>
         <nd ref="-4014"/>
         <nd ref="-5779"/>
@@ -18013,74 +16553,6 @@
         <nd ref="-23418"/>
         <tag k="alt_name" v="K St NW;US Hwy 29"/>
         <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23403"/>
-        <nd ref="-4012"/>
-        <nd ref="-5776"/>
-        <nd ref="-5777"/>
-        <nd ref="-4013"/>
-        <nd ref="-23432"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25027"/>
-        <nd ref="-4009"/>
-        <nd ref="-5774"/>
-        <nd ref="-4010"/>
-        <nd ref="-4011"/>
-        <nd ref="-5775"/>
-        <nd ref="-23403"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24645"/>
-        <nd ref="-2057"/>
-        <nd ref="-2058"/>
-        <nd ref="-7433"/>
-        <nd ref="-2059"/>
-        <nd ref="-2060"/>
-        <nd ref="-7434"/>
-        <nd ref="-2062"/>
-        <nd ref="-24603"/>
-        <tag k="alt_name" v="New York Ave NW"/>
-        <tag k="name" v="NEW YORK AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27898"/>
-        <nd ref="-3469"/>
-        <nd ref="-4650"/>
-        <nd ref="-3470"/>
-        <nd ref="-3471"/>
-        <nd ref="-4651"/>
-        <nd ref="-3472"/>
-        <nd ref="-4652"/>
-        <nd ref="-3473"/>
-        <nd ref="-24644"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36776"/>
-        <nd ref="-6216"/>
-        <nd ref="-737"/>
-        <nd ref="-38176"/>
-        <nd ref="-38469"/>
-        <nd ref="-28352"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -18103,6 +16575,26 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36776"/>
+        <nd ref="-827"/>
+        <nd ref="-828"/>
+        <nd ref="-5127"/>
+        <nd ref="-829"/>
+        <nd ref="-830"/>
+        <nd ref="-5130"/>
+        <nd ref="-831"/>
+        <nd ref="-5133"/>
+        <nd ref="-832"/>
+        <nd ref="-5136"/>
+        <nd ref="-5139"/>
+        <nd ref="-833"/>
+        <nd ref="-834"/>
+        <nd ref="-5142"/>
+        <nd ref="-5145"/>
+        <nd ref="-835"/>
+        <nd ref="-836"/>
+        <nd ref="-5148"/>
+        <nd ref="-837"/>
         <nd ref="-26244"/>
         <nd ref="-839"/>
         <nd ref="-840"/>
@@ -18125,69 +16617,6 @@
         <nd ref="-5175"/>
         <nd ref="-850"/>
         <nd ref="-26245"/>
-        <tag k="alt_name" v="25th St NW;Whitehurst Fwy Rmp"/>
-        <tag k="name" v="25TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33169"/>
-        <nd ref="-701"/>
-        <nd ref="-6176"/>
-        <nd ref="-703"/>
-        <nd ref="-6177"/>
-        <nd ref="-705"/>
-        <nd ref="-6178"/>
-        <nd ref="-707"/>
-        <nd ref="-6179"/>
-        <nd ref="-709"/>
-        <nd ref="-6180"/>
-        <nd ref="-711"/>
-        <nd ref="-6181"/>
-        <nd ref="-713"/>
-        <nd ref="-6182"/>
-        <nd ref="-716"/>
-        <nd ref="-6183"/>
-        <nd ref="-719"/>
-        <nd ref="-6184"/>
-        <nd ref="-722"/>
-        <nd ref="-725"/>
-        <nd ref="-727"/>
-        <nd ref="-6185"/>
-        <nd ref="-729"/>
-        <nd ref="-731"/>
-        <nd ref="-6186"/>
-        <nd ref="-733"/>
-        <nd ref="-735"/>
-        <nd ref="-6188"/>
-        <nd ref="-25041"/>
-        <tag k="alt_name" v="Virginia Ave NW"/>
-        <tag k="name" v="VIRGINIA AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36776"/>
-        <nd ref="-827"/>
-        <nd ref="-828"/>
-        <nd ref="-5127"/>
-        <nd ref="-829"/>
-        <nd ref="-830"/>
-        <nd ref="-5130"/>
-        <nd ref="-831"/>
-        <nd ref="-5133"/>
-        <nd ref="-832"/>
-        <nd ref="-5136"/>
-        <nd ref="-5139"/>
-        <nd ref="-833"/>
-        <nd ref="-834"/>
-        <nd ref="-5142"/>
-        <nd ref="-5145"/>
-        <nd ref="-835"/>
-        <nd ref="-836"/>
-        <nd ref="-5148"/>
-        <nd ref="-837"/>
-        <nd ref="-26244"/>
         <tag k="alt_name" v="25th St NW;Whitehurst Fwy Rmp"/>
         <tag k="name" v="25TH ST NW"/>
         <tag k="highway" v="road"/>
@@ -18232,28 +16661,36 @@
         <nd ref="-3233"/>
         <nd ref="-3234"/>
         <nd ref="-34762"/>
+        <nd ref="-5057"/>
+        <nd ref="-5060"/>
+        <nd ref="-5063"/>
+        <nd ref="-5066"/>
+        <nd ref="-5069"/>
+        <nd ref="-5072"/>
+        <nd ref="-5075"/>
+        <nd ref="-5078"/>
+        <nd ref="-5081"/>
+        <nd ref="-5083"/>
+        <nd ref="-5086"/>
+        <nd ref="-5089"/>
+        <nd ref="-5092"/>
+        <nd ref="-5095"/>
+        <nd ref="-5098"/>
+        <nd ref="-5100"/>
+        <nd ref="-5102"/>
+        <nd ref="-5104"/>
+        <nd ref="-5106"/>
+        <nd ref="-5108"/>
+        <nd ref="-5110"/>
+        <nd ref="-5113"/>
+        <nd ref="-5116"/>
+        <nd ref="-5119"/>
+        <nd ref="-5122"/>
+        <nd ref="-5125"/>
+        <nd ref="-5128"/>
+        <nd ref="-28984"/>
         <tag k="alt_name" v="Lincoln Memorial Cir"/>
         <tag k="name" v="LINCOLN MEMORIAL CIR SW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27982"/>
-        <nd ref="-4383"/>
-        <nd ref="-961"/>
-        <nd ref="-962"/>
-        <nd ref="-4384"/>
-        <nd ref="-4385"/>
-        <nd ref="-963"/>
-        <nd ref="-964"/>
-        <nd ref="-4386"/>
-        <nd ref="-965"/>
-        <nd ref="-966"/>
-        <nd ref="-967"/>
-        <nd ref="-4387"/>
-        <nd ref="-26596"/>
-        <tag k="alt_name" v="Washington Cir NW"/>
-        <tag k="name" v="WASHINGTON CIR NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -18274,6 +16711,17 @@
         <nd ref="-4365"/>
         <nd ref="-960"/>
         <nd ref="-34560"/>
+        <nd ref="-1865"/>
+        <nd ref="-4367"/>
+        <nd ref="-4368"/>
+        <nd ref="-1866"/>
+        <nd ref="-1867"/>
+        <nd ref="-4369"/>
+        <nd ref="-4370"/>
+        <nd ref="-1868"/>
+        <nd ref="-4371"/>
+        <nd ref="-1869"/>
+        <nd ref="-34430"/>
         <tag k="alt_name" v="Washington Cir NW"/>
         <tag k="name" v="WASHINGTON CIR NW"/>
         <tag k="highway" v="road"/>
@@ -18349,90 +16797,6 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20272"/>
-        <nd ref="-3446"/>
-        <nd ref="-3447"/>
-        <nd ref="-3448"/>
-        <nd ref="-6349"/>
-        <nd ref="-6351"/>
-        <nd ref="-3449"/>
-        <nd ref="-3450"/>
-        <nd ref="-3451"/>
-        <nd ref="-20273"/>
-        <tag k="alt_name" v="H St NW"/>
-        <tag k="name" v="H ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31969"/>
-        <nd ref="-3373"/>
-        <nd ref="-4421"/>
-        <nd ref="-3374"/>
-        <nd ref="-3375"/>
-        <nd ref="-3376"/>
-        <nd ref="-3377"/>
-        <nd ref="-3378"/>
-        <nd ref="-4422"/>
-        <nd ref="-3379"/>
-        <nd ref="-3380"/>
-        <nd ref="-4423"/>
-        <nd ref="-21940"/>
-        <tag k="alt_name" v="20th St NW"/>
-        <tag k="name" v="20TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23414"/>
-        <nd ref="-2726"/>
-        <nd ref="-2728"/>
-        <nd ref="-2730"/>
-        <nd ref="-5788"/>
-        <nd ref="-2732"/>
-        <nd ref="-5789"/>
-        <nd ref="-2734"/>
-        <nd ref="-2736"/>
-        <nd ref="-2738"/>
-        <nd ref="-23618"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26395"/>
-        <nd ref="-540"/>
-        <nd ref="-542"/>
-        <nd ref="-6278"/>
-        <nd ref="-544"/>
-        <nd ref="-546"/>
-        <nd ref="-549"/>
-        <nd ref="-552"/>
-        <nd ref="-554"/>
-        <nd ref="-556"/>
-        <nd ref="-6279"/>
-        <nd ref="-558"/>
-        <nd ref="-560"/>
-        <nd ref="-562"/>
-        <nd ref="-6280"/>
-        <nd ref="-564"/>
-        <nd ref="-566"/>
-        <nd ref="-568"/>
-        <nd ref="-6281"/>
-        <nd ref="-6282"/>
-        <nd ref="-570"/>
-        <nd ref="-572"/>
-        <nd ref="-6283"/>
-        <nd ref="-574"/>
-        <nd ref="-6284"/>
-        <nd ref="-34013"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25669"/>
         <nd ref="-2721"/>
@@ -18445,58 +16809,14 @@
         <nd ref="-2725"/>
         <nd ref="-5772"/>
         <nd ref="-25027"/>
+        <nd ref="-4009"/>
+        <nd ref="-5774"/>
+        <nd ref="-4010"/>
+        <nd ref="-4011"/>
+        <nd ref="-5775"/>
+        <nd ref="-23403"/>
         <tag k="alt_name" v="K St NW;US Hwy 29"/>
         <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-32091"/>
-        <nd ref="-1223"/>
-        <nd ref="-1221"/>
-        <nd ref="-1219"/>
-        <nd ref="-33168"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="3.53553"/>
-    </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22143"/>
-        <nd ref="-496"/>
-        <nd ref="-498"/>
-        <nd ref="-500"/>
-        <nd ref="-502"/>
-        <nd ref="-504"/>
-        <nd ref="-506"/>
-        <nd ref="-6254"/>
-        <nd ref="-508"/>
-        <nd ref="-510"/>
-        <nd ref="-6256"/>
-        <nd ref="-512"/>
-        <nd ref="-514"/>
-        <nd ref="-516"/>
-        <nd ref="-6257"/>
-        <nd ref="-518"/>
-        <nd ref="-520"/>
-        <nd ref="-6258"/>
-        <nd ref="-522"/>
-        <nd ref="-6259"/>
-        <nd ref="-524"/>
-        <nd ref="-526"/>
-        <nd ref="-6260"/>
-        <nd ref="-528"/>
-        <nd ref="-6261"/>
-        <nd ref="-530"/>
-        <nd ref="-532"/>
-        <nd ref="-534"/>
-        <nd ref="-6262"/>
-        <nd ref="-536"/>
-        <nd ref="-6263"/>
-        <nd ref="-538"/>
-        <nd ref="-22575"/>
-        <tag k="alt_name" v="G St NW"/>
-        <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="3.53553"/>
     </way>
@@ -18520,6 +16840,21 @@
         <tag k="error:circular" v="3.53553"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21390"/>
+        <nd ref="-3884"/>
+        <nd ref="-6225"/>
+        <nd ref="-3885"/>
+        <nd ref="-6226"/>
+        <nd ref="-3886"/>
+        <nd ref="-6227"/>
+        <nd ref="-6228"/>
+        <nd ref="-3887"/>
+        <nd ref="-3888"/>
+        <nd ref="-6229"/>
+        <nd ref="-3889"/>
+        <nd ref="-3890"/>
+        <nd ref="-6231"/>
+        <nd ref="-3891"/>
         <nd ref="-21313"/>
         <nd ref="-486"/>
         <nd ref="-488"/>
@@ -18529,6 +16864,24 @@
         <nd ref="-6235"/>
         <nd ref="-494"/>
         <nd ref="-21456"/>
+        <nd ref="-3892"/>
+        <nd ref="-3893"/>
+        <nd ref="-6237"/>
+        <nd ref="-6239"/>
+        <nd ref="-3894"/>
+        <nd ref="-6241"/>
+        <nd ref="-3895"/>
+        <nd ref="-3896"/>
+        <nd ref="-21918"/>
+        <nd ref="-3897"/>
+        <nd ref="-6243"/>
+        <nd ref="-3898"/>
+        <nd ref="-3899"/>
+        <nd ref="-3900"/>
+        <nd ref="-3901"/>
+        <nd ref="-3902"/>
+        <nd ref="-3903"/>
+        <nd ref="-22060"/>
         <tag k="alt_name" v="G St NW"/>
         <tag k="name" v="G ST NW"/>
         <tag k="highway" v="road"/>

--- a/test-files/cmd/slow/ConflateCmdHighwayExactMatchInputsTest/output.osm
+++ b/test-files/cmd/slow/ConflateCmdHighwayExactMatchInputsTest/output.osm
@@ -12653,21 +12653,6 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="-1"/>
     </node>
-    <way visible="true" id="-8705" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1188"/>
-        <nd ref="-1187"/>
-        <nd ref="-1186"/>
-        <nd ref="-1185"/>
-        <nd ref="-1184"/>
-        <nd ref="-1183"/>
-        <nd ref="-1031"/>
-        <tag k="alt_name" v="Constitution Ave NW"/>
-        <tag k="name" v="US Hwy 50"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8705"/>
-    </way>
     <way visible="true" id="-8696" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-274"/>
         <nd ref="-273"/>
@@ -12677,23 +12662,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8696"/>
-    </way>
-    <way visible="true" id="-8687" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2446"/>
-        <nd ref="-2448"/>
-        <nd ref="-2450"/>
-        <nd ref="-2452"/>
-        <nd ref="-2454"/>
-        <tag k="hoot:score:review" v="0.025"/>
-        <tag k="hoot:score:match" v="0.125"/>
-        <tag k="hoot:score:miss" v="0.85"/>
-        <tag k="uuid" v="{e65cad39-b0dd-5a29-b8f0-2574adc5cfa1}"/>
-        <tag k="name" v="E St NW"/>
-        <tag k="hoot:score:uuid" v="{676e01e6-70fc-512f-9d4c-dbfb4b5df977}"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8687"/>
     </way>
     <way visible="true" id="-8684" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1219"/>
@@ -12822,6 +12790,47 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8669"/>
+    </way>
+    <way visible="true" id="-8666" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2815"/>
+        <nd ref="-352"/>
+        <nd ref="-353"/>
+        <nd ref="-354"/>
+        <nd ref="-355"/>
+        <nd ref="-356"/>
+        <nd ref="-1676"/>
+        <nd ref="-357"/>
+        <nd ref="-358"/>
+        <nd ref="-359"/>
+        <nd ref="-2591"/>
+        <nd ref="-360"/>
+        <nd ref="-361"/>
+        <nd ref="-362"/>
+        <nd ref="-1698"/>
+        <nd ref="-363"/>
+        <nd ref="-365"/>
+        <nd ref="-367"/>
+        <nd ref="-368"/>
+        <nd ref="-369"/>
+        <nd ref="-370"/>
+        <nd ref="-371"/>
+        <nd ref="-3026"/>
+        <nd ref="-372"/>
+        <nd ref="-374"/>
+        <nd ref="-376"/>
+        <nd ref="-378"/>
+        <nd ref="-1570"/>
+        <nd ref="-380"/>
+        <nd ref="-345"/>
+        <nd ref="-382"/>
+        <nd ref="-1078"/>
+        <nd ref="-384"/>
+        <nd ref="-2837"/>
+        <tag k="name" v="I St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8666"/>
     </way>
     <way visible="true" id="-8663" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2446"/>
@@ -12998,29 +13007,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8603"/>
     </way>
-    <way visible="true" id="-8594" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1173"/>
-        <nd ref="-1796"/>
-        <nd ref="-1799"/>
-        <nd ref="-1802"/>
-        <nd ref="-1805"/>
-        <nd ref="-1808"/>
-        <nd ref="-1811"/>
-        <nd ref="-1814"/>
-        <nd ref="-1817"/>
-        <nd ref="-1820"/>
-        <nd ref="-1823"/>
-        <nd ref="-1825"/>
-        <nd ref="-1827"/>
-        <nd ref="-1829"/>
-        <nd ref="-1831"/>
-        <nd ref="-1833"/>
-        <tag k="name" v="Jefferson Dr SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8594"/>
-    </way>
     <way visible="true" id="-8588" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1527"/>
         <nd ref="-1530"/>
@@ -13103,6 +13089,35 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8567"/>
+    </way>
+    <way visible="true" id="-8564" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1031"/>
+        <nd ref="-1032"/>
+        <nd ref="-1033"/>
+        <nd ref="-1034"/>
+        <nd ref="-1035"/>
+        <nd ref="-1036"/>
+        <nd ref="-1037"/>
+        <nd ref="-1038"/>
+        <nd ref="-1039"/>
+        <nd ref="-1040"/>
+        <nd ref="-1041"/>
+        <nd ref="-1042"/>
+        <nd ref="-1043"/>
+        <nd ref="-1044"/>
+        <nd ref="-1045"/>
+        <nd ref="-1046"/>
+        <nd ref="-1047"/>
+        <nd ref="-1048"/>
+        <nd ref="-1049"/>
+        <nd ref="-1050"/>
+        <nd ref="-1052"/>
+        <nd ref="-1054"/>
+        <tag k="name" v="18th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8564"/>
     </way>
     <way visible="true" id="-8558" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2720"/>
@@ -13218,6 +13233,20 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8540"/>
     </way>
+    <way visible="true" id="-8537" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-3021"/>
+        <nd ref="-3020"/>
+        <nd ref="-3019"/>
+        <nd ref="-3018"/>
+        <nd ref="-3017"/>
+        <nd ref="-1827"/>
+        <tag k="alt_name" v="14th St SW;US Hwy 1"/>
+        <tag k="name" v="14th St NW"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8537"/>
+    </way>
     <way visible="true" id="-8534" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2388"/>
         <nd ref="-2391"/>
@@ -13253,6 +13282,48 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8525"/>
     </way>
+    <way visible="true" id="-8522" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-853"/>
+        <nd ref="-1779"/>
+        <nd ref="-1780"/>
+        <nd ref="-1781"/>
+        <nd ref="-1782"/>
+        <nd ref="-1783"/>
+        <nd ref="-1784"/>
+        <nd ref="-1785"/>
+        <nd ref="-1786"/>
+        <nd ref="-1787"/>
+        <nd ref="-1788"/>
+        <nd ref="-1789"/>
+        <nd ref="-1790"/>
+        <nd ref="-1791"/>
+        <nd ref="-1792"/>
+        <nd ref="-1793"/>
+        <nd ref="-1794"/>
+        <nd ref="-1797"/>
+        <nd ref="-1800"/>
+        <nd ref="-1803"/>
+        <nd ref="-1806"/>
+        <nd ref="-1809"/>
+        <nd ref="-1812"/>
+        <nd ref="-1815"/>
+        <nd ref="-1818"/>
+        <nd ref="-1821"/>
+        <nd ref="-1824"/>
+        <nd ref="-1826"/>
+        <nd ref="-1828"/>
+        <nd ref="-1830"/>
+        <nd ref="-1832"/>
+        <nd ref="-1834"/>
+        <nd ref="-1836"/>
+        <nd ref="-753"/>
+        <nd ref="-2668"/>
+        <tag k="name" v="25th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8522"/>
+    </way>
     <way visible="true" id="-8513" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2728"/>
         <nd ref="-1569"/>
@@ -13280,16 +13351,10 @@
         <tag k="hoot:id" v="-8507"/>
     </way>
     <way visible="true" id="-8504" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1165"/>
-        <nd ref="-2568"/>
-        <nd ref="-2569"/>
-        <nd ref="-2570"/>
-        <nd ref="-2571"/>
-        <nd ref="-2572"/>
-        <nd ref="-2573"/>
-        <nd ref="-2574"/>
         <nd ref="-2397"/>
         <nd ref="-2575"/>
+        <nd ref="-2576"/>
+        <tag k="alt_name" v="Pennsylvania Ave NW"/>
         <tag k="name" v="15th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
@@ -13319,6 +13384,27 @@
         <nd ref="-675"/>
         <nd ref="-677"/>
         <nd ref="-1833"/>
+        <nd ref="-679"/>
+        <nd ref="-681"/>
+        <nd ref="-684"/>
+        <nd ref="-687"/>
+        <nd ref="-690"/>
+        <nd ref="-693"/>
+        <nd ref="-696"/>
+        <nd ref="-699"/>
+        <nd ref="-702"/>
+        <nd ref="-705"/>
+        <nd ref="-707"/>
+        <nd ref="-2139"/>
+        <nd ref="-709"/>
+        <nd ref="-711"/>
+        <nd ref="-2669"/>
+        <nd ref="-713"/>
+        <nd ref="-715"/>
+        <nd ref="-717"/>
+        <nd ref="-719"/>
+        <nd ref="-721"/>
+        <nd ref="-1835"/>
         <tag k="alt_name" v="15th St SW"/>
         <tag k="name" v="Raoul Wallenberg Pl SW"/>
         <tag k="highway" v="unclassified"/>
@@ -13388,16 +13474,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8480"/>
     </way>
-    <way visible="true" id="-8474" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2575"/>
-        <nd ref="-2576"/>
-        <tag k="alt_name" v="15th St NW"/>
-        <tag k="name" v="Pennsylvania Ave NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8474"/>
-    </way>
     <way visible="true" id="-8471" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1545"/>
         <nd ref="-238"/>
@@ -13407,6 +13483,26 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8471"/>
+    </way>
+    <way visible="true" id="-8468" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-373"/>
+        <nd ref="-375"/>
+        <nd ref="-377"/>
+        <nd ref="-379"/>
+        <nd ref="-381"/>
+        <nd ref="-383"/>
+        <nd ref="-385"/>
+        <nd ref="-387"/>
+        <nd ref="-389"/>
+        <nd ref="-391"/>
+        <nd ref="-393"/>
+        <nd ref="-395"/>
+        <nd ref="-397"/>
+        <tag k="name" v="26th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8468"/>
     </way>
     <way visible="true" id="-8465" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1112"/>
@@ -13607,26 +13703,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8369"/>
     </way>
-    <way visible="true" id="-8363" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1600"/>
-        <nd ref="-1749"/>
-        <nd ref="-1751"/>
-        <nd ref="-1753"/>
-        <nd ref="-1755"/>
-        <nd ref="-1757"/>
-        <nd ref="-1759"/>
-        <nd ref="-1761"/>
-        <nd ref="-76"/>
-        <nd ref="-1763"/>
-        <nd ref="-779"/>
-        <nd ref="-17"/>
-        <nd ref="-738"/>
-        <tag k="name" v="22nd St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8363"/>
-    </way>
     <way visible="true" id="-8354" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1665"/>
         <nd ref="-1668"/>
@@ -13648,44 +13724,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8348"/>
-    </way>
-    <way visible="true" id="-8345" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2693"/>
-        <nd ref="-1173"/>
-        <tag k="name" v="Jefferson Dr SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8345"/>
-    </way>
-    <way visible="true" id="-8342" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-373"/>
-        <nd ref="-375"/>
-        <nd ref="-377"/>
-        <nd ref="-379"/>
-        <nd ref="-381"/>
-        <nd ref="-383"/>
-        <nd ref="-385"/>
-        <nd ref="-387"/>
-        <nd ref="-389"/>
-        <nd ref="-391"/>
-        <nd ref="-393"/>
-        <nd ref="-395"/>
-        <nd ref="-397"/>
-        <nd ref="-399"/>
-        <nd ref="-401"/>
-        <nd ref="-403"/>
-        <nd ref="-405"/>
-        <nd ref="-407"/>
-        <nd ref="-756"/>
-        <nd ref="-409"/>
-        <nd ref="-411"/>
-        <nd ref="-2680"/>
-        <tag k="name" v="26th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8342"/>
     </way>
     <way visible="true" id="-8339" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-781"/>
@@ -13775,19 +13813,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8312"/>
     </way>
-    <way visible="true" id="-8309" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-738"/>
-        <nd ref="-2295"/>
-        <nd ref="-1765"/>
-        <nd ref="-1767"/>
-        <nd ref="-1769"/>
-        <nd ref="-2729"/>
-        <tag k="name" v="22nd St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8309"/>
-    </way>
     <way visible="true" id="-8306" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1182"/>
         <nd ref="-1852"/>
@@ -13822,6 +13847,31 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8291"/>
+    </way>
+    <way visible="true" id="-8288" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2103"/>
+        <nd ref="-2106"/>
+        <nd ref="-2109"/>
+        <nd ref="-2112"/>
+        <nd ref="-2115"/>
+        <nd ref="-2118"/>
+        <nd ref="-2121"/>
+        <nd ref="-2123"/>
+        <nd ref="-2126"/>
+        <nd ref="-2129"/>
+        <nd ref="-2132"/>
+        <nd ref="-2135"/>
+        <nd ref="-2138"/>
+        <nd ref="-2141"/>
+        <nd ref="-2144"/>
+        <nd ref="-2147"/>
+        <nd ref="-2150"/>
+        <nd ref="-977"/>
+        <tag k="name" v="H St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8288"/>
     </way>
     <way visible="true" id="-8285" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2750"/>
@@ -13862,49 +13912,22 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8279"/>
     </way>
-    <way visible="true" id="-8264" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1600"/>
-        <nd ref="-1601"/>
-        <nd ref="-1602"/>
-        <nd ref="-1603"/>
-        <nd ref="-1604"/>
-        <nd ref="-1605"/>
-        <nd ref="-1606"/>
-        <nd ref="-1607"/>
-        <nd ref="-1608"/>
-        <nd ref="-1609"/>
-        <nd ref="-1610"/>
-        <nd ref="-1611"/>
-        <nd ref="-1612"/>
-        <nd ref="-1613"/>
-        <nd ref="-1614"/>
-        <nd ref="-1009"/>
-        <nd ref="-1426"/>
-        <nd ref="-1615"/>
-        <nd ref="-1616"/>
-        <nd ref="-1617"/>
-        <nd ref="-1618"/>
-        <nd ref="-1619"/>
-        <nd ref="-1620"/>
-        <nd ref="-1621"/>
-        <nd ref="-304"/>
-        <nd ref="-1622"/>
-        <nd ref="-1623"/>
-        <nd ref="-1821"/>
-        <nd ref="-1624"/>
-        <nd ref="-1625"/>
-        <nd ref="-1626"/>
-        <nd ref="-1627"/>
-        <nd ref="-1628"/>
-        <nd ref="-1629"/>
-        <nd ref="-373"/>
-        <nd ref="-1630"/>
-        <nd ref="-1631"/>
-        <tag k="name" v="I St NW"/>
+    <way visible="true" id="-8273" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-397"/>
+        <nd ref="-399"/>
+        <nd ref="-401"/>
+        <nd ref="-403"/>
+        <nd ref="-405"/>
+        <nd ref="-407"/>
+        <nd ref="-756"/>
+        <nd ref="-409"/>
+        <nd ref="-411"/>
+        <nd ref="-2680"/>
+        <tag k="name" v="26th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8264"/>
+        <tag k="hoot:id" v="-8273"/>
     </way>
     <way visible="true" id="-8255" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1527"/>
@@ -14006,25 +14029,41 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8240"/>
     </way>
-    <way visible="true" id="-8231" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-785"/>
-        <nd ref="-3042"/>
-        <nd ref="-3043"/>
-        <nd ref="-3044"/>
-        <nd ref="-3045"/>
-        <nd ref="-3046"/>
-        <nd ref="-3047"/>
-        <nd ref="-3049"/>
-        <nd ref="-1349"/>
-        <nd ref="-3051"/>
-        <nd ref="-3053"/>
-        <nd ref="-3055"/>
-        <nd ref="-3056"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
+    <way visible="true" id="-8234" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2787"/>
+        <nd ref="-1583"/>
+        <nd ref="-388"/>
+        <nd ref="-1584"/>
+        <nd ref="-1586"/>
+        <nd ref="-1588"/>
+        <nd ref="-1590"/>
+        <nd ref="-1592"/>
+        <nd ref="-1594"/>
+        <nd ref="-1596"/>
+        <nd ref="-1598"/>
+        <nd ref="-1599"/>
+        <nd ref="-1600"/>
+        <nd ref="-1601"/>
+        <nd ref="-1602"/>
+        <nd ref="-1603"/>
+        <nd ref="-1604"/>
+        <nd ref="-1605"/>
+        <nd ref="-1606"/>
+        <nd ref="-1607"/>
+        <nd ref="-1608"/>
+        <nd ref="-1609"/>
+        <nd ref="-1610"/>
+        <nd ref="-1611"/>
+        <nd ref="-1612"/>
+        <nd ref="-1613"/>
+        <nd ref="-1614"/>
+        <nd ref="-1009"/>
+        <nd ref="-1426"/>
+        <tag k="name" v="I St NW"/>
+        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8231"/>
+        <tag k="hoot:id" v="-8234"/>
     </way>
     <way visible="true" id="-8228" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2168"/>
@@ -14064,12 +14103,43 @@
         <nd ref="-857"/>
         <nd ref="-1189"/>
         <nd ref="-1188"/>
+        <nd ref="-1187"/>
+        <nd ref="-1186"/>
+        <nd ref="-1185"/>
+        <nd ref="-1184"/>
+        <nd ref="-1183"/>
+        <nd ref="-1031"/>
         <tag k="alt_name" v="Constitution Ave NW"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8222"/>
+    </way>
+    <way visible="true" id="-8219" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-779"/>
+        <nd ref="-17"/>
+        <nd ref="-738"/>
+        <nd ref="-2295"/>
+        <nd ref="-1765"/>
+        <nd ref="-1767"/>
+        <nd ref="-1769"/>
+        <nd ref="-2729"/>
+        <tag k="name" v="22nd St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8219"/>
+    </way>
+    <way visible="true" id="-8216" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1137"/>
+        <nd ref="-1138"/>
+        <nd ref="-904"/>
+        <tag k="name" v="E St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-8216"/>
     </way>
     <way visible="true" id="-8213" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-732"/>
@@ -14087,7 +14157,6 @@
         <tag k="hoot:id" v="-8213"/>
     </way>
     <way visible="true" id="-8210" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3017"/>
         <nd ref="-1827"/>
         <nd ref="-1680"/>
         <tag k="alt_name" v="US Hwy 1"/>
@@ -14096,19 +14165,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8210"/>
-    </way>
-    <way visible="true" id="-8207" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1830"/>
-        <nd ref="-1832"/>
-        <nd ref="-1834"/>
-        <nd ref="-1836"/>
-        <nd ref="-753"/>
-        <nd ref="-2668"/>
-        <tag k="name" v="25th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8207"/>
     </way>
     <way visible="true" id="-8204" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-900"/>
@@ -14181,43 +14237,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8183"/>
-    </way>
-    <way visible="true" id="-8180" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-853"/>
-        <nd ref="-1779"/>
-        <nd ref="-1780"/>
-        <nd ref="-1781"/>
-        <nd ref="-1782"/>
-        <nd ref="-1783"/>
-        <nd ref="-1784"/>
-        <nd ref="-1785"/>
-        <nd ref="-1786"/>
-        <nd ref="-1787"/>
-        <nd ref="-1788"/>
-        <nd ref="-1789"/>
-        <nd ref="-1790"/>
-        <nd ref="-1791"/>
-        <nd ref="-1792"/>
-        <nd ref="-1793"/>
-        <nd ref="-1794"/>
-        <nd ref="-1797"/>
-        <nd ref="-1800"/>
-        <nd ref="-1803"/>
-        <nd ref="-1806"/>
-        <nd ref="-1809"/>
-        <nd ref="-1812"/>
-        <nd ref="-1815"/>
-        <nd ref="-1818"/>
-        <nd ref="-1821"/>
-        <nd ref="-1824"/>
-        <nd ref="-1826"/>
-        <nd ref="-1828"/>
-        <nd ref="-1830"/>
-        <tag k="name" v="25th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-8180"/>
     </way>
     <way visible="true" id="-8174" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1438"/>
@@ -14686,16 +14705,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-8006"/>
     </way>
-    <way visible="true" id="-7997" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1137"/>
-        <nd ref="-1138"/>
-        <nd ref="-904"/>
-        <tag k="name" v="E St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7997"/>
-    </way>
     <way visible="true" id="-7985" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1437"/>
         <nd ref="-2689"/>
@@ -14728,6 +14737,24 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7979"/>
+    </way>
+    <way visible="true" id="-7976" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2073"/>
+        <nd ref="-2076"/>
+        <nd ref="-2079"/>
+        <nd ref="-2082"/>
+        <nd ref="-2085"/>
+        <nd ref="-2088"/>
+        <nd ref="-2091"/>
+        <nd ref="-2094"/>
+        <nd ref="-2097"/>
+        <nd ref="-2100"/>
+        <nd ref="-2103"/>
+        <tag k="name" v="H St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7976"/>
     </way>
     <way visible="true" id="-7964" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1518"/>
@@ -14806,33 +14833,44 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7937"/>
     </way>
-    <way visible="true" id="-7934" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2454"/>
-        <nd ref="-2456"/>
-        <nd ref="-2458"/>
-        <nd ref="-2119"/>
-        <nd ref="-2460"/>
-        <nd ref="-2462"/>
-        <nd ref="-2464"/>
-        <nd ref="-2466"/>
-        <nd ref="-2468"/>
-        <nd ref="-2471"/>
-        <nd ref="-1041"/>
-        <nd ref="-2474"/>
-        <nd ref="-2477"/>
-        <nd ref="-2480"/>
-        <nd ref="-2483"/>
-        <nd ref="-2485"/>
-        <nd ref="-2487"/>
-        <nd ref="-2489"/>
-        <nd ref="-2491"/>
-        <nd ref="-2493"/>
-        <nd ref="-2495"/>
-        <tag k="name" v="E St NW"/>
+    <way visible="true" id="-7931" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-781"/>
+        <nd ref="-2889"/>
+        <nd ref="-2890"/>
+        <nd ref="-2891"/>
+        <nd ref="-2892"/>
+        <nd ref="-2893"/>
+        <tag k="name" v="25th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7934"/>
+        <tag k="hoot:id" v="-7931"/>
+    </way>
+    <way visible="true" id="-7922" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2484"/>
+        <nd ref="-2486"/>
+        <nd ref="-2488"/>
+        <nd ref="-2490"/>
+        <nd ref="-2492"/>
+        <nd ref="-2494"/>
+        <nd ref="-2496"/>
+        <nd ref="-2498"/>
+        <nd ref="-2500"/>
+        <nd ref="-2502"/>
+        <nd ref="-2504"/>
+        <nd ref="-2506"/>
+        <nd ref="-2508"/>
+        <nd ref="-2510"/>
+        <nd ref="-2512"/>
+        <nd ref="-2514"/>
+        <nd ref="-2516"/>
+        <nd ref="-2517"/>
+        <nd ref="-2518"/>
+        <tag k="name" v="Ohio Dr SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7922"/>
     </way>
     <way visible="true" id="-7919" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3042"/>
@@ -15038,6 +15076,34 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7857"/>
     </way>
+    <way visible="true" id="-7854" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1426"/>
+        <nd ref="-1615"/>
+        <nd ref="-1616"/>
+        <nd ref="-1617"/>
+        <nd ref="-1618"/>
+        <nd ref="-1619"/>
+        <nd ref="-1620"/>
+        <nd ref="-1621"/>
+        <nd ref="-304"/>
+        <nd ref="-1622"/>
+        <nd ref="-1623"/>
+        <nd ref="-1821"/>
+        <nd ref="-1624"/>
+        <nd ref="-1625"/>
+        <nd ref="-1626"/>
+        <nd ref="-1627"/>
+        <nd ref="-1628"/>
+        <nd ref="-1629"/>
+        <nd ref="-373"/>
+        <nd ref="-1630"/>
+        <nd ref="-1631"/>
+        <tag k="name" v="I St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7854"/>
+    </way>
     <way visible="true" id="-7851" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1548"/>
         <nd ref="-1551"/>
@@ -15172,6 +15238,10 @@
         <tag k="hoot:id" v="-7779"/>
     </way>
     <way visible="true" id="-7776" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2581"/>
+        <nd ref="-2583"/>
+        <nd ref="-2585"/>
+        <nd ref="-2587"/>
         <nd ref="-2019"/>
         <nd ref="-1351"/>
         <nd ref="-2589"/>
@@ -15373,11 +15443,6 @@
         <tag k="hoot:id" v="-7710"/>
     </way>
     <way visible="true" id="-7707" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-781"/>
-        <nd ref="-2889"/>
-        <nd ref="-2890"/>
-        <nd ref="-2891"/>
-        <nd ref="-2892"/>
         <nd ref="-2893"/>
         <nd ref="-2894"/>
         <nd ref="-2895"/>
@@ -15385,6 +15450,17 @@
         <nd ref="-2897"/>
         <nd ref="-2898"/>
         <nd ref="-2374"/>
+        <nd ref="-2375"/>
+        <nd ref="-2376"/>
+        <nd ref="-2377"/>
+        <nd ref="-2378"/>
+        <nd ref="-2379"/>
+        <nd ref="-2380"/>
+        <nd ref="-2381"/>
+        <nd ref="-2382"/>
+        <nd ref="-2383"/>
+        <nd ref="-2384"/>
+        <tag k="alt_name" v="New Hampshire Ave NW"/>
         <tag k="name" v="25th St NW"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
@@ -15667,53 +15743,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7599"/>
-    </way>
-    <way visible="true" id="-7590" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1031"/>
-        <nd ref="-1032"/>
-        <nd ref="-1033"/>
-        <nd ref="-1034"/>
-        <nd ref="-1035"/>
-        <nd ref="-1036"/>
-        <nd ref="-1037"/>
-        <nd ref="-1038"/>
-        <nd ref="-1039"/>
-        <nd ref="-1040"/>
-        <nd ref="-1041"/>
-        <nd ref="-1042"/>
-        <nd ref="-1043"/>
-        <nd ref="-1044"/>
-        <nd ref="-1045"/>
-        <nd ref="-1046"/>
-        <nd ref="-1047"/>
-        <nd ref="-1048"/>
-        <nd ref="-1049"/>
-        <nd ref="-1050"/>
-        <nd ref="-1052"/>
-        <nd ref="-1054"/>
-        <nd ref="-1056"/>
-        <nd ref="-1058"/>
-        <nd ref="-1060"/>
-        <nd ref="-1062"/>
-        <nd ref="-1064"/>
-        <nd ref="-1066"/>
-        <nd ref="-1068"/>
-        <nd ref="-1070"/>
-        <nd ref="-1072"/>
-        <nd ref="-1074"/>
-        <nd ref="-1076"/>
-        <nd ref="-1078"/>
-        <nd ref="-1080"/>
-        <nd ref="-1082"/>
-        <nd ref="-1084"/>
-        <nd ref="-1086"/>
-        <nd ref="-1088"/>
-        <nd ref="-2654"/>
-        <tag k="name" v="18th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7590"/>
     </way>
     <way visible="true" id="-7584" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1383"/>
@@ -16004,33 +16033,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7503"/>
-    </way>
-    <way visible="true" id="-7497" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-800"/>
-        <nd ref="-803"/>
-        <nd ref="-806"/>
-        <nd ref="-809"/>
-        <nd ref="-812"/>
-        <nd ref="-815"/>
-        <nd ref="-818"/>
-        <nd ref="-821"/>
-        <nd ref="-824"/>
-        <nd ref="-827"/>
-        <nd ref="-830"/>
-        <nd ref="-833"/>
-        <nd ref="-836"/>
-        <nd ref="-839"/>
-        <nd ref="-842"/>
-        <nd ref="-845"/>
-        <nd ref="-848"/>
-        <nd ref="-851"/>
-        <nd ref="-853"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="Whitehurst Fwy Rmp"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7497"/>
     </way>
     <way visible="true" id="-7488" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2503"/>
@@ -16452,6 +16454,24 @@
         <nd ref="-2548"/>
         <nd ref="-2549"/>
         <nd ref="-2550"/>
+        <nd ref="-2551"/>
+        <nd ref="-2552"/>
+        <nd ref="-2553"/>
+        <nd ref="-2554"/>
+        <nd ref="-2555"/>
+        <nd ref="-2556"/>
+        <nd ref="-2557"/>
+        <nd ref="-2558"/>
+        <nd ref="-2559"/>
+        <nd ref="-2560"/>
+        <nd ref="-2561"/>
+        <nd ref="-2562"/>
+        <nd ref="-2563"/>
+        <nd ref="-2564"/>
+        <nd ref="-2565"/>
+        <nd ref="-2566"/>
+        <nd ref="-2567"/>
+        <nd ref="-1165"/>
         <tag k="alt_name" v="Raoul Wallenberg Pl SW"/>
         <tag k="name" v="15th St NW"/>
         <tag k="highway" v="unclassified"/>
@@ -16716,6 +16736,24 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7275"/>
     </way>
+    <way visible="true" id="-7272" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1600"/>
+        <nd ref="-1749"/>
+        <nd ref="-1751"/>
+        <nd ref="-1753"/>
+        <nd ref="-1755"/>
+        <nd ref="-1757"/>
+        <nd ref="-1759"/>
+        <nd ref="-1761"/>
+        <nd ref="-76"/>
+        <nd ref="-1763"/>
+        <nd ref="-779"/>
+        <tag k="name" v="22nd St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7272"/>
+    </way>
     <way visible="true" id="-7269" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1437"/>
         <nd ref="-36"/>
@@ -16760,20 +16798,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7260"/>
-    </way>
-    <way visible="true" id="-7254" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-213"/>
-        <nd ref="-214"/>
-        <nd ref="-215"/>
-        <nd ref="-216"/>
-        <nd ref="-217"/>
-        <nd ref="-218"/>
-        <nd ref="-2111"/>
-        <tag k="name" v="I- 66"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7254"/>
     </way>
     <way visible="true" id="-7248" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2957"/>
@@ -16829,6 +16853,33 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7236"/>
     </way>
+    <way visible="true" id="-7233" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-800"/>
+        <nd ref="-803"/>
+        <nd ref="-806"/>
+        <nd ref="-809"/>
+        <nd ref="-812"/>
+        <nd ref="-815"/>
+        <nd ref="-818"/>
+        <nd ref="-821"/>
+        <nd ref="-824"/>
+        <nd ref="-827"/>
+        <nd ref="-830"/>
+        <nd ref="-833"/>
+        <nd ref="-836"/>
+        <nd ref="-839"/>
+        <nd ref="-842"/>
+        <nd ref="-845"/>
+        <nd ref="-848"/>
+        <nd ref="-851"/>
+        <nd ref="-853"/>
+        <tag k="alt_name" v="25th St NW"/>
+        <tag k="name" v="Whitehurst Fwy Rmp"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7233"/>
+    </way>
     <way visible="true" id="-7230" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1718"/>
         <nd ref="-3132"/>
@@ -16854,18 +16905,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7230"/>
-    </way>
-    <way visible="true" id="-7224" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2581"/>
-        <nd ref="-2583"/>
-        <nd ref="-2585"/>
-        <nd ref="-2587"/>
-        <nd ref="-2019"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7224"/>
     </way>
     <way visible="true" id="-7218" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1105"/>
@@ -16964,6 +17003,20 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7188"/>
+    </way>
+    <way visible="true" id="-7185" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <nd ref="-217"/>
+        <nd ref="-218"/>
+        <nd ref="-2111"/>
+        <tag k="name" v="I- 66"/>
+        <tag k="highway" v="primary"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7185"/>
     </way>
     <way visible="true" id="-7182" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1906"/>
@@ -17195,47 +17248,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7119"/>
     </way>
-    <way visible="true" id="-7116" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2815"/>
-        <nd ref="-352"/>
-        <nd ref="-353"/>
-        <nd ref="-354"/>
-        <nd ref="-355"/>
-        <nd ref="-356"/>
-        <nd ref="-1676"/>
-        <nd ref="-357"/>
-        <nd ref="-358"/>
-        <nd ref="-359"/>
-        <nd ref="-2591"/>
-        <nd ref="-360"/>
-        <nd ref="-361"/>
-        <nd ref="-362"/>
-        <nd ref="-1698"/>
-        <nd ref="-363"/>
-        <nd ref="-365"/>
-        <nd ref="-367"/>
-        <nd ref="-368"/>
-        <nd ref="-369"/>
-        <nd ref="-370"/>
-        <nd ref="-371"/>
-        <nd ref="-3026"/>
-        <nd ref="-372"/>
-        <nd ref="-374"/>
-        <nd ref="-376"/>
-        <nd ref="-378"/>
-        <nd ref="-1570"/>
-        <nd ref="-380"/>
-        <nd ref="-345"/>
-        <nd ref="-382"/>
-        <nd ref="-1078"/>
-        <nd ref="-384"/>
-        <nd ref="-2837"/>
-        <tag k="name" v="I St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7116"/>
-    </way>
     <way visible="true" id="-7101" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-207"/>
         <nd ref="-209"/>
@@ -17287,26 +17299,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7092"/>
-    </way>
-    <way visible="true" id="-7089" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2787"/>
-        <nd ref="-1583"/>
-        <nd ref="-388"/>
-        <nd ref="-1584"/>
-        <nd ref="-1586"/>
-        <nd ref="-1588"/>
-        <nd ref="-1590"/>
-        <nd ref="-1592"/>
-        <nd ref="-1594"/>
-        <nd ref="-1596"/>
-        <nd ref="-1598"/>
-        <nd ref="-1599"/>
-        <nd ref="-1600"/>
-        <tag k="name" v="I St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-7089"/>
     </way>
     <way visible="true" id="-7083" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2259"/>
@@ -17553,6 +17545,26 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-7029"/>
     </way>
+    <way visible="true" id="-7020" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-785"/>
+        <nd ref="-3042"/>
+        <nd ref="-3043"/>
+        <nd ref="-3044"/>
+        <nd ref="-3045"/>
+        <nd ref="-3046"/>
+        <nd ref="-3047"/>
+        <nd ref="-3049"/>
+        <nd ref="-1349"/>
+        <nd ref="-3051"/>
+        <nd ref="-3053"/>
+        <nd ref="-3055"/>
+        <nd ref="-3056"/>
+        <tag k="name" v="I- 66"/>
+        <tag k="highway" v="primary"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-7020"/>
+    </way>
     <way visible="true" id="-7014" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1877"/>
         <nd ref="-1879"/>
@@ -17629,10 +17641,6 @@
         <tag k="hoot:id" v="-7005"/>
     </way>
     <way visible="true" id="-7002" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3017"/>
-        <nd ref="-3018"/>
-        <nd ref="-3019"/>
-        <nd ref="-3020"/>
         <nd ref="-3021"/>
         <nd ref="-3022"/>
         <nd ref="-3023"/>
@@ -17786,6 +17794,36 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6972"/>
     </way>
+    <way visible="true" id="-6969" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2437"/>
+        <nd ref="-1192"/>
+        <nd ref="-2439"/>
+        <nd ref="-2441"/>
+        <nd ref="-2443"/>
+        <nd ref="-2445"/>
+        <nd ref="-2447"/>
+        <nd ref="-2449"/>
+        <nd ref="-2451"/>
+        <nd ref="-2453"/>
+        <nd ref="-2455"/>
+        <nd ref="-2457"/>
+        <nd ref="-2459"/>
+        <nd ref="-2461"/>
+        <nd ref="-2463"/>
+        <nd ref="-2465"/>
+        <nd ref="-2467"/>
+        <nd ref="-2469"/>
+        <nd ref="-2472"/>
+        <nd ref="-2475"/>
+        <nd ref="-2478"/>
+        <nd ref="-2481"/>
+        <nd ref="-2484"/>
+        <tag k="name" v="Ohio Dr SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-6969"/>
+    </way>
     <way visible="true" id="-6960" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1442"/>
         <nd ref="-1229"/>
@@ -17850,41 +17888,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6957"/>
     </way>
-    <way visible="true" id="-6951" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2073"/>
-        <nd ref="-2076"/>
-        <nd ref="-2079"/>
-        <nd ref="-2082"/>
-        <nd ref="-2085"/>
-        <nd ref="-2088"/>
-        <nd ref="-2091"/>
-        <nd ref="-2094"/>
-        <nd ref="-2097"/>
-        <nd ref="-2100"/>
-        <nd ref="-2103"/>
-        <nd ref="-2106"/>
-        <nd ref="-2109"/>
-        <nd ref="-2112"/>
-        <nd ref="-2115"/>
-        <nd ref="-2118"/>
-        <nd ref="-2121"/>
-        <nd ref="-2123"/>
-        <nd ref="-2126"/>
-        <nd ref="-2129"/>
-        <nd ref="-2132"/>
-        <nd ref="-2135"/>
-        <nd ref="-2138"/>
-        <nd ref="-2141"/>
-        <nd ref="-2144"/>
-        <nd ref="-2147"/>
-        <nd ref="-2150"/>
-        <nd ref="-977"/>
-        <tag k="name" v="H St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-6951"/>
-    </way>
     <way visible="true" id="-6948" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1482"/>
         <nd ref="-1483"/>
@@ -17895,25 +17898,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6948"/>
-    </way>
-    <way visible="true" id="-6939" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2374"/>
-        <nd ref="-2375"/>
-        <nd ref="-2376"/>
-        <nd ref="-2377"/>
-        <nd ref="-2378"/>
-        <nd ref="-2379"/>
-        <nd ref="-2380"/>
-        <nd ref="-2381"/>
-        <nd ref="-2382"/>
-        <nd ref="-2383"/>
-        <nd ref="-2384"/>
-        <tag k="alt_name" v="25th St NW"/>
-        <tag k="name" v="New Hampshire Ave NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-6939"/>
     </way>
     <way visible="true" id="-6936" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2599"/>
@@ -17955,8 +17939,17 @@
         <nd ref="-2442"/>
         <nd ref="-2444"/>
         <nd ref="-2446"/>
+        <nd ref="-2448"/>
+        <nd ref="-2450"/>
+        <nd ref="-2452"/>
+        <nd ref="-2454"/>
+        <tag k="hoot:score:review" v="0.025"/>
+        <tag k="hoot:score:match" v="0.125"/>
         <tag k="alt_name" v="E St NW"/>
+        <tag k="hoot:score:miss" v="0.85"/>
+        <tag k="uuid" v="{e65cad39-b0dd-5a29-b8f0-2574adc5cfa1}"/>
         <tag k="name" v="Ellipse Rd NW"/>
+        <tag k="hoot:score:uuid" v="{676e01e6-70fc-512f-9d4c-dbfb4b5df977}"/>
         <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
@@ -18018,6 +18011,34 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6903"/>
+    </way>
+    <way visible="true" id="-6900" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2454"/>
+        <nd ref="-2456"/>
+        <nd ref="-2458"/>
+        <nd ref="-2119"/>
+        <nd ref="-2460"/>
+        <nd ref="-2462"/>
+        <nd ref="-2464"/>
+        <nd ref="-2466"/>
+        <nd ref="-2468"/>
+        <nd ref="-2471"/>
+        <nd ref="-1041"/>
+        <nd ref="-2474"/>
+        <nd ref="-2477"/>
+        <nd ref="-2480"/>
+        <nd ref="-2483"/>
+        <nd ref="-2485"/>
+        <nd ref="-2487"/>
+        <nd ref="-2489"/>
+        <nd ref="-2491"/>
+        <nd ref="-2493"/>
+        <nd ref="-2495"/>
+        <tag k="name" v="E St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-6900"/>
     </way>
     <way visible="true" id="-6894" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1144"/>
@@ -18179,6 +18200,20 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6855"/>
+    </way>
+    <way visible="true" id="-6849" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1078"/>
+        <nd ref="-1080"/>
+        <nd ref="-1082"/>
+        <nd ref="-1084"/>
+        <nd ref="-1086"/>
+        <nd ref="-1088"/>
+        <nd ref="-2654"/>
+        <tag k="name" v="18th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-6849"/>
     </way>
     <way visible="true" id="-6846" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2373"/>
@@ -18600,33 +18635,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6759"/>
     </way>
-    <way visible="true" id="-6755" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2550"/>
-        <nd ref="-2551"/>
-        <nd ref="-2552"/>
-        <nd ref="-2553"/>
-        <nd ref="-2554"/>
-        <nd ref="-2555"/>
-        <nd ref="-2556"/>
-        <nd ref="-2557"/>
-        <nd ref="-2558"/>
-        <nd ref="-2559"/>
-        <nd ref="-2560"/>
-        <nd ref="-2561"/>
-        <nd ref="-2562"/>
-        <nd ref="-2563"/>
-        <nd ref="-2564"/>
-        <nd ref="-2565"/>
-        <nd ref="-2566"/>
-        <nd ref="-2567"/>
-        <nd ref="-1165"/>
-        <tag k="alt_name" v="Raoul Wallenberg Pl SW"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-6755"/>
-    </way>
     <way visible="true" id="-6749" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2623"/>
         <nd ref="-938"/>
@@ -18811,54 +18819,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6713"/>
     </way>
-    <way visible="true" id="-6710" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2437"/>
-        <nd ref="-1192"/>
-        <nd ref="-2439"/>
-        <nd ref="-2441"/>
-        <nd ref="-2443"/>
-        <nd ref="-2445"/>
-        <nd ref="-2447"/>
-        <nd ref="-2449"/>
-        <nd ref="-2451"/>
-        <nd ref="-2453"/>
-        <nd ref="-2455"/>
-        <nd ref="-2457"/>
-        <nd ref="-2459"/>
-        <nd ref="-2461"/>
-        <nd ref="-2463"/>
-        <nd ref="-2465"/>
-        <nd ref="-2467"/>
-        <nd ref="-2469"/>
-        <nd ref="-2472"/>
-        <nd ref="-2475"/>
-        <nd ref="-2478"/>
-        <nd ref="-2481"/>
-        <nd ref="-2484"/>
-        <nd ref="-2486"/>
-        <nd ref="-2488"/>
-        <nd ref="-2490"/>
-        <nd ref="-2492"/>
-        <nd ref="-2494"/>
-        <nd ref="-2496"/>
-        <nd ref="-2498"/>
-        <nd ref="-2500"/>
-        <nd ref="-2502"/>
-        <nd ref="-2504"/>
-        <nd ref="-2506"/>
-        <nd ref="-2508"/>
-        <nd ref="-2510"/>
-        <nd ref="-2512"/>
-        <nd ref="-2514"/>
-        <nd ref="-2516"/>
-        <nd ref="-2517"/>
-        <nd ref="-2518"/>
-        <tag k="name" v="Ohio Dr SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-6710"/>
-    </way>
     <way visible="true" id="-6707" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2424"/>
         <nd ref="-514"/>
@@ -19019,6 +18979,26 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6683"/>
     </way>
+    <way visible="true" id="-6680" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1054"/>
+        <nd ref="-1056"/>
+        <nd ref="-1058"/>
+        <nd ref="-1060"/>
+        <nd ref="-1062"/>
+        <nd ref="-1064"/>
+        <nd ref="-1066"/>
+        <nd ref="-1068"/>
+        <nd ref="-1070"/>
+        <nd ref="-1072"/>
+        <nd ref="-1074"/>
+        <nd ref="-1076"/>
+        <nd ref="-1078"/>
+        <tag k="name" v="18th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-6680"/>
+    </way>
     <way visible="true" id="-6677" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1863"/>
         <nd ref="-442"/>
@@ -19101,36 +19081,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6662"/>
     </way>
-    <way visible="true" id="-6659" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1833"/>
-        <nd ref="-679"/>
-        <nd ref="-681"/>
-        <nd ref="-684"/>
-        <nd ref="-687"/>
-        <nd ref="-690"/>
-        <nd ref="-693"/>
-        <nd ref="-696"/>
-        <nd ref="-699"/>
-        <nd ref="-702"/>
-        <nd ref="-705"/>
-        <nd ref="-707"/>
-        <nd ref="-2139"/>
-        <nd ref="-709"/>
-        <nd ref="-711"/>
-        <nd ref="-2669"/>
-        <nd ref="-713"/>
-        <nd ref="-715"/>
-        <nd ref="-717"/>
-        <nd ref="-719"/>
-        <nd ref="-721"/>
-        <nd ref="-1835"/>
-        <tag k="alt_name" v="15th St SW"/>
-        <tag k="name" v="Raoul Wallenberg Pl SW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-6659"/>
-    </way>
     <way visible="true" id="-6653" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2736"/>
         <nd ref="-787"/>
@@ -19157,6 +19107,30 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6653"/>
+    </way>
+    <way visible="true" id="-6647" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2693"/>
+        <nd ref="-1173"/>
+        <nd ref="-1796"/>
+        <nd ref="-1799"/>
+        <nd ref="-1802"/>
+        <nd ref="-1805"/>
+        <nd ref="-1808"/>
+        <nd ref="-1811"/>
+        <nd ref="-1814"/>
+        <nd ref="-1817"/>
+        <nd ref="-1820"/>
+        <nd ref="-1823"/>
+        <nd ref="-1825"/>
+        <nd ref="-1827"/>
+        <nd ref="-1829"/>
+        <nd ref="-1831"/>
+        <nd ref="-1833"/>
+        <tag k="name" v="Jefferson Dr SW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-6647"/>
     </way>
     <way visible="true" id="-6644" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2875"/>
@@ -19331,6 +19305,22 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-6611"/>
+    </way>
+    <way visible="true" id="-6605" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1165"/>
+        <nd ref="-2568"/>
+        <nd ref="-2569"/>
+        <nd ref="-2570"/>
+        <nd ref="-2571"/>
+        <nd ref="-2572"/>
+        <nd ref="-2573"/>
+        <nd ref="-2574"/>
+        <nd ref="-2397"/>
+        <tag k="name" v="15th St NW"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-6605"/>
     </way>
     <way visible="true" id="-6599" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2991"/>

--- a/test-files/cmd/slow/ConflateCmdStatsAllDataTypesTest.sh.stdout
+++ b/test-files/cmd/slow/ConflateCmdStatsAllDataTypesTest.sh.stdout
@@ -1,8 +1,8 @@
 stats = (stat) OR (input map 1 stat) (input map 2 stat) (output map stat)
 Node Count	117	116	144	
-Way Count	14	12	21	
+Way Count	14	12	18	
 Relation Count	0	0	9	
-Total Feature Count	25	22	38	
+Total Feature Count	25	22	35	
 Total Conflatable Features	25	22	0	
 Percentage of Total Features Conflatable	100	100	0	
 Untagged Feature Count	0	0	0	
@@ -12,13 +12,13 @@ Number of Match Creators	3	3	3
 Features Conflatable by: hoot::BuildingMatchCreator	10	8	0	
 Features Conflatable by: hoot::HighwayMatchCreator	4	4	0	
 Features Conflatable by: hoot::ScriptMatchCreator,PoiGeneric.js	11	10		
-Total Conflated Features	0	0	17	
-Percentage of Total Features Conflated	0	0	44.73684210526316	
+Total Conflated Features	0	0	14	
+Percentage of Total Features Conflated	0	0	40	
 Total Features Marked for Review	0	0	11	
-Percentage of Total Features Marked for Review	0	0	28.94736842105263	
+Percentage of Total Features Marked for Review	0	0	31.42857142857143	
 Total Number of Reviews to be Made	0	0	8	
 Total Unmatched Features	25	22	21	
-Percentage of Total Features Unmatched	100	100	55.26315789473685	
+Percentage of Total Features Unmatched	100	100	60	
 POI Count	11	10	16	
 Conflatable POIs	11	10	0	
 Conflated POIs	0	0	5	
@@ -28,15 +28,15 @@ Unmatched POIs	11	10	11
 Percentage of POIs Conflated	0	0	31.25	
 Percentage of POIs Marked for Review	0	0	68.75	
 Percentage of Unmatched POIs	100	100	68.75	
-Highway Count	4	4	8	
+Highway Count	4	4	5	
 Conflatable Highways	4	4	0	
-Conflated Highways	0	0	7	
+Conflated Highways	0	0	4	
 Highways Marked for Review	0	0	0	
 Number of Highway Reviews to be Made	0	0	0	
 Unmatched Highways	4	4	1	
-Percentage of Highways Conflated	0	0	87.5	
+Percentage of Highways Conflated	0	0	80	
 Percentage of Highways Marked for Review	0	0	0	
-Percentage of Unmatched Highways	100	100	12.5	
+Percentage of Unmatched Highways	100	100	20	
 Building Count	10	8	11	
 Conflatable Buildings	10	8	0	
 Conflated Buildings	0	0	4	
@@ -84,7 +84,7 @@ Meters Squared of Areas Processed by Conflation	0	0	0
 Percentage of Areas Conflated	0	0	0	
 Percentage of Areas Marked for Review	0	0	0	
 Percentage of Unmatched Areas	0	0	100	
-Difference Between Total Features in Output and Total Features in Inputs			-9	
-Percentage Difference Between Total Features in Output and Total Features in Inputs			-19.14893617021277	
+Difference Between Total Features in Output and Total Features in Inputs			-12	
+Percentage Difference Between Total Features in Output and Total Features in Inputs			-25.53191489361702	
 
-10:26:05.047 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 252) Conflation job completed.
+14:02:10.093 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 252) Conflation job completed.

--- a/test-files/cmd/slow/ConflateCmdStatsGenericRiversTest.sh.stdout
+++ b/test-files/cmd/slow/ConflateCmdStatsGenericRiversTest.sh.stdout
@@ -1,8 +1,8 @@
 stats = (stat) OR (input map 1 stat) (input map 2 stat) (output map stat)
 Node Count	338	176	428	
-Way Count	14	15	101	
-Relation Count	0	0	10	
-Total Feature Count	14	15	110	
+Way Count	14	15	99	
+Relation Count	0	0	7	
+Total Feature Count	14	15	105	
 Total Conflatable Features	14	15	0	
 Percentage of Total Features Conflatable	100	100	0	
 Untagged Feature Count	0	0	0	
@@ -10,13 +10,13 @@ Total Unconflatable Features	0	0	0
 Percentage of Total Features Unconflatable	0	0	0	
 Number of Match Creators	1	1	1	
 Features Conflatable by: hoot::ScriptMatchCreator,LinearWaterway.js	14	15	0	
-Total Conflated Features	0	0	20	
-Percentage of Total Features Conflated	0	0	18.18181818181818	
+Total Conflated Features	0	0	17	
+Percentage of Total Features Conflated	0	0	16.19047619047619	
 Total Features Marked for Review	0	0	3	
-Percentage of Total Features Marked for Review	0	0	2.727272727272727	
+Percentage of Total Features Marked for Review	0	0	2.857142857142857	
 Total Number of Reviews to be Made	0	0	1	
-Total Unmatched Features	14	15	90	
-Percentage of Total Features Unmatched	100	100	81.81818181818183	
+Total Unmatched Features	14	15	88	
+Percentage of Total Features Unmatched	100	100	83.80952380952381	
 POI Count	0	0	0	
 Conflatable POIs	0	0	0	
 Conflated POIs	0	0	0	
@@ -44,16 +44,16 @@ Unmatched Buildings	0	0	0
 Percentage of Buildings Conflated	0	0	0	
 Percentage of Buildings Marked for Review	0	0	0	
 Percentage of Unmatched Buildings	0	0	0	
-Waterway Count	14	15	110	
+Waterway Count	14	15	105	
 Conflatable Waterways	14	15	0	
-Conflated Waterways	0	0	20	
+Conflated Waterways	0	0	17	
 Waterways Marked for Review	0	0	3	
 Number of Waterway Reviews to be Made	0	0	1	
-Unmatched Waterways	14	15	90	
+Unmatched Waterways	14	15	88	
 Meters of Waterway Processed by Conflation	0	0	6644.163191439025	
-Percentage of Waterways Conflated	0	0	18.18181818181818	
-Percentage of Waterways Marked for Review	0	0	2.727272727272727	
-Percentage of Unmatched Waterways	100	100	81.81818181818183	
+Percentage of Waterways Conflated	0	0	16.19047619047619	
+Percentage of Waterways Marked for Review	0	0	2.857142857142857	
+Percentage of Unmatched Waterways	100	100	83.80952380952381	
 Polygon Conflatable POI Count	0	0	0	
 Conflatable Polygon Conflatable POIs	0	0	0	
 Conflated Polygon Conflatable POIs	0	0	0	
@@ -82,7 +82,7 @@ Meters Squared of Areas Processed by Conflation	0	0	0
 Percentage of Areas Conflated	0	0	0	
 Percentage of Areas Marked for Review	0	0	0	
 Percentage of Unmatched Areas	0	0	0	
-Difference Between Total Features in Output and Total Features in Inputs			81	
-Percentage Difference Between Total Features in Output and Total Features in Inputs			279.3103448275862	
+Difference Between Total Features in Output and Total Features in Inputs			76	
+Percentage Difference Between Total Features in Output and Total Features in Inputs			262.0689655172414	
 
-14:04:33.547 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 252) Conflation job completed.
+20:27:08.268 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 252) Conflation job completed.

--- a/test-files/cmd/slow/ConflateCmdStatsToyTest.sh.stdout
+++ b/test-files/cmd/slow/ConflateCmdStatsToyTest.sh.stdout
@@ -1,8 +1,8 @@
 stats = (stat) OR (input map 1 stat) (input map 2 stat) (output map stat)
 Node Count	36	65	37	
-Way Count	4	4	8	
+Way Count	4	4	4	
 Relation Count	0	0	0	
-Total Feature Count	4	4	8	
+Total Feature Count	4	4	4	
 Total Conflatable Features	4	4	0	
 Percentage of Total Features Conflatable	100	100	0	
 Untagged Feature Count	0	0	0	
@@ -10,13 +10,13 @@ Total Unconflatable Features	0	0	0
 Percentage of Total Features Unconflatable	0	0	0	
 Number of Match Creators	6	6	6	
 Features Conflatable by: hoot::HighwayMatchCreator	4	4	0	
-Total Conflated Features	0	0	7	
-Percentage of Total Features Conflated	0	0	87.5	
+Total Conflated Features	0	0	3	
+Percentage of Total Features Conflated	0	0	75	
 Total Features Marked for Review	0	0	0	
 Percentage of Total Features Marked for Review	0	0	0	
 Total Number of Reviews to be Made	0	0	0	
 Total Unmatched Features	4	4	1	
-Percentage of Total Features Unmatched	100	100	12.5	
+Percentage of Total Features Unmatched	100	100	25	
 POI Count	0	0	0	
 Conflatable POIs	0	0	0	
 Conflated POIs	0	0	0	
@@ -26,15 +26,15 @@ Unmatched POIs	0	0	0
 Percentage of POIs Conflated	0	0	0	
 Percentage of POIs Marked for Review	0	0	0	
 Percentage of Unmatched POIs	0	0	0	
-Highway Count	4	4	8	
+Highway Count	4	4	4	
 Conflatable Highways	4	4	0	
-Conflated Highways	0	0	7	
+Conflated Highways	0	0	3	
 Highways Marked for Review	0	0	0	
 Number of Highway Reviews to be Made	0	0	0	
 Unmatched Highways	4	4	1	
-Percentage of Highways Conflated	0	0	87.5	
+Percentage of Highways Conflated	0	0	75	
 Percentage of Highways Marked for Review	0	0	0	
-Percentage of Unmatched Highways	100	100	12.5	
+Percentage of Unmatched Highways	100	100	25	
 Building Count	0	0	0	
 Conflatable Buildings	0	0	0	
 Conflated Buildings	0	0	0	
@@ -82,7 +82,7 @@ Meters Squared of Areas Processed by Conflation	0	0	0
 Percentage of Areas Conflated	0	0	0	
 Percentage of Areas Marked for Review	0	0	0	
 Percentage of Unmatched Areas	0	0	0	
-Difference Between Total Features in Output and Total Features in Inputs			0	
-Percentage Difference Between Total Features in Output and Total Features in Inputs			0	
+Difference Between Total Features in Output and Total Features in Inputs			-4	
+Percentage Difference Between Total Features in Output and Total Features in Inputs			-50	
 
-10:26:04.730 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 252) Conflation job completed.
+14:02:09.783 INFO  .../hoot/core/cmd/ConflateCmd.cpp( 252) Conflation job completed.

--- a/test-files/cmd/slow/ConflateCmdTest/output.osm
+++ b/test-files/cmd/slow/ConflateCmdTest/output.osm
@@ -269,22 +269,34 @@
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30"/>
         <nd ref="-16"/>
-        <nd ref="-36"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36"/>
         <nd ref="-20"/>
         <tag k="note" v="2"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="-21"/>
+        <nd ref="-1"/>
+        <nd ref="-17"/>
+        <nd ref="-31"/>
+        <tag k="note" v="0"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31"/>
+        <nd ref="-13"/>
+        <nd ref="-34"/>
+        <nd ref="-270"/>
+        <nd ref="-20"/>
+        <nd ref="-9"/>
+        <nd ref="-4"/>
+        <nd ref="-24"/>
         <nd ref="-272"/>
         <nd ref="-8"/>
         <nd ref="-29"/>
@@ -305,36 +317,6 @@
         <nd ref="-28"/>
         <nd ref="-14"/>
         <nd ref="-35"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-34"/>
-        <nd ref="-270"/>
-        <nd ref="-20"/>
-        <nd ref="-9"/>
-        <nd ref="-4"/>
-        <nd ref="-24"/>
-        <nd ref="-272"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-21"/>
-        <nd ref="-1"/>
-        <nd ref="-17"/>
-        <nd ref="-31"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31"/>
-        <nd ref="-13"/>
         <tag k="note" v="0"/>
         <tag k="highway" v="road"/>
         <tag k="error:circular" v="15"/>

--- a/test-files/cmd/slow/ServiceHootApiDbConflateTest/output1.osm
+++ b/test-files/cmd/slow/ServiceHootApiDbConflateTest/output1.osm
@@ -833,18 +833,9 @@
         <tag k="error:circular" v="15"/>
         <tag k="hoot:id" v="-162"/>
     </way>
-    <way visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30"/>
         <nd ref="-16"/>
-        <nd ref="-36"/>
-        <tag k="note" v="2"/>
-        <tag k="hoot:id" v="-1559904"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-159"/>
-    </way>
-    <way visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36"/>
         <nd ref="-20"/>
         <tag k="note" v="2"/>
@@ -854,7 +845,28 @@
         <tag k="error:circular" v="15"/>
         <tag k="hoot:id" v="-155"/>
     </way>
-    <way visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="-21"/>
+        <nd ref="-1"/>
+        <nd ref="-17"/>
+        <nd ref="-31"/>
+        <tag k="note" v="0"/>
+        <tag k="hoot:id" v="-1559902"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="hoot:id" v="-141"/>
+    </way>
+    <way visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31"/>
+        <nd ref="-13"/>
+        <nd ref="-34"/>
+        <nd ref="-270"/>
+        <nd ref="-20"/>
+        <nd ref="-9"/>
+        <nd ref="-4"/>
+        <nd ref="-24"/>
         <nd ref="-272"/>
         <nd ref="-8"/>
         <nd ref="-29"/>
@@ -875,45 +887,6 @@
         <nd ref="-28"/>
         <nd ref="-14"/>
         <nd ref="-35"/>
-        <tag k="note" v="0"/>
-        <tag k="hoot:id" v="-1559902"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-152"/>
-    </way>
-    <way visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-34"/>
-        <nd ref="-270"/>
-        <nd ref="-20"/>
-        <nd ref="-9"/>
-        <nd ref="-4"/>
-        <nd ref="-24"/>
-        <nd ref="-272"/>
-        <tag k="note" v="0"/>
-        <tag k="hoot:id" v="-1559902"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-144"/>
-    </way>
-    <way visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-21"/>
-        <nd ref="-1"/>
-        <nd ref="-17"/>
-        <nd ref="-31"/>
-        <tag k="note" v="0"/>
-        <tag k="hoot:id" v="-1559902"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-141"/>
-    </way>
-    <way visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-31"/>
-        <nd ref="-13"/>
         <tag k="note" v="0"/>
         <tag k="hoot:id" v="-1559902"/>
         <tag k="highway" v="road"/>

--- a/test-files/cmd/slow/ServiceHootApiDbConflateTest/output2.osm
+++ b/test-files/cmd/slow/ServiceHootApiDbConflateTest/output2.osm
@@ -2618,22 +2618,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-680"/>
     </way>
-    <way visible="true" id="-676" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-921"/>
-        <nd ref="-93"/>
-        <nd ref="-238"/>
-        <nd ref="-239"/>
-        <nd ref="-240"/>
-        <nd ref="-241"/>
-        <tag k="hoot:id" v="-11205"/>
-        <tag k="alt_name" v="South Pl NW"/>
-        <tag k="name" v="SOUTH EXECUTIVE AVE NW"/>
-        <tag k="foot" v="designated"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-676"/>
-    </way>
     <way visible="true" id="-672" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-233"/>
         <nd ref="-234"/>
@@ -2675,57 +2659,17 @@
         <nd ref="-579"/>
         <nd ref="-580"/>
         <nd ref="-244"/>
+        <nd ref="-243"/>
+        <nd ref="-209"/>
+        <nd ref="-210"/>
+        <nd ref="-68"/>
         <tag k="hoot:id" v="-4979"/>
-        <tag k="alt_name" v="Constitution Ave NW"/>
+        <tag k="alt_name" v="CONSTITUTION AVE NW;Constitution Ave NW"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-667"/>
-    </way>
-    <way visible="true" id="-665" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-68"/>
-        <nd ref="-210"/>
-        <nd ref="-209"/>
-        <nd ref="-243"/>
-        <nd ref="-244"/>
-        <tag k="hoot:id" v="-10906"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-665"/>
-    </way>
-    <way visible="true" id="-662" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-52"/>
-        <nd ref="-220"/>
-        <nd ref="-219"/>
-        <nd ref="-218"/>
-        <nd ref="-216"/>
-        <nd ref="-214"/>
-        <nd ref="-213"/>
-        <nd ref="-212"/>
-        <nd ref="-916"/>
-        <tag k="hoot:id" v="-10907"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-662"/>
-    </way>
-    <way visible="true" id="-658" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-916"/>
-        <nd ref="-211"/>
-        <nd ref="-68"/>
-        <tag k="hoot:id" v="-10907"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-658"/>
     </way>
     <way visible="true" id="-655" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-914"/>
@@ -2737,6 +2681,16 @@
         <nd ref="-222"/>
         <nd ref="-221"/>
         <nd ref="-52"/>
+        <nd ref="-220"/>
+        <nd ref="-219"/>
+        <nd ref="-218"/>
+        <nd ref="-216"/>
+        <nd ref="-214"/>
+        <nd ref="-213"/>
+        <nd ref="-212"/>
+        <nd ref="-916"/>
+        <nd ref="-211"/>
+        <nd ref="-68"/>
         <tag k="hoot:id" v="-10908"/>
         <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
@@ -2744,19 +2698,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-655"/>
-    </way>
-    <way visible="true" id="-651" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-138"/>
-        <nd ref="-229"/>
-        <nd ref="-228"/>
-        <nd ref="-914"/>
-        <tag k="hoot:id" v="-10908"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-651"/>
     </way>
     <way visible="true" id="-648" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-52"/>
@@ -2773,25 +2714,6 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-648"/>
     </way>
-    <way visible="true" id="-646" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-252"/>
-        <nd ref="-561"/>
-        <nd ref="-562"/>
-        <nd ref="-563"/>
-        <nd ref="-564"/>
-        <nd ref="-565"/>
-        <nd ref="-566"/>
-        <nd ref="-567"/>
-        <nd ref="-568"/>
-        <nd ref="-569"/>
-        <nd ref="-570"/>
-        <tag k="hoot:id" v="-3762"/>
-        <tag k="name" v="E St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-646"/>
-    </way>
     <way visible="true" id="-644" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-73"/>
         <nd ref="-75"/>
@@ -2804,6 +2726,16 @@
         <nd ref="-250"/>
         <nd ref="-251"/>
         <nd ref="-252"/>
+        <nd ref="-561"/>
+        <nd ref="-562"/>
+        <nd ref="-563"/>
+        <nd ref="-564"/>
+        <nd ref="-565"/>
+        <nd ref="-566"/>
+        <nd ref="-567"/>
+        <nd ref="-568"/>
+        <nd ref="-569"/>
+        <nd ref="-570"/>
         <tag k="hoot:id" v="-9372"/>
         <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
@@ -2826,28 +2758,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-641"/>
-    </way>
-    <way visible="true" id="-638" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-208"/>
-        <nd ref="-90"/>
-        <nd ref="-89"/>
-        <nd ref="-88"/>
-        <nd ref="-87"/>
-        <nd ref="-86"/>
-        <nd ref="-85"/>
-        <nd ref="-84"/>
-        <nd ref="-83"/>
-        <nd ref="-82"/>
-        <nd ref="-81"/>
-        <nd ref="-80"/>
-        <nd ref="-1"/>
-        <tag k="hoot:id" v="-9374"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-638"/>
     </way>
     <way visible="true" id="-635" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-57"/>
@@ -2894,7 +2804,11 @@
         <tag k="error:circular" v="5"/>
         <tag k="hoot:id" v="-631"/>
     </way>
-    <way visible="true" id="-629" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-627" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-125"/>
+        <nd ref="-119"/>
+        <nd ref="-118"/>
+        <nd ref="-262"/>
         <nd ref="-263"/>
         <nd ref="-530"/>
         <nd ref="-531"/>
@@ -2913,19 +2827,6 @@
         <nd ref="-544"/>
         <nd ref="-545"/>
         <nd ref="-546"/>
-        <tag k="hoot:id" v="-3752"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-629"/>
-    </way>
-    <way visible="true" id="-627" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-125"/>
-        <nd ref="-119"/>
-        <nd ref="-118"/>
-        <nd ref="-262"/>
-        <nd ref="-263"/>
         <tag k="hoot:id" v="-12909"/>
         <tag k="alt_name" v="15th St NW"/>
         <tag k="name" v="15TH ST NW"/>
@@ -2995,138 +2896,11 @@
         <nd ref="-54"/>
         <nd ref="-53"/>
         <nd ref="-73"/>
-        <tag k="hoot:id" v="-12523"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-620"/>
-    </way>
-    <way visible="true" id="-617" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-61"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <tag k="hoot:id" v="-12524"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-617"/>
-    </way>
-    <way visible="true" id="-614" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-68"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-64"/>
-        <nd ref="-63"/>
-        <tag k="hoot:id" v="-12525"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-614"/>
-    </way>
-    <way visible="true" id="-611" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-292"/>
-        <nd ref="-293"/>
-        <nd ref="-294"/>
-        <nd ref="-295"/>
-        <nd ref="-296"/>
-        <nd ref="-70"/>
-        <nd ref="-69"/>
-        <nd ref="-68"/>
-        <tag k="hoot:id" v="-12526"/>
-        <tag k="alt_name" v="17th St NW"/>
-        <tag k="name" v="17TH ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-611"/>
-    </way>
-    <way visible="true" id="-608" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-908"/>
-        <nd ref="-139"/>
-        <nd ref="-73"/>
-        <tag k="hoot:id" v="-10211"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-608"/>
-    </way>
-    <way visible="true" id="-605" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-204"/>
-        <nd ref="-149"/>
-        <nd ref="-148"/>
-        <nd ref="-147"/>
-        <nd ref="-146"/>
-        <nd ref="-145"/>
-        <nd ref="-144"/>
-        <nd ref="-907"/>
-        <tag k="hoot:id" v="-10211"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-605"/>
-    </way>
-    <way visible="true" id="-597" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-907"/>
-        <nd ref="-143"/>
-        <nd ref="-142"/>
-        <nd ref="-141"/>
-        <nd ref="-140"/>
-        <nd ref="-908"/>
-        <tag k="hoot:id" v="-10211"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-597"/>
-    </way>
-    <way visible="true" id="-594" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-904"/>
-        <nd ref="-157"/>
-        <nd ref="-156"/>
-        <nd ref="-155"/>
-        <nd ref="-154"/>
-        <nd ref="-153"/>
-        <nd ref="-152"/>
-        <nd ref="-151"/>
-        <nd ref="-150"/>
-        <nd ref="-208"/>
-        <tag k="hoot:id" v="-10212"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-594"/>
-    </way>
-    <way visible="true" id="-590" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-125"/>
-        <nd ref="-158"/>
-        <nd ref="-904"/>
-        <tag k="hoot:id" v="-10212"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-590"/>
-    </way>
-    <way visible="true" id="-588" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-297"/>
+        <nd ref="-298"/>
+        <nd ref="-299"/>
         <nd ref="-300"/>
         <nd ref="-603"/>
         <nd ref="-604"/>
@@ -3153,28 +2927,108 @@
         <nd ref="-625"/>
         <nd ref="-626"/>
         <nd ref="-627"/>
-        <tag k="hoot:id" v="-1884"/>
-        <tag k="name" v="17th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-588"/>
-    </way>
-    <way visible="true" id="-586" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-73"/>
-        <nd ref="-72"/>
-        <nd ref="-71"/>
-        <nd ref="-297"/>
-        <nd ref="-298"/>
-        <nd ref="-299"/>
-        <nd ref="-300"/>
-        <tag k="hoot:id" v="-12577"/>
+        <tag k="hoot:id" v="-12523"/>
         <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-586"/>
+        <tag k="hoot:id" v="-620"/>
+    </way>
+    <way visible="true" id="-614" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <tag k="hoot:id" v="-12525"/>
+        <tag k="alt_name" v="17th St NW"/>
+        <tag k="name" v="17TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-614"/>
+    </way>
+    <way visible="true" id="-611" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-292"/>
+        <nd ref="-293"/>
+        <nd ref="-294"/>
+        <nd ref="-295"/>
+        <nd ref="-296"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <tag k="hoot:id" v="-12526"/>
+        <tag k="alt_name" v="17th St NW"/>
+        <tag k="name" v="17TH ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-611"/>
+    </way>
+    <way visible="true" id="-597" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-204"/>
+        <nd ref="-149"/>
+        <nd ref="-148"/>
+        <nd ref="-147"/>
+        <nd ref="-146"/>
+        <nd ref="-145"/>
+        <nd ref="-144"/>
+        <nd ref="-907"/>
+        <nd ref="-143"/>
+        <nd ref="-142"/>
+        <nd ref="-141"/>
+        <nd ref="-140"/>
+        <nd ref="-908"/>
+        <nd ref="-139"/>
+        <nd ref="-73"/>
+        <tag k="hoot:id" v="-10211"/>
+        <tag k="alt_name" v="E St NW"/>
+        <tag k="name" v="E ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-597"/>
+    </way>
+    <way visible="true" id="-590" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-125"/>
+        <nd ref="-158"/>
+        <nd ref="-904"/>
+        <nd ref="-157"/>
+        <nd ref="-156"/>
+        <nd ref="-155"/>
+        <nd ref="-154"/>
+        <nd ref="-153"/>
+        <nd ref="-152"/>
+        <nd ref="-151"/>
+        <nd ref="-150"/>
+        <nd ref="-208"/>
+        <nd ref="-90"/>
+        <nd ref="-89"/>
+        <nd ref="-88"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-1"/>
+        <tag k="hoot:id" v="-10212"/>
+        <tag k="alt_name" v="E St NW"/>
+        <tag k="name" v="E ST NW"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="5"/>
+        <tag k="hoot:id" v="-590"/>
     </way>
     <way visible="true" id="-583" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-301"/>
@@ -3185,6 +3039,9 @@
         <nd ref="-124"/>
         <nd ref="-123"/>
         <nd ref="-138"/>
+        <nd ref="-229"/>
+        <nd ref="-228"/>
+        <nd ref="-914"/>
         <tag k="hoot:id" v="-10664"/>
         <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
@@ -3258,7 +3115,13 @@
         <nd ref="-367"/>
         <nd ref="-366"/>
         <nd ref="-921"/>
+        <nd ref="-93"/>
+        <nd ref="-238"/>
+        <nd ref="-239"/>
+        <nd ref="-240"/>
+        <nd ref="-241"/>
         <tag k="hoot:id" v="-2458"/>
+        <tag k="alt_name" v="SOUTH EXECUTIVE AVE NW"/>
         <tag k="name" v="South Pl NW"/>
         <tag k="foot" v="designated"/>
         <tag k="highway" v="path"/>

--- a/test-files/cmd/slow/ServiceOsmApiDbHootApiDbDcStreetsConflateTest/output.osm
+++ b/test-files/cmd/slow/ServiceOsmApiDbHootApiDbDcStreetsConflateTest/output.osm
@@ -17597,6 +17597,56 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="4566"/>
     </node>
+    <node visible="true" id="4581" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8954039999999992" lon="-77.0418899000000010">
+        <tag k="hoot:id" v="4581"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4581"/>
+    </node>
+    <node visible="true" id="4582" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8954019999999971" lon="-77.0420158999999956">
+        <tag k="hoot:id" v="4582"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4582"/>
+    </node>
+    <node visible="true" id="4583" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8953980000000001" lon="-77.0427028999999948">
+        <tag k="hoot:id" v="4583"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4583"/>
+    </node>
+    <node visible="true" id="4584" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8953950000000006" lon="-77.0430408999999941">
+        <tag k="hoot:id" v="4584"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4584"/>
+    </node>
+    <node visible="true" id="4585" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8953950000000006" lon="-77.0433569000000062">
+        <tag k="hoot:id" v="4585"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4585"/>
+    </node>
+    <node visible="true" id="4586" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8953980000000001" lon="-77.0434719000000001">
+        <tag k="hoot:id" v="4586"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4586"/>
+    </node>
+    <node visible="true" id="4587" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8954039999999992" lon="-77.0436679000000026">
+        <tag k="hoot:id" v="4587"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4587"/>
+    </node>
+    <node visible="true" id="4588" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8954000000000022" lon="-77.0440669000000042">
+        <tag k="hoot:id" v="4588"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4588"/>
+    </node>
+    <node visible="true" id="4589" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8954049999999967" lon="-77.0447958999999969">
+        <tag k="hoot:id" v="4589"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4589"/>
+    </node>
+    <node visible="true" id="4590" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8954299999999975" lon="-77.0449179000000015">
+        <tag k="hoot:id" v="4590"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="4590"/>
+    </node>
     <node visible="true" id="4591" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3" lat="38.8920949999999976" lon="-77.0501588999999996">
         <tag k="hoot:id" v="4591"/>
         <tag k="hoot:status" v="2"/>
@@ -17878,6 +17928,9 @@
         <nd ref="1216"/>
         <nd ref="1218"/>
         <nd ref="1053"/>
+        <nd ref="27"/>
+        <nd ref="29"/>
+        <nd ref="4692"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="4"/>
         <tag k="hoot:status" v="3"/>
@@ -18620,7 +18673,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="26"/>
     </way>
-    <way visible="true" id="27" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="27" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="3469"/>
         <nd ref="3470"/>
         <nd ref="3471"/>
@@ -18629,11 +18682,9 @@
         <nd ref="3474"/>
         <nd ref="3475"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="27"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -18947,8 +18998,10 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="42"/>
     </way>
-    <way visible="true" id="43" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
-        <nd ref="4695"/>
+    <way visible="true" id="43" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="1073"/>
+        <nd ref="1073"/>
+        <nd ref="869"/>
         <nd ref="870"/>
         <nd ref="871"/>
         <nd ref="872"/>
@@ -18959,20 +19012,27 @@
         <nd ref="877"/>
         <nd ref="112"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="43"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+        <nd ref="549"/>
+        <nd ref="878"/>
+        <nd ref="879"/>
+        <nd ref="880"/>
+        <nd ref="881"/>
+        <nd ref="882"/>
+        <nd ref="883"/>
         <nd ref="4694"/>
         <nd ref="884"/>
         <nd ref="885"/>
         <nd ref="886"/>
         <nd ref="887"/>
         <nd ref="4693"/>
+        <nd ref="888"/>
+        <nd ref="3469"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="44"/>
         <tag k="hoot:status" v="3"/>
@@ -19306,7 +19366,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="61"/>
     </way>
-    <way visible="true" id="62" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="62" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="3702"/>
         <nd ref="3703"/>
         <nd ref="3704"/>
@@ -19316,20 +19376,31 @@
         <nd ref="3711"/>
         <nd ref="3713"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="62"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="62"/>
     </way>
     <way visible="true" id="63" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+        <nd ref="3702"/>
+        <nd ref="3703"/>
+        <nd ref="3704"/>
+        <nd ref="3705"/>
+        <nd ref="3707"/>
+        <nd ref="3709"/>
+        <nd ref="3711"/>
         <nd ref="3713"/>
         <nd ref="3715"/>
         <nd ref="3717"/>
         <nd ref="3719"/>
         <nd ref="3721"/>
         <nd ref="3723"/>
+        <nd ref="3724"/>
+        <nd ref="3725"/>
+        <nd ref="3726"/>
+        <nd ref="3727"/>
+        <nd ref="3728"/>
+        <nd ref="3729"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="63"/>
         <tag k="hoot:status" v="3"/>
@@ -19355,7 +19426,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="64"/>
     </way>
-    <way visible="true" id="65" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="65" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="3723"/>
         <nd ref="3724"/>
         <nd ref="3725"/>
@@ -19364,11 +19435,9 @@
         <nd ref="3728"/>
         <nd ref="3729"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="65"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="17th St NW"/>
         <tag k="name" v="17TH ST NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="65"/>
     </way>
     <way visible="true" id="66" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -19395,6 +19464,37 @@
         <nd ref="3732"/>
         <nd ref="3733"/>
         <nd ref="3469"/>
+        <nd ref="3470"/>
+        <nd ref="3471"/>
+        <nd ref="3472"/>
+        <nd ref="3473"/>
+        <nd ref="3474"/>
+        <nd ref="3475"/>
+        <nd ref="4623"/>
+        <nd ref="4624"/>
+        <nd ref="4625"/>
+        <nd ref="4626"/>
+        <nd ref="4627"/>
+        <nd ref="4628"/>
+        <nd ref="4629"/>
+        <nd ref="4630"/>
+        <nd ref="4631"/>
+        <nd ref="4632"/>
+        <nd ref="4633"/>
+        <nd ref="4634"/>
+        <nd ref="4635"/>
+        <nd ref="4636"/>
+        <nd ref="4637"/>
+        <nd ref="4638"/>
+        <nd ref="4639"/>
+        <nd ref="4640"/>
+        <nd ref="4641"/>
+        <nd ref="4642"/>
+        <nd ref="4643"/>
+        <nd ref="4644"/>
+        <nd ref="4645"/>
+        <nd ref="4646"/>
+        <nd ref="4647"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="67"/>
         <tag k="hoot:status" v="3"/>
@@ -19550,6 +19650,23 @@
         <nd ref="2247"/>
         <nd ref="2249"/>
         <nd ref="2250"/>
+        <nd ref="4550"/>
+        <nd ref="4551"/>
+        <nd ref="4552"/>
+        <nd ref="4553"/>
+        <nd ref="4554"/>
+        <nd ref="4555"/>
+        <nd ref="4556"/>
+        <nd ref="4557"/>
+        <nd ref="4558"/>
+        <nd ref="4559"/>
+        <nd ref="4560"/>
+        <nd ref="4561"/>
+        <nd ref="4562"/>
+        <nd ref="4563"/>
+        <nd ref="4564"/>
+        <nd ref="4565"/>
+        <nd ref="4566"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="74"/>
         <tag k="hoot:status" v="3"/>
@@ -20161,7 +20278,8 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="111"/>
     </way>
-    <way visible="true" id="112" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="112" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="112"/>
         <nd ref="112"/>
         <nd ref="3065"/>
         <nd ref="3066"/>
@@ -20176,11 +20294,9 @@
         <nd ref="3075"/>
         <nd ref="4276"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="112"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="E St NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="112"/>
     </way>
     <way visible="true" id="113" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -20234,7 +20350,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="113"/>
     </way>
-    <way visible="true" id="114" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="114" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="4276"/>
         <nd ref="3076"/>
         <nd ref="3077"/>
@@ -20242,11 +20358,9 @@
         <nd ref="3079"/>
         <nd ref="549"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="114"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="E St NW;Ellipse Rd NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="114"/>
     </way>
     <way visible="true" id="115" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -20278,6 +20392,16 @@
         <nd ref="3087"/>
         <nd ref="3088"/>
         <nd ref="3750"/>
+        <nd ref="4581"/>
+        <nd ref="4582"/>
+        <nd ref="4583"/>
+        <nd ref="4584"/>
+        <nd ref="4585"/>
+        <nd ref="4586"/>
+        <nd ref="4587"/>
+        <nd ref="4588"/>
+        <nd ref="4589"/>
+        <nd ref="4590"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="116"/>
         <tag k="hoot:status" v="3"/>
@@ -20640,8 +20764,10 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="139"/>
     </way>
-    <way visible="true" id="140" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
-        <nd ref="4692"/>
+    <way visible="true" id="140" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
+        <nd ref="1053"/>
+        <nd ref="27"/>
+        <nd ref="29"/>
         <nd ref="30"/>
         <nd ref="31"/>
         <nd ref="32"/>
@@ -20651,11 +20777,9 @@
         <nd ref="36"/>
         <nd ref="3833"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="140"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="140"/>
     </way>
     <way visible="true" id="141" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -20672,6 +20796,14 @@
         <tag k="hoot:id" v="141"/>
     </way>
     <way visible="true" id="142" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+        <nd ref="4692"/>
+        <nd ref="30"/>
+        <nd ref="31"/>
+        <nd ref="32"/>
+        <nd ref="33"/>
+        <nd ref="34"/>
+        <nd ref="35"/>
+        <nd ref="36"/>
         <nd ref="3833"/>
         <nd ref="37"/>
         <nd ref="38"/>
@@ -20682,6 +20814,7 @@
         <nd ref="47"/>
         <nd ref="49"/>
         <nd ref="4691"/>
+        <nd ref="3713"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="142"/>
         <tag k="hoot:status" v="3"/>
@@ -20690,18 +20823,16 @@
         <tag k="highway" v="road"/>
         <tag k="hoot:id" v="142"/>
     </way>
-    <way visible="true" id="143" timestamp="1970-01-01T00:00:00Z" version="2" changeset="3">
+    <way visible="true" id="143" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
         <nd ref="3713"/>
         <nd ref="51"/>
         <nd ref="52"/>
         <nd ref="53"/>
         <nd ref="54"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="143"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="highway" v="road"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="143"/>
     </way>
     <way visible="true" id="144" timestamp="1970-01-01T00:00:00Z" version="1" changeset="2">
@@ -25540,9 +25671,15 @@
         <nd ref="4387"/>
         <nd ref="4386"/>
         <nd ref="4700"/>
+        <nd ref="2588"/>
+        <nd ref="2589"/>
+        <nd ref="2590"/>
+        <nd ref="2591"/>
+        <nd ref="2592"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="396"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="alt_name" v="SOUTH EXECUTIVE AVE NW"/>
         <tag k="name" v="South Pl NW"/>
         <tag k="foot" v="designated"/>
         <tag k="highway" v="path"/>
@@ -25560,118 +25697,69 @@
         <nd ref="4599"/>
         <nd ref="4600"/>
         <nd ref="54"/>
+        <nd ref="53"/>
+        <nd ref="52"/>
+        <nd ref="51"/>
+        <nd ref="3713"/>
         <tag k="accuracy" v="5"/>
         <tag k="hoot:id" v="400"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="alt_name" v="Constitution Ave NW"/>
+        <tag k="alt_name" v="CONSTITUTION AVE NW;Constitution Ave NW"/>
         <tag k="name" v="US Hwy 50"/>
         <tag k="highway" v="secondary"/>
         <tag k="hoot:id" v="400"/>
     </way>
-    <way visible="true" id="401" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4691"/>
-        <nd ref="3713"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="401"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="401"/>
-    </way>
-    <way visible="true" id="403" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="1053"/>
-        <nd ref="27"/>
-        <nd ref="29"/>
-        <nd ref="4692"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="403"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="403"/>
-    </way>
-    <way visible="true" id="406" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="2250"/>
-        <nd ref="4550"/>
-        <nd ref="4551"/>
-        <nd ref="4552"/>
-        <nd ref="4553"/>
-        <nd ref="4554"/>
-        <nd ref="4555"/>
-        <nd ref="4556"/>
-        <nd ref="4557"/>
-        <nd ref="4558"/>
-        <nd ref="4559"/>
-        <nd ref="4560"/>
-        <nd ref="4561"/>
-        <nd ref="4562"/>
-        <nd ref="4563"/>
-        <nd ref="4564"/>
-        <nd ref="4565"/>
-        <nd ref="4566"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="406"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="name" v="15th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="406"/>
-    </way>
-    <way visible="true" id="408" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4693"/>
-        <nd ref="888"/>
-        <nd ref="3469"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="408"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="408"/>
-    </way>
-    <way visible="true" id="409" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="549"/>
-        <nd ref="878"/>
-        <nd ref="879"/>
-        <nd ref="880"/>
-        <nd ref="881"/>
-        <nd ref="882"/>
-        <nd ref="883"/>
-        <nd ref="4694"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="409"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="E St NW"/>
-        <tag k="name" v="E ST NW"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="409"/>
-    </way>
-    <way visible="true" id="410" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="404" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="2559"/>
         <nd ref="4616"/>
         <nd ref="4617"/>
         <nd ref="4618"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="410"/>
+        <tag k="hoot:id" v="404"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="E Executive Ave NW"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="410"/>
+        <tag k="hoot:id" v="404"/>
     </way>
-    <way visible="true" id="412" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="406" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="1073"/>
         <nd ref="869"/>
         <nd ref="4695"/>
+        <nd ref="870"/>
+        <nd ref="871"/>
+        <nd ref="872"/>
+        <nd ref="873"/>
+        <nd ref="874"/>
+        <nd ref="875"/>
+        <nd ref="876"/>
+        <nd ref="877"/>
+        <nd ref="112"/>
+        <nd ref="3065"/>
+        <nd ref="3066"/>
+        <nd ref="3067"/>
+        <nd ref="3068"/>
+        <nd ref="3069"/>
+        <nd ref="3070"/>
+        <nd ref="3071"/>
+        <nd ref="3072"/>
+        <nd ref="3073"/>
+        <nd ref="3074"/>
+        <nd ref="3075"/>
+        <nd ref="4276"/>
+        <nd ref="3076"/>
+        <nd ref="3077"/>
+        <nd ref="3078"/>
+        <nd ref="3079"/>
+        <nd ref="549"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="412"/>
+        <tag k="hoot:id" v="406"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="E St NW"/>
+        <tag k="alt_name" v="E St NW;Ellipse Rd NW"/>
         <tag k="name" v="E ST NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="412"/>
+        <tag k="hoot:id" v="406"/>
     </way>
-    <way visible="true" id="413" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="407" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="3843"/>
         <nd ref="4208"/>
         <nd ref="4209"/>
@@ -25697,14 +25785,14 @@
         <nd ref="4239"/>
         <nd ref="4697"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="413"/>
+        <tag k="hoot:id" v="407"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="413"/>
+        <tag k="hoot:id" v="407"/>
     </way>
-    <way visible="true" id="414" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="408" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4696"/>
         <nd ref="4254"/>
         <nd ref="4256"/>
@@ -25719,14 +25807,14 @@
         <nd ref="4274"/>
         <nd ref="4276"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="414"/>
+        <tag k="hoot:id" v="408"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="414"/>
+        <tag k="hoot:id" v="408"/>
     </way>
-    <way visible="true" id="415" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="409" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="4698"/>
         <nd ref="593"/>
         <nd ref="594"/>
@@ -25746,14 +25834,14 @@
         <nd ref="608"/>
         <nd ref="3843"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="415"/>
+        <tag k="hoot:id" v="409"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="415"/>
+        <tag k="hoot:id" v="409"/>
     </way>
-    <way visible="true" id="416" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="410" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="549"/>
         <nd ref="552"/>
         <nd ref="554"/>
@@ -25766,64 +25854,14 @@
         <nd ref="568"/>
         <nd ref="4699"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="416"/>
+        <tag k="hoot:id" v="410"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="416"/>
+        <tag k="hoot:id" v="410"/>
     </way>
-    <way visible="true" id="417" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="3475"/>
-        <nd ref="4623"/>
-        <nd ref="4624"/>
-        <nd ref="4625"/>
-        <nd ref="4626"/>
-        <nd ref="4627"/>
-        <nd ref="4628"/>
-        <nd ref="4629"/>
-        <nd ref="4630"/>
-        <nd ref="4631"/>
-        <nd ref="4632"/>
-        <nd ref="4633"/>
-        <nd ref="4634"/>
-        <nd ref="4635"/>
-        <nd ref="4636"/>
-        <nd ref="4637"/>
-        <nd ref="4638"/>
-        <nd ref="4639"/>
-        <nd ref="4640"/>
-        <nd ref="4641"/>
-        <nd ref="4642"/>
-        <nd ref="4643"/>
-        <nd ref="4644"/>
-        <nd ref="4645"/>
-        <nd ref="4646"/>
-        <nd ref="4647"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="417"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="name" v="17th St NW"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:id" v="417"/>
-    </way>
-    <way visible="true" id="418" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
-        <nd ref="4700"/>
-        <nd ref="2588"/>
-        <nd ref="2589"/>
-        <nd ref="2590"/>
-        <nd ref="2591"/>
-        <nd ref="2592"/>
-        <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="418"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="alt_name" v="South Pl NW"/>
-        <tag k="name" v="SOUTH EXECUTIVE AVE NW"/>
-        <tag k="foot" v="designated"/>
-        <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="418"/>
-    </way>
-    <way visible="true" id="419" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
+    <way visible="true" id="411" timestamp="1970-01-01T00:00:00Z" version="1" changeset="3">
         <nd ref="2559"/>
         <nd ref="2560"/>
         <nd ref="2561"/>
@@ -25832,11 +25870,11 @@
         <nd ref="2564"/>
         <nd ref="4701"/>
         <tag k="accuracy" v="5"/>
-        <tag k="hoot:id" v="419"/>
+        <tag k="hoot:id" v="411"/>
         <tag k="hoot:status" v="3"/>
         <tag k="alt_name" v="Executive Ave NW;South Pl NW"/>
         <tag k="name" v="SOUTH EXECUTIVE AVE NW"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:id" v="419"/>
+        <tag k="hoot:id" v="411"/>
     </way>
 </osm>

--- a/test-files/cmd/slow/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest.sh.stdout
+++ b/test-files/cmd/slow/serial/ServiceOsmApiDbHootApiDbDcStreetsConflateTest.sh.stdout
@@ -36,12 +36,12 @@ STEP 11b: Writing a XML changeset file that is the difference between the croppe
 STEP 12: Executing the SQL changeset on the osm api db...
 
 Changeset(s) Created: 1
-Changeset Details: min_lat=38.8920931, max_lat=38.902523, min_lon=-77.0501589, max_lon=-77.0336319, num_changes=154
-Node(s) Created: 109
+Changeset Details: min_lat=38.8920931, max_lat=38.902523, min_lon=-77.0501589, max_lon=-77.0336319, num_changes=149
+Node(s) Created: 119
 Node(s) Modified: 0
 Node(s) Deleted: 0
-Way(s) Created: 20
-Way(s) Modified: 25
+Way(s) Created: 13
+Way(s) Modified: 17
 Way(s) Deleted: 0
 Relation(s) Created: 0
 Relation(s) Modified: 0
@@ -52,6 +52,6 @@ STEP 14: Reading the entire contents of the osm api db, for the SQL changeset wo
 
 STEP 15: Cleaning up database...
 
-16:56:31.148 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 35
-16:56:31.385 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 36
-16:56:31.628 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 37
+15:53:40.867 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 69
+15:53:41.128 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 70
+15:53:41.380 INFO  ...ot/core/io/HootApiDbWriter.cpp( 144) Removing map with ID: 71


### PR DESCRIPTION
Refs #2232 
`DuplicateWayRemover` now keeps way IDs and parent IDs correctly that are then passed on to the `WayJoiner`.  Also created a new relation visitor to fix up some of the errors that are introduced into relations because of the way joining.