### PR TITLE
OSM file containing "action='delete'" crashes when converted to Shapefile

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -809,6 +809,9 @@ void OgrWriter::writeElement(ElementPtr &element)
 
 void OgrWriter::writeElement(ElementPtr &element, bool debug)
 {
+  //  Do not attempt to write empty elements
+  if (!element)
+    return;
   Tags sourceTags = element->getTags();
   Tags destTags;
   for (Tags::const_iterator it = element->getTags().begin(); it != element->getTags().end(); ++it)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -415,6 +415,7 @@ bool OsmXmlReader::startElement(const QString & /* namespaceURI */,
       }
       else
       {
+        LOG_DEBUG("Node " << attributes.value("id") << " set to delete.");
         _element.reset();
       }
     }
@@ -426,6 +427,7 @@ bool OsmXmlReader::startElement(const QString & /* namespaceURI */,
       }
       else
       {
+        LOG_DEBUG("Way " << attributes.value("id") << " set to delete.");
         _element.reset();
       }
     }
@@ -437,6 +439,7 @@ bool OsmXmlReader::startElement(const QString & /* namespaceURI */,
       }
       else
       {
+        LOG_DEBUG("Relation " << attributes.value("id") << " set to delete.");
         _element.reset();
       }
     }


### PR DESCRIPTION
Added debug messages for `action='delete'` elements in `OsmXmlReader` and ignore `NULL` elements in the streaming `OgrWriter` class.
