### PR TITLE
Generate gcov and include in sonar scan of hoot C++

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -453,9 +453,9 @@ ifeq ($(BUILD_RND),rnd)
 	genhtml coverage/core/rnd/RndTrimmed.info --output-directory coverage/core/rnd/ 2>&1 | grep -v -F "geninfo" >> coverage/core/rnd/log
 endif
 
-core-coverage: coverage/core/core/index.html coverage/core/hadoop/index.html coverage/core/tbs/index.html core-rnd-coverage
+core-coverage: coverage/core/core/index.html coverage/core/tbs/index.html core-rnd-coverage
 
-coverage: services-coverage ui-coverage coverage/core/core/index.html coverage/core/hadoop/index.html coverage/core/tbs/index.html core-rnd-coverage
+coverage: services-coverage ui-coverage coverage/core/core/index.html coverage/core/tbs/index.html core-rnd-coverage
 
 conf/dictionary/WordsAbridged.sqlite: conf/dictionary/WordsAbridged.sqlite.gz
 	gunzip -c $^ > $@

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -91,6 +91,7 @@ sudo yum -y install \
     hoot-gdal \
     hoot-gdal-devel \
     hoot-gdal-python \
+    lcov \
     libicu-devel \
     libpng-devel \
     libtool \

--- a/scripts/cover/gcovHoot.sh
+++ b/scripts/cover/gcovHoot.sh
@@ -10,27 +10,24 @@ fi
 cd $HOOT_HOME
 
 # hoot-core coverage
