### PR TITLE
Fix timestamps in exports from osm api db

### DIFF
--- a/docs/commands/map-diff.asciidoc
+++ b/docs/commands/map-diff.asciidoc
@@ -5,13 +5,14 @@
 The +map-diff+ command checks to see if maps are essentially the same. Returns 0 if they're the same or 1 if they differ 
 significantly. If they differ significantly warnings will be printed with more information.
 
-* +--ignore-uuid+ - Ignore UUID's in the map comparison
-* +input1+        - Input 1 (e.g. .osm file).
-* intpu2          - Input 2 (e.g. .osm file).
+* +--ignore-uuid+   - Ignore UUID's in the map comparison
+* +--use-datetime+  - Do not ignore source:datetime & source:ingest:datetime
+* +input1+          - Input 1 (e.g. .osm file).
+* +intpu2+          - Input 2 (e.g. .osm file).
 
 === Usage
 
 --------------------------------------
-map-diff [--ignore-uuid] (input1) (input2)
+map-diff [--ignore-uuid] [--use-datetime] (input1) (input2)
 --------------------------------------
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -196,6 +196,11 @@ public:
     //members that are out of bounds.
     CPPUNIT_ASSERT_EQUAL(5, (int)map->getRelations().size());
 
+    // Verify timestamps look OK
+    WayPtr pWay = map->getWays().begin()->second;
+    CPPUNIT_ASSERT(0 != pWay->getTimestamp());
+
+
     //Need to remove timestamps, otherwise they cause issues with the compare
     QList<ElementAttributeType> types;
     types.append(ElementAttributeType(ElementAttributeType::Timestamp));

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -33,6 +33,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/elements/ElementAttributeType.h>
 #include <hoot/core/io/ApiDb.h>
 #include <hoot/core/io/OsmApiDb.h>
 #include <hoot/core/io/OsmApiDbReader.h>
@@ -43,6 +44,7 @@
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/io/OsmApiDbBulkInserter.h>
+#include <hoot/core/visitors/RemoveAttributeVisitor.h>
 
 // Qt
 #include <QDir>
@@ -193,6 +195,12 @@ public:
     //All but one of the six relations should be returned.  The relation not returned contains all
     //members that are out of bounds.
     CPPUNIT_ASSERT_EQUAL(5, (int)map->getRelations().size());
