### PR TITLE
Move Copyright Check to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   archive-create:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-hoot-release@sha256:d41955e2b2b7bff973a23f289e373fb2c8117339b97fbefe2244c9e295b93f10
+      - image: hootenanny/rpmbuild-hoot-release@sha256:9a99b469bd84c2d2b47e0bab56ad5a977d558a28b032181db32a7d6e16335639
     steps:
       - checkout
       - run:
@@ -27,7 +27,7 @@ jobs:
   archive-upload:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:cfee4a229812fed0993b9fa27cd4291b68b19d24b316e77c4c40074e3c7b249e
+      - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
         user: rpmbuild
     steps:
       - attach_workspace:
@@ -39,7 +39,7 @@ jobs:
   copyright:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-generic@sha256:1a90408da44fc3577634210f3a93ac6d80ad7330e7f7eee1d51b1544f0d835c7
+      - image: hootenanny/rpmbuild-generic@sha256:73127bc570c1f2b8f35a8c162786a3c5a7fbf10e435ce98eb8d91761fcf8829a
         user: rpmbuild
         environment:
           HOOT_HOME: '/rpmbuild/hootenanny'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,18 @@ jobs:
           name: 'Upload Hootenanny Archive'
           command: |
             find archives -type f -exec aws s3 cp {} s3://hoot-archives/circle/$CIRCLE_BRANCH/ \;
+  copyright:
+    working_directory: '/rpmbuild/hootenanny'
+    docker:
+      - image: hootenanny/rpmbuild-generic@sha256:1a90408da44fc3577634210f3a93ac6d80ad7330e7f7eee1d51b1544f0d835c7
+        user: rpmbuild
+        environment:
+          HOOT_HOME: '/rpmbuild/hootenanny'
+    steps:
+      - checkout
+      - run:
+          name: 'Check Copyright Headers'
+          command: ./scripts/copyright/UpdateAllCopyrightHeaders.sh
 
 workflows:
   version: 2
@@ -45,3 +57,4 @@ workflows:
       - archive-upload:
           requires:
             - archive-create
+      - copyright

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
     // Configurable parameters for users to skip steps and control pipeline behavior
     parameters {
         booleanParam(name: 'Destroy_VM', defaultValue: true)
-        booleanParam(name: 'License_headers', defaultValue: true)
         booleanParam(name: 'Hoot_provision', defaultValue: true)
         booleanParam(name: 'Configure_Tests', defaultValue: false)
         booleanParam(name: 'Build', defaultValue: true)
@@ -42,17 +41,6 @@ pipeline {
                     cp -R ../software.ubuntu1404 software
                     rm -rf ./test-files/ui/screenshot_*.png
                 '''
-            }
-        }
-        stage("License Header") {
-            when { expression { return params.License_headers } }
-            steps {
-                 script { 
-                    sh '''
-                        export HOOT_HOME=`pwd`
-                        ./scripts/copyright/UpdateAllCopyrightHeaders.sh
-                    '''
-                }
             }
         }
         stage("Hoot Provision") {


### PR DESCRIPTION
This PR moves the copyright check from Jenkins to CircleCI allowing it to run concurrently with the Jenkins tests (reducing overall test suite run time).  Container images used in testing were also upgraded to the latest versions available on Docker Hub.

After merge to `develop`, it should be made a required check for the branch in GitHub and likewise for `master` when we cut the next release.