### PR TITLE
Add sonar step for hoot services

### DIFF
--- a/hoot-services/Makefile
+++ b/hoot-services/Makefile
@@ -64,13 +64,13 @@ coverage:
 	# Run the integration tests for the code coverage, so we get a report covering all of the code.
 	../scripts/maven/mvn-build $(MVN_QUIET) coverage
 	rm -rf ../coverage/services
-	cp -R target/site/cobertura ../coverage
-	mv ../coverage/cobertura ../coverage/services
+	cp -R target/site/jacoco ../coverage
+	mv ../coverage/jacoco ../coverage/services
 
 clean-coverage:
-	#../scripts/maven/mvn-build $(MVN_QUIET) cobertura:clean
-	rm -rf target/site/cobertura
-	rm -rf target/cobertura
+	#../scripts/maven/mvn-build $(MVN_QUIET) jacoco:restore-instrumented-classes
+	rm -rf target/site/jacoco
+	rm -rf target/jacoco
 	rm -rf ../coverage/services
 
 test: config

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
             agent { label 'Breeze (CentOS 7)' }
             steps {
                 withSonarQubeEnv('Breeze Sonarqube') {
-                    sh 'cd hoot/hoot-services; mvn sonar:sonar'
+                    sh 'cd hoot-services; mvn sonar:sonar'
                 }
             }
         }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -123,10 +123,11 @@ pipeline {
             }
         }
         stage("Sonar") {
-            agent { label 'Breeze (CentOS 7)' }
             steps {
+                // rysnc the build folders back to host system so scan
+                sh "vagrant rsync-back ${params.Box}"
                 withSonarQubeEnv('Breeze Sonarqube') {
-                    sh 'cd hoot-services; mvn sonar:sonar'
+                    sh "cd hoot-services; mvn sonar:sonar"
                 }
             }
         }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
         booleanParam(name: 'Core_tests', defaultValue: true)
         booleanParam(name: 'Services_tests', defaultValue: true)
         booleanParam(name: 'UI_tests', defaultValue: true)
+        booleanParam(name: 'Sonar', defaultValue: false)
         string(name: 'Box', defaultValue: 'default', description: 'Vagrant Box')
     }
     stages {
@@ -123,6 +124,12 @@ pipeline {
             }
         }
         stage("Sonar") {
+            anyOf {
+                    expression { return params.Sonar }
+                    // Work around to run sonar scans during nightly cron triggers but not on commits to develop.  Logic can be udpated
+                    // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
+                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 21..23 }
+                }
             steps {
                 // rysnc the build folders back to host system so scan
                 sh "vagrant rsync-back ${params.Box}"

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -124,12 +124,14 @@ pipeline {
             }
         }
         stage("Sonar") {
-            anyOf {
+            when {
+                anyOf {
                     expression { return params.Sonar }
                     // Work around to run sonar scans during nightly cron triggers but not on commits to develop.  Logic can be udpated
                     // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
                     expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 21..23 }
                 }
+            }
             steps {
                 // rysnc the build folders back to host system so scan
                 sh "vagrant rsync-back ${params.Box}"

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -122,6 +122,14 @@ pipeline {
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; make -s ui-test'"
             }
         }
+        stage("Sonar") {
+            agent { label 'Breeze (CentOS 7)' }
+            steps {
+                withSonarQubeEnv('Breeze Sonarqube') {
+                    sh 'cd hoot/hoot-services; mvn sonar:sonar'
+                }
+            }
+        }
     }
     post {
         always {

--- a/scripts/maven/mvn-build
+++ b/scripts/maven/mvn-build
@@ -177,7 +177,7 @@ case $PHASE in
    ARGS="$ARGS verify"
    ;;   
    "coverage")
-   ARGS="$ARGS cobertura:cobertura-integration-test"
+   ARGS="$ARGS jacoco:prepare-agent install"
    ;;
    "clean")
    ARGS="$ARGS clean"


### PR DESCRIPTION
Adding sonar scan step to hoot pipeline.  Right now it will just scan hoot-services in the nightly run or on a rerun if specified us build parameter.  Updated services code coverage to be calculated off of jacoco instead of corbetura because sonarqube has better support for jacoco.