+
+    //Need to remove timestamps, otherwise they cause issues with the compare
+    QList<ElementAttributeType> types;
+    types.append(ElementAttributeType(ElementAttributeType::Timestamp));
+    RemoveAttributeVisitor attrVis(types);
+    map->visitRw(attrVis);
 
     TestUtils::mkpath("test-output/io/ServiceOsmApiDbReaderTest");
     MapProjector::projectToWgs84(map);

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+// Hoot
+#include <hoot/core/OsmMap.h>
+#include <hoot/core/io/OsmXmlReader.h>
+#include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/io/OsmPbfReader.h>
+#include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/scoring/MapComparator.h>
+#include <hoot/core/visitors/SetTagVisitor.h>
+#include <hoot/core/util/MapProjector.h>
+
+#define int64 opencv_broken_int
+#include <hoot/core/util/OpenCv.h>
+#undef int64
+
+using namespace hoot;
+
+// Tgs
+#include <tgs/Statistics/Random.h>
+
+// Boost
+using namespace boost;
+
+// CPP Unit
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/TestAssert.h>
+#include <cppunit/TestFixture.h>
+
+// Qt
+#include <QDebug>
+#include <QThread>
+
+// Standard
+#include <stdio.h>
+
+class MapComparatorTest : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(MapComparatorTest);
+  CPPUNIT_TEST(runTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void runTest()
+  {
+    OsmXmlReader reader;
+    reader.setAddSourceDateTime(true);
+
+    OsmMap::resetCounters();
+    OsmMapPtr map1(new OsmMap());
+    reader.read("test-files/ToyTestA.osm", map1);
+
+    OsmMap::resetCounters();
+    OsmMapPtr map2(new OsmMap());
+    reader.read("test-files/ToyTestA.osm", map2);
+
+    MapComparator uut;
+
+    // Make sure the maps are the same
+    bool match = uut.isMatch(map1, map2);
+    CPPUNIT_ASSERT(match);
+
+    // Now turn on datetime checking...
+    uut.setUseDateTime();
+
+    // Change dates...
+    SetTagVisitor vtor("source:datetime", "1989-12-13T12:34:56Z");
+    map2->visitRw(vtor);
+
+    // Make sure it fails now!
+    {
+      DisableLog dl; // Temporarily disable log
+      (void) dl;     // Avoid unused var warning
+      match = uut.isMatch(map1, map2);
+    }
+    CPPUNIT_ASSERT(!match);
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(MapComparatorTest);
+
+
+

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/cmd/MapDiffCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/MapDiffCmd.cpp
@@ -69,7 +69,6 @@ public:
       mapCompare.setUseDateTime();
     }
 
-
     if (args.size() != 2)
     {
       cout << getHelp() << endl << endl;

--- a/hoot-core/src/main/cpp/hoot/core/elements/Element.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Element.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef ELEMENT_H
 #define ELEMENT_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/Element.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Element.h
@@ -104,8 +104,8 @@ public:
   long getVersion() const { return _getElementData().getVersion(); }
   void setVersion(long version) { _getElementData().setVersion(version); }
 
-  unsigned int getTimestamp() const { return _getElementData().getTimestamp(); }
-  void setTimestamp(unsigned int timestamp) { _getElementData().setTimestamp(timestamp); }
+  quint64 getTimestamp() const { return _getElementData().getTimestamp(); }
+  void setTimestamp(quint64 timestamp) { _getElementData().setTimestamp(timestamp); }
 
   QString getUser() const { return _getElementData().getUser(); }
   void setUser(QString user) { _getElementData().setUser(user); }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementData.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementData.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "Element.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementData.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementData.cpp
@@ -32,7 +32,7 @@ namespace hoot
 
 long ElementData::CHANGESET_EMPTY = 0;
 long ElementData::VERSION_EMPTY = 0;
-unsigned int ElementData::TIMESTAMP_EMPTY = 0;
+quint64 ElementData::TIMESTAMP_EMPTY = 0;
 QString ElementData::USER_EMPTY = QString();
 long ElementData::UID_EMPTY = 0;
 bool ElementData::VISIBLE_EMPTY = true;

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementData.h
@@ -57,7 +57,7 @@ public:
 
   static long CHANGESET_EMPTY;
   static long VERSION_EMPTY;
-  static unsigned int TIMESTAMP_EMPTY;
+  static quint64 TIMESTAMP_EMPTY;
   static QString USER_EMPTY;
   static long UID_EMPTY;
   static bool VISIBLE_EMPTY;
@@ -109,7 +109,7 @@ protected:
   ElementData(long id = LLONG_MIN, const Tags& tags = Tags(), Meters circularError = -1,
               long changeset = ElementData::CHANGESET_EMPTY,
               long version = ElementData::VERSION_EMPTY,
-              unsigned int timestamp = ElementData::TIMESTAMP_EMPTY,
+              quint64 timestamp = ElementData::TIMESTAMP_EMPTY,
               QString user = ElementData::USER_EMPTY, long uid = ElementData::UID_EMPTY,
               bool visible = ElementData::VISIBLE_EMPTY);
 
@@ -118,7 +118,7 @@ protected:
   Meters _circularError;
   long _changeset;
   long _version;
-  unsigned int _timestamp;
+  quint64 _timestamp;
   QString _user;
   long _uid;
   bool _visible;
@@ -126,7 +126,7 @@ protected:
 };
 
 inline ElementData::ElementData(long id, const Tags& tags, Meters circularError, long changeset,
-                         long version, unsigned int timestamp, QString user, long uid,
+                         long version, quint64 timestamp, QString user, long uid,
                          bool visible)
   : _id(id),
     _tags(tags),

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementData.h
@@ -81,8 +81,8 @@ public:
   long getVersion() const { return _version; }
   void setVersion(long version) { _version = version; }
 
-  unsigned int getTimestamp() const { return _timestamp; }
-  void setTimestamp(unsigned int timestamp) { _timestamp = timestamp; }
+  quint64 getTimestamp() const { return _timestamp; }
+  void setTimestamp(quint64 timestamp) { _timestamp = timestamp; }
 
   QString getUser() const { return _user; }
   void setUser(QString user) { _user = user; }

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef _ELEMENTS_NODE_H_
 #define _ELEMENTS_NODE_H_

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.h
@@ -84,7 +84,7 @@ public:
     Meters circularError);
 
   static boost::shared_ptr<Node> newSp(Status s, long id, double x, double y, Meters circularError,
-                                       long changeset, long version, unsigned int timestamp,
+                                       long changeset, long version, quint64 timestamp,
                                        QString user = ElementData::USER_EMPTY,
                                        long uid = ElementData::UID_EMPTY,
                                        bool visible = ElementData::VISIBLE_EMPTY);
