### PR TITLE
Integrate sonar scanning into hoot pipeline

### DIFF
--- a/scripts/cover/coverGcov.sh
+++ b/scripts/cover/coverGcov.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -e
+
+# set HOOT_HOME if not set
+if [ -z "$HOOT_HOME" ]; then
+    HOOT_HOME=~/hoot
+fi
+
+# generate gcov files from gcda files
+cd $HOOT_HOME
+
+# hoot-core coverage
+mkdir gcovCore
+cd gcovCore
+gcov ../hoot-core/tmp/debug/*.gcda
+# fix path
+sed -i 's/Source:src/Source:hoot-core\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
+mv *.gcov ../
+cd ..
+
+# tbs coverage
+mkdir gcovTbs
+cd gcovTbs
+gcov ../tbs/tmp/debug/*.gcda
+# fix path
+sed -i 's/Source:src/Source:tbs\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
+mv *.gcov ../
+cd ..
+
+# tgs coverage
+mkdir gcovTgs
+cd gcovTgs
+gcov ../tgs/tmp/obj/debug/*.gcda
+# fix path
+sed -i 's/Source:src/Source:tgs\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
+mv *.gcov ../
+cd ..
+
+# hoot-rnd coverage
+mkdir gcovRnd
+cd gcovRnd
+gcov ../hoot-rnd/tmp/debug/*.gcda
+# fix path
+sed -i 's/Source:src/Source:hoot-rnd\/src/g' *.gcov
+sed -i 's/Source:..\//Source:/g' *.gcov
+mv *.gcov ../
+cd ..

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
             steps{
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i '/make -s clean && make -sj\$(nproc)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$(nproc)' VagrantBuild.sh'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i \'/make -s clean && make -sj\$(nproc)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$(nproc)\' VagrantBuild.sh'"
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     environment {
         // Work around to run certain tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
         // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
-        IS_NIGHTLY = Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..22
+        IS_NIGHTLY = expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 }
     }
 
     triggers {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/\"--with-uitests\"/\"--with-uitests --with-coverage\"/g VagrantBuild.sh'"
+                        sh "sed -i 's/--with-uitests/--with-uitests --with-coverage/g' VagrantBuild.sh"
                     }
                 }
             }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
             steps{
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/\"make -s clean && make -sj$(nproc)\"/\"make -s clean && build-wrapper-linux-x86-64 --out-dir bw-outputmake -sj$(nproc)\"/g VagrantBuild.sh'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/\"make -s clean && make -sj\$(nproc)\"/\"make -s clean && build-wrapper-linux-x86-64 --out-dir bw-outputmake -sj\$(nproc)\"/g VagrantBuild.sh'"
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -94,11 +94,11 @@ pipeline {
             steps{
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/"make -s clean && make -sj$(nproc)"/"make -s clean && build-wrapper-linux-x86-64 --out-dir bw-outputmake -sj$(nproc)"/g VagrantBuild.sh'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/\"make -s clean && make -sj$(nproc)\"/\"make -s clean && build-wrapper-linux-x86-64 --out-dir bw-outputmake -sj$(nproc)\"/g VagrantBuild.sh'"
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/"--with-uitests"/"--with-uitests --with-coverage"/g VagrantBuild.sh'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/\"--with-uitests\"/\"--with-uitests --with-coverage\"/g VagrantBuild.sh'"
                     }
                 }
             }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -4,12 +4,6 @@
 pipeline {
     agent { label 'master' }
 
-    environment {
-        // Work around to run certain tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
-        // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
-        IS_NIGHTLY = expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 }
-    }
-
     triggers {
         // Set nightly trigger
         cron((BRANCH_NAME == "master" || BRANCH_NAME == "develop") ? "H H(20-21) * * 1-5" : "")
@@ -72,7 +66,9 @@ pipeline {
             when { 
                 anyOf {
                     expression { return params.Configure_Tests }
-                    expression { return IS_NIGHTLY }
+                    // Work around to run certain tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
+                    // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
+                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 } }
                 }
             }
             steps {
@@ -135,7 +131,7 @@ pipeline {
                     expression { return params.Sonar }
                     changeRequest()
                     allOf {
-                        expression { IS_NIGHTLY }
+                        expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 } }
                         branch 'develop'
                     }
                 }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
             steps{
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/\"make -s clean && make -sj\$(nproc)\"/\"make -s clean && build-wrapper-linux-x86-64 --out-dir bw-outputmake -sj\$(nproc)\"/g VagrantBuild.sh'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i '/make -s clean && make -sj\$\(nproc\)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$\(nproc)' VagrantBuild.sh'"
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
                     // Configure for sonar if user selected it, pull-request, or nightly run of develop
                     expression { return params.Sonar }
                     changeRequest()
-                    allof {
+                    allOf {
                         expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..22 }
                         branch 'develop'
                     }
@@ -134,7 +134,7 @@ pipeline {
                 anyOf {
                     expression { return params.Sonar }
                     changeRequest()
-                    allof {
+                    allOf {
                         expression { IS_NIGHTLY }
                         branch 'develop'
                     }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
             steps{
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i \'/make -s clean && make -sj\$(nproc)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$(nproc)\' VagrantBuild.sh'"
+                sh "sed -i '/make -s clean && make -sj\$(nproc)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$(nproc)' VagrantBuild.sh"
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -131,7 +131,7 @@ pipeline {
                     expression { return params.Sonar }
                     changeRequest()
                     allOf {
-                        expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 } }
+                        expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 }
                         branch 'develop'
                     }
                 }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -3,14 +3,21 @@
 
 pipeline {
     agent { label 'master' }
+
+    environment {
+        // Work around to run certain tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
+        // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
+        IS_NIGHTLY = Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..22
+    }
+
     triggers {
-        // Set nightly triggers
+        // Set nightly trigger
         cron((BRANCH_NAME == "master" || BRANCH_NAME == "develop") ? "H H(20-21) * * 1-5" : "")
     }
+
     // Configurable parameters for users to skip steps and control pipeline behavior
     parameters {
         booleanParam(name: 'Destroy_VM', defaultValue: true)
-        booleanParam(name: 'Static_analysis', defaultValue: true)
         booleanParam(name: 'License_headers', defaultValue: true)
         booleanParam(name: 'Hoot_provision', defaultValue: true)
         booleanParam(name: 'Configure_Tests', defaultValue: false)
@@ -21,11 +28,12 @@ pipeline {
         booleanParam(name: 'Sonar', defaultValue: false)
         string(name: 'Box', defaultValue: 'default', description: 'Vagrant Box')
     }
+
     stages {
         stage("Destroy VM") {
             when { expression { return params.Destroy_VM } }
             steps {
-                // Attempt to destroy exiting VM but don't stop job if not there
+                // Existing VM may or may not exist depending on previous runs
                 sh "vagrant destroy -f ${params.Box} || true"
             }
         }
@@ -42,29 +50,14 @@ pipeline {
                 '''
             }
         }
-        // Need to expand this step to more robust static analysis scanning with SonarQube
-        // and publish results
-        stage ("Static checks") {
-            parallel {
-                stage("Static Analysis") {
-                    when { 
-                        expression { return params.Static_analysis }
-                        not { branch 'PR-*' }
-                    }
-                    steps {
-                        sh 'cppcheck --enable=all --inconclusive --xml-version=2 --verbose --check-config . 2> cppcheck.xml'
-                    }
-                }
-                stage("License Header") {
-                    when { expression { return params.License_headers } }
-                    steps {
-                        script { 
-                            sh '''
-                                export HOOT_HOME=`pwd`
-                                ./scripts/copyright/UpdateAllCopyrightHeaders.sh
-                            '''
-                        }
-                    }
+        stage("License Header") {
+            when { expression { return params.License_headers } }
+            steps {
+                 script { 
+                    sh '''
+                        export HOOT_HOME=`pwd`
+                        ./scripts/copyright/UpdateAllCopyrightHeaders.sh
+                    '''
                 }
             }
         }
@@ -79,27 +72,40 @@ pipeline {
             when { 
                 anyOf {
                     expression { return params.Configure_Tests }
-                    // Work around to run configuration tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
-                    // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
-                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..22 }
+                    expression { return IS_NIGHTLY }
                 }
             }
             steps {
-                // Run configuration tests
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; ./scripts/TestConfigure.sh &> Hoot_Config_Test || { cat Hoot_Config_Test; false; }'"
+            }
+        }
+        stage("Sonar Config") {
+            when {
+                anyOf {
+                    // Configure for sonar if user selected it, pull-request, or nightly run of develop
+                    expression { return params.Sonar }
+                    changeRequest()
+                    allof {
+                        expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..22 }
+                        branch 'develop'
+                    }
+                }
+            }
+            steps{
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
+                // Compile with build watcher to allow for sonar scanning in subsequent steps
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/"make -s clean && make -sj$(nproc)"/"make -s clean && build-wrapper-linux-x86-64 --out-dir bw-outputmake -sj$(nproc)"/g VagrantBuild.sh'"
+                script {
+                    if (env.BRANCH_NAME == "develop") {
+                        // Compile instrumented code for develop branch which allows for calculating coverage
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i s/"--with-uitests"/"--with-uitests --with-coverage"/g VagrantBuild.sh'"
+                    }
+                }
             }
         }
         stage("Build") {
             when { expression { return params.Build } }
             steps {
-                // NOTE: Ubuntu only, may need more complex logic if other OS are included in pipeline
-                sh '''
-                    cp LocalConfig.pri.orig LocalConfig.pri
-                    echo "QMAKE_CXXFLAGS += -Werror" >> LocalConfig.pri
-                    sed -i s/"QMAKE_CXX=g++"/"#QMAKE_CXX=g++"/g LocalConfig.pri
-                    sed -i s/"#QMAKE_CXX=ccache g++"/"QMAKE_CXX=ccache g++"/g LocalConfig.pri
-                '''
-                
                 // Perform remainder of provisioning
                 sh "vagrant provision ${params.Box} --provision-with build,EGD,tomcat,mapnik"
             }       
@@ -127,18 +133,33 @@ pipeline {
             when {
                 anyOf {
                     expression { return params.Sonar }
-                    // Work around to run sonar scans during nightly cron triggers but not on commits to develop.  Logic can be udpated
-                    // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
-                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 }
+                    changeRequest()
+                    allof {
+                        expression { IS_NIGHTLY }
+                        branch 'develop'
+                    }
                 }
             }
-            steps {
-                // rysnc the build folders back to host system so scan
-                sh "vagrant rsync-back ${params.Box}"
-                withSonarQubeEnv('Breeze Sonarqube') {
-                    sh "cd hoot-services; mvn sonar:sonar"
+            steps{
+                script {
+                    if (env.BRANCH_NAME.startsWith("PR-")) {
+                        // PR scan will use github plugin
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME} ${env.CHANGE_ID} ${env.DGIS_BOT_TOKEN}'"
+                    }
+                    else {
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/gcovHoot.sh'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh ${env.SONAR_CLOUD_KEY} ${env.BRANCH_NAME}'"
+                    }
+
                 }
             }
+            //steps {
+            //    // rysnc the build folders back to host system so scan
+            //    sh "vagrant rsync-back ${params.Box}"
+            //    withSonarQubeEnv('Breeze Sonarqube') {
+            //        sh "cd hoot-services; mvn sonar:sonar"
+            //    }
+            //}
         }
     }
     post {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
             steps{
                 sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i '/make -s clean && make -sj\$\(nproc\)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$\(nproc)' VagrantBuild.sh'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; sed -i '/make -s clean && make -sj\$(nproc)/c\\make -s clean && build-wrapper-linux-x86-64 --out-dir bw-output make -sj\$(nproc)' VagrantBuild.sh'"
                 script {
                     if (env.BRANCH_NAME == "develop") {
                         // Compile instrumented code for develop branch which allows for calculating coverage

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                     expression { return params.Configure_Tests }
                     // Work around to run certain tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
                     // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
-                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 } }
+                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 } 
                 }
             }
             steps {

--- a/scripts/sonar/sonar-build.sh
+++ b/scripts/sonar/sonar-build.sh
@@ -7,35 +7,3 @@ aclocal && autoconf && autoheader && automake --add-missing --copy
 
 # Make with the sonar build watcher
 build-wrapper-linux-x86-64 --out-dir bw-output make -sj$(nproc)
-
-# Build out the scan command
-CMD="sonar-scanner"
-CMD+=" -Dsonar.projectKey=hoot"
-CMD+=" -Dsonar.sources=./hoot-cmd,./hoot-core,./hoot-core-test,./hoot-js,./hoot-rnd,./hoot-test,./tbs,./tgs"
-CMD+=" -Dsonar.cfamily.build-wrapper-output=bw-output"
-CMD+=" -Dsonar.host.url=https://sonarcloud.io"
-CMD+=" -Dsonar.organization=hootenanny"
-CMD+=" -Dsonar.cfamily.threads=4"
-CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
-CMD+=" -Dsonar.cfamily.lcov.reportsPaths=./coverage/core/core/Core.info"
-CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
-
-# Optional scan parameters based off parameters passed into script
-if [ -n "$1" ]; then
-    # This is the hoot sonarcloud project key, requried to pass scan results to sever for analysis and display
-    CMD+=" -Dsonar.login=$1"
-fi
-if [ -n "$2" ]; then
-    CMD+=" -Dsonar.branch.name=$2"
-fi
-if [ -n "$3" ]; then
-    # Optional pull request number that will match scan with git hub pull-request
-    CMD+=" -Dsonar.github.pullRequest=$3"
-    CMD+=" -Dsonar.analysis.mode=preview"
-fi
-if [ -n "$4" ]; then
-    # Optional token to allow scan to post comments to github ticket
-    CMD+=" -Dsonar.github.oauth=$4"
-fi
- 
-eval $CMD

--- a/scripts/sonar/sonar-scan.sh
+++ b/scripts/sonar/sonar-scan.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+# Build out the scan command
+CMD="sonar-scanner"
+CMD+=" -Dsonar.projectKey=hoot"
+CMD+=" -Dsonar.sources=./hoot-core,./hoot-js,./hoot-rnd,./tbs,./tgs"
+CMD+=" -Dsonar.cfamily.build-wrapper-output=bw-output"
+CMD+=" -Dsonar.host.url=https://sonarcloud.io"
+CMD+=" -Dsonar.organization=hootenanny"
+CMD+=" -Dsonar.cfamily.threads=4"
+CMD+=" -Dsonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql"
+CMD+=" -Dsonar.github.repository=ngageoint/hootenanny"
+CMD+=" -Dsonar.cfamily.gcov.reportsPath=$HOOT_HOME"
+
+# Optional scan parameters based off parameters passed into script
+if [ -n "$1" ]; then
+    # This is the hoot sonarcloud project key, requried to pass scan results to sever for analysis and display
+    CMD+=" -Dsonar.login=$1"
+fi
+if [ -n "$2" ]; then
+    CMD+=" -Dsonar.branch.name=$2"
+fi
+if [ -n "$3" ]; then
+    # Optional pull request number that will match scan with git hub pull-request
+    CMD+=" -Dsonar.github.pullRequest=$3"
+    CMD+=" -Dsonar.analysis.mode=preview"
+fi
+if [ -n "$4" ]; then
+    # Optional token to allow scan to post comments to github ticket
+    CMD+=" -Dsonar.github.oauth=$4"
+fi
+ 
+eval $CMD


### PR DESCRIPTION
Scans should take place for pull-requests and the nightly run of develop.  Coverage should only be calculated on the nightly run of develop.