### PR TITLE
Add github pull-request support to sonar scan pipeline

### DIFF
--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -41,16 +41,26 @@ pipeline {
         }
         stage("Build") {
             steps {
-                // Build and scan
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh ${env.SONAR_CLOUD_KEY}'"
+                script {
+                    if (env.BRANCH_NAME.startsWith("PR-")) {
+                        // This is a pull request so we need to pass PR info to the scripts
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME} ${env.CHANGE_ID} ${env.DGIS_BOT_TOKEN}'"
+                    }
+                    else {
+                        // Scan for a regular branch
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
+                    }
+                }
             }       
         }
     }
     post {
         always {
             script {
-                // Send build notification
-                notifySlack(currentBuild.result, "#builds_hoot")
+                if (!env.BRANCH_NAME.startsWith("PR-")) {
+                    // Send build notification
+                    notifySlack(currentBuild.result, "#builds_hoot")
+                }
             }
         }
         success {

--- a/scripts/sonar/sonar-build.sh
+++ b/scripts/sonar/sonar-build.sh
@@ -8,13 +8,34 @@ aclocal && autoconf && autoheader && automake --add-missing --copy
 # Make with the sonar build watcher
 build-wrapper-linux-x86-64 --out-dir bw-output make -sj$(nproc)
 
-# Perform scan and upload to sonar scanner
-sonar-scanner \
-    -Dsonar.projectKey=hoot \
-    -Dsonar.sources=./hoot-cmd,./hoot-core,./hoot-core-test,./hoot-js,./hoot-rnd,./hoot-test,./tbs,./tgs \
-    -Dsonar.cfamily.build-wrapper-output=bw-output \
-    -Dsonar.host.url=https://sonarcloud.io \
-    -Dsonar.organization=hootenanny \
-    -Dsonar.login=$1 \
-    -Dsonar.cfamily.threads=4 \
-    -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql
+# Build out the scan command
+CMD="sonar-scanner"
+CMD+=" -Dsonar.projectKey=hoot"
+CMD+=" -Dsonar.sources=./hoot-cmd,./hoot-core,./hoot-core-test,./hoot-js,./hoot-rnd,./hoot-test,./tbs,./tgs"
+CMD+=" -Dsonar.cfamily.build-wrapper-output=bw-output"
+CMD+=" -Dsonar.host.url=https://sonarcloud.io"
+CMD+=" -Dsonar.organization=hootenanny"
+CMD+=" -Dsonar.cfamily.threads=4"
+CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
+CMD+=" -Dsonar.cfamily.lcov.reportsPaths=./coverage/core/core/Core.info"
+CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
+
+# Optional scan parameters based off parameters passed into script
+if [ -n "$1" ]; then
+    # This is the hoot sonarcloud project key, requried to pass scan results to sever for analysis and display
+    CMD+=" -Dsonar.login=$1"
+fi
+if [ -n "$2" ]; then
+    CMD+=" -Dsonar.branch.name=$2"
+fi
+if [ -n "$3" ]; then
+    # Optional pull request number that will match scan with git hub pull-request
+    CMD+=" -Dsonar.github.pullRequest=$3"
+    CMD+=" -Dsonar.analysis.mode=preview"
+fi
+if [ -n "$4" ]; then
+    # Optional token to allow scan to post comments to github ticket
+    CMD+=" -Dsonar.github.oauth=$4"
+fi
+ 
+eval $CMD


### PR DESCRIPTION
These changes will scan pull-requests upon creation and changes.  It will fail the scan job if any new critical or high findings are introduced in the branch.  It will also make inline comments in the pull-request diffs identifying scan results in the newly proposed code changes.