@@ -164,7 +164,7 @@ inline NodePtr Node::newSp(Status s, long id, double x, double y, Meters circula
 }
 
 inline NodePtr Node::newSp(Status s, long id, double x, double y, Meters circularError,
-                           long changeset, long version, unsigned int timestamp, QString user,
+                           long changeset, long version, quint64 timestamp, QString user,
                            long uid, bool visible)
 {
   NodePtr result = SharedPtrPool<Node>::getInstance().allocate();

--- a/hoot-core/src/main/cpp/hoot/core/elements/NodeData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/NodeData.h
@@ -49,7 +49,7 @@ public:
   double getY() const { return _y; }
 
   void init(long id, double x, double y, long changeset = ElementData::CHANGESET_EMPTY,
-            long version = ElementData::VERSION_EMPTY, long timestamp = ElementData::TIMESTAMP_EMPTY,
+            long version = ElementData::VERSION_EMPTY, quint64 timestamp = ElementData::TIMESTAMP_EMPTY,
             QString user = ElementData::USER_EMPTY, long uid = ElementData::UID_EMPTY,
             bool visible = ElementData::VISIBLE_EMPTY);
 
@@ -66,7 +66,7 @@ protected:
 };
 
 inline void NodeData::init(long id, double x, double y, long changeset, long version,
-  long timestamp, QString user, long uid, bool visible)
+  quint64 timestamp, QString user, long uid, bool visible)
 {
  _id = id;
  _x = x;

--- a/hoot-core/src/main/cpp/hoot/core/elements/NodeData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/NodeData.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef _ELEMENTS_NODE_DATA_H_
 #define _ELEMENTS_NODE_DATA_H_

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "Relation.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
@@ -78,7 +78,7 @@ private:
 };
 
 Relation::Relation(Status s, long id, Meters circularError, QString type, long changeset,
-                   long version, unsigned int timestamp, QString user, long uid, bool visible) :
+                   long version, quint64 timestamp, QString user, long uid, bool visible) :
 Element(s)
 {
   _relationData.reset(new RelationData(id, changeset, version, timestamp, user, uid, visible));

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -70,7 +70,7 @@ public:
   Relation(Status s, long id, Meters circularError, QString type = "",
            long changeset = ElementData::CHANGESET_EMPTY,
            long version = ElementData::VERSION_EMPTY,
-           unsigned int timestamp = ElementData::TIMESTAMP_EMPTY,
+           quint64 timestamp = ElementData::TIMESTAMP_EMPTY,
            QString user = ElementData::USER_EMPTY, long uid = ElementData::UID_EMPTY,
            bool visible = ElementData::VISIBLE_EMPTY);
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -52,7 +52,7 @@ namespace hoot
 {
 
 Way::Way(Status s, long id, Meters circularError, long changeset, long version,
-         unsigned int timestamp, QString user, long uid, bool visible, long pid)
+         quint64 timestamp, QString user, long uid, bool visible, long pid)
   : Element(s)
 {
   _wayData.reset(new WayData(id, changeset, version, timestamp, user, uid, visible, pid));

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -56,7 +56,7 @@ public:
 
   Way(Status s, long id, Meters circularError, long changeset = ElementData::CHANGESET_EMPTY,
       long version = ElementData::VERSION_EMPTY,
-      unsigned int timestamp = ElementData::TIMESTAMP_EMPTY,
+      quint64 timestamp = ElementData::TIMESTAMP_EMPTY,
       QString user = ElementData::USER_EMPTY, long uid = ElementData::UID_EMPTY,
       bool visible = ElementData::VISIBLE_EMPTY, long pid = WayData::PID_EMPTY);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
@@ -123,6 +123,10 @@ NodePtr HootApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& 
   long nodeId = _mapElementId(map, ElementId::node(resultIterator.value(0).toLongLong())).getId();
   LOG_VART(ElementId(ElementType::Node, nodeId));
 
+  // Timestamp
+  QDateTime dt = resultIterator.value(ApiDb::NODES_TIMESTAMP).toDateTime();
+  dt.setTimeSpec(Qt::UTC);
+
   NodePtr node(
     Node::newSp(
       _status,
@@ -132,8 +136,7 @@ NodePtr HootApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& 
       -1,
       resultIterator.value(ApiDb::NODES_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::NODES_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::NODES_TIMESTAMP)
-          .toDateTime().toMSecsSinceEpoch() / 1000));
+      dt.toMSecsSinceEpoch() / 1000));
 
   node->setTags(ApiDb::unescapeTags(resultIterator.value(ApiDb::NODES_TAGS)));
   _updateMetadataOnElement(node);
