### PR TITLE
Add logic for release candidate VMs to Jenkinsfile

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -156,9 +156,19 @@ pipeline {
             }
         }
         success {
-            // If all tests passed, clean everything up
-            sh "vagrant destroy -f ${params.Box}"
-            cleanWs()
+            script {
+                if (!env.BRANCH_NAME.startsWith("release")) {
+                    // Don't clean up this workspace.  We want to leave it up for acceptance testing
+                    def VERS = sh(returnStdout: true, script: "vagrant ssh default -c 'cd hoot; ./scripts/git/GitVersion.sh'")
+                    def URL = sh(returnStdout: true, script: "vagrant ssh-config default | grep HostName | awk '{print \$2}'")
+                    URL = URL.trim()
+                    slackSend channel: "#builds_hoot", message: "Release candidate version ${VERS} ready for testing https://${URL}:8080/hootenanny-id/"
+                } else {
+                    // If all tests passed, clean everything up
+                    sh "vagrant destroy -f ${params.Box}"
+                    cleanWs()
+                }
+            }
         }
         failure {
             script {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -159,8 +159,8 @@ pipeline {
             script {
                 if (env.BRANCH_NAME.startsWith("release")) {
                     // Don't clean up this workspace.  We want to leave it up for acceptance testing
-                    def VERS = sh(returnStdout: true, script: "vagrant ssh default -c 'cd hoot; ./scripts/git/GitVersion.sh'")
-                    def URL = sh(returnStdout: true, script: "vagrant ssh-config default | grep HostName | awk '{print \$2}'")
+                    def VERS = sh(returnStdout: true, script: "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/git/GitVersion.sh'")
+                    def URL = sh(returnStdout: true, script: "vagrant ssh-config ${params.Box} | grep HostName | awk '{print \$2}'")
                     URL = URL.trim()
                     slackSend channel: "#builds_hoot", message: "Release candidate version ${VERS} ready for testing https://${URL}:8080/hootenanny-id/"
                 } else {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
         }
         success {
             script {
-                if (!env.BRANCH_NAME.startsWith("release")) {
+                if (env.BRANCH_NAME.startsWith("release")) {
                     // Don't clean up this workspace.  We want to leave it up for acceptance testing
                     def VERS = sh(returnStdout: true, script: "vagrant ssh default -c 'cd hoot; ./scripts/git/GitVersion.sh'")
                     def URL = sh(returnStdout: true, script: "vagrant ssh-config default | grep HostName | awk '{print \$2}'")


### PR DESCRIPTION
Don't destroy the release candidate VMs to they can be tested during the release process.  Add message to notify the VM is ready for testing.