-mkdir gcov-hoot-core
-cd gcov-hoot-core
-gcov ../hoot-core/tmp/debug/*.gcda
+cd hoot-core
+gcov tmp/debug/*.gcda
 # fix path
 sed -i 's/src/hoot-core\/src/g' *.gcov
 mv *.gcov ../
 cd ..
 
 #tbs coverage
-mkdir gcov-tbs
-cd gcov-tbs
-gcov ../tbs/tmp/debug/*.gcda
+cd tbs
+gcov tmp/debug/*.gcda
 # fix path
 sed -i 's/src/tbs\/src/g' *.gcov
 mv *.gcov ../
 cd ..
 
 # hoot-rnd coverage
-mkdir gcov-hoot-rnd
-cd gcov-hoot-rnd
-gcov ../hoot-rnd/tmp/debug/*.gcda
+cd hoot-rnd
+gcov tmp/debug/*.gcda
 # fix path
 sed -i 's/src/hoot-rnd\/src/g' *.gcov
 mv *.gcov ../

--- a/scripts/cover/gcovHoot.sh
+++ b/scripts/cover/gcovHoot.sh
@@ -8,6 +8,30 @@ fi
 
 # generate gcov files from gcda files
 cd $HOOT_HOME
-gcov ./hoot-core/tmp/debug/*.gcda
-gcov ./tbs/tmp/debug/*.gcda
-gcov ./hoot-rnd/tmp/debug/*.gcda
+
+# hoot-core coverage
+mkdir gcov-hoot-core
+cd gcov-hoot-core
+gcov ../hoot-core/tmp/debug/*.gcda
+# fix path
+sed -i 's/src/hoot-core\/src/g' *.gcov
+mv *.gcov ./
+cd ..
+
+#tbs coverage
+mkdir gcov-tbs
+cd gcov-tbs
+gcov ../tbs/tmp/debug/*.gcda
+# fix path
+sed -i 's/src/tbs\/src/g' *.gcov
+mv *.gcov ./
+cd ..
+
+# hoot-rnd coverage
+mkdir gcov-hoot-rnd
+cd gcov-hoot-rnd
+gcov ../hoot-rnd/tmp/debug/*.gcda
+# fix path
+sed -i 's/src/hoot-rnd\/src/g' *.gcov
+mv *.gcov ./
+cd ..

--- a/scripts/cover/gcovHoot.sh
+++ b/scripts/cover/gcovHoot.sh
@@ -15,7 +15,7 @@ cd gcov-hoot-core
 gcov ../hoot-core/tmp/debug/*.gcda
 # fix path
 sed -i 's/src/hoot-core\/src/g' *.gcov
-mv *.gcov ./
+mv *.gcov ../
 cd ..
 
 #tbs coverage
@@ -24,7 +24,7 @@ cd gcov-tbs
 gcov ../tbs/tmp/debug/*.gcda
 # fix path
 sed -i 's/src/tbs\/src/g' *.gcov
-mv *.gcov ./
+mv *.gcov ../
 cd ..
 
 # hoot-rnd coverage
@@ -33,5 +33,5 @@ cd gcov-hoot-rnd
 gcov ../hoot-rnd/tmp/debug/*.gcda
 # fix path
 sed -i 's/src/hoot-rnd\/src/g' *.gcov
-mv *.gcov ./
+mv *.gcov ../
 cd ..

--- a/scripts/cover/gcovHoot.sh
+++ b/scripts/cover/gcovHoot.sh
@@ -10,25 +10,41 @@ fi
 cd $HOOT_HOME
 
 # hoot-core coverage
-cd hoot-core
-gcov tmp/debug/*.gcda
+mkdir gcovCore
+cd gcovCore
+gcov ../hoot-core/tmp/debug/*.gcda
 # fix path
-sed -i 's/src/hoot-core\/src/g' *.gcov
+sed -i 's/Source:src/Source:hoot-core\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
 mv *.gcov ../
 cd ..
 
-#tbs coverage
-cd tbs
-gcov tmp/debug/*.gcda
+# tbs coverage
+mkdir gcovTbs
+cd gcovTbs
+gcov ../tbs/tmp/debug/*.gcda
 # fix path
-sed -i 's/src/tbs\/src/g' *.gcov
+sed -i 's/Source:src/Source:tbs\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
+mv *.gcov ../
+cd ..
+
+# tgs coverage
+mkdir gcovTgs
+cd gcovTgs
+gcov ../tgs/tmp/obj/debug/*.gcda
+# fix path
+sed -i 's/Source:src/Source:tgs\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
 mv *.gcov ../
 cd ..
 
 # hoot-rnd coverage
-cd hoot-rnd
-gcov tmp/debug/*.gcda
+mkdir gcovRnd
+cd gcovRnd
+gcov ../hoot-rnd/tmp/debug/*.gcda
 # fix path
-sed -i 's/src/hoot-rnd\/src/g' *.gcov
+sed -i 's/Source:src/Source:hoot-rnd\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
 mv *.gcov ../
 cd ..

--- a/scripts/cover/gcovHoot.sh
+++ b/scripts/cover/gcovHoot.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# set HOOT_HOME if not set
+if [ -z "$HOOT_HOME" ]; then
+    HOOT_HOME=~/hoot
+fi
+
+# generate gcov files from gcda files
+cd $HOOT_HOME
+gcov ./hoot-core/tmp/debug/*.gcda
+gcov ./tbs/tmp/debug/*.gcda
+gcov ./hoot-rnd/tmp/debug/*.gcda

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -55,7 +55,7 @@ pipeline {
                         // Generate .gcov intermediate files
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/gcovHoot.sh'"
                         // Perform sonar scan (will include coverage information)
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} release'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} develop'"
                     }
                 }
             }       

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -71,6 +71,7 @@ pipeline {
             // If all tests passed, clean everything up
             //sh "vagrant destroy -f ${params.Box}"
             //cleanWs()
+            echo 'success'
         }
         failure {
             script {

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -51,9 +51,11 @@ pipeline {
                         // Scan for a regular branch
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh'"
                         // Run tests so coverage reports are created
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/jenkins/TestInitialNightly.sh'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel \$(nproc)'"
+                        // Generate .gcov intermediate files
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/gcovHoot.sh'"
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
+                        // Perform sonar scan (will include coverage information)
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} release'"
                     }
                 }
             }       

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -70,7 +70,7 @@ pipeline {
         success {
             // If all tests passed, clean everything up
             //sh "vagrant destroy -f ${params.Box}"
-            cleanWs()
+            //cleanWs()
         }
         failure {
             script {

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -52,6 +52,7 @@ pipeline {
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh'"
                         // Run tests so coverage reports are created
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/jenkins/TestInitialNightly.sh'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/gcovHoot.sh'"
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
                     }
                 }

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -70,8 +70,8 @@ pipeline {
         }
         success {
             // If all tests passed, clean everything up
-            //sh "vagrant destroy -f ${params.Box}"
-            //cleanWs()
+            sh "vagrant destroy -f ${params.Box}"
+            cleanWs()
             echo 'success'
         }
         failure {

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -55,7 +55,7 @@ pipeline {
                         // Generate .gcov intermediate files
                         sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/gcovHoot.sh'"
                         // Perform sonar scan (will include coverage information)
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} develop'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
                     }
                 }
             }       

--- a/scripts/jenkins/Jenkinsfile_scan
+++ b/scripts/jenkins/Jenkinsfile_scan
@@ -43,12 +43,16 @@ pipeline {
             steps {
                 script {
                     if (env.BRANCH_NAME.startsWith("PR-")) {
-                        // This is a pull request so we need to pass PR info to the scripts
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME} ${env.CHANGE_ID} ${env.DGIS_BOT_TOKEN}'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh'"
+                        // This is a pull request so we need to pass PR info to the scan script
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME} ${env.CHANGE_ID} ${env.DGIS_BOT_TOKEN}'"
                     }
                     else {
                         // Scan for a regular branch
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-build.sh'"
+                        // Run tests so coverage reports are created
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/jenkins/TestInitialNightly.sh'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
                     }
                 }
             }       
@@ -65,7 +69,7 @@ pipeline {
         }
         success {
             // If all tests passed, clean everything up
-            sh "vagrant destroy -f ${params.Box}"
+            //sh "vagrant destroy -f ${params.Box}"
             cleanWs()
         }
         failure {

--- a/scripts/sonar/sonar-build.sh
+++ b/scripts/sonar/sonar-build.sh
@@ -3,39 +3,7 @@ set -e
 
 # Configure the make
 aclocal && autoconf && autoheader && automake --add-missing --copy
-./configure --quiet --with-rnd --with-services --with-uitests
+./configure --quiet --with-rnd --with-services --with-uitests --with-coverage
 
 # Make with the sonar build watcher
 build-wrapper-linux-x86-64 --out-dir bw-output make -sj$(nproc)
-
-# Build out the scan command
-CMD="sonar-scanner"
-CMD+=" -Dsonar.projectKey=hoot"
-CMD+=" -Dsonar.sources=./hoot-cmd,./hoot-core,./hoot-core-test,./hoot-js,./hoot-rnd,./hoot-test,./tbs,./tgs"
-CMD+=" -Dsonar.cfamily.build-wrapper-output=bw-output"
-CMD+=" -Dsonar.host.url=https://sonarcloud.io"
-CMD+=" -Dsonar.organization=hootenanny"
-CMD+=" -Dsonar.cfamily.threads=4"
-CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
-CMD+=" -Dsonar.cfamily.lcov.reportsPaths=./coverage/core/core/Core.info"
-CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
-
-# Optional scan parameters based off parameters passed into script
-if [ -n "$1" ]; then
-    # This is the hoot sonarcloud project key, requried to pass scan results to sever for analysis and display
-    CMD+=" -Dsonar.login=$1"
-fi
-if [ -n "$2" ]; then
-    CMD+=" -Dsonar.branch.name=$2"
-fi
-if [ -n "$3" ]; then
-    # Optional pull request number that will match scan with git hub pull-request
-    CMD+=" -Dsonar.github.pullRequest=$3"
-    CMD+=" -Dsonar.analysis.mode=preview"
-fi
-if [ -n "$4" ]; then
-    # Optional token to allow scan to post comments to github ticket
-    CMD+=" -Dsonar.github.oauth=$4"
-fi
- 
-eval $CMD

--- a/scripts/sonar/sonar-scan.sh
+++ b/scripts/sonar/sonar-scan.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+# Build out the scan command
+CMD="sonar-scanner"
+CMD+=" -Dsonar.projectKey=hoot"
+CMD+=" -Dsonar.sources=./hoot-cmd,./hoot-core,./hoot-core-test,./hoot-js,./hoot-rnd,./hoot-test,./tbs,./tgs"
+CMD+=" -Dsonar.cfamily.build-wrapper-output=bw-output"
+CMD+=" -Dsonar.host.url=https://sonarcloud.io"
+CMD+=" -Dsonar.organization=hootenanny"
+CMD+=" -Dsonar.cfamily.threads=4"
+CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
+CMD+=" -Dsonar.cfamily.lcov.reportsPaths=./coverage/core/core/Core.info"
+CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
+
+# Optional scan parameters based off parameters passed into script
+if [ -n "$1" ]; then
+    # This is the hoot sonarcloud project key, requried to pass scan results to sever for analysis and display
+    CMD+=" -Dsonar.login=$1"
+fi
+if [ -n "$2" ]; then
+    CMD+=" -Dsonar.branch.name=$2"
+fi
+if [ -n "$3" ]; then
+    # Optional pull request number that will match scan with git hub pull-request
+    CMD+=" -Dsonar.github.pullRequest=$3"
+    CMD+=" -Dsonar.analysis.mode=preview"
+fi
+if [ -n "$4" ]; then
+    # Optional token to allow scan to post comments to github ticket
+    CMD+=" -Dsonar.github.oauth=$4"
+fi
+ 
+eval $CMD

--- a/scripts/sonar/sonar-scan.sh
+++ b/scripts/sonar/sonar-scan.sh
@@ -10,8 +10,8 @@ CMD+=" -Dsonar.host.url=https://sonarcloud.io"
 CMD+=" -Dsonar.organization=hootenanny"
 CMD+=" -Dsonar.cfamily.threads=4"
 CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
-CMD+=" -Dsonar.cfamily.lcov.reportsPaths=./coverage/core/core/Core.info"
 CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
+CMD+=" -Dsonar.cfamily.gcov.reportsPath=hoot_core,tbs,hoot-rnd"
 
 # Optional scan parameters based off parameters passed into script
 if [ -n "$1" ]; then

--- a/scripts/sonar/sonar-scan.sh
+++ b/scripts/sonar/sonar-scan.sh
@@ -4,7 +4,7 @@ set -e
 # Build out the scan command
 CMD="sonar-scanner"
 CMD+=" -Dsonar.projectKey=hoot"
-CMD+=" -Dsonar.sources=./hoot-cmd,./hoot-core,./hoot-core-test,./hoot-js,./hoot-rnd,./hoot-test,./tbs,./tgs"
+CMD+=" -Dsonar.sources=./hoot-core,./hoot-js,./hoot-rnd,./tbs,./tgs"
 CMD+=" -Dsonar.cfamily.build-wrapper-output=bw-output"
 CMD+=" -Dsonar.host.url=https://sonarcloud.io"
 CMD+=" -Dsonar.organization=hootenanny"

--- a/scripts/sonar/sonar-scan.sh
+++ b/scripts/sonar/sonar-scan.sh
@@ -11,7 +11,7 @@ CMD+=" -Dsonar.organization=hootenanny"
 CMD+=" -Dsonar.cfamily.threads=4"
 CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
 CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
-CMD+=" -Dsonar.cfamily.gcov.reportsPath=hoot_core,tbs,hoot-rnd"
+CMD+=" -Dsonar.cfamily.gcov.reportsPath=./"
 
 # Optional scan parameters based off parameters passed into script
 if [ -n "$1" ]; then

--- a/scripts/sonar/sonar-scan.sh
+++ b/scripts/sonar/sonar-scan.sh
@@ -11,7 +11,7 @@ CMD+=" -Dsonar.organization=hootenanny"
 CMD+=" -Dsonar.cfamily.threads=4"
 CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
 CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
-CMD+=" -Dsonar.cfamily.gcov.reportsPath=./"
+CMD+=" -Dsonar.cfamily.gcov.reportsPath=$HOOT_HOME"
 
 # Optional scan parameters based off parameters passed into script
 if [ -n "$1" ]; then


### PR DESCRIPTION
Split up scan scripts to allow running tests steps after compiling with build watcher and performing scan.  Remove some hoot directories that aren't production code.  Include scan files.  Compile with coverage flag.