@@ -158,6 +161,10 @@ WayPtr HootApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& ma
   const long newWayId = _mapElementId(map, ElementId::way(wayId)).getId();
   LOG_VART(ElementId(ElementType::Way, wayId));
 
+  // Timestamp
+  QDateTime dt = resultIterator.value(ApiDb::WAYS_TIMESTAMP).toDateTime();
+  dt.setTimeSpec(Qt::UTC);
+
   WayPtr way(
     new Way(
       _status,
@@ -165,8 +172,7 @@ WayPtr HootApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& ma
       -1,
       resultIterator.value(ApiDb::WAYS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::WAYS_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::WAYS_TIMESTAMP)
-          .toDateTime().toMSecsSinceEpoch() / 1000));
+      dt.toMSecsSinceEpoch() / 1000));
 
   way->setTags(ApiDb::unescapeTags(resultIterator.value(ApiDb::WAYS_TAGS)));
   _updateMetadataOnElement(way);
@@ -196,6 +202,10 @@ RelationPtr HootApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, 
   const long newRelationId = _mapElementId(map, ElementId::relation(relationId)).getId();
   LOG_VART(ElementId(ElementType::Relation, relationId));
 
+  // Timestamp
+  QDateTime dt = resultIterator.value(ApiDb::RELATIONS_TIMESTAMP).toDateTime();
+  dt.setTimeSpec(Qt::UTC);
+
   RelationPtr relation(
     new Relation(
       _status,
@@ -204,8 +214,7 @@ RelationPtr HootApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, 
       "",/*MetadataTags::RelationCollection()*/ //services db doesn't support relation "type" yet
       resultIterator.value(ApiDb::RELATIONS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::RELATIONS_VERSION).toLongLong(),
-        resultIterator.value(ApiDb::RELATIONS_TIMESTAMP)
-          .toDateTime().toMSecsSinceEpoch() / 1000));
+      dt.toMSecsSinceEpoch() / 1000));
 
   relation->setTags(ApiDb::unescapeTags(resultIterator.value(ApiDb::RELATIONS_TAGS)));
   _updateMetadataOnElement(relation);

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
@@ -132,10 +132,8 @@ NodePtr HootApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& 
       -1,
       resultIterator.value(ApiDb::NODES_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::NODES_VERSION).toLongLong(),
-      OsmUtils::fromTimeString(
-        resultIterator.value(ApiDb::NODES_TIMESTAMP)
-          .toDateTime()
-          .toString("yyyy-MM-ddThh:mm:ssZ"))));
+      resultIterator.value(ApiDb::NODES_TIMESTAMP)
+          .toDateTime().toMSecsSinceEpoch() / 1000));
 
   node->setTags(ApiDb::unescapeTags(resultIterator.value(ApiDb::NODES_TAGS)));
   _updateMetadataOnElement(node);
@@ -167,10 +165,8 @@ WayPtr HootApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& ma
       -1,
       resultIterator.value(ApiDb::WAYS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::WAYS_VERSION).toLongLong(),
