### PR TITLE
Add railways as conflatable feature type

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2290,6 +2290,69 @@ Sets the progress reporting format to the type specified for classes that suppor
 reporting.  Currently, 'json' is the only valid reporting format. If left blank, progress is not
 reported.
 
+=== railway.angle.sample.distance
+
+* Data Type: double
+* Default Value: `20.0`
+
+Distance, in meters, used for sampling railway data during angle histogram extraction with the
+SampledAngleHistogramExtractor
+
+=== railway.match.threshold
+
+* Data Type: double
+* Default Value: `${conflate.match.threshold.default}`
+
+The threshold at which a match is called a match for railwayss.
+
+See also:
+
+ * _Estimate Pairwise Relationships_, <<hootalgo>>
+
+=== railway.matcher.heading.delta
+
+* Data Type: double
+* Default Value: `150.0`
+
+The distance around a point on a railway to look when calculating the heading. See
+`way.matcher.heading.delta`.
+
+=== railway.matcher.max.angle
+
+* Data Type: double
+* Default Value: `90.0`
+
+Sets that maximum angle that is still considered a railway match. Units in degrees.
+
+=== railway.miss.threshold
+
+* Data Type: double
+* Default Value: `${conflate.miss.threshold.default}`
+
+The threshold at which a miss is called a miss for railways.
+
+See also:
+
+ * _Estimate Pairwise Relationships_, <<hootalgo>>
+
+=== railway.review.threshold
+
+* Data Type: double
+* Default Value: `${conflate.review.threshold.default}`
+
+The threshold at which a review is called a review for railways.
+
+See also:
+
+ * _Estimate Pairwise Relationships_, <<hootalgo>>
+
+=== railway.subline.matcher
+
+* Data Type: string
+* Default Value: `hoot::MaximalSublineMatcher`
+
+The way subline matcher to use when determining matching sublines.
+
 === reader.add.source.datetime
 
 * Data Type: bool
@@ -2502,6 +2565,13 @@ The search radius to use when conflating highways.  See `search.radius.default`.
 
 The search radius to use when conflating waterways.  Not used if
 waterway.auto.calc.search.radius = true.  See `search.radius.default`.
+
+=== search.radius.railway
+
+* Data Type: double
+* Default Value: `15`
+
+The search radius to use when conflating railways.
 
 === set.tag.visitor.append.to.existing.value
 

--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -1133,6 +1133,16 @@
             "defaultvalue":"hoot::MaximalSublineMatcher",
             "hoot_key":"railway.subline.matcher",
             "required":"true"
+        },
+        {
+            "id":"railway_matcher_max_angle",
+            "minvalue":"0.0",
+            "maxvalue":"360.0",
+            "defaultvalue":"90.0",
+            "elem_type":"double",
+            "description":"Sets that maximum angle that is still considered a railway match. Units in degrees.",
+            "name":"Railway Matcher Max Angle",
+            "hoot_key":"railway.matcher.max.angle"
         }
     ]
 }

--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -1054,7 +1054,7 @@
                 "id":"search_radius_waterway",
                 "minvalue":"-1",
                 "elem_type":"double",
-                "description":"The search radius to use when conflating highways. If two features are within the search radius then they will be considered for conflation. If the value is -1 then the circular error will be used to calculate an appropriate search radius.",
+                "description":"The search radius to use when conflating waterways. If two features are within the search radius then they will be considered for conflation. If the value is -1 then the circular error will be used to calculate an appropriate search radius.",
                 "maxvalue":"",
                 "name":"Search Radius Waterway",
                 "defaultvalue":"-1",
@@ -1083,5 +1083,101 @@
                 "hoot_key":"waterway.rubber.sheet.ref"
             }
         ]
