### PR TITLE
Wrong output filename extension

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.cpp
@@ -115,7 +115,7 @@ void OsmGbdxJsonWriter::_newOutputFile()
     while (QFile::exists(url))
     {
       inc++;
-      url = _outputDir.filePath(QString("%1_%2_%3.xml").arg(_outputFileName).arg(inc,2,10,QChar('0')).arg(_fileNumber));
+      url = _outputDir.filePath(QString("%1_%2_%3.json").arg(_outputFileName).arg(inc,2,10,QChar('0')).arg(_fileNumber));
     }
 //    LOG_ERROR("Final name: " + url);
   }


### PR DESCRIPTION
refs: #2424 

I screwed up the file extension for non-unique files.

@mschicker could you review this please.