-      OsmUtils::fromTimeString(
-        resultIterator.value(ApiDb::WAYS_TIMESTAMP)
-          .toDateTime()
-          .toString("yyyy-MM-ddThh:mm:ssZ"))));
+      resultIterator.value(ApiDb::WAYS_TIMESTAMP)
+          .toDateTime().toMSecsSinceEpoch() / 1000));
 
   way->setTags(ApiDb::unescapeTags(resultIterator.value(ApiDb::WAYS_TAGS)));
   _updateMetadataOnElement(way);
@@ -208,10 +204,8 @@ RelationPtr HootApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, 
       "",/*MetadataTags::RelationCollection()*/ //services db doesn't support relation "type" yet
       resultIterator.value(ApiDb::RELATIONS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::RELATIONS_VERSION).toLongLong(),
-      OsmUtils::fromTimeString(
         resultIterator.value(ApiDb::RELATIONS_TIMESTAMP)
-          .toDateTime()
-          .toString("yyyy-MM-ddThh:mm:ssZ"))));
+          .toDateTime().toMSecsSinceEpoch() / 1000));
 
   relation->setTags(ApiDb::unescapeTags(resultIterator.value(ApiDb::RELATIONS_TAGS)));
   _updateMetadataOnElement(relation);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
@@ -29,6 +29,7 @@
 // hoot
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Settings.h>
+#include <hoot/core/util/OsmUtils.h>
 #include <hoot/core/elements/ElementId.h>
 #include <hoot/core/elements/ElementType.h>
 #include <hoot/core/io/ApiDb.h>
@@ -36,6 +37,7 @@
 
 // Qt
 #include <QUrl>
+#include <QDateTime>
 
 using namespace geos::geom;
 using namespace std;
@@ -138,7 +140,9 @@ NodePtr OsmApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& m
       _defaultCircularError,
       resultIterator.value(ApiDb::NODES_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::NODES_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::NODES_TIMESTAMP).toUInt()));
+      OsmUtils::fromTimeString(resultIterator.value(ApiDb::NODES_TIMESTAMP)
+                               .toDateTime()
+                               .toString("yyyy-MM-ddThh:mm:ssZ"))));
 
   _parseAndSetTagsOnElement(node);
   _updateMetadataOnElement(node);
@@ -174,7 +178,9 @@ WayPtr OsmApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& map
       _defaultCircularError,
       resultIterator.value(ApiDb::WAYS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::WAYS_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::WAYS_TIMESTAMP).toUInt()));
+      OsmUtils::fromTimeString(resultIterator.value(ApiDb::WAYS_TIMESTAMP)
+                               .toDateTime()
+                               .toString("yyyy-MM-ddThh:mm:ssZ"))));
 
   // if performance becomes an issue, try reading these out in batch at the same time
   // the element results are read
@@ -218,8 +224,9 @@ RelationPtr OsmApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, c
       "",
       resultIterator.value(ApiDb::RELATIONS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::RELATIONS_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::RELATIONS_TIMESTAMP).toUInt()));
-
+      OsmUtils::fromTimeString(resultIterator.value(ApiDb::RELATIONS_TIMESTAMP)
+                               .toDateTime()
+                               .toString("yyyy-MM-ddThh:mm:ssZ"))));
   _parseAndSetTagsOnElement(relation);
 
   // These could be read out in batch at the same time the element results are read.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
@@ -140,9 +140,8 @@ NodePtr OsmApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& m
       _defaultCircularError,
       resultIterator.value(ApiDb::NODES_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::NODES_VERSION).toLongLong(),
-      OsmUtils::fromTimeString(resultIterator.value(ApiDb::NODES_TIMESTAMP)
-                               .toDateTime()
-                               .toString("yyyy-MM-ddThh:mm:ssZ"))));
+      resultIterator.value(ApiDb::NODES_TIMESTAMP)
+          .toDateTime().toMSecsSinceEpoch() / 1000));
 
   _parseAndSetTagsOnElement(node);
   _updateMetadataOnElement(node);
@@ -178,9 +177,8 @@ WayPtr OsmApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& map
       _defaultCircularError,
       resultIterator.value(ApiDb::WAYS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::WAYS_VERSION).toLongLong(),
