### PR TITLE
2367 Translation Server returns fcodes and allowed geometries 

### DIFF
--- a/plugins/TranslationServer.js
+++ b/plugins/TranslationServer.js
@@ -469,28 +469,51 @@ var getFCodes = function(params) {
         var geomType = params.geometry;
         var translation = params.translation;
 
-        //Treat vertex geom type as point
-        if (geomType.toLowerCase() === 'vertex') geomType = 'point';
-
         //Get valid FCODEs for this translation and geometry type
         var schema = schemaMap[translation].getDbSchema();
+        var fcodes = {};
+        if(geomType){
+            //Treat vertex geom type as point
+            if (geomType.toLowerCase() === 'vertex') geomType = 'point';
 
-        console.log(geomType + ', ' + translation + ', ' + schema.length);
-        var fcodes = schema
-            .filter(function(d) {
-                return d.geom.toLowerCase() === geomType.toLowerCase();
-            })
-            .map(function(d) {
+            console.log(geomType + ', ' + translation + ', ' + schema.length);
+            fcodes = schema
+                .filter(function(d) {
+                    return d.geom.toLowerCase() === geomType.toLowerCase();
+                })
+                .map(function(d) {
+                    return {
+                        fcode: d.fcode,
+                        desc: d.desc
+                    }
+                });
+        } else{
+           var allFcodes = schema
+                .map(function(d) {
                 return {
                     fcode: d.fcode,
-                    desc: d.desc
+                    desc: d.desc,
+                    geom: d.geom
                 }
-            })
-            .sort(function(a, b) {
-                return a.fcode - b.fcode;
             });
+            Object.entries(allFcodes).forEach(function(prop){
+                var fCodeData = prop[1];
+                var fCode = fCodeData.fcode;
+                if(!fcodes.hasOwnProperty(fCode)){
+                  fcodes[fCode] = fCodeData;
+                  var desc = fCodeData.desc;
+                  fcodes[fCode].geom = [fCodeData.geom];
+                } else{
+                  var fCodeData = fcodes[fCode];
+                  fcodes[fCode].geom.push(fCodeData.geom);
+                }
+            });
+            fcodes = [fcodes];
+        }
 
-        return fcodes;
+        return fcodes.sort(function(a, b) {
+                return a.fcode - b.fcode;
+                });
     }
 }
 

--- a/plugins/TranslationServer.js
+++ b/plugins/TranslationServer.js
@@ -471,12 +471,11 @@ var getFCodes = function(params) {
 
         //Get valid FCODEs for this translation and geometry type
         var schema = schemaMap[translation].getDbSchema();
-        var fcodes = {};
-        if(geomType){
+        var fcodes;
+        if (geomType) {
             //Treat vertex geom type as point
             if (geomType.toLowerCase() === 'vertex') geomType = 'point';
 
-            console.log(geomType + ', ' + translation + ', ' + schema.length);
             fcodes = schema
                 .filter(function(d) {
                     return d.geom.toLowerCase() === geomType.toLowerCase();
@@ -487,33 +486,26 @@ var getFCodes = function(params) {
                         desc: d.desc
                     }
                 });
-        } else{
-           var allFcodes = schema
-                .map(function(d) {
-                return {
-                    fcode: d.fcode,
-                    desc: d.desc,
-                    geom: d.geom
-                }
-            });
-            Object.entries(allFcodes).forEach(function(prop){
-                var fCodeData = prop[1];
-                var fCode = fCodeData.fcode;
-                if(!fcodes.hasOwnProperty(fCode)){
-                  fcodes[fCode] = fCodeData;
-                  var desc = fCodeData.desc;
-                  fcodes[fCode].geom = [fCodeData.geom];
-                } else{
-                  var fCodeData = fcodes[fCode];
-                  fcodes[fCode].geom.push(fCodeData.geom);
-                }
-            });
-            fcodes = [fcodes];
+        } else {
+
+            fcodes = Object.values(schema
+                .reduce(function(map, d) {
+                    if (map[d.fcode]) {
+                        map[d.fcode].geom.push(d.geom);
+                    } else {
+                        map[d.fcode] = {
+                            fcode: d.fcode,
+                            desc: d.desc,
+                            geom: [d.geom]
+                        };
+                    }
+                    return map;
+                }, {}));
         }
 
         return fcodes.sort(function(a, b) {
                 return a.fcode - b.fcode;
-                });
+            });
     }
 }
 

--- a/plugins/test/TranslationServer.js
+++ b/plugins/test/TranslationServer.js
@@ -46,6 +46,16 @@ describe('TranslationServer', function () {
             }).length, 190);
         });
 
+        it('should return fcodes for MGCP with no geometry', function(){
+            var fcodes = server.getFCodes({
+                method: 'GET',
+                translation: 'MGCP'
+            });
+
+            assert.equal(fcodes.length, 196);
+            assert.equal(fcodes[0].geom[0], 'Area');
+        });
+
     });
 
     describe('handleInputs', function() {


### PR DESCRIPTION
This basically takes the logic from "populateGeometriesForSchema" that was in TM 174 (that returned a list of fcodes and allowed geometries) and brings it into the hoot translation server. Would it be better to just return a list of fcodes and then create a separate request for allowed geometries for a given fcode or is it better to get it all in one request?