### PR TITLE
Prevent SmallWayMerger from merging intersections created by IntersectionSplitter

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/SmallWayMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/SmallWayMerger.cpp
@@ -133,6 +133,13 @@ void SmallWayMerger::_mergeWays(const set<long>& ids)
     return;
   }
 
+  // if either one is a loop (because it's really an interseciont, even though
+  // "only" two ways intersect!)
+  if (w1->isSimpleLoop() || w2->isSimpleLoop())
+  {
+    return;
+  }
+
   // if they're from the same input sets & have effectively the same tags
   if (w1->getStatus() == w2->getStatus() &&
       _diff->diff(_map, w1, w2) == 0.0)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/SmallWayMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/SmallWayMerger.cpp
@@ -133,7 +133,7 @@ void SmallWayMerger::_mergeWays(const set<long>& ids)
     return;
   }
 
-  // if either one is a loop (because it's really an interseciont, even though
+  // if either one is a loop (because it's really an intersection, even though
   // "only" two ways intersect!)
   if (w1->isSimpleLoop() || w2->isSimpleLoop())
   {

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -228,11 +228,7 @@ bool Way::isOneWay() const
 
 bool Way::isSimpleLoop() const
 {
-  if (getNodeId(0) == getNodeId(getNodeCount()-1))
-  {
-    return true;
-  }
-  return false;
+  return (getFirstNodeId() == getLastNodeId());
 }
 
 bool Way::isValidPolygon() const

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -226,6 +226,15 @@ bool Way::isOneWay() const
   return result;
 }
 
+bool Way::isSimpleLoop() const
+{
+  if (getNodeId(0) == getNodeId(getNodeCount()-1))
+  {
+    return true;
+  }
+  return false;
+}
+
 bool Way::isValidPolygon() const
 {
   size_t nc = getNodeCount();

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -139,6 +139,13 @@ public:
   bool isOneWay() const;
 
   /**
+   * @brief isSimpleLoop - checks to see if the way starts and ends at the same
+   *                       node. If it does, return true.
+   * @return true if the way starts and ends at the same node
+   */
+  bool isSimpleLoop() const;
+
+  /**
    * Returns true if this could possibly be a valid polygon. This is only checking for rudimentary
    * conditions and doesn't look for bow ties, etc.
    */


### PR DESCRIPTION
The SmallWayMerger is pretty careful not to undo the work done by the IntersectionSplitter, but it was not handling the scenario where a way Ts into a looped way. Now it does!

Refs #2401 