-      OsmUtils::fromTimeString(resultIterator.value(ApiDb::WAYS_TIMESTAMP)
-                               .toDateTime()
-                               .toString("yyyy-MM-ddThh:mm:ssZ"))));
+      resultIterator.value(ApiDb::WAYS_TIMESTAMP)
+          .toDateTime().toMSecsSinceEpoch() / 1000));
 
   // if performance becomes an issue, try reading these out in batch at the same time
   // the element results are read
@@ -224,9 +222,8 @@ RelationPtr OsmApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, c
       "",
       resultIterator.value(ApiDb::RELATIONS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::RELATIONS_VERSION).toLongLong(),
-      OsmUtils::fromTimeString(resultIterator.value(ApiDb::RELATIONS_TIMESTAMP)
-                               .toDateTime()
-                               .toString("yyyy-MM-ddThh:mm:ssZ"))));
+      resultIterator.value(ApiDb::RELATIONS_TIMESTAMP)
+          .toDateTime().toMSecsSinceEpoch() / 1000));
   _parseAndSetTagsOnElement(relation);
 
   // These could be read out in batch at the same time the element results are read.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
@@ -131,6 +131,10 @@ NodePtr OsmApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& m
   const double lon =
     resultIterator.value(ApiDb::NODES_LONGITUDE).toLongLong() / (double)ApiDb::COORDINATE_SCALE;
 
+  // Timestamp
+  QDateTime dt = resultIterator.value(ApiDb::NODES_TIMESTAMP).toDateTime();
+  dt.setTimeSpec(Qt::UTC);
+
   NodePtr node(
     Node::newSp(
       _status,
@@ -140,8 +144,7 @@ NodePtr OsmApiDbReader::_resultToNode(const QSqlQuery& resultIterator, OsmMap& m
       _defaultCircularError,
       resultIterator.value(ApiDb::NODES_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::NODES_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::NODES_TIMESTAMP)
-          .toDateTime().toMSecsSinceEpoch() / 1000));
+      dt.toMSecsSinceEpoch() / 1000));
 
   _parseAndSetTagsOnElement(node);
   _updateMetadataOnElement(node);
@@ -170,6 +173,10 @@ WayPtr OsmApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& map
     LOG_VARD(newWayId);
   }
 
+  // Timestamp
+  QDateTime dt = resultIterator.value(ApiDb::WAYS_TIMESTAMP).toDateTime();
+  dt.setTimeSpec(Qt::UTC);
+
   WayPtr way(
     new Way(
       _status,
@@ -177,8 +184,7 @@ WayPtr OsmApiDbReader::_resultToWay(const QSqlQuery& resultIterator, OsmMap& map
       _defaultCircularError,
       resultIterator.value(ApiDb::WAYS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::WAYS_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::WAYS_TIMESTAMP)
-          .toDateTime().toMSecsSinceEpoch() / 1000));
+      dt.toMSecsSinceEpoch() / 1000));
 
   // if performance becomes an issue, try reading these out in batch at the same time
   // the element results are read
@@ -214,6 +220,10 @@ RelationPtr OsmApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, c
     LOG_VART(newRelationId);
   }
 
+  // Timestamp
+  QDateTime dt = resultIterator.value(ApiDb::RELATIONS_TIMESTAMP).toDateTime();
+  dt.setTimeSpec(Qt::UTC);
+
   RelationPtr relation(
     new Relation(
       _status,
@@ -222,8 +232,7 @@ RelationPtr OsmApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, c
       "",
       resultIterator.value(ApiDb::RELATIONS_CHANGESET).toLongLong(),
       resultIterator.value(ApiDb::RELATIONS_VERSION).toLongLong(),
-      resultIterator.value(ApiDb::RELATIONS_TIMESTAMP)
-          .toDateTime().toMSecsSinceEpoch() / 1000));
+      dt.toMSecsSinceEpoch() / 1000));
   _parseAndSetTagsOnElement(relation);
 
   // These could be read out in batch at the same time the element results are read.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
@@ -164,6 +164,8 @@ public:
 
   bool getSortedTypeThenId() { return _typeThenId; }
 