-    }
+    },
+    {
+        "id":"hoot_railway_options",
+        "elem_type":"group",
+        "description":"Hootenanny Railway options",
+        "name":"Railway Options",
+        "members":[
+        {
+            "id":"hoot_enable_railway_options",
+            "elem_type":"checkbox",
+            "override":{
+                "elem_type":"checkbox"
+            },
+            "description":"Enable railway options",
+            "name":"Enabled",
+            "defaultvalue":"true",
+            "onchange":"true"
+        },
+        {
+            "id":"railway_match_creator",
+            "elem_type":"string",
+            "description":"List of MatchCreators to use during conflation. This can modify what features will be conflated (e.g. buildings, roads, etc.).",
+            "name":"Match Creator",
+            "required":"true",
+            "defaultvalue":"hoot::ScriptMatchCreator,Railway.js",
+            "override":{
+                "defaultvalue":"hoot::ScriptMatchCreator,Railway.js"
+            },
+            "hoot_key":"match.creators"
+        },
+        {
+            "id":"railway_merger_creator",
+            "elem_type":"string",
+            "description":"List of MergerCreators to use during conflation. This can modify what features will be conflated (e.g. buildings, roads, etc.).",
+            "name":"Merger Creator",
+            "required":"true",
+            "defaultvalue":"hoot::ScriptMergerCreator",
+            "override":{
+                "defaultvalue":"hoot::ScriptMergerCreator"
+            },
+            "hoot_key":"merger.creators"
+        },
+        {
+            "id":"railway_way_subline_matcher",
+            "elem_type":"string",
+            "description":"The way subline matcher to use when determining matching sublines.",
+            "name":"Railway Subline Matcher",
+            "defaultvalue":"hoot::MaximalSublineMatcher",
+            "hoot_key":"railway.subline.matcher",
+            "required":"true"
+        },
+        {
+            "id":"railway_way_angle_sample_distance",
+            "minvalue":"0.01",
+            "elem_type":"double",
+            "description":"Distance, in meters, used for sampling during angle histogram extraction with the SampledAngleHistogramExtractor",
+            "maxvalue":"",
+            "name":"Railway Angle Sample Distance",
+            "defaultvalue":"20.0",
+            "hoot_key":"railway.angle.sample.distance"
+        },
+        {
+            "id":"railway_way_matcher_heading_delta",
+            "minvalue":"0.0",
+            "elem_type":"double",
+            "description":"The distance around a point on a way to look when calculating the heading. A larger value will smooth out the heading values on a line. A smaller value will make the heading values correspond directly to the heading on the way at that point. This is primarily used in subline matching. Values are in meters.",
+            "maxvalue":"360.0",
+            "name":"Railway Matcher Heading Delta",
+            "defaultvalue":"150.0",
+            "hoot_key":"railway.matcher.heading.delta"
+        },
+        {
+            "id":"railway_matcher_max_angle",
+            "minvalue":"0.0",
+            "elem_type":"double",
+            "description":"Sets that maximum angle that is still considered a railway match. Units in degrees.",
+            "maxvalue":"360.0",
+            "name":"Railway Matcher Max Angle",
+            "defaultvalue":"90.0",
+            "hoot_key":"railway.matcher.max.angle"
+        },
+        {
+            "id":"search_radius_railway",
+            "minvalue":"-1",
+            "elem_type":"double",
+            "description":"The search radius to use when conflating railways. If two features are within the search radius then they will be considered for conflation. If the value is -1 then the circular error will be used to calculate an appropriate search radius.",
+            "maxvalue":"",
+            "name":"Search Radius Railway",
+            "defaultvalue":"-1",
+            "disabled":"true",
+            "override":{
+                "defaultvalue":"-1"
+            },
+            "hoot_key":"search.radius.railway"
+        }
+    ]
+}
 ]

--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -1133,50 +1133,6 @@
             "defaultvalue":"hoot::MaximalSublineMatcher",
             "hoot_key":"railway.subline.matcher",
             "required":"true"
