### PR TITLE
Add lcov to provisioning for coverage reports

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -91,6 +91,7 @@ sudo yum -y install \
     hoot-gdal \
     hoot-gdal-devel \
     hoot-gdal-python \
+    lcov \
     libicu-devel \
     libpng-devel \
     libtool \


### PR DESCRIPTION
Forgot to add this in a previous commit.  Nightly job failed because lack of lcov.