+  void setAddSourceDateTime(bool add) { _addSourceDateTime = add; }
+
   /**
    * Checks to see if an input is sorted
    *

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.cpp
@@ -111,11 +111,15 @@ public:
       in2.set("uuid","None");
     }
 
+    // By default, hoot will usually set these tags when ingesting a file
+    // this can cause problems when comparing files during testing, so we
+    // have the option to ignore it here.
     if (!_useDateTime)
     {
       in1.set("source:ingest:datetime","None");  // Wipe out the ingest datetime
       in2.set("source:ingest:datetime","None");
-      in1.set("source:datetime","None");  // Wipe out source datetime
+
+      in1.set("source:datetime","None");  // Wipe out the ingest datetime
       in2.set("source:datetime","None");
     }
 
@@ -231,10 +235,11 @@ private:
   int _errorCount;
 };
 
-MapComparator::MapComparator()
+MapComparator::MapComparator():
+  _ignoreUUID(false),
+  _useDateTime(false)
 {
-  _ignoreUUID = false;
-  _useDateTime = false;
+  // blank
 }
 
 bool MapComparator::isMatch(boost::shared_ptr<OsmMap> ref, boost::shared_ptr<OsmMap> test)

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.cpp
@@ -115,6 +115,8 @@ public:
     {
       in1.set("source:ingest:datetime","None");  // Wipe out the ingest datetime
       in2.set("source:ingest:datetime","None");
+      in1.set("source:datetime","None");  // Wipe out source datetime
+      in2.set("source:datetime","None");
     }
 
     if (in1 != in2)

--- a/hoot-core/src/main/cpp/hoot/core/util/OsmUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/OsmUtils.cpp
@@ -119,22 +119,22 @@ void OsmUtils::saveMap(boost::shared_ptr<const OsmMap> map, QString path)
   OsmMapWriterFactory::write(map, path);
 }
 
-QString OsmUtils::toTimeString(unsigned int timestamp)
+QString OsmUtils::toTimeString(quint64 timestamp)
 {
   // convert time in seconds since epoch into timestamp string
-  time_t tt = (time_t) timestamp;
-  char buf[128];
-  strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", gmtime(&tt));
-  return QString::fromUtf8(buf);
+  QDateTime dt;
+  dt.setTimeSpec(Qt::UTC);
+  dt.setMSecsSinceEpoch(timestamp*1000);
+  return dt.toString("yyyy-MM-ddThh:mm:ssZ");
 }
 
-unsigned int OsmUtils::fromTimeString(QString timestamp)
+quint64 OsmUtils::fromTimeString(QString timestamp)
 {
   struct tm t;
   strptime(timestamp.toStdString().c_str(), "%Y-%m-%dT%H:%M:%SZ", &t);
 
   // calc time in seconds since epoch
-  return (unsigned int)(t.tm_sec + t.tm_min*60 + t.tm_hour*3600 + t.tm_yday*86400 +
+  return (quint64)(t.tm_sec + t.tm_min*60 + t.tm_hour*3600 + t.tm_yday*86400 +
     (t.tm_year-70)*31536000 + ((t.tm_year-69)/4)*86400 -
     ((t.tm_year-1)/100)*86400 + ((t.tm_year+299)/400)*86400);
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/OsmUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/OsmUtils.h
@@ -148,18 +148,18 @@ class OsmUtils
     static void saveMap(boost::shared_ptr<const OsmMap> map, QString path);
 
     /**
-      Converts an unsigned int timestamp (time from epoch) to a QString (utc zulu)
+      Converts a 64-bit unsigned int timestamp (seconds from epoch) to a QString (utc zulu)
 
-      @param timestamp unsigned int time encoding in seconds from the epoch (1970-01-01 00:00:00)
+      @param timestamp quint64 time encoding in seconds from the epoch (1970-01-01T00:00:00Z)
       */
-    static QString toTimeString(unsigned int timestamp);
+    static QString toTimeString(quint64 timestamp);
 
     /**
       Converts a utc zulu timestamp to time since the epoch in seconds.
 
       @param timestamp in utc zulu string to be convered to seconds from the epoch (1970-01-01 00:00:00)
       */
-    static unsigned int fromTimeString(QString timestamp);
+    static quint64 fromTimeString(QString timestamp);
 
     /**
      * Returns a time string for the current time


### PR DESCRIPTION
Ref: #2362 

It looks like the OsmApiDBReader class was mishandling timestamps from the database.

I just sort of mirrored what HootApiDBReader does, and now sample output looks much better!