-        },
-        {
-            "id":"railway_way_angle_sample_distance",
-            "minvalue":"0.01",
-            "elem_type":"double",
-            "description":"Distance, in meters, used for sampling during angle histogram extraction with the SampledAngleHistogramExtractor",
-            "maxvalue":"",
-            "name":"Railway Angle Sample Distance",
-            "defaultvalue":"20.0",
-            "hoot_key":"railway.angle.sample.distance"
-        },
-        {
-            "id":"railway_way_matcher_heading_delta",
-            "minvalue":"0.0",
-            "elem_type":"double",
-            "description":"The distance around a point on a way to look when calculating the heading. A larger value will smooth out the heading values on a line. A smaller value will make the heading values correspond directly to the heading on the way at that point. This is primarily used in subline matching. Values are in meters.",
-            "maxvalue":"360.0",
-            "name":"Railway Matcher Heading Delta",
-            "defaultvalue":"150.0",
-            "hoot_key":"railway.matcher.heading.delta"
-        },
-        {
-            "id":"railway_matcher_max_angle",
-            "minvalue":"0.0",
-            "elem_type":"double",
-            "description":"Sets that maximum angle that is still considered a railway match. Units in degrees.",
-            "maxvalue":"360.0",
-            "name":"Railway Matcher Max Angle",
-            "defaultvalue":"90.0",
-            "hoot_key":"railway.matcher.max.angle"
-        },
-        {
-            "id":"search_radius_railway",
-            "minvalue":"-1",
-            "elem_type":"double",
-            "description":"The search radius to use when conflating railways. If two features are within the search radius then they will be considered for conflation. If the value is -1 then the circular error will be used to calculate an appropriate search radius.",
-            "maxvalue":"",
-            "name":"Search Radius Railway",
-            "defaultvalue":"-1",
-            "disabled":"true",
-            "override":{
-                "defaultvalue":"-1"
-            },
-            "hoot_key":"search.radius.railway"
         }
     ]
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/extractors/AttributeDistanceExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/extractors/AttributeDistanceExtractor.h
@@ -34,7 +34,7 @@ namespace hoot
 
 /**
  * See exporatory funds report for details.
- * Compares "distance" between tags
+ * Calculates "distance" between tags using hoot::TagComparator
  */
 class AttributeDistanceExtractor : public WayFeatureExtractor
 {
@@ -50,7 +50,7 @@ public:
   virtual std::string getName() const;
 
   virtual QString getDescription() const
-  { return "TODO"; }
+  { return "Calculates \"distance\" between tags using hoot::TagComparator"; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/extractors/ParallelScoreExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/extractors/ParallelScoreExtractor.cpp
@@ -22,44 +22,29 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
-#ifndef ATTRIBUTEDISTANCEEXTRACTOR_H
-#define ATTRIBUTEDISTANCEEXTRACTOR_H
 
-#include "WayFeatureExtractor.h"
+#include "ParallelScoreExtractor.h"
+
+// Hoot
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/algorithms/ProbabilityOfMatch.h>
 
 namespace hoot
 {
 
-/**
- * See exporatory funds report for details.
- * Compares "distance" between tags
- */
-class AttributeDistanceExtractor : public WayFeatureExtractor
+HOOT_FACTORY_REGISTER(FeatureExtractor, ParallelScoreExtractor)
+
+ParallelScoreExtractor::ParallelScoreExtractor():
+  WayFeatureExtractor()
 {
-public:
-  static std::string className() { return "hoot::AttributeDistanceExtractor"; }
-
-  AttributeDistanceExtractor(ValueAggregatorPtr wayAgg, QString key = "");
-
-  AttributeDistanceExtractor(QString key = "");
-
-  virtual std::string getClassName() const { return className(); }
-
-  virtual std::string getName() const;
-
-  virtual QString getDescription() const
-  { return "TODO"; }
-
-protected:
-
-  double _extract(const OsmMap& map, const ConstWayPtr& w1, const ConstWayPtr& w2) const;
-
-  bool _useWeight;
-  QString _key;
-};
-
 }
 
-#endif // ATTRIBUTEDISTANCEEXTRACTOR_H
+double ParallelScoreExtractor::_extract(const OsmMap& map, const ConstWayPtr& w1,
+                                        const ConstWayPtr& w2) const
+{
+  return ProbabilityOfMatch::getInstance().parallelScore(map.shared_from_this(), w1, w2);
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/conflate/extractors/ParallelScoreExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/extractors/ParallelScoreExtractor.h
@@ -22,39 +22,37 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2005 VividSolutions (http://www.vividsolutions.com/)
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
-#ifndef CENTROIDDISTANCEEXTRACTOR_H
-#define CENTROIDDISTANCEEXTRACTOR_H
+#ifndef PARALLELSCOREEXTRACTOR_H
+#define PARALLELSCOREEXTRACTOR_H
 
-#include "AbstractDistanceExtractor.h"
+#include "WayFeatureExtractor.h"
 
 namespace hoot
 {
 
 /**
- * @author RoadMatcher
- * @copyright GPL
- * http://www.vividsolutions.com/products.asp?catg=spaapp&code=roadmatcher
- * The ideas were shamelessly taken from RoadMatcher, but reimplemented in C++ with Hootenanny
- * appropriate data structures.
+ * Derive a score from how parallel the ways are
  */
-class CentroidDistanceExtractor : public AbstractDistanceExtractor
+class ParallelScoreExtractor : public WayFeatureExtractor
 {
 public:
-  static std::string className() { return "hoot::CentroidDistanceExtractor"; }
 
-  virtual double distance(const OsmMap& map, const boost::shared_ptr<const Element>& target,
-    const boost::shared_ptr<const Element>& candidate) const;
+  static std::string className() { return "hoot::ParallelScoreExtractor"; }
 
-  virtual std::string getClassName() const { return CentroidDistanceExtractor::className(); }
+  ParallelScoreExtractor();
+
+  virtual std::string getClassName() const { return className(); }
 
   virtual QString getDescription() const
-  { return "Converts target & candidate to geometries, finds their centroids, "
-           "calculates the distance between those two points"; }
+  { return "Derives a score from how parallel teh ways are to each-other"; }
+
+protected:
+
+  double _extract(const OsmMap& map, const ConstWayPtr& w1, const ConstWayPtr& w2) const;
 };
 
 }
 
-#endif // CENTROIDDISTANCEEXTRACTOR_H
+#endif // PARALLELSCOREEXTRACTOR_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/extractors/ParallelScoreExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/extractors/ParallelScoreExtractor.h
@@ -46,7 +46,7 @@ public:
   virtual std::string getClassName() const { return className(); }
 
   virtual QString getDescription() const
-  { return "Derives a score from how parallel teh ways are to each-other"; }
+  { return "Derives a score from how parallel the ways are to each-other"; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -2045,6 +2045,23 @@ bool OsmSchema::isPoi(const Element& e)
   return result;
 }
 
+bool OsmSchema::isRailway(const Element& e)
+{
+  if (e.getElementType() == ElementType::Way || e.getElementType() == ElementType::Relation)
+  {
+    const Tags& tags = e.getTags();
+    for (Tags::const_iterator it = tags.constBegin(); it != tags.constEnd(); ++it)
+    {
+      if (it.key() == "railway" || isAncestor(it.key(), "railway") ||
+          (it.key() == "type" && isAncestor("railway=" + it.value(), "railway")))
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 bool OsmSchema::isReversed(const Element& e) const
 {
   bool result = false;

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
@@ -467,6 +467,11 @@ public:
   bool hasName(const Element& element) const;
 
   /**
+   * Returns true if the specified element is a railway.
+   */
+  bool isRailway(const Element &e);
+
+  /**
    * Returns true if this is a reversed unidirectional way. (E.g. oneway=reverse)
    */
   bool isReversed(const Element& e) const;

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -79,6 +79,8 @@ void OsmSchemaJs::Init(Handle<Object> exports)
               FunctionTemplate::New(current, isMetaData)->GetFunction());
   schema->Set(String::NewFromUtf8(current, "isPoi"),
               FunctionTemplate::New(current, isPoi)->GetFunction());
+  schema->Set(String::NewFromUtf8(current, "isRailway"),
+              FunctionTemplate::New(current, isRailway)->GetFunction());
   schema->Set(String::NewFromUtf8(current, "isLinearHighway"),
               FunctionTemplate::New(current, isLinearHighway)->GetFunction());
   schema->Set(String::NewFromUtf8(current, "score"),
@@ -223,6 +225,16 @@ void OsmSchemaJs::isPoi(const FunctionCallbackInfo<Value>& args)
   ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, OsmSchema::getInstance().isPoi(*e)));
+}
+
+void OsmSchemaJs::isRailway(const FunctionCallbackInfo<Value>& args)
+{
+  Isolate* current = args.GetIsolate();
+  HandleScope scope(current);
+
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+
+  args.GetReturnValue().Set(Boolean::New(current, OsmSchema::getInstance().isRailway(*e)));
 }
 
 void OsmSchemaJs::hasName(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
@@ -56,10 +56,11 @@ private:
   static void isBuilding(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isHgisPoi(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isLinear(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void isLinearHighway(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isLinearWaterway(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isMetaData(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isPoi(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void isLinearHighway(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void isRailway(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void score(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void scoreOneWay(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void hasName(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -1,0 +1,276 @@
+"use strict";
+
+var MATCH_OVERLAP_THRESHOLD = 0.75;
+var MISS_OVERLAP_THRESHOLD = 0.15;
+
+exports.description = "Railways";
+exports.experimental = false;
+exports.baseFeatureType = "Railway";
+
+exports.candidateDistanceSigma = 1.0; // 1.0 * (CE95 + Worst CE95);
+exports.matchThreshold = parseFloat(hoot.get("railway.match.threshold"));
+exports.missThreshold = parseFloat(hoot.get("railway.miss.threshold"));
+exports.reviewThreshold = parseFloat(hoot.get("railway.review.threshold"));
+
+var sublineMatcher =
+  new hoot.MaximalSublineStringMatcher(
+    { "way.matcher.max.angle": hoot.get("railway.matcher.max.angle"),
+      "way.subline.matcher": hoot.get("railway.subline.matcher") });
+var sampledAngleHistogramExtractor =
+  new hoot.SampledAngleHistogramExtractor(
+    { "way.angle.sample.distance" : hoot.get("railway.angle.sample.distance"),
+      "way.matcher.heading.delta" : hoot.get("railway.matcher.heading.delta") });
+var weightedShapeDistanceExtractor = new hoot.WeightedShapeDistanceExtractor();
+
+/**
+ * Runs before match creation occurs and provides an opportunity to perform custom initialization.
+ */
+exports.calculateSearchRadius = function(map)
+{
+  exports.searchRadius = parseFloat(hoot.get("search.radius.railway"));
+  hoot.log("Using specified search radius for railway conflation: " + exports.searchRadius);
+}
+
+/**
+ * Returns true if e is a candidate for a match. Implementing this method is
+ * optional, but may dramatically increase speed if you can cull some features
+ * early on.
+ */
+exports.isMatchCandidate = function(map, e)
+{
+  return isRailway(e);
+};
+
+/**
+ * If this function returns true then all overlapping matches will be treated
+ * as a group. For now that means if two matches overlap then the whole group
+ * will be marked as needing review.
+ *
+ * If this function returns false the conflation routines will attempt to
+ * pick the best subset of matches that do not conflict.
+ */
+exports.isWholeGroup = function()
+{
+    return false;
+};
+
+/**
+ * Returns the match score for the three class relationships.
+ * - match
+ * - miss
+ * - review
+ *
+ * The scores should always sum to one. If they don't you will be taunted
+ * mercilessly and we'll normalize it anyway. :P
+ */
+exports.matchScore = function(map, e1, e2)
+{
+  var result = { miss: 1.0, explain:"miss" };
+
+  if (e1.getStatusString() === e2.getStatusString()) {
+    return result;
+  }
+
+  // extract the sublines needed for matching
+  var sublines = sublineMatcher.extractMatchingSublines(map, e1, e2);
+  if (sublines) {
+    //result = { match: 1.0, explain:"match" };
+    //return result;
+
+    var m = sublines.map;
+    var m1 = sublines.match1;
+    var m2 = sublines.match2;
+
+    var sampledAngleHistogramValue = sampledAngleHistogramExtractor.extract(m, m1, m2);
+    var weightedShapeDistanceValue = weightedShapeDistanceExtractor.extract(m, m1, m2);
+
+    var attribs = [sampledAngleHistogramValue, weightedShapeDistanceValue];
+    var classification = WekaClassifier.classify(attribs);
+    if (1 === classification) {
+      hoot.trace("Found Match!");
+      result = { match: 1.0, explain:"match" };
+    }
+  }
+
+  return result;
+};
+
+/**
+ * The internals of geometry merging can become quite complex. Typically this
+ * method will simply call another hoot method to perform the appropriate merging
+ * of geometries.
+ *
+ * If this method is exported then the mergePair method should not be exported.
+ *
+ * @param map The map that is being conflated
+ * @param pairs An array of ElementId pairs that will be merged.
+ * @param replaced An empty array is passed in, the method should fill the array
+ *      with all the replacements that occur during the merge process (e.g. if two
+ *      elements (way:1 & way:2) are merged into one element (way:3), then the
+ *      replaced array should contain [[way:1, way:3], [way:1, way:3]] where all
+ *      the "way:*" objects are of the ElementId type.
+ */
+exports.mergeSets = function(map, pairs, replaced)
+{
+  hoot.trace("Merging elements.");
+  // snap the ways in the second input to the first input. Use the default tag
+  // merge method.
+  return snapWays(sublineMatcher, map, pairs, replaced);
+};
+
+exports.getMatchFeatureDetails = function(map, e1, e2)
+{
+  var featureDetails = [];
+
+  // extract the sublines needed for matching
+  var sublines = sublineMatcher.extractMatchingSublines(map, e1, e2);
+  if (sublines)
+  {
+    var m = sublines.map;
+    var m1 = sublines.match1;
+    var m2 = sublines.match2;
+
+    featureDetails["sampledAngleHistogramValue"] = sampledAngleHistogramExtractor.extract(m, m1, m2);
+    featureDetails["weightedShapeDistanceValue"] = weightedShapeDistanceExtractor.extract(m, m1, m2);
+  }
+
+  return featureDetails;
+};
+
+
+
+/* Classifier derived using Weka 3.8
+ * Using a manually-matched dataset which was probably too small
+ * REPTree classifier
+ *
+ * === Summary ===
+ * Correctly Classified Instances         369          79.3548 %
+ * Incorrectly Classified Instances        96          20.6452 %
+ * Kappa statistic                          0.1823
+ * Mean absolute error                      0.192
+ * Root mean squared error                  0.316
+ * Relative absolute error                 86.5813 %
+ * Root relative squared error             95.2511 %
+ * Total Number of Instances              465
+ *
+ * Argument should be Object[2] = { Double sampledAngleHistogramValue,
+ *                                  Double weightedShapeDistanceValue }
+ */
+
+class WekaClassifier {
+
+  static classify(i) {
+    var p = NaN;
+    p = WekaClassifier.Nbf90f236(i);
+    return p;
+  }
+
+  static Nbf90f236(i) {
+    var p = NaN;
+    // weightedShapeDistanceValue
+    if (i[1] == null) {
+      p = 1;
+    } else if (i[1] < 0.9996969548964832) {
+      p = 1;
+    } else if (true) {
+    p = WekaClassifier.Na1878427(i);
+    }
+    return p;
+  }
+  static Na1878427(i) {
+    var p = NaN;
+    // sampledAngleHistogramValue
+    if (i[0] == null) {
+      p = 1;
+    } else if (i[0] < 0.9999867882954654) {
+    p = WekaClassifier.N4649dd508(i);
+    } else if (true) {
+      p = 1;
+    }
+    return p;
+  }
+  static N4649dd508(i) {
+    var p = NaN;
+    // sampledAngleHistogramValue
+    if (i[0] == null) {
+      p = 0;
+    } else if (i[0] < 0.9994555988547049) {
+    p = WekaClassifier.N300d0e419(i);
+    } else if (true) {
+      p = 0;
+    }
+    return p;
+  }
+  static N300d0e419(i) {
+    var p = NaN;
+    // weightedShapeDistanceValue
+    if (i[1] == null) {
+      p = 1;
+    } else if (i[1] < 0.9999996992930555) {
+    p = WekaClassifier.N734e8f7410(i);
+    } else if (true) {
+      p = 1;
+    }
+    return p;
+  }
+  static N734e8f7410(i) {
+    var p = NaN;
+    // weightedShapeDistanceValue
+    if (i[1] == null) {
+      p = 1;
+    } else if (i[1] < 0.9999980378189885) {
+    p = WekaClassifier.N3add333711(i);
+    } else if (true) {
+      p = 0;
+    }
+    return p;
+  }
+  static N3add333711(i) {
+    var p = NaN;
+    // weightedShapeDistanceValue
+    if (i[1] == null) {
+      p = 1;
+    } else if (i[1] < 0.9997304137129573) {
+      p = 0;
+    } else if (true) {
+    p = WekaClassifier.N3276ca6112(i);
+    }
+    return p;
+  }
+  static N3276ca6112(i) {
+    var p = NaN;
+    // sampledAngleHistogramValue
+    if (i[0] == null) {
+      p = 1;
+    } else if (i[0] < 0.6118379265697682) {
+      p = 1;
+    } else if (true) {
+    p = WekaClassifier.N6ad1b56813(i);
+    }
+    return p;
+  }
+  static N6ad1b56813(i) {
+    var p = NaN;
+    // sampledAngleHistogramValue
+    if (i[0] == null) {
+      p = 1;
+    } else if (i[0] < 0.9545753445646151) {
+    p = WekaClassifier.N6de3b26914(i);
+    } else if (true) {
+      p = 1;
+    }
+    return p;
+  }
+  static N6de3b26914(i) {
+    var p = NaN;
+    // sampledAngleHistogramValue
+    if (i[0] == null) {
+      p = 0;
+    } else if (i[0] < 0.908430154556233) {
+      p = 1;
+    } else if (true) {
+      p = 0;
+    }
+    return p;
+  }
+}

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -101,9 +101,6 @@ exports.matchScore = function(map, e1, e2)
     var edgeDistance  = edgeDistanceExtractor.extract(m, m1, m2);
     var hausdorffDistance = hausdorffDistanceExtractor.extract(m, m1, m2);
 
-    //var sampledAngleHistogramValue = sampledAngleHistogramExtractor.extract(m, m1, m2);
-    //var weightedShapeDistanceValue = weightedShapeDistanceExtractor.extract(m, m1, m2);
-
     var attribs = [distanceScore, edgeDistance, hausdorffDistance];
     var classification = WekaClassifier.classify(attribs);
     if (0 === classification) {
@@ -156,8 +153,8 @@ exports.getMatchFeatureDetails = function(map, e1, e2)
     featureDetails["edgeDistance"]               = edgeDistanceExtractor.extract(m, m1, m2);
     featureDetails["euclideanDistance"]          = euclideanDistanceExtractor.extract(m, m1, m2);
     featureDetails["hausdorffDistance"]          = hausdorffDistanceExtractor.extract(m, m1, m2);
-    featureDetails["parallelScoreExtractor"]     = parallelScoreExtractor.extract(m, m1, m2);
-    featureDetails["lengthScoreExtractor"]       = lengthScoreExtractor.extract(m, m1, m2);
+    featureDetails["parallelScore"]              = parallelScoreExtractor.extract(m, m1, m2);
+    featureDetails["lengthScore"]                = lengthScoreExtractor.extract(m, m1, m2);
   }
 
   return featureDetails;

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -17,11 +17,6 @@ var sublineMatcher =
     { "way.matcher.max.angle": hoot.get("railway.matcher.max.angle"),
       "way.subline.matcher": hoot.get("railway.subline.matcher") });
 
-var sampledAngleHistogramExtractor =
-  new hoot.SampledAngleHistogramExtractor(
-    { "way.angle.sample.distance" : hoot.get("railway.angle.sample.distance"),
-      "way.matcher.heading.delta" : hoot.get("railway.matcher.heading.delta") });
-
 var distanceScoreExtractor = new hoot.DistanceScoreExtractor();
 
 // Use default spacing, 5 meters
@@ -147,14 +142,13 @@ exports.getMatchFeatureDetails = function(map, e1, e2)
     var m1 = sublines.match1;
     var m2 = sublines.match2;
 
-    featureDetails["sampledAngleHistogramValue"] = sampledAngleHistogramExtractor.extract(m, m1, m2);
-    featureDetails["weightedShapeDistanceValue"] = weightedShapeDistanceExtractor.extract(m, m1, m2);
-    featureDetails["distanceScore"]              = distanceScoreExtractor.extract(m, m1, m2);
-    featureDetails["edgeDistance"]               = edgeDistanceExtractor.extract(m, m1, m2);
-    featureDetails["euclideanDistance"]          = euclideanDistanceExtractor.extract(m, m1, m2);
-    featureDetails["hausdorffDistance"]          = hausdorffDistanceExtractor.extract(m, m1, m2);
-    featureDetails["parallelScore"]              = parallelScoreExtractor.extract(m, m1, m2);
-    featureDetails["lengthScore"]                = lengthScoreExtractor.extract(m, m1, m2);
+    featureDetails["weightedShapeDistance"] = weightedShapeDistanceExtractor.extract(m, m1, m2);
+    featureDetails["distanceScore"]         = distanceScoreExtractor.extract(m, m1, m2);
+    featureDetails["edgeDistance"]          = edgeDistanceExtractor.extract(m, m1, m2);
+    featureDetails["euclideanDistance"]     = euclideanDistanceExtractor.extract(m, m1, m2);
+    featureDetails["hausdorffDistance"]     = hausdorffDistanceExtractor.extract(m, m1, m2);
+    featureDetails["parallelScore"]         = parallelScoreExtractor.extract(m, m1, m2);
+    featureDetails["lengthScore"]           = lengthScoreExtractor.extract(m, m1, m2);
   }
 
   return featureDetails;

--- a/rules/lib/HootLib.js
+++ b/rules/lib/HootLib.js
@@ -230,6 +230,17 @@ function isPoi(e)
 }
 
 /**
+ * Returns true if the specified element is an railway element.
+ *
+ * See the OSM wiki for more information:
+ * http://wiki.openstreetmap.org/wiki/Railway
+ */
+function isRailway(e)
+{
+    return hoot.OsmSchema.isRailway(e);
+}
+
+/**
  * Returns true if the specified element has a name
  */
 function hasName(e)


### PR DESCRIPTION
Refs #2311 
Don't forget to merge the 2311 hoot-tests branch! (regression test)!

So... on the data I've been playing with, it scores like this:
```
|                 |        |\3=.       expected     |
|                 |        | miss  | match | review |
|/3. test outcome | miss   |   -   |    24 |     0  |
                  | match  |     5 |    75 |     0  |
                  | review |     0 |     0 |     0  |

correct: 0.721154
wrong: 0.278846
unnecessary reviews: 0
```
I suppose that leaves room for improvement... but I figure we might as well get the feature in there.