### PR TITLE
Nightly Regression

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
@@ -73,6 +73,9 @@ void PoiPolygonMerger::apply(const OsmMapPtr& map, vector< pair<ElementId, Eleme
   // Merge all the building parts together into a single building entity using the typical building
   // merge process.
   ElementId finalBuildingEid = _mergeBuildings(map, buildings1, buildings2, replaced);
+  //  If no buildings are merged (many-to-many) then exit here
+  if (finalBuildingEid.isNull())
+    return;
   LOG_VART(finalBuildingEid);
 
   ElementPtr finalBuilding = map->getElement(finalBuildingEid);
@@ -272,6 +275,9 @@ ElementId PoiPolygonMerger::_mergeBuildings(const OsmMapPtr& map,
   assert(replaced.size() == 0);
   //assert(pairs.size() == 0);  //This fails on a poi-building case test.
   BuildingMerger(pairs).apply(map, replaced);
+  //  Empty replaced vector indicates a many-to-many review
+  if (replaced.size() < 1)
+    return ElementId();
   assert(replaced.size() > 0);
 
   set<ElementId> newElement;


### PR DESCRIPTION
Refs #2404 
Many to many matches in PoiPoly fail an assert.
```
  BuildingMerger(pairs).apply(map, replaced);
  assert(replaced.size() > 0);
```
When the `BuildingMerger` code runs into a many-to-many case, a relation is created and nothing is pushed into the `replaced` vector.  This will cause the above assert to fail.  Instead return a NULL `ElementId`.  This is then caught in the `PoiPolygonMerger::apply` code and all of the rest of the function is skipped because nothing was merged and so tags don't need to be updated.  This was causing regression tests failures.