### PR TITLE
Reset Environment for all unit tests in CppUnit framework

### DIFF
--- a/hoot-core-test/hoot-core-test.pro
+++ b/hoot-core-test/hoot-core-test.pro
@@ -15,6 +15,7 @@ DEPENDPATH += \
     ../tbs/src/main/cpp/ \
     ../tgs/src/main/cpp/ \
     ../hoot-core/src/main/cpp/ \
+    src/test/cpp/ \
 
 INCLUDEPATH += \
   $${DEPENDPATH} \

--- a/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/OsmMapTest.cpp
@@ -32,27 +32,24 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/conflate/Conflator.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/Conflator.h>
 #include <hoot/core/elements/Element.h>
 #include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/index/KnnWayIterator.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/ops/RemoveWayOp.h>
 #include <hoot/core/util/ElementConverter.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
-#include <hoot/core/ops/RemoveWayOp.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
-using namespace hoot;
-
 // Qt
-#include <QDebug>
 #include <QTime>
-#include <QDir>
 
 // TGS
 #include <tgs/RStarTree/KnnIterator.h>
@@ -60,15 +57,13 @@ using namespace hoot;
 #include <tgs/Statistics/Random.h>
 using namespace Tgs;
 
-#include "TestUtils.h"
-
 using namespace geos::geom;
 using namespace std;
 
 namespace hoot
 {
 
-class OsmMapTest : public CppUnit::TestFixture
+class OsmMapTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmMapTest);
   CPPUNIT_TEST(runCopyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
@@ -195,6 +195,13 @@ public:
   static hoot::AutoRegisterResetInstance<ClassName> ClassName##AutoRegisterReset;
 
 
+class HootTestFixture : public CppUnit::TestFixture
+{
+public:
+  virtual void setUp()    { TestUtils::resetEnvironment(); }
+  virtual void tearDown() { TestUtils::resetEnvironment(); }
+};
+
 }
 
 #endif // TESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/AlphaShapeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/AlphaShapeTest.cpp
@@ -33,12 +33,10 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/AlphaShape.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
-
-// Qt
-#include <QDir>
 
 // Standard
 #include <fstream>
@@ -48,13 +46,13 @@
 // Tgs
 #include <tgs/Statistics/Random.h>
 
-#include "../TestUtils.h"
-
 using namespace geos::geom;
-using namespace hoot;
 using namespace std;
 
-class AlphaShapeTest : public CppUnit::TestFixture
+namespace hoot
+{
+
+class AlphaShapeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AlphaShapeTest);
   CPPUNIT_TEST(runTest);
@@ -63,8 +61,9 @@ class AlphaShapeTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/algorithms");
   }
 
@@ -147,3 +146,4 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AlphaShapeTest, "quick");
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/BufferedLineSegmentIntersectorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/BufferedLineSegmentIntersectorTest.cpp
@@ -37,6 +37,7 @@
 #include <geos/geom/Point.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/BufferedLineSegmentIntersector.h>
 #include <hoot/core/util/Log.h>
 
@@ -44,16 +45,13 @@
 #include <tgs/Statistics/Random.h>
 #include <tgs/System/Time.h>
 
-#include "../TestUtils.h"
-
 using namespace geos::geom;
-using namespace hoot;
 using namespace std;
 
 namespace hoot
 {
 
-class BufferedLineSegmentIntersectorTest : public CppUnit::TestFixture
+class BufferedLineSegmentIntersectorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BufferedLineSegmentIntersectorTest);
   CPPUNIT_TEST(runCircleTest);
@@ -228,6 +226,6 @@ public:
   }
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BufferedLineSegmentIntersectorTest, "quick");
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/ExpectationIntersectionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/ExpectationIntersectionTest.cpp
@@ -32,13 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/ExpectationIntersection.h>
 #include <hoot/core/util/Log.h>
 
 // OpenCV
 // #include <opencv/cv.h>
 
-// tbs
+// Boost
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/variate_generator.hpp>
@@ -46,16 +47,14 @@
 // Tgs
 #include <tgs/Statistics/Random.h>
 
-#include "../TestUtils.h"
+using namespace cv;
+using namespace std;
 
 namespace hoot
 {
 
-using namespace cv;
-using namespace hoot;
-using namespace std;
 
-class ExpectationIntersectionTest : public CppUnit::TestFixture
+class ExpectationIntersectionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ExpectationIntersectionTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/KskipBigramDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/KskipBigramDistanceTest.cpp
@@ -35,19 +35,15 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/KskipBigramDistance.h>
 #include <hoot/core/algorithms/Translator.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QString>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class KskipBigramDistanceTest : public CppUnit::TestFixture
+class KskipBigramDistanceTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(KskipBigramDistanceTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/KskipBigramDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/KskipBigramDistanceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/LevenshteinDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/LevenshteinDistanceTest.cpp
@@ -35,10 +35,10 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/algorithms/Translator.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // Qt
 #include <QString>
@@ -49,7 +49,7 @@ using namespace hoot;
 namespace hoot
 {
 
-class LevenshteinDistanceTest : public CppUnit::TestFixture
+class LevenshteinDistanceTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(LevenshteinDistanceTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/LongestCommonNodeStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/LongestCommonNodeStringTest.cpp
@@ -29,16 +29,12 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/LongestCommonNodeString.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/OsmMap.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -53,7 +49,10 @@ using namespace boost;
 #include <sstream>
 using namespace std;
 
-class LongestCommonNodeStringTest : public CppUnit::TestFixture
+namespace hoot
+{
+
+class LongestCommonNodeStringTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(LongestCommonNodeStringTest);
   CPPUNIT_TEST(runTest);
@@ -93,3 +92,4 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(LongestCommonNodeStringTest);
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineMatcherTest.cpp
@@ -33,21 +33,14 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MaximalNearestSublineMatcher.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
@@ -58,7 +51,7 @@ namespace hoot
  * all the hard core tests are in MaximalNearestSublineTest. This just makes sure the interface is
  * wrapped properly.
  */
-class MaximalNearestSublineMatcherTest : public CppUnit::TestFixture
+class MaximalNearestSublineMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MaximalNearestSublineMatcherTest);
   CPPUNIT_TEST(runSimpleTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalNearestSublineTest.cpp
@@ -29,21 +29,17 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
-#include <hoot/core/conflate/Conflator.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MaximalNearestSubline.h>
 #include <hoot/core/algorithms/WayAverager.h>
+#include <hoot/core/conflate/Conflator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ElementConverter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -51,17 +47,14 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // Standard
 #include <sstream>
 using namespace std;
 
-#include "../TestUtils.h"
+namespace hoot
+{
 
-class MaximalNearestSublineTest : public CppUnit::TestFixture
+class MaximalNearestSublineTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MaximalNearestSublineTest);
   CPPUNIT_TEST(runTest);
@@ -71,8 +64,9 @@ class MaximalNearestSublineTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/algorithms/");
   }
 
@@ -254,3 +248,4 @@ public:
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MaximalNearestSublineTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MaximalNearestSublineTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineStringMatcherTest.cpp
@@ -30,15 +30,12 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MaximalSublineStringMatcher.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -46,23 +43,17 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // Standard
 #include <sstream>
 #include <iomanip>
 using namespace std;
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class MaximalSublineStringMatcherTest : public CppUnit::TestFixture
+class MaximalSublineStringMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MaximalSublineStringMatcherTest);
   CPPUNIT_TEST(evaluateMatchTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MaximalSublineTest.cpp
@@ -35,24 +35,20 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmXmlReader.h>
-#include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MaximalNearestSubline.h>
 #include <hoot/core/algorithms/MaximalSubline.h>
 #include <hoot/core/algorithms/WaySplitter.h>
+#include <hoot/core/algorithms/linearreference/WaySublineMatch.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmXmlReader.h>
+#include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ElementConverter.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-#include <hoot/core/algorithms/linearreference/WaySublineMatch.h>
-using namespace hoot;
-
-// Qt
-#include <QDir>
-#include <QString>
 
 // Standard
 #include <string>
@@ -60,15 +56,13 @@ using namespace hoot;
 // TGS
 #include <tgs/System/Time.h>
 
-#include "../TestUtils.h"
-
 using namespace geos::geom;
 using namespace std;
 
 namespace hoot
 {
 
-class MaximalSublineTest : public CppUnit::TestFixture
+class MaximalSublineTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MaximalSublineTest);
   CPPUNIT_TEST(runCircleTest);
@@ -84,11 +78,6 @@ class MaximalSublineTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   void addEndNode(OsmMapPtr map, Coordinate c, QString note)
   {

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MeanWordSetDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MeanWordSetDistanceTest.cpp
@@ -35,25 +35,17 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MeanWordSetDistance.h>
 #include <hoot/core/algorithms/ExactStringDistance.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-using namespace hoot;
-
-// Qt
-#include <QString>
-
-// Standard
-#include <string>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class MeanWordSetDistanceTest : public CppUnit::TestFixture
+class MeanWordSetDistanceTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MeanWordSetDistanceTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/MultiLineStringSplitterTest.cpp
@@ -35,25 +35,16 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MultiLineStringSplitter.h>
 #include <hoot/core/algorithms/linearreference/MultiLineStringLocation.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Qt
-#include <QDir>
-#include <QString>
-
-// Standard
-#include <string>
+#include <hoot/core/util/MapProjector.h>
 
 // TGS
 #include <tgs/System/Time.h>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -61,7 +52,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiLineStringSplitterTest : public CppUnit::TestFixture
+class MultiLineStringSplitterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiLineStringSplitterTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
@@ -34,27 +34,20 @@
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/linear_congruential.hpp>
 
-// Qt
-#include <QFile>
-#include <QTextStream>
-#include <QString>
-#include <QDir>
-
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/util/Log.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/RdpWayGeneralizer.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-
-#include "../TestUtils.h"
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class RdpWayGeneralizerTest : public CppUnit::TestFixture
+class RdpWayGeneralizerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RdpWayGeneralizerTest);
   CPPUNIT_TEST(runPerpendicularDistanceTest);
@@ -69,10 +62,10 @@ class RdpWayGeneralizerTest : public CppUnit::TestFixture
 
 public:
 
-  QMap<QString, QList<ConstNodePtr > > _inputPointsCache;
-  QMap<QString, QList<Coordinate> > _inputCoordsCache;
+  QMap<QString, QList<ConstNodePtr>> _inputPointsCache;
+  QMap<QString, QList<Coordinate>> _inputCoordsCache;
 
-  QList<ConstNodePtr > readPoints(const QString filePath)
+  QList<ConstNodePtr> readPoints(const QString filePath)
   {
     OsmMap::resetCounters();
 
@@ -88,7 +81,7 @@ public:
     }
 
     QTextStream textStream(&file);
-    QList<ConstNodePtr > points;
+    QList<ConstNodePtr> points;
     OsmMapPtr map(new OsmMap());
     while (!textStream.atEnd())
     {
@@ -148,14 +141,14 @@ public:
     return outFile;
   }
 
-  QString writePointOutput(const QList<ConstNodePtr >& points, const QString outDir,
+  QString writePointOutput(const QList<ConstNodePtr>& points, const QString outDir,
                            const QString outFileName)
   {
     OsmMap::resetCounters();
     OsmMapPtr map(new OsmMap());
 
     //points will be empty for the generalize calls with way inputs instead of points
-    for (QList<ConstNodePtr >::const_iterator it = points.constBegin();
+    for (QList<ConstNodePtr>::const_iterator it = points.constBegin();
          it != points.constEnd(); ++it)
     {
       NodePtr nodeCopy(new Node(*(*it).get()));
@@ -167,7 +160,7 @@ public:
 
   void runPerpendicularDistanceTest()
   {
-    const QList<ConstNodePtr >& inputPoints =
+    const QList<ConstNodePtr>& inputPoints =
       readPoints("test-files/algorithms/RdpWayGeneralizerTest/RdpWayGeneralizerTestDataset1.txt");
     CPPUNIT_ASSERT_EQUAL(197, inputPoints.size());
 
@@ -181,12 +174,12 @@ public:
 
   void runCalcPointsInput1aTest()
   {
-    const QList<ConstNodePtr >& inputPoints =
+    const QList<ConstNodePtr>& inputPoints =
       readPoints("test-files/algorithms/RdpWayGeneralizerTest/RdpWayGeneralizerTestDataset1.txt");
     CPPUNIT_ASSERT_EQUAL(197, inputPoints.size());
 
     RdpWayGeneralizer generalizer(0.1);
-    const QList<ConstNodePtr >& outputPoints =
+    const QList<ConstNodePtr>& outputPoints =
       generalizer.getGeneralizedPoints(inputPoints);
     CPPUNIT_ASSERT_EQUAL(148, outputPoints.size());
     QString outFile =
@@ -199,12 +192,12 @@ public:
 
   void runCalcPointsInput1bTest()
   {
-    const QList<ConstNodePtr >& inputPoints =
+    const QList<ConstNodePtr>& inputPoints =
       readPoints("test-files/algorithms/RdpWayGeneralizerTest/RdpWayGeneralizerTestDataset1.txt");
     CPPUNIT_ASSERT_EQUAL(197, inputPoints.size());
 
     RdpWayGeneralizer generalizer(5.9);
-    const QList<ConstNodePtr >& outputPoints =
+    const QList<ConstNodePtr>& outputPoints =
       generalizer.getGeneralizedPoints(inputPoints);
     CPPUNIT_ASSERT_EQUAL(22, outputPoints.size());
     QString outFile =
@@ -217,12 +210,12 @@ public:
 
   void runCalcPointsInput2aTest()
   {
-    const QList<ConstNodePtr >& inputPoints =
+    const QList<ConstNodePtr>& inputPoints =
       readPoints("test-files/algorithms/RdpWayGeneralizerTest/RdpWayGeneralizerTestDataset2.txt");
     CPPUNIT_ASSERT_EQUAL(77, inputPoints.size());
 
     RdpWayGeneralizer generalizer(0.1);
-    const QList<ConstNodePtr >& outputPoints =
+    const QList<ConstNodePtr>& outputPoints =
       generalizer.getGeneralizedPoints(inputPoints);
     CPPUNIT_ASSERT_EQUAL(48, outputPoints.size());
     QString outFile =
@@ -235,12 +228,12 @@ public:
 
   void runCalcPointsInput2bTest()
   {
-    const QList<ConstNodePtr >& inputPoints =
+    const QList<ConstNodePtr>& inputPoints =
       readPoints("test-files/algorithms/RdpWayGeneralizerTest/RdpWayGeneralizerTestDataset2.txt");
     CPPUNIT_ASSERT_EQUAL(77, inputPoints.size());
 
     RdpWayGeneralizer generalizer(5.9);
-    const QList<ConstNodePtr >& outputPoints =
+    const QList<ConstNodePtr>& outputPoints =
       generalizer.getGeneralizedPoints(inputPoints);
     CPPUNIT_ASSERT_EQUAL(4, outputPoints.size());
     QString outFile =
@@ -334,7 +327,7 @@ public:
 
 };
 
-//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MultiLineStringSplitterTest, "current");
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(RdpWayGeneralizerTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(RdpWayGeneralizerTest, "quick");
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/SoundexTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/SoundexTest.cpp
@@ -35,19 +35,15 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/Soundex.h>
 #include <hoot/core/algorithms/Translator.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
-// Qt
-#include <QString>
+namespace hoot
+{
 
-// Standard
-#include <string>
-
-
-class SoundexTest : public CppUnit::TestFixture
+class SoundexTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SoundexTest);
   CPPUNIT_TEST(runTest);
@@ -57,20 +53,20 @@ public:
 
   void runTest()
   {
-    CPPUNIT_ASSERT_EQUAL(QString("R163"), Soundex::encode("Robert"));
-    CPPUNIT_ASSERT_EQUAL(QString("R163"), Soundex::encode("Rupert"));
-    CPPUNIT_ASSERT_EQUAL(QString("R150"), Soundex::encode("Rubin"));
-    CPPUNIT_ASSERT_EQUAL(QString("A261"), Soundex::encode("Ashcraft"));
-    CPPUNIT_ASSERT_EQUAL(QString("A261"), Soundex::encode("Ashcroft"));
-    CPPUNIT_ASSERT_EQUAL(QString("T522"), Soundex::encode("Tymczak"));
-    CPPUNIT_ASSERT_EQUAL(QString("P236"), Soundex::encode("Pfister"));
+    HOOT_STR_EQUALS(QString("R163"), Soundex::encode("Robert"));
+    HOOT_STR_EQUALS(QString("R163"), Soundex::encode("Rupert"));
+    HOOT_STR_EQUALS(QString("R150"), Soundex::encode("Rubin"));
+    HOOT_STR_EQUALS(QString("A261"), Soundex::encode("Ashcraft"));
+    HOOT_STR_EQUALS(QString("A261"), Soundex::encode("Ashcroft"));
+    HOOT_STR_EQUALS(QString("T522"), Soundex::encode("Tymczak"));
+    HOOT_STR_EQUALS(QString("P236"), Soundex::encode("Pfister"));
 
     // check boundary conditions. Soundex shouldn't take two words as input, but we should handle
     // it.
-    CPPUNIT_ASSERT_EQUAL(QString("H643"), Soundex::encode("hi world"));
+    HOOT_STR_EQUALS(QString("H643"), Soundex::encode("hi world"));
     // short words should have zeros appended
-    CPPUNIT_ASSERT_EQUAL(QString("H000"), Soundex::encode("hi"));
-    CPPUNIT_ASSERT_EQUAL(QString("L200"), Soundex::encode("LoOk"));
+    HOOT_STR_EQUALS(QString("H000"), Soundex::encode("hi"));
+    HOOT_STR_EQUALS(QString("L200"), Soundex::encode("LoOk"));
 
     CPPUNIT_ASSERT_EQUAL(4, Soundex::compareSoundex("Washington", "Washingtin"));
     CPPUNIT_ASSERT_EQUAL(1, Soundex::compareSoundex("fish", "swimmer"));
@@ -81,3 +77,4 @@ public:
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(SoundexTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(SoundexTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/TranslatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/TranslatorTest.cpp
@@ -35,22 +35,18 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/Soundex.h>
 #include <hoot/core/algorithms/Translator.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // Qt
-#include <QString>
 #include <QStringList>
-
-// Standard
-#include <string>
 
 namespace hoot
 {
 
-class TranslatorTest : public CppUnit::TestFixture
+class TranslatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TranslatorTest);
   CPPUNIT_TEST(runTest);
@@ -62,17 +58,17 @@ public:
   {
     QStringList result;
     result << "building";
-    CPPUNIT_ASSERT_EQUAL(result, Translator::getInstance().toEnglishAll("gedung"));
+    HOOT_STR_EQUALS(result, Translator::getInstance().toEnglishAll("gedung"));
 
     result.clear();
     result << "office building";
     result << "agency building";
     result << "bureau building";
-    CPPUNIT_ASSERT_EQUAL(result, Translator::getInstance().toEnglishAll("kantor gedung"));
+    HOOT_STR_EQUALS(result, Translator::getInstance().toEnglishAll("kantor gedung"));
 
     result.clear();
     result << "hospital";
-    CPPUNIT_ASSERT_EQUAL(result, Translator::getInstance().toEnglishAll("rumah sakit"));
+    HOOT_STR_EQUALS(result, Translator::getInstance().toEnglishAll("rumah sakit"));
 
     result.clear();
     result << "general hospital office";
@@ -81,18 +77,18 @@ public:
     result << "hospital office";
     result << "hospital agency";
     result << "hospital bureau";
-    CPPUNIT_ASSERT_EQUAL(result, Translator::getInstance().toEnglishAll("rumah sakit umum kantor"));
+    HOOT_STR_EQUALS(result, Translator::getInstance().toEnglishAll("rumah sakit umum kantor"));
 
     result.clear();
     result << "ryba office bar";
     result << "ryba agency bar";
     result << "ryba bureau bar";
-    CPPUNIT_ASSERT_EQUAL(result, Translator::getInstance().toEnglishAll(
+    HOOT_STR_EQUALS(result, Translator::getInstance().toEnglishAll(
       QString::fromUtf8("рыба kantor bar")));
 
     result.clear();
     result << "embassy hungaria";
-    CPPUNIT_ASSERT_EQUAL(result, Translator::getInstance().toEnglishAll(
+    HOOT_STR_EQUALS(result, Translator::getInstance().toEnglishAll(
       QString::fromUtf8("Kedutaan Besar Hungaria")));
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayJoinerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayJoinerTest.cpp
@@ -25,9 +25,8 @@
  * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-#include "../TestUtils.h"
-
 //  Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/WayJoiner.h>
 #include <hoot/core/conflate/UnifyingConflator.h>
 #include <hoot/core/conflate/splitter/CornerSplitter.h>
@@ -41,7 +40,7 @@
 namespace hoot
 {
 
-class WayJoinerTest : public CppUnit::TestFixture
+class WayJoinerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayJoinerTest);
   CPPUNIT_TEST(runSimpleTest);
@@ -51,8 +50,9 @@ class WayJoinerTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/algorithms/wayjoiner");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayMatchStringMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayMatchStringMergerTest.cpp
@@ -25,9 +25,8 @@
  * @copyright Copyright (C) 2013, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-#include "../TestUtils.h"
-
 // hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/WayMatchStringMerger.h>
 #include <hoot/core/algorithms/WayMatchStringSplitter.h>
 #include <hoot/core/algorithms/linearreference/WayString.h>
@@ -40,15 +39,12 @@
 #include <hoot/core/visitors/FindWaysVisitor.h>
 #include <hoot/core/visitors/FindNodesVisitor.h>
 
-// Qt
-#include <QDir>
-
 using namespace std;
 
 namespace hoot
 {
 
-class WayMatchStringMergerTest : public CppUnit::TestFixture
+class WayMatchStringMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayMatchStringMergerTest);
   CPPUNIT_TEST(runMergeNodeTest);
@@ -58,8 +54,9 @@ class WayMatchStringMergerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/algorithms/");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/LocationOfPointTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/LocationOfPointTest.cpp
@@ -36,15 +36,14 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/LocationOfPoint.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
-
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class LocationOfPointTest : public CppUnit::TestFixture
+class LocationOfPointTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(LocationOfPointTest);
   //TODO: fixme or remove me - #1737

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocationTest.cpp
@@ -36,20 +36,19 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/MultiLineStringLocation.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
 #include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 
-#include "../../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class MultiLineStringLocationTest : public CppUnit::TestFixture
+class MultiLineStringLocationTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiLineStringLocationTest);
   CPPUNIT_TEST(runSingleWayTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayLocationTest.cpp
@@ -36,18 +36,17 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class WayLocationTest : public CppUnit::TestFixture
+class WayLocationTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayLocationTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverterTest.cpp
@@ -26,15 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/NaiveWayMatchStringMapping.h>
 #include <hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.h>
-
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class WayMatchStringMappingConverterTest : public CppUnit::TestFixture
+class WayMatchStringMappingConverterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayMatchStringMappingConverterTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WayStringTest.cpp
@@ -26,13 +26,12 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/WayString.h>
 #include <hoot/core/algorithms/linearreference/WaySubline.h>
 #include <hoot/core/util/ElementConverter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/ElementCountVisitor.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -40,7 +39,7 @@ using namespace std;
 namespace hoot
 {
 
-class WayStringTest : public CppUnit::TestFixture
+class WayStringTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayStringTest);
   CPPUNIT_TEST(runBasicTests);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineMatchStringTest.cpp
@@ -36,11 +36,10 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/WaySublineMatchString.h>
 #include <hoot/core/ops/CopyMapSubsetOp.h>
 #include <hoot/core/util/Log.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -48,7 +47,7 @@ using namespace std;
 namespace hoot
 {
 
-class WaySublineMatchStringTest : public CppUnit::TestFixture
+class WaySublineMatchStringTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WaySublineMatchStringTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineStringTest.cpp
@@ -30,18 +30,18 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/elements/Way.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
+#include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
-#include "../../TestUtils.h"
+using namespace geos::geom;
 
 namespace hoot
 {
-using namespace geos::geom;
 
-class WaySublineStringTest : public CppUnit::TestFixture
+class WaySublineStringTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WaySublineStringTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/linearreference/WaySublineTest.cpp
@@ -31,18 +31,18 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/linearreference/WaySubline.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/ElementConverter.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
-#include "../../TestUtils.h"
+using namespace geos::geom;
 
 namespace hoot
 {
-using namespace geos::geom;
 
-class WaySublineTest : public CppUnit::TestFixture
+class WaySublineTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WaySublineTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolverTest.cpp
@@ -32,11 +32,9 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/optimizer/IntegerProgrammingSolver.h>
 #include <hoot/core/util/Log.h>
-
-// Qt
-#include <QDir>
 
 // Standard
 #include <fstream>
@@ -48,7 +46,7 @@ using namespace std;
 namespace hoot
 {
 
-class IntegerProgrammingSolverTest : public CppUnit::TestFixture
+class IntegerProgrammingSolverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(IntegerProgrammingSolverTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolverTest.cpp
@@ -26,9 +26,9 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/optimizer/SingleAssignmentProblemSolver.h>
 #include <hoot/core/util/Log.h>
-#include "../../TestUtils.h"
 
 using namespace std;
 
@@ -63,7 +63,7 @@ public:
   }
 };
 
-class SingleAssignmentProblemSolverTest : public CppUnit::TestFixture
+class SingleAssignmentProblemSolverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SingleAssignmentProblemSolverTest);
   CPPUNIT_TEST(runTest1);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/MostEnglishNameTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/MostEnglishNameTest.cpp
@@ -26,16 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/string/MostEnglishName.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class MostEnglishNameTest : public CppUnit::TestFixture
+class MostEnglishNameTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MostEnglishNameTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/SqliteWeightedWordDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/SqliteWeightedWordDistanceTest.cpp
@@ -26,18 +26,17 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/string/SqliteWordWeightDictionary.h>
 #include <hoot/core/util/Log.h>
 
 // Tgs
 #include <tgs/System/SystemInfo.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class SqliteWordWeightDictionaryTest : public CppUnit::TestFixture
+class SqliteWordWeightDictionaryTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SqliteWordWeightDictionaryTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/StringTokenizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/StringTokenizerTest.cpp
@@ -26,16 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/string/StringTokenizer.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class StringTokenizerTest : public CppUnit::TestFixture
+class StringTokenizerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(StringTokenizerTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionaryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionaryTest.cpp
@@ -26,18 +26,17 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/string/TextFileWordWeightDictionary.h>
 #include <hoot/core/util/Log.h>
 
 // Tgs
 #include <tgs/System/SystemInfo.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class TextFileWordWeightDictionaryTest : public CppUnit::TestFixture
+class TextFileWordWeightDictionaryTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TextFileWordWeightDictionaryTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/WeightedWordDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/string/WeightedWordDistanceTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/algorithms/MeanWordSetDistance.h>
 #include <hoot/core/algorithms/string/TextFileWordWeightDictionary.h>
@@ -38,12 +39,10 @@
 // Tgs
 #include <tgs/System/SystemInfo.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class WeightedWordDistanceTest : public CppUnit::TestFixture
+class WeightedWordDistanceTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WeightedWordDistanceTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/BBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/BBoxTest.cpp
@@ -35,9 +35,8 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/zindex/BBox.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -45,7 +44,7 @@ using namespace std;
 namespace hoot
 {
 
-class BBoxTest : public CppUnit::TestFixture
+class BBoxTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BBoxTest);
   CPPUNIT_TEST(testBasics);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/LongBoxTest.cpp
@@ -35,17 +35,16 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/zindex/LongBox.h>
 #include <hoot/core/util/Log.h>
-
-#include "../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class LongBoxTest : public CppUnit::TestFixture
+class LongBoxTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(LongBoxTest);
   CPPUNIT_TEST(testBasics);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/RangeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/RangeTest.cpp
@@ -35,14 +35,13 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/zindex/Range.h>
-
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class RangeTest : public CppUnit::TestFixture
+class RangeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RangeTest);
   CPPUNIT_TEST(testBasics);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZCurveRangerTest.cpp
@@ -35,19 +35,18 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/zindex/ZCurveRanger.h>
 #include <hoot/core/algorithms/zindex/Range.h>
 #include <hoot/core/algorithms/zindex/BBox.h>
 #include <hoot/core/util/Log.h>
-
-#include "../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class ZCurveRangerTest : public CppUnit::TestFixture
+class ZCurveRangerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ZCurveRangerTest);
   CPPUNIT_TEST(testMaxBitColumn);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZValueTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/zindex/ZValueTest.cpp
@@ -35,16 +35,15 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/zindex/ZValue.h>
-
-#include "../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class ZValueTest : public CppUnit::TestFixture
+class ZValueTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ZValueTest);
   CPPUNIT_TEST(testBasics);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/AlphaShapeGeneratorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/AlphaShapeGeneratorTest.cpp
@@ -26,13 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/AlphaShapeGenerator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/core/conflate/AlphaShapeGenerator.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,16 +41,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class AlphaShapeGeneratorTest : public CppUnit::TestFixture
+class AlphaShapeGeneratorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AlphaShapeGeneratorTest);
   CPPUNIT_TEST(runBasicTest);
@@ -59,8 +54,9 @@ class AlphaShapeGeneratorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate/");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ConflatorTest.cpp
@@ -26,13 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/conflate/Conflator.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/Conflator.h>
 #include <hoot/core/elements/Element.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,16 +41,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class ConflatorTest : public CppUnit::TestFixture
+class ConflatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ConflatorTest);
   CPPUNIT_TEST(runPbfTest);
@@ -59,8 +54,9 @@ class ConflatorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/CookieCutterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/CookieCutterTest.cpp
@@ -27,6 +27,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/CookieCutter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
@@ -41,16 +42,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class CookieCutterTest : public CppUnit::TestFixture
+class CookieCutterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CookieCutterTest);
   CPPUNIT_TEST(runTest);
@@ -62,8 +57,9 @@ class CookieCutterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/MapCleanerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/MapCleanerTest.cpp
@@ -26,21 +26,17 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/MapCleaner.h>
-#include <hoot/core/ops/MergeNearbyNodes.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/ops/MergeNearbyNodes.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/Settings.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -48,16 +44,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class MapCleanerTest : public CppUnit::TestFixture
+class MapCleanerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MapCleanerTest);
   CPPUNIT_TEST(runBasicTest);
@@ -65,8 +55,9 @@ class MapCleanerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeReplacementsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/NodeReplacementsTest.cpp
@@ -26,10 +26,10 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/NodeReplacements.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -37,16 +37,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class NodeReplacementsTest : public CppUnit::TestFixture
+class NodeReplacementsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NodeReplacementsTest);
   CPPUNIT_TEST(runSimplifyTest);
@@ -55,8 +49,9 @@ class NodeReplacementsTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/ReviewMarkerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/ReviewMarkerTest.cpp
@@ -26,20 +26,17 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/ReviewMarker.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 
-using namespace hoot;
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class ReviewMarkerTest : public CppUnit::TestFixture
+class ReviewMarkerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ReviewMarkerTest);
   CPPUNIT_TEST(runNeedsReviewTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/RubberSheetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/RubberSheetTest.cpp
@@ -26,12 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/conflate/RubberSheet.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/MapCropper.h>
+#include <hoot/core/util/MapProjector.h>
 
 #include <tgs/Statistics/Random.h>
 
@@ -43,11 +44,8 @@
 
 // Qt
 #include <QDebug>
-#include <QDir>
 #include <QBuffer>
 #include <QByteArray>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -55,7 +53,7 @@ using namespace std;
 namespace hoot
 {
 
-class RubberSheetTest : public CppUnit::TestFixture
+class RubberSheetTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RubberSheetTest);
   CPPUNIT_TEST(runSimpleTest);
@@ -67,8 +65,9 @@ class RubberSheetTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/SearchRadiusCalculatorTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/conflate/SearchRadiusCalculator.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -43,20 +44,15 @@
 #include <cppunit/TestFixture.h>
 
 // Qt
-#include <QDebug>
-#include <QDir>
 #include <QBuffer>
 #include <QByteArray>
 
-#include "../TestUtils.h"
-
-using namespace boost;
 using namespace std;
 
 namespace hoot
 {
 
-class SearchRadiusCalculatorTest : public CppUnit::TestFixture
+class SearchRadiusCalculatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SearchRadiusCalculatorTest);
   CPPUNIT_TEST(runCalcResultTest);
@@ -90,7 +86,7 @@ public:
     searchRadiusCalculator.setConfiguration(testSettings);
 
     searchRadiusCalculator.apply(map);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(34.334710, any_cast<double>(searchRadiusCalculator.getResult()), 1e-6);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(34.334710, boost::any_cast<double>(searchRadiusCalculator.getResult()), 1e-6);
   }
 
   void runBadPreOpTest()
@@ -163,7 +159,7 @@ public:
     searchRadiusCalculator.setConfiguration(testSettings);
 
     searchRadiusCalculator.apply(map);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(32.675054, any_cast<double>(searchRadiusCalculator.getResult()), 1e-6);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(32.675054, boost::any_cast<double>(searchRadiusCalculator.getResult()), 1e-6);
   }
 
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/WayCleanerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/WayCleanerTest.cpp
@@ -35,22 +35,15 @@
 #include <geos/geom/Geometry.h>
 
 // Hoot
-#include <hoot/core/io/OsmXmlReader.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/WayCleaner.h>
+#include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QTest>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class WayCleanerTest : public CppUnit::TestFixture
+class WayCleanerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayCleanerTest);
   CPPUNIT_TEST(runDuplicateNodesTest);
@@ -130,8 +123,7 @@ public:
   }
 };
 
-}
-
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(WayCleanerTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(WayCleanerTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/HistogramTest.cpp
@@ -25,15 +25,15 @@
  * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
+//  Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/extractors/Histogram.h>
 #include <hoot/core/util/Log.h>
-
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class HistogramTest : public CppUnit::TestFixture
+class HistogramTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(HistogramTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/SampledAngleHistogramExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/SampledAngleHistogramExtractorTest.cpp
@@ -26,16 +26,16 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/extractors/SampledAngleHistogramExtractor.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -43,12 +43,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class SampledAngleHistogramExtractorTest : public CppUnit::TestFixture
+class SampledAngleHistogramExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SampledAngleHistogramExtractorTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/WeightedMetricDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/extractors/WeightedMetricDistanceExtractorTest.cpp
@@ -26,13 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/extractors/WeightedMetricDistanceExtractor.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-using namespace hoot;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,12 +40,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class WeightedMetricDistanceExtractorTest : public CppUnit::TestFixture
+class WeightedMetricDistanceExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WeightedMetricDistanceExtractorTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/frechet/FrechetDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/frechet/FrechetDistanceTest.cpp
@@ -51,7 +51,7 @@ using namespace std;
 namespace hoot
 {
 
-class FrechetDistanceTest : public CppUnit::TestFixture
+class FrechetDistanceTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(FrechetDistanceTest);
   CPPUNIT_TEST(simpleFrechet);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/frechet/FrechetSublineMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/frechet/FrechetSublineMatcherTest.cpp
@@ -33,14 +33,15 @@
 
 // GEOS
 #include <geos/geom/LineString.h>
+
 // Hoot
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/frechet/FrechetSublineMatcher.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-#include <hoot/core/conflate/frechet/FrechetSublineMatcher.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -48,7 +49,7 @@ using namespace std;
 namespace hoot
 {
 
-class FrechetSublineMatcherTest : public CppUnit::TestFixture
+class FrechetSublineMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(FrechetSublineMatcherTest);
   CPPUNIT_TEST(singleSublineTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayExpertClassifierTest.cpp
@@ -33,29 +33,22 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class HighwayExpertClassifierTest : public CppUnit::TestFixture
+class HighwayExpertClassifierTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(HighwayExpertClassifierTest);
   CPPUNIT_TEST(runSimpleIntersectionTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchCreatorTest.cpp
@@ -32,27 +32,19 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/highway/HighwayMatchCreator.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
-
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class HighwayMatchCreatorTest : public CppUnit::TestFixture
+class HighwayMatchCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(HighwayMatchCreatorTest);
   CPPUNIT_TEST(runIsCandidateTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
@@ -33,6 +33,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MaximalNearestSublineMatcher.h>
 #include <hoot/core/algorithms/MaximalSublineStringMatcher.h>
 #include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
@@ -44,23 +45,15 @@
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class HighwayMatchTest : public CppUnit::TestFixture
+class HighwayMatchTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(HighwayMatchTest);
   CPPUNIT_TEST(runMajorOverlapTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwaySnapMergerTest.cpp
@@ -36,6 +36,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MaximalSublineStringMatcher.h>
 #include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
 #include <hoot/core/conflate/highway/HighwayMatch.h>
@@ -49,16 +50,8 @@
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -66,7 +59,7 @@ using namespace std;
 namespace hoot
 {
 
-class HighwaySnapMergerTest : public CppUnit::TestFixture
+class HighwaySnapMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(HighwaySnapMergerTest);
   CPPUNIT_TEST(runReverseTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/GreedyConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/GreedyConstrainedMatchesTest.cpp
@@ -25,31 +25,16 @@
  * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
-
 // Hoot
+#include <hoot/core/conflate/matching/Match.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
 #include <hoot/core/conflate/match-graph/GreedyConstrainedMatches.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/matching/MatchClassification.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -57,28 +42,17 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Hoot
-#include <hoot/core/conflate/matching/Match.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Standard
 #include <iostream>
 
 // Tgs
 #include <tgs/StreamUtils.h>
 
-#include "../../TestUtils.h"
-
+using namespace std;
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace std;
-using namespace Tgs;
 
 class ConstrainedFakeMatch : public Match
 {
@@ -184,7 +158,7 @@ public:
 
 };
 
-class GreedyConstrainedMatchesTest : public CppUnit::TestFixture
+class GreedyConstrainedMatchesTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(GreedyConstrainedMatchesTest);
   CPPUNIT_TEST(runFindSubgraphsTest);
@@ -234,12 +208,14 @@ public:
 
   virtual void setUp()
   {
+    HootTestFixture::setUp();
     MergerFactory::getInstance().clear();
     MergerFactory::getInstance().registerCreator(new ConstrainedFakeCreator());
   }
 
   virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     MergerFactory::getInstance().clear();
     MergerFactory::getInstance().registerDefaultCreators();
   }

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/MatchGraphTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/MatchGraphTest.cpp
@@ -42,11 +42,11 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/match-graph/MatchGraph.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/matching/MatchClassification.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -54,25 +54,17 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Standard
 #include <iostream>
 
 // Tgs
 #include <tgs/StreamUtils.h>
 
-#include "../../TestUtils.h"
-
+using namespace std;
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace std;
-using namespace Tgs;
 
 class FakeMatch : public Match
 {
@@ -136,7 +128,7 @@ private:
   boost::shared_ptr<const MatchThreshold> _threshold;
 };
 
-class MatchGraphTest : public CppUnit::TestFixture
+class MatchGraphTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MatchGraphTest);
   CPPUNIT_TEST(runFindSubgraphsTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/match-graph/OptimalConstrainedMatchesTest.cpp
@@ -25,31 +25,16 @@
  * @copyright Copyright (C) 2014, 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
-
 // Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/matching/Match.h>
+#include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
 #include <hoot/core/conflate/match-graph/OptimalConstrainedMatches.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/matching/MatchClassification.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -57,28 +42,17 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Hoot
-#include <hoot/core/conflate/matching/Match.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Standard
 #include <iostream>
 
 // Tgs
 #include <tgs/StreamUtils.h>
 
-#include "../../TestUtils.h"
-
+using namespace std;
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace std;
-using namespace Tgs;
 
 class ConstrainedFakeMatch : public Match
 {
@@ -183,7 +157,7 @@ public:
   }
 };
 
-class OptimalConstrainedMatchesTest : public CppUnit::TestFixture
+class OptimalConstrainedMatchesTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OptimalConstrainedMatchesTest);
   CPPUNIT_TEST(runFindSubgraphsTest);
@@ -234,12 +208,14 @@ public:
 
   virtual void setUp()
   {
+    HootTestFixture::setUp();
     MergerFactory::getInstance().clear();
     MergerFactory::getInstance().registerCreator(new ConstrainedFakeCreator());
   }
 
   virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     MergerFactory::getInstance().clear();
     MergerFactory::getInstance().registerDefaultCreators();
   }

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/NodeMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/NodeMatcherTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/NodeMatcher.h>
 #include <hoot/core/util/Settings.h>
 
@@ -38,14 +39,12 @@
 // Standard
 #include <math.h>
 
-#include "../../TestUtils.h"
-
 using namespace std;
 
 namespace hoot
 {
 
-class NodeMatcherTest : public CppUnit::TestFixture
+class NodeMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NodeMatcherTest);
   CPPUNIT_TEST(runSimpleAnglesTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/merging/SmallWayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/merging/SmallWayMergerTest.cpp
@@ -26,12 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/merging/SmallWayMerger.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -39,16 +40,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class SmallWayMergerTest : public CppUnit::TestFixture
+class SmallWayMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SmallWayMergerTest);
   CPPUNIT_TEST(runBasicTest);
@@ -56,8 +51,9 @@ class SmallWayMergerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeLocationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeLocationTest.cpp
@@ -26,13 +26,13 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/EdgeLocation.h>
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class EdgeLocationTest : public CppUnit::TestFixture
+class EdgeLocationTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeLocationTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchSetFinderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchSetFinderTest.cpp
@@ -26,22 +26,19 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
-#include "../../TestUtils.h"
-#include <hoot/core/criterion/TagCriterion.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
 #include <hoot/core/conflate/network/EdgeMatchSetFinder.h>
 #include <hoot/core/conflate/network/OsmNetworkExtractor.h>
-
-// Qt
-#include <QDir>
+#include <hoot/core/criterion/TagCriterion.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/MapProjector.h>
 
 namespace hoot
 {
 
-class EdgeMatchSetFinderTest : public CppUnit::TestFixture
+class EdgeMatchSetFinderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeMatchSetFinderTest);
   CPPUNIT_TEST(partialTest1);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchTest.cpp
@@ -26,13 +26,13 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/EdgeMatch.h>
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class EdgeMatchTest : public CppUnit::TestFixture
+class EdgeMatchTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeMatchTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeStringTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeStringTest.cpp
@@ -26,14 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/EdgeString.h>
-#include "../../TestUtils.h"
+#include <hoot/core/util/MapProjector.h>
 
 namespace hoot
 {
 
-class EdgeStringTest : public CppUnit::TestFixture
+class EdgeStringTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeStringTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeSublineMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeSublineMatchTest.cpp
@@ -26,14 +26,14 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
-#include <hoot/core/util/Log.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/EdgeSublineMatch.h>
+#include <hoot/core/util/Log.h>
 
 namespace hoot
 {
 
-class EdgeSublineMatchTest : public CppUnit::TestFixture
+class EdgeSublineMatchTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeSublineMatchTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeSublineTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeSublineTest.cpp
@@ -26,13 +26,13 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/EdgeSubline.h>
-#include "../../TestUtils.h"
 
 namespace hoot
 {
 
-class EdgeSublineTest : public CppUnit::TestFixture
+class EdgeSublineTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeSublineTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/LegacyVertexMatcherTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/LegacyVertexMatcherTest.cpp
@@ -26,19 +26,18 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
-#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/conflate/network/LegacyVertexMatcher.h>
 #include <hoot/core/conflate/network/NetworkDetails.h>
 #include <hoot/core/conflate/network/OsmNetworkExtractor.h>
-
+#include <hoot/core/io/OsmMapReaderFactory.h>
 
 namespace hoot
 {
 
-class LegacyVertexMatcherTest : public CppUnit::TestFixture
+class LegacyVertexMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(LegacyVertexMatcherTest);
   CPPUNIT_TEST(toyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/NetworkDetailsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/NetworkDetailsTest.cpp
@@ -26,15 +26,15 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/conflate/network/EdgeMatchSetFinder.h>
+#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/TagCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/GeometryUtils.h>
-#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
-#include <hoot/core/conflate/network/EdgeMatchSetFinder.h>
-#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
+#include <hoot/core/util/MapProjector.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -42,7 +42,7 @@ using namespace std;
 namespace hoot
 {
 
-class NetworkDetailsTest : public CppUnit::TestFixture
+class NetworkDetailsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NetworkDetailsTest);
   CPPUNIT_TEST(calculateDistanceTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/NetworkEdgeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/NetworkEdgeTest.cpp
@@ -26,11 +26,11 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/network/NetworkEdge.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-#include <hoot/core/conflate/network/NetworkEdge.h>
 
 using namespace geos::geom;
 
@@ -39,7 +39,7 @@ namespace hoot
 
 TEST_UTILS_REGISTER_RESET(NetworkVertex)
 
-class NetworkEdgeTest : public CppUnit::TestFixture
+class NetworkEdgeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NetworkEdgeTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/NetworkVertexTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/NetworkVertexTest.cpp
@@ -26,10 +26,10 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/network/NetworkVertex.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/network/NetworkVertex.h>
 
 using namespace geos::geom;
 
@@ -38,7 +38,7 @@ namespace hoot
 
 TEST_UTILS_REGISTER_RESET(NetworkVertex)
 
-class NetworkVertexTest : public CppUnit::TestFixture
+class NetworkVertexTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NetworkVertexTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/OsmNetworkExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/OsmNetworkExtractorTest.cpp
@@ -26,16 +26,16 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/criterion/HighwayCriterion.h>
-#include <hoot/core/util/Log.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/network/OsmNetworkExtractor.h>
+#include <hoot/core/criterion/HighwayCriterion.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/util/Log.h>
 
 namespace hoot
 {
 
-class OsmNetworkExtractorTest : public CppUnit::TestFixture
+class OsmNetworkExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmNetworkExtractorTest);
   CPPUNIT_TEST(toyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/OsmNetworkTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/OsmNetworkTest.cpp
@@ -26,17 +26,17 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/network/OsmNetwork.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-#include <hoot/core/conflate/network/OsmNetwork.h>
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class OsmNetworkTest : public CppUnit::TestFixture
+class OsmNetworkTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmNetworkTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
@@ -26,15 +26,15 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-#include <hoot/core/visitors/FindWaysVisitor.h>
 #include <hoot/core/visitors/FindNodesVisitor.h>
+#include <hoot/core/visitors/FindWaysVisitor.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -42,7 +42,7 @@ using namespace std;
 namespace hoot
 {
 
-class PoiPolygonMatchCreatorTest : public CppUnit::TestFixture
+class PoiPolygonMatchCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonMatchCreatorTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchTest.cpp
@@ -26,18 +26,17 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatch.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
-
-#include "../../TestUtils.h"
+#include <hoot/core/util/Log.h>
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonMatchTest : public CppUnit::TestFixture
+class PoiPolygonMatchTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonMatchTest);
   CPPUNIT_TEST(matchTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -26,14 +26,14 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/merging/MarkForReviewMerger.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
-#include <hoot/core/conflate/polygon/BuildingMatchCreator.h>
-#include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatch.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMerger.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.h>
+#include <hoot/core/conflate/polygon/BuildingMatchCreator.h>
+#include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 
@@ -43,7 +43,7 @@ using namespace std;
 namespace hoot
 {
 
-class PoiPolygonMergerCreatorTest : public CppUnit::TestFixture
+class PoiPolygonMergerCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonMergerCreatorTest);
   CPPUNIT_TEST(basicTest);
@@ -148,16 +148,11 @@ public:
     HOOT_STR_EQUALS(1, (dynamic_cast<MarkForReviewMerger*>(mergers[0]) != 0));
   }
 
-  void setUp()
+  virtual void setUp()
   {
-    TestUtils::resetEnvironment();
+    HootTestFixture::setUp();
     conf().set(ConfigOptions().getMatchCreatorsKey(), "hoot::PoiPolygonMatchCreator");
     conf().set(ConfigOptions().getMergerCreatorsKey(), "hoot::PoiPolygonMergerCreator");
-  }
-
-  void tearDown()
-  {
-    TestUtils::resetEnvironment();
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerTest.cpp
@@ -26,8 +26,7 @@
  */
 
 // Hoot
-#include "../../TestUtils.h"
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMerger.h>
 #include <hoot/core/elements/ConstElementVisitor.h>
 #include <hoot/core/io/OsmJsonWriter.h>
@@ -35,10 +34,8 @@
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
-
-// Qt
-#include <QDir>
 
 using namespace geos::geom;
 using namespace std;
@@ -49,7 +46,7 @@ namespace hoot
 /**
  * See "Hootenanny - POI to Building" power point for a description of the tests.
  */
-class PoiPolygonMergerTest : public CppUnit::TestFixture
+class PoiPolygonMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonMergerTest);
   CPPUNIT_TEST(basicTest);
@@ -63,8 +60,9 @@ class PoiPolygonMergerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate/poi-polygon/PoiPolygonMergerTest");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractorTest.cpp
@@ -27,9 +27,9 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractor.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -37,14 +37,12 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonAddressScoreExtractorTest : public CppUnit::TestFixture
+class PoiPolygonAddressScoreExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonAddressScoreExtractorTest);
   CPPUNIT_TEST(runTagTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractorTest.cpp
@@ -27,9 +27,9 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonAlphaShapeDistanceExtractor.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -37,12 +37,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../../TestUtils.h"
-
 namespace hoot
 {
 
-class PoiPolygonAlphaShapeDistanceExtractorTest : public CppUnit::TestFixture
+class PoiPolygonAlphaShapeDistanceExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonAlphaShapeDistanceExtractorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractorTest.cpp
@@ -26,14 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractor.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-#include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonDistanceExtractor.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -41,14 +41,12 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonDistanceExtractorTest : public CppUnit::TestFixture
+class PoiPolygonDistanceExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonDistanceExtractorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractorTest.cpp
@@ -27,11 +27,11 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractor.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -39,14 +39,12 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonNameScoreExtractorTest : public CppUnit::TestFixture
+class PoiPolygonNameScoreExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonNameScoreExtractorTest);
   CPPUNIT_TEST(scoreTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractorTest.cpp
@@ -27,9 +27,9 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/elements/Way.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractor.h>
-using namespace hoot;
+#include <hoot/core/elements/Way.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -37,14 +37,12 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../../../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonTypeScoreExtractorTest : public CppUnit::TestFixture
+class PoiPolygonTypeScoreExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonTypeScoreExtractorTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterionTest.cpp
@@ -26,19 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../../../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonPoiCriterionTest : public CppUnit::TestFixture
+class PoiPolygonPoiCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonPoiCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterionTest.cpp
@@ -26,19 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../../../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class PoiPolygonPolyCriterionTest : public CppUnit::TestFixture
+class PoiPolygonPolyCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonPolyCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitorTest.cpp
@@ -26,7 +26,7 @@
  */
 
 // Hoot
-#include "../../../TestUtils.h"
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitor.h>
@@ -42,7 +42,7 @@ using namespace std;
 namespace hoot
 {
 
-class PoiPolygonMatchVisitorTest : public CppUnit::TestFixture
+class PoiPolygonMatchVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PoiPolygonMatchVisitorTest);
   CPPUNIT_TEST(runIsCandidateTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
@@ -26,8 +26,8 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/polygon/BuildingMatch.h>
 #include <hoot/core/conflate/polygon/BuildingMatchCreator.h>
@@ -35,6 +35,7 @@
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/RemoveWayOp.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
@@ -44,23 +45,15 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class BuildingMatchCreatorTest : public CppUnit::TestFixture
+class BuildingMatchCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingMatchCreatorTest);
   CPPUNIT_TEST(runMatchTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMergerTest.cpp
@@ -43,6 +43,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/polygon/BuildingMerger.h>
 #include <hoot/core/elements/ConstElementVisitor.h>
 #include <hoot/core/elements/Way.h>
@@ -61,23 +62,15 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class BuildingMergerTest : public CppUnit::TestFixture
+class BuildingMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingMergerTest);
   CPPUNIT_TEST(runMatchTest);
@@ -88,8 +81,9 @@ class BuildingMergerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate/polygon");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/BufferedOverlapExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/BufferedOverlapExtractorTest.cpp
@@ -26,12 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/polygon/extractors/BufferedOverlapExtractor.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
@@ -41,23 +42,15 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class BufferedOverlapExtractorTest : public CppUnit::TestFixture
+class BufferedOverlapExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BufferedOverlapExtractorTest);
   CPPUNIT_TEST(runRoadsTest);
@@ -65,11 +58,6 @@ class BufferedOverlapExtractorTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   OsmMapPtr _map;
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/CentroidDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/CentroidDistanceExtractorTest.cpp
@@ -26,13 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/polygon/extractors/CentroidDistanceExtractor.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-using namespace hoot;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,32 +40,19 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../../TestUtils.h"
 
 namespace hoot
 {
 
-class CentroidDistanceExtractorTest : public CppUnit::TestFixture
+class CentroidDistanceExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CentroidDistanceExtractorTest);
   CPPUNIT_TEST(runRoadsTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   OsmMapPtr _map;
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/EdgeDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/EdgeDistanceExtractorTest.cpp
@@ -26,8 +26,8 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/aggregator/MeanAggregator.h>
 #include <hoot/core/algorithms/aggregator/QuantileAggregator.h>
 #include <hoot/core/algorithms/aggregator/RmseAggregator.h>
@@ -36,6 +36,7 @@
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
@@ -45,23 +46,15 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class EdgeDistanceExtractorTest : public CppUnit::TestFixture
+class EdgeDistanceExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(EdgeDistanceExtractorTest);
   CPPUNIT_TEST(runBuildingsTest);
@@ -69,11 +62,6 @@ class EdgeDistanceExtractorTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   void runBuildingsTest()
   {

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractorTest.cpp
@@ -26,13 +26,13 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/polygon/extractors/HausdorffDistanceExtractor.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-using namespace hoot;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,32 +40,19 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../../../TestUtils.h"
 
 namespace hoot
 {
 
-class HausdorffDistanceExtractorTest : public CppUnit::TestFixture
+class HausdorffDistanceExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(HausdorffDistanceExtractorTest);
   CPPUNIT_TEST(runRoadsTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   OsmMapPtr _map;
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/NameExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/NameExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/NameExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/extractors/NameExtractorTest.cpp
@@ -26,18 +26,16 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MeanWordSetDistance.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/conflate/polygon/extractors/NameExtractor.h>
 #include <hoot/core/elements/Node.h>
-using namespace hoot;
-
-#include "../../../TestUtils.h"
 
 namespace hoot
 {
 
-class NameExtractorTest : public CppUnit::TestFixture
+class NameExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NameExtractorTest);
   CPPUNIT_TEST(runMeanLevenshteinTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/CornerSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/CornerSplitterTest.cpp
@@ -27,10 +27,11 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/splitter/CornerSplitter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -38,16 +39,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class CornerSplitterTest : public CppUnit::TestFixture
+class CornerSplitterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CornerSplitterTest);
   CPPUNIT_TEST(runTest);
@@ -55,8 +50,9 @@ class CornerSplitterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate/splitter");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/DualWaySplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/DualWaySplitterTest.cpp
@@ -32,25 +32,21 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/splitter/DualWaySplitter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/core/conflate/splitter/DualWaySplitter.h>
-
-// Qt
-#include <QDebug>
+#include <hoot/core/util/MapProjector.h>
 
 // TGS
 #include <tgs/StreamUtils.h>
 using namespace Tgs;
 
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class DualWaySplitterTest : public CppUnit::TestFixture
+class DualWaySplitterTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(DualWaySplitterTest);
     CPPUNIT_TEST(simpleTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/IntersectionSplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/IntersectionSplitterTest.cpp
@@ -27,6 +27,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/splitter/IntersectionSplitter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
@@ -37,16 +38,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class IntersectionSplitterTest : public CppUnit::TestFixture
+class IntersectionSplitterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(IntersectionSplitterTest);
   CPPUNIT_TEST(runTest);
@@ -55,8 +50,9 @@ class IntersectionSplitterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate/splitter");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/LargeWaySplitterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/splitter/LargeWaySplitterTest.cpp
@@ -26,13 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/splitter/LargeWaySplitter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,16 +41,10 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class LargeWaySplitterTest : public CppUnit::TestFixture
+class LargeWaySplitterTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(LargeWaySplitterTest);
     CPPUNIT_TEST(runToyTest);
@@ -57,9 +52,9 @@ class LargeWaySplitterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
-    TestUtils::resetEnvironment();
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/stats/ConflateStatsHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/stats/ConflateStatsHelperTest.cpp
@@ -27,11 +27,9 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/stats/ConflateStatsHelper.h>
 #include <hoot/core/ops/stats/SingleStat.h>
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -39,15 +37,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class ConflateStatsHelperTest : public CppUnit::TestFixture
+class ConflateStatsHelperTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ConflateStatsHelperTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/tile/TileBoundsCalculatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/tile/TileBoundsCalculatorTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/tile/TileBoundsCalculator.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
@@ -37,19 +38,13 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../../TestUtils.h"
-
 using namespace geos::geom;
 using namespace std;
 
 namespace hoot
 {
 
-class TileBoundsCalculatorTest : public CppUnit::TestFixture
+class TileBoundsCalculatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TileBoundsCalculatorTest);
   CPPUNIT_TEST(runToyTest);
@@ -57,8 +52,9 @@ class TileBoundsCalculatorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/tile/TileConflatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/tile/TileConflatorTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/splitter/LargeWaySplitter.h>
 #include <hoot/core/conflate/tile/LocalTileWorker.h>
 #include <hoot/core/conflate/MapCleaner.h>
@@ -37,10 +38,6 @@
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -48,16 +45,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../../TestUtils.h"
-
 namespace hoot
 {
 
-class TileConflatorTest : public CppUnit::TestFixture
+class TileConflatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TileConflatorTest);
   CPPUNIT_TEST(runToyTest);
@@ -65,16 +56,14 @@ class TileConflatorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 
   void runToyTest()
   {
-    srand(0);
-    OsmMap::resetCounters();
-    Settings::getInstance().clear();
     conf().set(ConfigOptions().getUuidHelperRepeatableKey(), true);
     conf().set(ConfigOptions().getUnifyOptimizerTimeLimitKey(), -1);
 
@@ -92,11 +81,6 @@ public:
 
     HOOT_FILE_EQUALS("test-files/conflate/TileConflatorTest.osm",
                      "test-output/conflate/TileConflatorTest.osm");
-  }
-
-  virtual void tearDown()
-  {
-    Settings::getInstance().clear();
   }
 
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/AreaCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/AreaCriterionTest.cpp
@@ -26,19 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/AreaCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class AreaCriterionTest : public CppUnit::TestFixture
+class AreaCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AreaCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/BuildingCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/BuildingCriterionTest.cpp
@@ -30,18 +30,14 @@
 #include <boost/iostreams/filter/bzip2.hpp>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class BuildingCriterionTest : public CppUnit::TestFixture
+class BuildingCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/BuildingWayNodeCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/BuildingWayNodeCriterionTest.cpp
@@ -26,15 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingWayNodeCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class BuildingWayNodeCriterionTest : public CppUnit::TestFixture
+class BuildingWayNodeCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingWayNodeCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/NonBuildingAreaCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/NonBuildingAreaCriterionTest.cpp
@@ -26,17 +26,13 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/NonBuildingAreaCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class NonBuildingAreaCriterionTest : public CppUnit::TestFixture
+class NonBuildingAreaCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NonBuildingAreaCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/TagCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/TagCriterionTest.cpp
@@ -26,19 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/TagCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class TagCriterionTest : public CppUnit::TestFixture
+class TagCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/TagValueNumericRangeCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/TagValueNumericRangeCriterionTest.cpp
@@ -26,19 +26,15 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/TagValueNumericRangeCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class TagValueNumericRangeCriterionTest : public CppUnit::TestFixture
+class TagValueNumericRangeCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagValueNumericRangeCriterionTest);
   CPPUNIT_TEST(runInRangeTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/WayCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/WayCriterionTest.cpp
@@ -27,19 +27,15 @@
 
 
 // Hoots
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/WayCriterion.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class WayCriterionTest : public CppUnit::TestFixture
+class WayCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayCriterionTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/NodeTest.cpp
@@ -36,24 +36,19 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 // Tgs
 #include <tgs/HashMap.h>
 
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class NodeTest : public CppUnit::TestFixture
+class NodeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NodeTest);
   CPPUNIT_TEST(runCopyTest);
@@ -72,7 +67,7 @@ public:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.2, n->getX(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.3, n->getY(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(3.14, n->getCircularError(), 1e-3);
-    CPPUNIT_ASSERT_EQUAL(QString("bar"), n->getTags()["foo"]);
+    HOOT_STR_EQUALS(QString("bar"), n->getTags()["foo"]);
 
     NodePtr n2(new Node(*n));
     HOOT_STR_EQUALS(Status::Unknown1, (Status::TypeEnum)n2->getStatus().getEnum());
@@ -80,7 +75,7 @@ public:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.2, n2->getX(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.3, n2->getY(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(3.14, n2->getCircularError(), 1e-3);
-    CPPUNIT_ASSERT_EQUAL(QString("bar"), n2->getTags()["foo"]);
+    HOOT_STR_EQUALS(QString("bar"), n2->getTags()["foo"]);
   }
 
   void runSetTest()
@@ -95,7 +90,7 @@ public:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.2, n->getX(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.3, n->getY(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(3.14, n->getCircularError(), 1e-3);
-    CPPUNIT_ASSERT_EQUAL(QString("bar"), n->getTags()["foo"]);
+    HOOT_STR_EQUALS(QString("bar"), n->getTags()["foo"]);
 
     n->setX(3.4);
     n->setY(4.5);
@@ -108,13 +103,12 @@ public:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(3.4, n->getX(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(4.5, n->getY(), 1e-3);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.718, n->getCircularError(), 1e-3);
-    CPPUNIT_ASSERT_EQUAL(QString("cheese"), n->getTags()["foo"]);
+    HOOT_STR_EQUALS(QString("cheese"), n->getTags()["foo"]);
   }
 
 };
 
-}
-
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(NodeTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(NodeTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/RelationTest.cpp
@@ -27,18 +27,17 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/ElementCountVisitor.h>
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class RelationTest : public CppUnit::TestFixture
+class RelationTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RelationTest);
   CPPUNIT_TEST(runCircularVisitRo1Test);

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/TagsTest.cpp
@@ -32,9 +32,9 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Tags.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // Qt
 #include <QRegExp>
@@ -42,12 +42,10 @@ using namespace hoot;
 // Tgs
 #include <tgs/HashMap.h>
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class TagsTest : public CppUnit::TestFixture
+class TagsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagsTest);
   CPPUNIT_TEST(runSplitTest);
@@ -122,8 +120,7 @@ public:
   }
 };
 
-}
-
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TagsTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TagsTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/WayTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/WayTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/WayTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/WayTest.cpp
@@ -26,16 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class WayTest : public CppUnit::TestFixture
+class WayTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayTest);
   CPPUNIT_TEST(runRemoveTest);
@@ -62,7 +60,6 @@ public:
   }
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(WayTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/index/ClosePointHashTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/ClosePointHashTest.cpp
@@ -26,8 +26,8 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/index/ClosePointHash.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -50,7 +50,10 @@ using namespace std;
 #include <tgs/StreamUtils.h>
 using namespace Tgs;
 
-class ClosePointHashTest : public CppUnit::TestFixture
+namespace hoot
+{
+
+class ClosePointHashTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ClosePointHashTest);
   CPPUNIT_TEST(runBasicTest);
@@ -151,3 +154,4 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ClosePointHashTest);
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
@@ -32,6 +32,7 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/index/metric-hybrid/FqTree.h>
 #include <hoot/core/io/OsmPbfReader.h>
@@ -43,13 +44,12 @@
 // Tgs
 #include <tgs/System/Time.h>
 
-#include "../../TestUtils.h"
 
+using namespace hoot::hybrid;
 using namespace std;
 
 namespace hoot
 {
-using namespace hybrid;
 
 class FqDummyData
 {
@@ -70,7 +70,7 @@ std::ostream& operator<<(std::ostream & o, const FqDummyData& dd)
   return o;
 }
 
-class FqTreeTest : public CppUnit::TestFixture
+class FqTreeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(FqTreeTest);
   CPPUNIT_TEST(runBuildIndexTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
@@ -32,11 +32,12 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/index/metric-hybrid/RFqHybridTree.h>
 #include <hoot/core/io/OsmPbfReader.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
@@ -50,14 +51,12 @@
 #include <tgs/Optimization/NelderMead.h>
 #include <tgs/System/Time.h>
 
-#include "../../TestUtils.h"
-
 using namespace geos::geom;
+using namespace hoot::hybrid;
 using namespace std;
 
 namespace hoot
 {
-using namespace hybrid;
 
 class RFqHybridDummyData
 {
@@ -102,7 +101,7 @@ std::ostream& operator<<(std::ostream & o, const RFqHybridDummyData& dd)
   return o;
 }
 
-class RFqHybridTreeTest : public CppUnit::TestFixture
+class RFqHybridTreeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RFqHybridTreeTest);
   CPPUNIT_TEST(runEmptyIndexTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RTreeTest.cpp
@@ -32,6 +32,7 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/index/metric-hybrid/RTree.h>
 #include <hoot/core/io/OsmPbfReader.h>
@@ -44,14 +45,12 @@
 #include <tgs/Statistics/Random.h>
 #include <tgs/System/Time.h>
 
-#include "../../TestUtils.h"
-
 using namespace geos::geom;
+using namespace hoot::hybrid;
 using namespace std;
 
 namespace hoot
 {
-using namespace hybrid;
 
 class DummyData
 {
@@ -72,7 +71,7 @@ std::ostream& operator<<(std::ostream & o, const DummyData& dd)
   return o;
 }
 
-class RTreeTest : public CppUnit::TestFixture
+class RTreeTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RTreeTest);
   CPPUNIT_TEST(runBuildIndexTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffReaderTest.cpp
@@ -30,20 +30,16 @@
 #include <boost/iostreams/filter/bzip2.hpp>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ArffReader.h>
 #include <hoot/core/scoring/DataSamples.h>
 #include <hoot/core/scoring/MatchFeatureExtractor.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class ArffReaderTest : public CppUnit::TestFixture
+class ArffReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ArffReaderTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ArffWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ArffWriterTest.cpp
@@ -26,21 +26,17 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/io/ArffWriter.h>
 #include <hoot/core/scoring/MatchFeatureExtractor.h>
-#include <hoot/core/conflate/matching/MatchType.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class ArffWriterTest : public CppUnit::TestFixture
+class ArffWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ArffWriterTest);
   CPPUNIT_TEST(runBasicTest);
@@ -48,8 +44,9 @@ class ArffWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/ArffWriterTest/");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ChangesetDeriverTest.cpp
@@ -26,22 +26,18 @@
  */
 
 // Hoot
-#include <hoot/core/io/ElementSorter.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ChangesetDeriver.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/ChangesetProvider.h>
+#include <hoot/core/io/ElementSorter.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/CalculateHashVisitor2.h>
-
-#include "../TestUtils.h"
-
-// Qt
-#include <QDebug>
 
 namespace hoot
 {
 
-class ChangesetDeriverTest : public CppUnit::TestFixture
+class ChangesetDeriverTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(ChangesetDeriverTest);
     CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/DataConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/DataConverterTest.cpp
@@ -32,15 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/DataConverter.h>
 #include <hoot/core/util/ConfigOptions.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class DataConverterTest : public CppUnit::TestFixture
+class DataConverterTest : public HootTestFixture
 {
   //just testing input validation here, as the command line tests get the rest
   CPPUNIT_TEST_SUITE(DataConverterTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementCacheLruTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementCacheLruTest.cpp
@@ -30,20 +30,20 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
+
 // Hoot
-#include <hoot/core/io/ElementCacheLRU.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Element.h>
 #include <hoot/core/elements/Node.h>
-#include <hoot/core/elements/Way.h>
 #include <hoot/core/elements/Relation.h>
 #include <hoot/core/elements/Status.h>
-
-#include "../TestUtils.h"
+#include <hoot/core/elements/Way.h>
+#include <hoot/core/io/ElementCacheLRU.h>
 
 namespace hoot
 {
 
-class ElementCacheLruTest : public CppUnit::TestFixture
+class ElementCacheLruTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ElementCacheLruTest);
   CPPUNIT_TEST(runCacheSizeTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementComparerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementComparerTest.cpp
@@ -26,18 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ElementComparer.h>
 #include <hoot/core/visitors/CalculateHashVisitor2.h>
-
-#include "../TestUtils.h"
-
-// Qt
-#include <QDebug>
 
 namespace hoot
 {
 
-class ElementComparerTest : public CppUnit::TestFixture
+class ElementComparerTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(ElementComparerTest);
     CPPUNIT_TEST(runNodeWithinDistanceThresholdTest1);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ElementSorterTest.cpp
@@ -27,23 +27,16 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/ElementSorter.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/io/ElementSorter.h>
 #include <hoot/core/util/Log.h>
-
-// Boost
-using namespace boost;
-
-// Qt
-#include <QDebug>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class ElementSorterTest : public CppUnit::TestFixture
+class ElementSorterTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(ElementSorterTest);
     CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ImplicitTagRulesSqliteReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ImplicitTagRulesSqliteReaderTest.cpp
@@ -24,19 +24,19 @@
  *
  * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
+
 // Hoot
-#include "../TestUtils.h"
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ImplicitTagRulesSqliteReader.h>
 
 // Qt
-#include <QDir>
 #include <QSet>
 #include <QString>
 
 namespace hoot
 {
 
-class ImplicitTagRulesSqliteReaderTest : public CppUnit::TestFixture
+class ImplicitTagRulesSqliteReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ImplicitTagRulesSqliteReaderTest);
   CPPUNIT_TEST(runTagsTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ImplicitTagRulesSqliteWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ImplicitTagRulesSqliteWriterTest.cpp
@@ -25,16 +25,13 @@
  * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // Hoot
-#include "../TestUtils.h"
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ImplicitTagRulesSqliteWriter.h>
-
-// Qt
-#include <QDir>
 
 namespace hoot
 {
 
-class ImplicitTagRulesSqliteWriterTest : public CppUnit::TestFixture
+class ImplicitTagRulesSqliteWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ImplicitTagRulesSqliteWriterTest);
   CPPUNIT_TEST(runWriteTest);
@@ -42,8 +39,9 @@ class ImplicitTagRulesSqliteWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/ImplicitTagRulesSqliteWriterTest");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectInputStreamTest.cpp
@@ -32,17 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ObjectInputStream.h>
 #include <hoot/core/io/Serializable.h>
 #include <hoot/core/util/Factory.h>
 
-using namespace hoot;
-
 // Standard
 #include <sstream>
 using namespace std;
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
@@ -70,7 +67,7 @@ public:
 
 HOOT_FACTORY_REGISTER_BASE(TestClass)
 
-class ObjectInputStreamTest : public CppUnit::TestFixture
+class ObjectInputStreamTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ObjectInputStreamTest);
   CPPUNIT_TEST(runToyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ObjectOutputStreamTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ObjectOutputStreamTest.cpp
@@ -32,15 +32,12 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ObjectOutputStream.h>
-
-using namespace hoot;
 
 // Standard
 #include <sstream>
 using namespace std;
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
@@ -64,7 +61,7 @@ public:
   int b;
 };
 
-class ObjectOutputStreamTest : public CppUnit::TestFixture
+class ObjectOutputStreamTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ObjectOutputStreamTest);
   CPPUNIT_TEST(runToyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
@@ -26,31 +26,22 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OgrReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/Progress.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
-
-#include "../TestUtils.h"
-
-// Qt
-#include <QDebug>
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class OgrReaderTest : public CppUnit::TestFixture
+class OgrReaderTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(OgrReaderTest);
     CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -32,20 +32,16 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OgrWriter.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class OgrWriterTest : public CppUnit::TestFixture
+class OgrWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OgrWriterTest);
   CPPUNIT_TEST(runGdbTest);
@@ -55,8 +51,9 @@ class OgrWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonReaderTest.cpp
@@ -31,23 +31,18 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmGeoJsonReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmGeoJsonReaderTest : public CppUnit::TestFixture
+class OsmGeoJsonReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmGeoJsonReaderTest);
   CPPUNIT_TEST(runAllDataTypesTest);
@@ -60,8 +55,9 @@ class OsmGeoJsonReaderTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/GeoJson");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonWriterTest.cpp
@@ -31,23 +31,18 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmGeoJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmGeoJsonWriterTest : public CppUnit::TestFixture
+class OsmGeoJsonWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmGeoJsonWriterTest);
   CPPUNIT_TEST(runAllDataTypesTest);
@@ -59,8 +54,9 @@ class OsmGeoJsonWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/GeoJson");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -45,7 +45,7 @@
 namespace hoot
 {
 
-class OsmJsonReaderTest : public CppUnit::TestFixture
+class OsmJsonReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmJsonReaderTest);
   CPPUNIT_TEST(nodeTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmMapReaderFactoryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmMapReaderFactoryTest.cpp
@@ -26,15 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmMapReaderFactoryTest : public CppUnit::TestFixture
+class OsmMapReaderFactoryTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmMapReaderFactoryTest);
   CPPUNIT_TEST(runUnsupportedBoundingBoxRead);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
@@ -27,18 +27,14 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
-
-using namespace hoot;
 using namespace hoot::pb;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -46,20 +42,14 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 #include <zlib.h>
-
-#include "../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class OsmPbfReaderTest : public CppUnit::TestFixture
+class OsmPbfReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmPbfReaderTest);
   CPPUNIT_TEST(runOffsetsTest);
@@ -86,8 +76,9 @@ class OsmPbfReaderTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io");
   }
 
@@ -385,8 +376,8 @@ public:
     {
       exceptionMsg = e.what();
     }
-    CPPUNIT_ASSERT_EQUAL(QString("Error opening test-files/fileDoesntExist.osm.pbf for reading."),
-                         exceptionMsg);
+    HOOT_STR_EQUALS(QString("Error opening test-files/fileDoesntExist.osm.pbf for reading."),
+                    exceptionMsg);
   }
 
   void runReadMapTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfWriterTest.cpp
@@ -33,28 +33,22 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmPbfWriter.h>
+using namespace hoot::pb;
 
 // Tgs
 #include <tgs/Statistics/Random.h>
-
-using namespace hoot;
-using namespace hoot::pb;
-
-// Qt
-#include <QDir>
 
 // Standard
 #include <sstream>
 using namespace std;
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class OsmPbfWriterTest : public CppUnit::TestFixture
+class OsmPbfWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmPbfWriterTest);
   CPPUNIT_TEST(runToyTest);
@@ -66,8 +60,9 @@ class OsmPbfWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
@@ -26,24 +26,17 @@
  */
 
 // Hoot
-#include "TestOsmChangesetProvider.h"
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ChangesetProvider.h>
 #include <hoot/core/io/ElementInputStream.h>
 #include <hoot/core/io/OsmXmlChangesetFileWriter.h>
+#include <hoot/core/io/TestOsmChangesetProvider.h>
 #include <hoot/core/util/ConfigOptions.h>
-
-// Qt
-#include <QDebug>
-#include <QFile>
-#include <QFileInfo>
-#include <QDir>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmXmlChangesetFileWriterTest : public CppUnit::TestFixture
+class OsmXmlChangesetFileWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmXmlChangesetFileWriterTest);
   CPPUNIT_TEST(runSimpleTest);
@@ -52,8 +45,9 @@ class OsmXmlChangesetFileWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/OsmXmlChangesetFileWriterTest");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
@@ -27,24 +27,15 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
-
-// Qt
-#include <QDebug>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmXmlReaderTest : public CppUnit::TestFixture
+class OsmXmlReaderTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(OsmXmlReaderTest);
     CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -32,16 +32,12 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/HootApiDbBulkInserter.h>
 #include <hoot/core/io/HootApiDbReader.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/FileUtils.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
 
 namespace hoot
 {
@@ -52,7 +48,7 @@ namespace hoot
  * rework the inheritance of the two classes as described in HootApiDbBulkWriter to get rid of the
  * unneeded functionality in HootApiDbBulkWriter.
  */
-class ServiceHootApiDbBulkInserterTest : public CppUnit::TestFixture
+class ServiceHootApiDbBulkInserterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceHootApiDbBulkInserterTest);
   CPPUNIT_TEST(runPsqlDbOfflineTest);
@@ -64,8 +60,9 @@ public:
 
   long mapId;
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     mapId = -1;
     ServicesDbTestUtils::deleteUser(userEmail());
 
@@ -77,8 +74,9 @@ public:
     TestUtils::mkpath("test-output/io/ServiceHootApiDbBulkInserterTest");
   }
 
-  void tearDown()
+  virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     ServicesDbTestUtils::deleteUser(userEmail());
 
     if (mapId != -1)

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -33,6 +33,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/ElementAttributeType.h>
 #include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/io/HootApiDbReader.h>
@@ -40,24 +41,19 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/RemoveAttributesVisitor.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
-
 using namespace std;
 
 namespace hoot
 {
 
-class ServiceHootApiDbReaderTest : public CppUnit::TestFixture
+class ServiceHootApiDbReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceHootApiDbReaderTest);
   CPPUNIT_TEST(runCalculateBoundsTest);
@@ -92,8 +88,9 @@ public:
     TestUtils::mkpath("test-output/io/ServiceHootApiDbReaderTest");
   }
 
-  void tearDown()
+  virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     ServicesDbTestUtils::deleteUser(userEmail());
 
     if (mapId != -1)

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -32,14 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/HootApiDb.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
-
+//  Qt
 #include <QTextCodec>
 
 using namespace std;
@@ -47,7 +47,7 @@ using namespace std;
 namespace hoot
 {
 
-class ServiceHootApiDbTest : public CppUnit::TestFixture
+class ServiceHootApiDbTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceHootApiDbTest);
 
@@ -88,8 +88,9 @@ public:
     database.close();
   }
 
-  void tearDown()
+  virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     ServicesDbTestUtils::deleteUser(userEmail());
 
     if (mapId != -1)

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -32,8 +32,10 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/io/HootApiDbWriter.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/util/OsmUtils.h>
@@ -46,15 +48,12 @@
 #include <tgs/BigContainers/BigMap.h>
 #include <tgs/System/Time.h>
 
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
-
 using namespace std;
 
 namespace hoot
 {
 
-class ServiceHootApiDbWriterTest : public CppUnit::TestFixture
+class ServiceHootApiDbWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceHootApiDbWriterTest);
   CPPUNIT_TEST(runEscapeTest);
@@ -82,8 +81,9 @@ public:
     database.close();
   }
 
-  void tearDown()
+  virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     ServicesDbTestUtils::deleteUser(userEmail());
 
     if (mapId != -1)

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
@@ -32,19 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiDbBulkInserter.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmApiDbReader.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/DbUtils.h>
 #include <hoot/core/util/StringUtils.h>
-
-// Qt
-#include <QDir>
-#include <QFileInfo>
-
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
 
 namespace hoot
 {
@@ -56,7 +51,7 @@ namespace hoot
  * - unresolved relation members
  * - config options error handling
  */
-class ServiceOsmApiDbBulkInserterTest : public CppUnit::TestFixture
+class ServiceOsmApiDbBulkInserterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceOsmApiDbBulkInserterTest);
   CPPUNIT_TEST(runPsqlDbOfflineTest);
@@ -72,8 +67,9 @@ class ServiceOsmApiDbBulkInserterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/ServiceOsmApiDbBulkInserterTest/");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -33,6 +33,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/ElementAttributeType.h>
 #include <hoot/core/io/ApiDb.h>
 #include <hoot/core/io/OsmApiDb.h>
@@ -40,24 +41,19 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/io/OsmApiDbBulkInserter.h>
 #include <hoot/core/visitors/RemoveAttributesVisitor.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
-
 using namespace std;
 
 namespace hoot
 {
 
-class ServiceOsmApiDbReaderTest : public CppUnit::TestFixture
+class ServiceOsmApiDbReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceOsmApiDbReaderTest);
   CPPUNIT_TEST(runReadOsmApiTest);
@@ -69,8 +65,9 @@ public:
 
   static QString userEmail() { return "ServiceOsmApiDbReaderTest@hoottestcpp.org"; }
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     ServicesDbTestUtils::deleteDataFromOsmApiTestDatabase();
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
@@ -32,8 +32,10 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiDb.h>
 #include <hoot/core/io/OsmApiDbSqlChangesetApplier.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
@@ -42,15 +44,12 @@
 #include <QDateTime>
 #include <QSqlError>
 
-#include "../TestUtils.h"
-#include "ServicesDbTestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class ServiceOsmApiDbSqlChangesetApplierTest : public CppUnit::TestFixture
+class ServiceOsmApiDbSqlChangesetApplierTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceOsmApiDbSqlChangesetApplierTest);
   CPPUNIT_TEST(runSqlChangesetWriteTest);
@@ -66,13 +65,15 @@ public:
 
   long mapId;
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     deleteUser(userEmail());
   }
 
-  void tearDown()
+  virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     deleteUser(userEmail());
 
     OsmApiDb database;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
@@ -26,26 +26,15 @@
  */
 
 // Hoot
-#include "TestOsmChangesetProvider.h"
-#include "ServicesDbTestUtils.h"
-
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
+#include <hoot/core/io/TestOsmChangesetProvider.h>
 #include <hoot/core/io/OsmApiDbSqlChangesetFileWriter.h>
-
-// Boost
-using namespace boost;
-
-// Qt
-#include <QDebug>
-#include <QFile>
-#include <QFileInfo>
-#include <QDir>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class ServiceOsmApiDbSqlChangesetFileWriterTest : public CppUnit::TestFixture
+class ServiceOsmApiDbSqlChangesetFileWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceOsmApiDbSqlChangesetFileWriterTest);
   CPPUNIT_TEST(runBasicTest);
@@ -56,13 +45,15 @@ public:
 
   OsmApiDb database;
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/ServiceOsmApiDbSqlChangesetFileWriterTest");
   }
 
-  void tearDown()
+  virtual void tearDown()
   {
+    HootTestFixture::tearDown();
     database.open(ServicesDbTestUtils::getOsmApiDbUrl());
     database.deleteData();
     database.close();

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
@@ -32,6 +32,7 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiDb.h>
 
 using namespace std;
@@ -39,7 +40,7 @@ using namespace std;
 namespace hoot
 {
 
-class ServiceOsmApiDbTest : public CppUnit::TestFixture
+class ServiceOsmApiDbTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceOsmApiDbTest);
   CPPUNIT_TEST(runToOsmApiCoordConvertTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -32,6 +32,7 @@
 #include <cppunit/TestAssert.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/io/OsmApiDbReader.h>
 #include <hoot/core/util/ConfigOptions.h>
@@ -44,8 +45,6 @@
 
 // Tgs
 #include <tgs/StreamUtils.h>
-
-#include "../TestUtils.h"
 
 using namespace std;
 using namespace Tgs;

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayManipulationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayManipulationTest.cpp
@@ -32,21 +32,19 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/manipulators/DividedHighwayManipulation.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
 
 // Qt
 #include <QDebug>
-#include <QDir>
 
 // TGS
 #include <tgs/StreamUtils.h>
-
-#include "../TestUtils.h"
 
 using namespace std;
 using namespace Tgs;
@@ -54,7 +52,7 @@ using namespace Tgs;
 namespace hoot
 {
 
-class DividedHighwayManipulationTest : public CppUnit::TestFixture
+class DividedHighwayManipulationTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(DividedHighwayManipulationTest);
   CPPUNIT_TEST(individualManipulationsTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/DividedHighwayMergerTest.cpp
@@ -33,29 +33,24 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/conflate/Conflator.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/Conflator.h>
 #include <hoot/core/criterion/ParallelWayFilter.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/manipulators/DividedHighwayManipulation.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 // TGS
 #include <tgs/StreamUtils.h>
 using namespace Tgs;
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class DividedHighwayMergerTest : public CppUnit::TestFixture
+class DividedHighwayMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(DividedHighwayMergerTest);
   //CPPUNIT_TEST(allManipulationsTest); //TODO: re-enable or remove?
@@ -65,8 +60,9 @@ class DividedHighwayMergerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/manipulators/WayMergeManipulationTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/manipulators/WayMergeManipulationTest.cpp
@@ -25,7 +25,6 @@
  * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
@@ -33,31 +32,24 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/manipulators/WayMergeManipulation.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 // TGS
 #include <tgs/StreamUtils.h>
+
 using namespace Tgs;
-
-#include "../TestUtils.h"
-
 using namespace std;
 
 namespace hoot
 {
 
-class WayMergeManipulationTest : public CppUnit::TestFixture
+class WayMergeManipulationTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WayMergeManipulationTest);
   CPPUNIT_TEST(individualManipulationsTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineRemoveOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineRemoveOpTest.cpp
@@ -27,14 +27,12 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/BuildingOutlineRemoveOp.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,19 +40,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// hoot
-#include <hoot/core/util/MapProjector.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class BuildingOutlineRemoveOpTest : public CppUnit::TestFixture
+class BuildingOutlineRemoveOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingOutlineRemoveOpTest);
   CPPUNIT_TEST(runSelfIntersectingRelationTest);
@@ -87,9 +76,7 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BuildingOutlineRemoveOpTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BuildingOutlineRemoveOpTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineUpdateOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingOutlineUpdateOpTest.cpp
@@ -27,14 +27,12 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/BuildingOutlineUpdateOp.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,19 +40,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// hoot
-#include <hoot/core/util/MapProjector.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class BuildingOutlineUpdateOpTest : public CppUnit::TestFixture
+class BuildingOutlineUpdateOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingOutlineUpdateOpTest);
   CPPUNIT_TEST(runSelfIntersectingRelationTest);
@@ -63,8 +52,9 @@ class BuildingOutlineUpdateOpTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/ops/BuildingOutlineUpdateOp/");
   }
 
@@ -121,9 +111,7 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BuildingOutlineUpdateOpTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BuildingOutlineUpdateOpTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingPartMergeOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/BuildingPartMergeOpTest.cpp
@@ -27,14 +27,12 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/BuildingPartMergeOp.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -47,22 +45,15 @@ using namespace boost;
 #include <geos/geom/Point.h>
 
 // hoot
-#include <hoot/core/util/MapProjector.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class BuildingPartMergeOpTest : public CppUnit::TestFixture
+class BuildingPartMergeOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(BuildingPartMergeOpTest);
   CPPUNIT_TEST(runToyTest);
@@ -93,9 +84,7 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BuildingPartMergeOpTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(BuildingPartMergeOpTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/CalculateStatsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/CalculateStatsOpTest.cpp
@@ -27,6 +27,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/ops/CalculateStatsOp.h>
 #include <hoot/core/util/ConfigOptions.h>
@@ -40,12 +41,10 @@
 // Qt
 #include <qnumeric.h>
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class CalculateStatsOpTest : public CppUnit::TestFixture
+class CalculateStatsOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CalculateStatsOpTest);
   CPPUNIT_TEST(runStatsNumTest);
@@ -55,15 +54,10 @@ class CalculateStatsOpTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
-    TestUtils::resetEnvironment();
+    HootTestFixture::setUp();
     conf().set(ConfigOptions::getStatsTranslateScriptKey(), "${HOOT_HOME}/translations/HootTest.js");
-  }
-
-  void tearDown()
-  {
-    TestUtils::resetEnvironment();
   }
 
   //this is here just to prevent someone from adding a stat that doesn't get tested in this test
@@ -417,9 +411,7 @@ private:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(hoot::CalculateStatsOpTest, "slow");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(hoot::CalculateStatsOpTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/CookieCutterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/CookieCutterOpTest.cpp
@@ -27,14 +27,13 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/CookieCutterOp.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,20 +41,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// hoot
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/conflate/MapCleaner.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class CookieCutterOpTest : public CppUnit::TestFixture
+class CookieCutterOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CookieCutterOpTest);
   CPPUNIT_TEST(runTest);
@@ -93,9 +82,7 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(CookieCutterOpTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(CookieCutterOpTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/DuplicateNameRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/DuplicateNameRemoverTest.cpp
@@ -26,14 +26,10 @@
  */
 
 // Hoot
-#include <hoot/core/ops/DuplicateNameRemover.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/ops/DuplicateNameRemover.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -41,17 +37,12 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-#include "../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class DuplicateNameRemoverTest : public CppUnit::TestFixture
+class DuplicateNameRemoverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(DuplicateNameRemoverTest);
   CPPUNIT_TEST(runCaseInsensitiveTest);
@@ -79,7 +70,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(1, (int)map->getWays().size());
     const Tags& tags = map->getWay(way->getElementId())->getTags();
     CPPUNIT_ASSERT_EQUAL(1, tags.size());
-    CPPUNIT_ASSERT_EQUAL(QString("test"), tags.get("name"));
+    HOOT_STR_EQUALS(QString("test"), tags.get("name"));
   }
 
   void runCaseSensitiveTest()
@@ -100,7 +91,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(1, (int)map->getWays().size());
     const Tags& tags = map->getWay(way->getElementId())->getTags();
     CPPUNIT_ASSERT_EQUAL(1, tags.size());
-    CPPUNIT_ASSERT_EQUAL(QString("test;TEST"), tags.get("name"));
+    HOOT_STR_EQUALS(QString("test;TEST"), tags.get("name"));
   }
 
   void runExtraNamesTest()
@@ -122,8 +113,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(1, (int)map->getWays().size());
     const Tags& tags = map->getWay(way->getElementId())->getTags();
     CPPUNIT_ASSERT_EQUAL(2, tags.size());
-    CPPUNIT_ASSERT_EQUAL(QString("test"), tags.get("name"));
-    CPPUNIT_ASSERT_EQUAL(QString("blah"), tags.get("alt_name"));
+    HOOT_STR_EQUALS(QString("test"), tags.get("name"));
+    HOOT_STR_EQUALS(QString("blah"), tags.get("alt_name"));
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/DuplicateWayRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/DuplicateWayRemoverTest.cpp
@@ -29,29 +29,21 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/ops/DuplicateWayRemover.h>
+#include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/core/OsmMap.h>
+#include <hoot/core/ops/DuplicateWayRemover.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 // Standard
 #include <sstream>
@@ -61,12 +53,10 @@ using namespace std;
 #include <tgs/StreamUtils.h>
 using namespace Tgs;
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class DuplicateWayRemoverTest : public CppUnit::TestFixture
+class DuplicateWayRemoverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(DuplicateWayRemoverTest);
   CPPUNIT_TEST(runTest);
@@ -76,8 +66,9 @@ class DuplicateWayRemoverTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate");
   }
 
@@ -166,8 +157,7 @@ public:
   }
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(DuplicateWayRemoverTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(DuplicateWayRemoverTest, "current");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/FindIntersectionsOpTest.cpp
@@ -30,8 +30,8 @@
 #include <geos/geom/Point.h>
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -40,21 +40,16 @@
 #include <hoot/core/ops/RefRemoveOp.h>
 #include <hoot/core/ops/FindIntersectionsOp.h>
 #include <hoot/core/util/Log.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
+#include <hoot/core/util/MapProjector.h>
 
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class FindIntersectionsOpTest : public CppUnit::TestFixture
+class FindIntersectionsOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(FindIntersectionsOpTest);
   CPPUNIT_TEST(runToyTest);
@@ -62,9 +57,9 @@ class FindIntersectionsOpTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
-    TestUtils::resetEnvironment();
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/ops/FindIntersectionsOp/");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MapCropperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MapCropperTest.cpp
@@ -26,20 +26,17 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ObjectInputStream.h>
 #include <hoot/core/io/ObjectOutputStream.h>
-#include <hoot/core/ops/MapCropper.h>
-#include <hoot/core/util/Log.h>
-#include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmXmlReader.h>
+#include <hoot/core/ops/MapCropper.h>
 #include <hoot/core/util/ElementConverter.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/Settings.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -53,13 +50,8 @@ using namespace boost;
 #include <geos/geom/Envelope.h>
 #include <geos/geom/Polygon.h>
 
-// Qt
-#include <QDebug>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -68,7 +60,7 @@ using namespace Tgs;
 namespace hoot
 {
 
-class MapCropperTest : public CppUnit::TestFixture
+class MapCropperTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MapCropperTest);
   CPPUNIT_TEST(runGeometryTest);
@@ -298,9 +290,7 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MapCropperTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MapCropperTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MergeNearbyNodesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MergeNearbyNodesTest.cpp
@@ -26,18 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/ops/MergeNearbyNodes.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OgrReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/ops/MergeNearbyNodes.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/Progress.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -45,15 +41,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class MergeNearbyNodesTest : public CppUnit::TestFixture
+class MergeNearbyNodesTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(MergeNearbyNodesTest);
     CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/NoInformationElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/NoInformationElementRemoverTest.cpp
@@ -26,13 +26,10 @@
  */
 
 // Hoot
-#include <hoot/core/ops/NoInformationElementRemover.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/ops/NoInformationElementRemover.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,17 +37,12 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-#include "../TestUtils.h"
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class NoInformationElementRemoverTest : public CppUnit::TestFixture
+class NoInformationElementRemoverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(NoInformationElementRemoverTest);
   CPPUNIT_TEST(runWayWithInfoOneNodeWithoutInfoTest);
@@ -118,8 +110,8 @@ public:
     ConstNodePtr parsedNode1 = map->getNode(node1->getElementId().getId());
     const Tags& node1Tags = parsedNode1->getTags();
     CPPUNIT_ASSERT_EQUAL(2, node1Tags.size());
-    CPPUNIT_ASSERT_EQUAL(QString("test1"), node1Tags.get("hoot:test"));
-    CPPUNIT_ASSERT_EQUAL(QString("test1"), node1Tags.get("test"));
+    HOOT_STR_EQUALS(QString("test1"), node1Tags.get("hoot:test"));
+    HOOT_STR_EQUALS(QString("test1"), node1Tags.get("test"));
 
     CPPUNIT_ASSERT(!map->containsNode(node2->getElementId().getId()));
   }
@@ -152,7 +144,7 @@ public:
   void runEmptyWayOrphanNodesTest()
   {
     OsmMap::resetCounters();
-    shared_ptr<OsmMap> map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
 
     QList<NodePtr> nodes;
     NodePtr node1(new Node(Status::Unknown1, map->createNextNodeId(), Coordinate(0.0, 0.0), 15));
@@ -357,7 +349,7 @@ public:
   void runRelationWithoutInfoAllElementsWithoutInfoTest()
   {
     OsmMap::resetCounters();
-    shared_ptr<OsmMap> map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
 
     NodePtr node1(new Node(Status::Unknown1, map->createNextNodeId(), Coordinate(0.0, 0.0), 15));
     node1->getTags().appendValue("hoot:test", "test1");
@@ -388,7 +380,7 @@ public:
   void runUnrelatedElementsWithInfoTest()
   {
     OsmMap::resetCounters();
-    shared_ptr<OsmMap> map(new OsmMap());
+    OsmMapPtr map(new OsmMap());
 
     NodePtr node1(new Node(Status::Unknown1, map->createNextNodeId(), Coordinate(0.0, 0.0), 15));
     node1->getTags().appendValue("hoot:test", "test1");

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RecursiveElementRemoverTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RecursiveElementRemoverTest.cpp
@@ -26,15 +26,11 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,12 +38,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
+namespace hoot
+{
 
-#include "../TestUtils.h"
-
-class RecursiveElementRemoverTest : public CppUnit::TestFixture
+class RecursiveElementRemoverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RecursiveElementRemoverTest);
   CPPUNIT_TEST(removeRelationTest);
@@ -190,3 +184,4 @@ public:
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(RecursiveElementRemoverTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(RecursiveElementRemoverTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RefRemoveOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RefRemoveOpTest.cpp
@@ -31,6 +31,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -39,20 +40,14 @@
 #include <hoot/core/ops/RefRemoveOp.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class RefRemoveOpTest : public CppUnit::TestFixture
+class RefRemoveOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RefRemoveOpTest);
   CPPUNIT_TEST(runToyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RemoveEmptyRelationsOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RemoveEmptyRelationsOpTest.cpp
@@ -27,14 +27,14 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/ops/RemoveEmptyRelationsOp.h>
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class RemoveEmptyRelationsOpTest : public CppUnit::TestFixture
+class RemoveEmptyRelationsOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveEmptyRelationsOpTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToGeographicOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToGeographicOpTest.cpp
@@ -31,6 +31,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -38,20 +39,14 @@
 #include <hoot/core/ops/ReprojectToGeographicOp.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class ReprojectToGeographicOpTest : public CppUnit::TestFixture
+class ReprojectToGeographicOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ReprojectToGeographicOpTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ReprojectToPlanarOpTest.cpp
@@ -31,6 +31,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -40,18 +41,15 @@
 
 // Qt
 #include <QDebug>
-#include <QDir>
 
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class ReprojectToPlanarOpTest : public CppUnit::TestFixture
+class ReprojectToPlanarOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ReprojectToPlanarOpTest);
   CPPUNIT_TEST(runTest);
@@ -59,8 +57,9 @@ class ReprojectToPlanarOpTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::resetEnvironment();
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/TrivialOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/TrivialOpTest.cpp
@@ -27,6 +27,8 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/CookieCutterOp.h>
@@ -41,10 +43,7 @@
 #include <hoot/core/ops/SuperfluousNodeRemover.h>
 #include <hoot/core/ops/WaySplitterOp.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
+#include <hoot/core/util/MapProjector.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -52,22 +51,12 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// hoot
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/conflate/MapCleaner.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
-
 using namespace std;
 
 namespace hoot
 {
 
-class TrivialOpTest : public CppUnit::TestFixture
+class TrivialOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TrivialOpTest);
   CPPUNIT_TEST(runTest);
@@ -150,9 +139,7 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TrivialOpTest, "quick");
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TrivialOpTest, "current");
 
-
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/WaySplitterOpTest.cpp
@@ -31,6 +31,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -38,20 +39,14 @@
 #include <hoot/core/ops/WaySplitterOp.h>
 #include <hoot/core/util/Log.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class WaySplitterOpTest : public CppUnit::TestFixture
+class WaySplitterOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(WaySplitterOpTest);
   CPPUNIT_TEST(runTest);
@@ -59,8 +54,9 @@ class WaySplitterOpTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::resetEnvironment();
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/OsmSchemaTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/OsmSchemaTest.cpp
@@ -26,12 +26,11 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Tags.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/Log.h>
-
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -43,8 +42,6 @@ using namespace hoot;
 #include <QDebug>
 #include <QFile>
 
-#include "../TestUtils.h"
-
 const double epsilon = 1e-6;
 
 using namespace geos::geom;
@@ -53,7 +50,7 @@ using namespace std;
 namespace hoot
 {
 
-class OsmSchemaTest : public CppUnit::TestFixture
+class OsmSchemaTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmSchemaTest);
   CPPUNIT_TEST(averageTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/OverwriteTagMergerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/OverwriteTagMergerTest.cpp
@@ -26,10 +26,10 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/schema/OverwriteTagMerger.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -37,15 +37,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class OverwriteTagMergerTest : public CppUnit::TestFixture
+class OverwriteTagMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OverwriteTagMergerTest);
   CPPUNIT_TEST(overwriteTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/SchemaCheckerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/SchemaCheckerTest.cpp
@@ -26,13 +26,12 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Tags.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/schema/SchemaChecker.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/Log.h>
-
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,18 +39,12 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QFile>
-
-#include "../TestUtils.h"
-
 const double epsilon = 1e-6;
 
 namespace hoot
 {
 
-class SchemaCheckerTest : public CppUnit::TestFixture
+class SchemaCheckerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SchemaCheckerTest);
   CPPUNIT_TEST(checkUnknownTypeTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/ScoreMatrixTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/ScoreMatrixTest.cpp
@@ -26,17 +26,16 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/schema/ScoreMatrix.h>
 #include <hoot/core/util/Log.h>
-
-#include "../TestUtils.h"
 
 using namespace std;
 
 namespace hoot
 {
 
-class ScoreMatrixTest : public CppUnit::TestFixture
+class ScoreMatrixTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ScoreMatrixTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagAncestorDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagAncestorDifferencerTest.cpp
@@ -26,15 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/schema/TagAncestorDifferencer.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class TagAncestorDifferencerTest : public CppUnit::TestFixture
+class TagAncestorDifferencerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagAncestorDifferencerTest);
   CPPUNIT_TEST(compareRailwaysTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagCategoryDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagCategoryDifferencerTest.cpp
@@ -26,15 +26,14 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/schema/TagCategoryDifferencer.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class TagCategoryDifferencerTest : public CppUnit::TestFixture
+class TagCategoryDifferencerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagCategoryDifferencerTest);
   CPPUNIT_TEST(compareRailwaysTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/schema/TagComparator.h>
 #include <hoot/core/scoring/TextTable.h>
@@ -38,15 +39,12 @@
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
 using namespace std;
 
 namespace hoot
 {
 
-class TagComparatorTest : public CppUnit::TestFixture
+class TagComparatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagComparatorTest);
   CPPUNIT_TEST(averageTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagMergerFactoryTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagMergerFactoryTest.cpp
@@ -26,10 +26,10 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/schema/TagMergerFactory.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -37,10 +37,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
+namespace hoot
+{
 
-class TagMergerFactoryTest : public CppUnit::TestFixture
+class TagMergerFactoryTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagMergerFactoryTest);
   CPPUNIT_TEST(averageTest);
@@ -85,3 +85,4 @@ public:
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TagMergerFactoryTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TranslateStringDistanceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TranslateStringDistanceTest.cpp
@@ -35,21 +35,17 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/MeanWordSetDistance.h>
 #include <hoot/core/algorithms/ExactStringDistance.h>
 #include <hoot/core/algorithms/LevenshteinDistance.h>
 #include <hoot/core/schema/TranslateStringDistance.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
-// Qt
-#include <QString>
+namespace hoot
+{
 
-// Standard
-#include <string>
-
-
-class TranslateStringDistanceTest : public CppUnit::TestFixture
+class TranslateStringDistanceTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TranslateStringDistanceTest);
   CPPUNIT_TEST(runTest);
@@ -74,3 +70,4 @@ public:
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TranslateStringDistanceTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(TranslateStringDistanceTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TranslatedTagDifferencerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TranslatedTagDifferencerTest.cpp
@@ -36,24 +36,16 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/schema/TranslatedTagDifferencer.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
-
-// Qt
-#include <QString>
-
-// Standard
-#include <string>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class TranslateTagDifferencerTest : public CppUnit::TestFixture
+class TranslateTagDifferencerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TranslateTagDifferencerTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/AttributeComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/AttributeComparatorTest.cpp
@@ -28,6 +28,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/scoring/AttributeComparator.h>
@@ -35,8 +36,6 @@
 #define int64 opencv_broken_int
 #include <hoot/core/util/OpenCv.h>
 #undef int64
-
-using namespace hoot;
 
 // Tgs
 #include <tgs/Statistics/Random.h>
@@ -56,7 +55,10 @@ using namespace boost;
 // Standard
 #include <stdio.h>
 
-class AttributeComparatorTest : public CppUnit::TestFixture
+namespace hoot
+{
+
+class AttributeComparatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AttributeComparatorTest);
   CPPUNIT_TEST(runTest);
@@ -91,5 +93,5 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(AttributeComparatorTest);
 
-
+}
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
@@ -27,6 +27,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmPbfReader.h>
@@ -60,7 +61,10 @@ using namespace boost;
 // Standard
 #include <stdio.h>
 
-class MapComparatorTest : public CppUnit::TestFixture
+namespace hoot
+{
+
+class MapComparatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MapComparatorTest);
   CPPUNIT_TEST(runTest);
@@ -107,5 +111,5 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(MapComparatorTest);
 
-
+}
 

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
@@ -26,6 +26,7 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/UnifyingConflator.h>
 #include <hoot/core/criterion/TagKeyCriterion.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -37,10 +38,6 @@
 #include <hoot/core/visitors/FilteredVisitor.h>
 #include <hoot/core/visitors/AddUuidVisitor.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -48,19 +45,12 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
-// Standard
-#include <stdio.h>
-
 using namespace std;
 
 namespace hoot
 {
 
-class MatchComparatorTest : public CppUnit::TestFixture
+class MatchComparatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MatchComparatorTest);
   CPPUNIT_TEST(runTest);
@@ -119,7 +109,7 @@ public:
 
 };
 
-}
-
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MatchComparatorTest, "current");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MatchComparatorTest, "quick");
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchFeatureExtractorTest.cpp
@@ -33,6 +33,7 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/MapCleaner.h>
 #include <hoot/core/conflate/polygon/BuildingMatchCreator.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -43,16 +44,10 @@
 // Tgs
 #include <tgs/Statistics/Random.h>
 
-// Qt
-#include <QDir>
-#include <QFile>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class MatchFeatureExtractorTest : public CppUnit::TestFixture
+class MatchFeatureExtractorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MatchFeatureExtractorTest);
   CPPUNIT_TEST(runBuildingTest);
@@ -60,8 +55,9 @@ class MatchFeatureExtractorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::resetEnvironment();
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.cpp
@@ -27,13 +27,12 @@
 #include "ConflateCaseTest.h"
 
 // hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/cmd/ConflateCmd.h>
+#include <hoot/core/test/TestSetup.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/cmd/ConflateCmd.h>
-
-#include "../TestUtils.h"
-#include "TestSetup.h"
 
 namespace hoot
 {

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTest.h
@@ -28,10 +28,9 @@
 #define CONFLATECASETEST_H
 
 // Qt
-#include <QDir>
 #include <QStringList>
 
-#include "AbstractTest.h"
+#include <hoot/core/test/AbstractTest.h>
 
 namespace hoot
 {

--- a/hoot-core-test/src/test/cpp/hoot/core/test/TempTestFileName.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/TempTestFileName.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef TEMPTESTFILENAME_H
 #define TEMPTESTFILENAME_H

--- a/hoot-core-test/src/test/cpp/hoot/core/test/TempTestFileName.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/TempTestFileName.h
@@ -28,7 +28,6 @@
 #define TEMPTESTFILENAME_H
 
 // Qt
-#include <QDir>
 #include <QStringList>
 
 namespace hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/test/TestSetup.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/TestSetup.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "TestSetup.h"
 

--- a/hoot-core-test/src/test/cpp/hoot/core/test/TestSetup.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/TestSetup.cpp
@@ -26,7 +26,7 @@
  */
 #include "TestSetup.h"
 
-#include "../TestUtils.h"
+#include <hoot/core/TestUtils.h>
 
 namespace hoot
 {
@@ -46,4 +46,5 @@ void TestSetup::reset()
 {
   TestUtils::resetEnvironment(_confs);
 }
+
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/util/GeometryConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/GeometryConverterTest.cpp
@@ -35,6 +35,7 @@
 #include <geos/geom/Geometry.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/util/ElementConverter.h>
 #include <hoot/core/util/Log.h>
 
@@ -43,7 +44,7 @@ using namespace geos::geom;
 namespace hoot
 {
 
-class GeometryConverterTest : public CppUnit::TestFixture
+class GeometryConverterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(GeometryConverterTest);
   CPPUNIT_TEST(emptyWayTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/util/GeometryUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/GeometryUtilsTest.cpp
@@ -26,9 +26,9 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -36,14 +36,13 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class GeometryUtilsTest : public CppUnit::TestFixture
+class GeometryUtilsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(GeometryUtilsTest);
   CPPUNIT_TEST(calculateDestinationTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/util/MapProjectorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/MapProjectorTest.cpp
@@ -37,18 +37,16 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/WayHeading.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-using namespace hoot;
 
 // Tbs
 #include <tbs/stats/SampleStats.h>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -56,7 +54,7 @@ using namespace std;
 namespace hoot
 {
 
-class MapProjectorTest : public CppUnit::TestFixture
+class MapProjectorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MapProjectorTest);
   CPPUNIT_TEST(runErrorTest);
@@ -68,18 +66,12 @@ public:
   boost::minstd_rand rng;
   ofstream fs;
 
-  void setUp()
+  virtual void setUp()
   {
-    TestUtils::resetEnvironment();
+    HootTestFixture::setUp();
     // we are testing the map reprojector so we don't want to force to a single projection.
     conf().set(ConfigOptions::getTestForceOrthographicProjectionKey(), false);
   }
-
-  void tearDown()
-  {
-    TestUtils::resetEnvironment();
-  }
-
 
   Radians calculateAngle(Coordinate p1, Coordinate p2, Coordinate p3)
   {

--- a/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/MultiPolygonCreatorTest.cpp
@@ -29,15 +29,9 @@
 #include <geos/geom/Geometry.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/polygon/MultiPolygonCreator.h>
 #include <hoot/core/util/FindNodesInWayFactory.h>
-using namespace hoot;
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 using namespace std;
@@ -45,7 +39,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiPolygonCreatorTest : public CppUnit::TestFixture
+class MultiPolygonCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiPolygonCreatorTest);
   CPPUNIT_TEST(runBadOuterRingsTest);
@@ -226,7 +220,6 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MultiPolygonCreatorTest, "quick");
 
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
@@ -26,9 +26,9 @@
  */
 
 // Hoot
-#include <hoot/core/util/Settings.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/util/Log.h>
-using namespace hoot;
+#include <hoot/core/util/Settings.h>
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -36,15 +36,10 @@ using namespace hoot;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class SettingsTest : public CppUnit::TestFixture
+class SettingsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SettingsTest);
   CPPUNIT_TEST(envTest);
@@ -59,10 +54,10 @@ public:
     Settings uut;
     uut.loadEnvironment();
     char* path = getenv("PATH");
-    CPPUNIT_ASSERT_EQUAL(QString(path), uut.getString("PATH"));
+    HOOT_STR_EQUALS(QString(path), uut.getString("PATH"));
 
     uut.set("mypath", "my path: ${PATH}");
-    CPPUNIT_ASSERT_EQUAL(QString("my path: ") + path, uut.getString("mypath"));
+    HOOT_STR_EQUALS(QString("my path: ") + path, uut.getString("mypath"));
   }
 
   void replaceTest()
@@ -73,16 +68,16 @@ public:
     uut.set("perty.test.num.runs", 2);
     uut.set("osm.map.writer.factory.writer", "1");
     uut.set("osm.map.reader.factory.reader", "${perty.csm.D}");
-    CPPUNIT_ASSERT_EQUAL(QString("2"), uut.getString("osm.map.reader.factory.reader"));
+    HOOT_STR_EQUALS(QString("2"), uut.getString("osm.map.reader.factory.reader"));
 
     uut.set("osm.map.reader.factory.reader", "${perty.csm.D} ${osm.map.writer.factory.writer}");
-    CPPUNIT_ASSERT_EQUAL(QString("2 1"), uut.getString("osm.map.reader.factory.reader"));
+    HOOT_STR_EQUALS(QString("2 1"), uut.getString("osm.map.reader.factory.reader"));
 
     uut.set("osm.map.reader.factory.reader", "${osm.map.writer.factory.writer} ${osm.map.writer.factory.writer}");
-    CPPUNIT_ASSERT_EQUAL(QString("1 1"), uut.getString("osm.map.reader.factory.reader"));
+    HOOT_STR_EQUALS(QString("1 1"), uut.getString("osm.map.reader.factory.reader"));
 
     uut.set("perty.csm.D", "${doesnt.exist}");
-    CPPUNIT_ASSERT_EQUAL(QString(""), uut.getString("perty.csm.D"));
+    HOOT_STR_EQUALS(QString(""), uut.getString("perty.csm.D"));
 
     HOOT_STR_EQUALS("", uut.getValue("${doesnt.exist}"));
     HOOT_STR_EQUALS("1", uut.getValue("${osm.map.writer.factory.writer}"));

--- a/hoot-core-test/src/test/cpp/hoot/core/util/StringUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/StringUtilsTest.cpp
@@ -32,15 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/StringUtils.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class StringUtilsTest : public CppUnit::TestFixture
+class StringUtilsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(StringUtilsTest);
   CPPUNIT_TEST(runHasAlphabeticCharTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/UuidHelperTest.cpp
@@ -32,15 +32,14 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/UuidHelper.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class UuidHelperTest : public CppUnit::TestFixture
+class UuidHelperTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(UuidHelperTest);
   CPPUNIT_TEST(uuid5Test);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/AddAttributesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/AddAttributesVisitorTest.cpp
@@ -33,19 +33,15 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/visitors/AddAttributesVisitor.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 
-#include "../TestUtils.h"
-
-// Qt
-#include <QDir>
-
 namespace hoot
 {
 
-class AddAttributesVisitorTest : public CppUnit::TestFixture
+class AddAttributesVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AddAttributesVisitorTest);
   CPPUNIT_TEST(runAddAttributesTest);
@@ -59,8 +55,9 @@ class AddAttributesVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/visitors");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/AddGeometryTypeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/AddGeometryTypeVisitorTest.cpp
@@ -27,26 +27,21 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmJsonWriter.h>
-#include <hoot/core/criterion/PoiCriterion.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
-#include <hoot/core/visitors/AddGeometryTypeVisitor.h>
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/criterion/PoiCriterion.h>
+#include <hoot/core/io/OsmJsonWriter.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/visitors/AddGeometryTypeVisitor.h>
 
 using namespace std;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class AddGeometryTypeVisitorTest : public CppUnit::TestFixture
+class AddGeometryTypeVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AddGeometryTypeVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/CalculateHashVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/CalculateHashVisitorTest.cpp
@@ -27,17 +27,13 @@
 
 // hoot
 #include <hoot/core/util/Log.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/visitors/CalculateHashVisitor.h>
-
-#include "../TestUtils.h"
-
-using namespace std;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class CalculateHashVisitorTest : public CppUnit::TestFixture
+class CalculateHashVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CalculateHashVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/CountManualMatchesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/CountManualMatchesVisitorTest.cpp
@@ -27,19 +27,14 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/visitors/CountManualMatchesVisitor.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
-using namespace Tgs;
 
-class CountManualMatchesVisitorTest : public CppUnit::TestFixture
+class CountManualMatchesVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CountManualMatchesVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/ImplicitPoiTypeTaggerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/ImplicitPoiTypeTaggerTest.cpp
@@ -26,19 +26,16 @@
  */
 
 // Hoot
-#include "../TestUtils.h"
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/ImplicitTagRulesSqliteWriter.h>
 #include <hoot/core/io/OsmJsonReader.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/ImplicitPoiTypeTagger.h>
-#include <hoot/core/io/ImplicitTagRulesSqliteWriter.h>
-
-// Qt
-#include <QDir>
 
 namespace hoot
 {
 
-class ImplicitPoiTypeTaggerTest : public CppUnit::TestFixture
+class ImplicitPoiTypeTaggerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ImplicitPoiTypeTaggerTest);
   CPPUNIT_TEST(runBasicTest);
@@ -52,13 +49,10 @@ public:
   static QString inDir() { return "test-files/visitors/ImplicitPoiTypeTaggerTest"; }
   static QString outDir() { return "test-output/visitors/ImplicitPoiTypeTaggerTest"; }
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath(outDir());
-  }
-  void tearDown()
-  {
-    TestUtils::resetEnvironment();
   }
 
   void runBasicTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepNodesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepNodesVisitorTest.cpp
@@ -33,22 +33,17 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/visitors/KeepNodesVisitor.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class KeepNodesVisitorTest : public CppUnit::TestFixture
+class KeepNodesVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(KeepNodesVisitorTest);
   CPPUNIT_TEST(runToyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/KeepTagsVisitorTest.cpp
@@ -33,16 +33,15 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/visitors/TagKeyCountVisitor.h>
 #include <hoot/core/visitors/KeepTagsVisitor.h>
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class KeepTagsVisitorTest : public CppUnit::TestFixture
+class KeepTagsVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(KeepTagsVisitorTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
@@ -27,17 +27,14 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/MatchCandidateCountVisitor.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -45,18 +42,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class MatchCandidateCountVisitorTest : public CppUnit::TestFixture
+class MatchCandidateCountVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MatchCandidateCountVisitorTest);
   CPPUNIT_TEST(runBuildingMatchCandidateCountTest);
@@ -68,11 +57,6 @@ class MatchCandidateCountVisitorTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void tearDown()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   void runBuildingMatchCandidateCountTest()
   {
@@ -94,7 +78,7 @@ public:
     map->visitRo(uut);
     CPPUNIT_ASSERT_EQUAL((int)18, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long>>(uut.getData());
     CPPUNIT_ASSERT_EQUAL(1, matchCandidateCountsByMatchCreator.size());
     CPPUNIT_ASSERT_EQUAL((long)18, matchCandidateCountsByMatchCreator["hoot::BuildingMatchCreator"]);
   }
@@ -119,7 +103,7 @@ public:
     map->visitRo(uut);
     CPPUNIT_ASSERT_EQUAL((int)8, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long>>(uut.getData());
     CPPUNIT_ASSERT_EQUAL(1, matchCandidateCountsByMatchCreator.size());
     CPPUNIT_ASSERT_EQUAL((long)8, matchCandidateCountsByMatchCreator["hoot::HighwayMatchCreator"]);
   }
@@ -147,7 +131,7 @@ public:
 
     CPPUNIT_ASSERT_EQUAL((int)34, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long>>(uut.getData());
     CPPUNIT_ASSERT_EQUAL(3, matchCandidateCountsByMatchCreator.size());
     //These don't add up to the total...is there some overlap here?
     CPPUNIT_ASSERT_EQUAL((long)18, matchCandidateCountsByMatchCreator["hoot::BuildingMatchCreator"]);
@@ -182,7 +166,7 @@ public:
     map->visitRo(uut);
     CPPUNIT_ASSERT_EQUAL((int)21, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long>>(uut.getData());
     CPPUNIT_ASSERT_EQUAL(1, matchCandidateCountsByMatchCreator.size());
     CPPUNIT_ASSERT_EQUAL(
       (long)21, matchCandidateCountsByMatchCreator["hoot::ScriptMatchCreator,PoiGeneric.js"]);
@@ -211,7 +195,7 @@ public:
     map->visitRo(uut);
     CPPUNIT_ASSERT_EQUAL((int)21, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long>>(uut.getData());
     CPPUNIT_ASSERT_EQUAL(1, matchCandidateCountsByMatchCreator.size());
     LOG_VARD(matchCandidateCountsByMatchCreator);
     CPPUNIT_ASSERT_EQUAL(
@@ -240,7 +224,7 @@ public:
     map->visitRo(uut);
     CPPUNIT_ASSERT_EQUAL((int)21, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long>>(uut.getData());
     CPPUNIT_ASSERT_EQUAL(1, matchCandidateCountsByMatchCreator.size());
     CPPUNIT_ASSERT_EQUAL(
       (long)21, matchCandidateCountsByMatchCreator["hoot::ScriptMatchCreator,PoiGeneric.js"]);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MedianNodeVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MedianNodeVisitorTest.cpp
@@ -27,18 +27,16 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/MedianNodeVisitor.h>
-using namespace hoot;
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class MedianNodeVisitorTest : public CppUnit::TestFixture
+class MedianNodeVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MedianNodeVisitorTest);
   CPPUNIT_TEST(runTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveAttributesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveAttributesVisitorTest.cpp
@@ -33,20 +33,16 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/visitors/RemoveAttributesVisitor.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/elements/ElementAttributeType.h>
-
-#include "../TestUtils.h"
-
-// Qt
-#include <QDir>
+#include <hoot/core/visitors/RemoveAttributesVisitor.h>
 
 namespace hoot
 {
 
-class RemoveAttributesVisitorTest : public CppUnit::TestFixture
+class RemoveAttributesVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveAttributesVisitorTest);
   CPPUNIT_TEST(runRemoveAttributesTest);
@@ -55,8 +51,9 @@ class RemoveAttributesVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/visitors");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitorTest.cpp
@@ -36,28 +36,23 @@
 #include <geos/geom/Point.h>
 
 // hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/visitors/RemoveDuplicateAreaVisitor.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/FindWaysVisitor.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
+#include <hoot/core/visitors/RemoveDuplicateAreaVisitor.h>
 
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class RemoveDuplicateAreaVisitorTest : public CppUnit::TestFixture
+class RemoveDuplicateAreaVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveDuplicateAreaVisitorTest);
   CPPUNIT_TEST(runToyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitorTest.cpp
@@ -27,14 +27,13 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class RemoveDuplicateWayNodesVisitorTest : public CppUnit::TestFixture
+class RemoveDuplicateWayNodesVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveDuplicateWayNodesVisitorTest);
   CPPUNIT_TEST(runInvalidWayTest1);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveElementsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveElementsVisitorTest.cpp
@@ -27,24 +27,19 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmJsonWriter.h>
-#include <hoot/core/criterion/PoiCriterion.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
-#include <hoot/core/visitors/RemoveElementsVisitor.h>
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/criterion/PoiCriterion.h>
+#include <hoot/core/io/OsmJsonWriter.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/visitors/RemoveElementsVisitor.h>
 
 namespace hoot
 {
-using namespace Tgs;
 
-class RemoveElementsVisitorTest : public CppUnit::TestFixture
+class RemoveElementsVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveElementsVisitorTest);
   CPPUNIT_TEST(runTest);
@@ -54,8 +49,9 @@ class RemoveElementsVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/visitors");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitorTest.cpp
@@ -27,20 +27,18 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/ReviewMarker.h>
 #include <hoot/core/ops/RemoveElementOp.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/RemoveInvalidReviewRelationsVisitor.h>
 
-#include "../TestUtils.h"
-
 using namespace std;
-using namespace Tgs;
 
 namespace hoot
 {
 
-class RemoveInvalidReviewRelationsVisitorTest : public CppUnit::TestFixture
+class RemoveInvalidReviewRelationsVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveInvalidReviewRelationsVisitorTest);
   CPPUNIT_TEST(runInvalidMemberCountTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorMultipleCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorMultipleCriterionTest.cpp
@@ -27,27 +27,22 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmJsonWriter.h>
-#include <hoot/core/criterion/PoiCriterion.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/BuildingCriterion.h>
-#include <hoot/core/visitors/RemoveRef2VisitorMultipleCriterion.h>
 #include <hoot/core/criterion/ChainCriterion.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
+#include <hoot/core/criterion/PoiCriterion.h>
+#include <hoot/core/io/OsmJsonWriter.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/visitors/RemoveRef2VisitorMultipleCriterion.h>
 
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class RemoveRef2VisitorMultipleCriterionTest : public CppUnit::TestFixture
+class RemoveRef2VisitorMultipleCriterionTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveRef2VisitorMultipleCriterionTest);
   CPPUNIT_TEST(runToyTest1);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveRef2VisitorTest.cpp
@@ -27,27 +27,22 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/criterion/PoiCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmJsonWriter.h>
-#include <hoot/core/criterion/PoiCriterion.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/RemoveRef2Visitor.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-
 // TGS
 #include <tgs/Statistics/Random.h>
-
-#include "../TestUtils.h"
+using namespace Tgs;
 
 namespace hoot
 {
-using namespace Tgs;
 
-class RemoveRef2VisitorTest : public CppUnit::TestFixture
+class RemoveRef2VisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveRef2VisitorTest);
   CPPUNIT_TEST(runToyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RemoveTagsVisitorTest.cpp
@@ -33,20 +33,16 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/visitors/RemoveTagsVisitor.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/criterion/NodeCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/criterion/NodeCriterion.h>
-
-#include "../TestUtils.h"
-
-// Qt
-#include <QDir>
+#include <hoot/core/visitors/RemoveTagsVisitor.h>
 
 namespace hoot
 {
 
-class RemoveTagsVisitorTest : public CppUnit::TestFixture
+class RemoveTagsVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(RemoveTagsVisitorTest);
   CPPUNIT_TEST(runRemoveTest);
@@ -56,8 +52,9 @@ class RemoveTagsVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/visitors");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SetTagValueVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SetTagValueVisitorTest.cpp
@@ -33,19 +33,15 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/visitors/SetTagValueVisitor.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
-
-#include "../TestUtils.h"
-
-// Qt
-#include <QDir>
+#include <hoot/core/visitors/SetTagValueVisitor.h>
 
 namespace hoot
 {
 
-class SetTagValueVisitorTest : public CppUnit::TestFixture
+class SetTagValueVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SetTagValueVisitorTest);
   CPPUNIT_TEST(runAddNewTest);
@@ -58,8 +54,9 @@ class SetTagValueVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/visitors");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitLongLinearWaysVisitorTest.cpp
@@ -34,17 +34,16 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/SplitLongLinearWaysVisitor.h>
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class SplitLongLinearWaysVisitorTest : public CppUnit::TestFixture
+class SplitLongLinearWaysVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SplitLongLinearWaysVisitorTest);
   CPPUNIT_TEST(defaultConstructorNoOpTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SplitNameVisitorTest.cpp
@@ -27,22 +27,17 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/SplitNameVisitor.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class SplitNameVisitorTest : public CppUnit::TestFixture
+class SplitNameVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SplitNameVisitorTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/StatusUpdateVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/StatusUpdateVisitorTest.cpp
@@ -33,19 +33,15 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/visitors/StatusUpdateVisitor.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 
-#include "../TestUtils.h"
-
-// Qt
-#include <QDir>
-
 namespace hoot
 {
 
-class StatusUpdateVisitorTest : public CppUnit::TestFixture
+class StatusUpdateVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(StatusUpdateVisitorTest);
   CPPUNIT_TEST(runUpdateTest);
@@ -54,8 +50,9 @@ class StatusUpdateVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/visitors");
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/SumNumericTagsVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/SumNumericTagsVisitorTest.cpp
@@ -27,19 +27,14 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/visitors/SumNumericTagsVisitor.h>
 
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
-
 namespace hoot
 {
-using namespace Tgs;
 
-class SumNumericTagsVisitorTest : public CppUnit::TestFixture
+class SumNumericTagsVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SumNumericTagsVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagCountVisitorTest.cpp
@@ -33,19 +33,14 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/visitors/TagCountVisitor.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class TagCountVisitorTest : public CppUnit::TestFixture
+class TagCountVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagCountVisitorTest);
   CPPUNIT_TEST(totalTagCountTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagKeyCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagKeyCountVisitorTest.cpp
@@ -33,15 +33,14 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/visitors/TagKeyCountVisitor.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class TagKeyCountVisitorTest : public CppUnit::TestFixture
+class TagKeyCountVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagKeyCountVisitorTest);
   CPPUNIT_TEST(tagKeyCountTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TagRenameKeyVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TagRenameKeyVisitorTest.cpp
@@ -33,16 +33,15 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/visitors/TagRenameKeyVisitor.h>
 #include <hoot/core/visitors/TagKeyCountVisitor.h>
 
-#include "../TestUtils.h"
-
 namespace hoot
 {
 
-class TagRenameKeyVisitorTest : public CppUnit::TestFixture
+class TagRenameKeyVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TagRenameKeyVisitorTest);
   CPPUNIT_TEST(tagRenameKeyTest);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/TransliterateNameVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/TransliterateNameVisitorTest.cpp
@@ -27,24 +27,19 @@
 
 // hoot
 #include <hoot/core/OsmMap.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmJsonWriter.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/criterion/PoiCriterion.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
-#include <hoot/core/visitors/TransliterateNameVisitor.h>
-#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/io/OsmJsonWriter.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-
-// Qt
-#include <QDir>
-
-#include "../TestUtils.h"
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/visitors/TransliterateNameVisitor.h>
 
 namespace hoot
 {
-using namespace Tgs;
 
-class TransliterateNameVisitorTest : public CppUnit::TestFixture
+class TransliterateNameVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(TransliterateNameVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.h
@@ -27,9 +27,8 @@
 #ifndef MINSUMWORDSETDISTANCE_H
 #define MINSUMWORDSETDISTANCE_H
 
-#include "../StringDistanceConsumer.h"
-
 // Hoot
+#include <hoot/core/algorithms/StringDistanceConsumer.h>
 #include <hoot/core/algorithms/string/StringTokenizer.h>
 
 // Tgs

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef MINSUMWORDSETDISTANCE_H
 #define MINSUMWORDSETDISTANCE_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitor.cpp
@@ -24,27 +24,26 @@
  *
  * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
+
 #include "PoiPolygonMatchVisitor.h"
 
 // hoot
 #include <hoot/core/conflate/matching/MatchType.h>
+#include <hoot/core/conflate/poi-polygon/PoiPolygonMatch.h>
+#include <hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h>
+#include <hoot/core/conflate/poi-polygon/filters/PoiPolygonPolyCriterion.h>
+#include <hoot/core/conflate/poi-polygon/filters/PoiPolygonPoiCriterion.h>
+#include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/visitors/IndexElementsVisitor.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/OsmSchema.h>
-
-#include "../PoiPolygonMatch.h"
-#include "../filters/PoiPolygonPolyCriterion.h"
-#include "../filters/PoiPolygonPoiCriterion.h"
-#include "../PoiPolygonTagIgnoreListReader.h"
+#include <hoot/core/visitors/IndexElementsVisitor.h>
 
 // Boost
 #include <boost/bind.hpp>
 
 // tgs
 #include <tgs/RStarTree/MemoryPageStore.h>
-
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/visitors/PoiPolygonMatchVisitor.h
@@ -28,15 +28,14 @@
 #define POIPOLYGONMATCHVISITOR_H
 
 // hoot
+#include <hoot/core/OsmMap.h>
 #include <hoot/core/elements/ConstElementVisitor.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/matching/Match.h>
-#include <hoot/core/OsmMap.h>
-#include "../PoiPolygonRfClassifier.h"
+#include <hoot/core/conflate/poi-polygon/PoiPolygonRfClassifier.h>
 
 // tgs
 #include <tgs/RStarTree/HilbertRTree.h>
-
 
 namespace hoot
 {

--- a/hoot-js/src/main/cpp/hoot/js/conflate/ReviewMarkerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/ReviewMarkerJs.cpp
@@ -28,15 +28,15 @@
 #include "ReviewMarkerJs.h"
 
 // hoot
+#include <hoot/core/conflate/ReviewMarker.h>
+#include <hoot/js/JsRegistrar.h>
+#include <hoot/js/OsmMapJs.h>
+#include <hoot/js/elements/ElementJs.h>
 #include <hoot/js/util/HootExceptionJs.h>
 #include <hoot/js/util/PopulateConsumersJs.h>
 #include <hoot/js/util/StreamUtilsJs.h>
 #include <hoot/js/visitors/ElementVisitorJs.h>
 #include <hoot/js/visitors/JsFunctionVisitor.h>
-#include <hoot/js/JsRegistrar.h>
-#include <hoot/core/conflate/ReviewMarker.h>
-#include "../elements/ElementJs.h"
-#include "../OsmMapJs.h"
 
 using namespace std;
 using namespace v8;

--- a/hoot-js/src/test/cpp/hoot/js/JavaScriptTranslatorTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/JavaScriptTranslatorTest.cpp
@@ -25,9 +25,6 @@
  * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-//Boost
-#include <boost/shared_ptr.hpp>
-
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
@@ -35,6 +32,7 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/ScriptTranslator.h>
 #include <hoot/core/io/ScriptToOgrTranslator.h>
 #include <hoot/core/io/ScriptTranslatorFactory.h>
@@ -44,14 +42,12 @@
 #include <hoot/core/io/schema/Schema.h>
 #include <hoot/core/util/Log.h>
 
-#include <hoot/core/TestUtils.h>
-
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class JavaScriptTranslatorTest : public CppUnit::TestFixture
+class JavaScriptTranslatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(JavaScriptTranslatorTest);
   CPPUNIT_TEST(runSchemaTest);
@@ -67,7 +63,7 @@ public:
     boost::shared_ptr<ScriptTranslator> st(ScriptTranslatorFactory::getInstance().createTranslator(
                                       "test-files/io/SampleTranslation.js"));
 
-    boost::shared_ptr<ScriptToOgrTranslator>uut = boost::dynamic_pointer_cast<ScriptToOgrTranslator>(st);
+    boost::shared_ptr<ScriptToOgrTranslator> uut = boost::dynamic_pointer_cast<ScriptToOgrTranslator>(st);
 
     if (!uut)
     {

--- a/hoot-js/src/test/cpp/hoot/js/JavaScriptTranslatorTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/JavaScriptTranslatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-js/src/test/cpp/hoot/js/PluginContextTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/PluginContextTest.cpp
@@ -27,7 +27,6 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-
 #include <hoot/js/HootJsStable.h>
 #include <hoot/js/JsRegistrar.h>
 #include <hoot/js/PluginContext.h>
@@ -40,7 +39,7 @@ using namespace v8;
 namespace hoot
 {
 
-class PluginContextTest : public CppUnit::TestFixture
+class PluginContextTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PluginContextTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-js/src/test/cpp/hoot/js/conflate/ElementMergerJsTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/ElementMergerJsTest.cpp
@@ -27,11 +27,11 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/js/HootJsStable.h>
-#include <hoot/js/conflate/ElementMergerJs.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/MapProjector.h>
+#include <hoot/js/HootJsStable.h>
+#include <hoot/js/conflate/ElementMergerJs.h>
 
 // Std
 #include <string>
@@ -65,7 +65,7 @@ namespace hoot
  * conversion of the map arg from a nodejs object to a hoot object.  That gets tested by the element
  * merge service mocha plugin test, plugins/test/ElementMergerServer.js.
  */
-class ElementMergerJsTest : public CppUnit::TestFixture
+class ElementMergerJsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ElementMergerJsTest);
   CPPUNIT_TEST(poiToPolyMergeWayAsPolyTest);

--- a/hoot-js/src/test/cpp/hoot/js/conflate/js/ScriptMatchCreatorTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/js/ScriptMatchCreatorTest.cpp
@@ -26,11 +26,11 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/js/HootJsStable.h>
 #include <hoot/js/conflate/js/ScriptMatch.h>
 #include <hoot/js/conflate/js/ScriptMatchCreator.h>
@@ -46,7 +46,7 @@ using namespace v8;
 namespace hoot
 {
 
-class ScriptMatchCreatorTest : public CppUnit::TestFixture
+class ScriptMatchCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ScriptMatchCreatorTest);
   CPPUNIT_TEST(runIsCandidateTest);

--- a/hoot-js/src/test/cpp/hoot/js/conflate/js/ScriptMatchTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/js/ScriptMatchTest.cpp
@@ -26,11 +26,11 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/js/HootJsStable.h>
 #include <hoot/js/conflate/js/ScriptMatch.h>
 #include <hoot/js/conflate/js/ScriptMatchCreator.h>
@@ -47,7 +47,7 @@ using namespace v8;
 namespace hoot
 {
 
-class ScriptMatchTest : public CppUnit::TestFixture
+class ScriptMatchTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ScriptMatchTest);
   //TODO: should this test be re-enabled?

--- a/hoot-js/src/test/cpp/hoot/js/util/DataConvertJsTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/util/DataConvertJsTest.cpp
@@ -44,7 +44,7 @@ using namespace v8;
 namespace hoot
 {
 
-class DataConvertJsTest : public CppUnit::TestFixture
+class DataConvertJsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(DataConvertJsTest);
   CPPUNIT_TEST(qvariantTest);

--- a/hoot-js/src/test/cpp/hoot/js/util/UuidHelperJsTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/util/UuidHelperJsTest.cpp
@@ -45,7 +45,7 @@ using namespace v8;
 namespace hoot
 {
 
-class UuidHelperJsTest : public CppUnit::TestFixture
+class UuidHelperJsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(UuidHelperJsTest);
   CPPUNIT_TEST(uuidHashTest);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetWriter.h
@@ -30,8 +30,8 @@
 // hoot
 #include <hoot/core/io/OsmChangeWriter.h>
 #include <hoot/core/io/OsmJsonWriter.h>
-#include "../visitors/AddExportTagsVisitor.h"
 #include <hoot/core/util/Configurable.h>
+#include <hoot/rnd/visitors/AddExportTagsVisitor.h>
 
 // Qt
 #include <QFile>

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef MULTIARY_INGEST_CHANGESET_WRITER_H
 #define MULTIARY_INGEST_CHANGESET_WRITER_H

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkChangesetWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkChangesetWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SPARKCHANGESETWRITER_H
 #define SPARKCHANGESETWRITER_H

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkChangesetWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkChangesetWriter.h
@@ -30,13 +30,12 @@
 // hoot
 #include <hoot/core/io/OsmChangeWriter.h>
 #include <hoot/core/io/OsmJsonWriter.h>
-#include "../visitors/AddExportTagsVisitor.h"
 #include <hoot/core/util/Configurable.h>
+#include <hoot/rnd/conflate/multiary/SearchBoundsCalculator.h>
+#include <hoot/rnd/visitors/AddExportTagsVisitor.h>
 
 // Qt
 #include <QFile>
-
-#include "../conflate/multiary/SearchBoundsCalculator.h"
 
 namespace hoot
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkJsonWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkJsonWriter.h
@@ -29,12 +29,11 @@
 
 // hoot
 #include <hoot/core/io/PartialOsmMapWriter.h>
+#include <hoot/rnd/conflate/multiary/SearchBoundsCalculator.h>
+#include <hoot/rnd/visitors/AddExportTagsVisitor.h>
 
 // Qt
 #include <QFile>
-
-#include "../conflate/multiary/SearchBoundsCalculator.h"
-#include "../visitors/AddExportTagsVisitor.h"
 
 namespace hoot
 {

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/CumulativeConflatorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/CumulativeConflatorTest.cpp
@@ -29,13 +29,10 @@
 #include <hoot/core/TestUtils.h>
 #include <hoot/rnd/conflate/CumulativeConflator.h>
 
-// Qt
-#include <QDir>
-
 namespace hoot
 {
 
-class CumulativeConflatorTest : public CppUnit::TestFixture
+class CumulativeConflatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(CumulativeConflatorTest);
   CPPUNIT_TEST(basicTest);
@@ -44,15 +41,14 @@ class CumulativeConflatorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/conflate/");
   }
 
   void basicTest()
   {
-    TestUtils::resetEnvironment();
-    OsmMap::resetCounters();
     Settings::getInstance().set(ConfigOptions::getWriterCleanReviewTagsKey(), false);
     Settings::getInstance().set(
       ConfigOptions::getTagMergerDefaultKey(), "hoot::ProvenanceAwareOverwriteTagMerger");
@@ -67,8 +63,6 @@ public:
     HOOT_FILE_EQUALS(
       "test-files/conflate/CumulativeConflatorTest/CumulativeConflatorTest.osm",
       "test-output/conflate/CumulativeConflatorTest.osm");
-
-    TestUtils::resetEnvironment();
   }
 
 };

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryHierarchicalClusterAlgorithmTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryHierarchicalClusterAlgorithmTest.cpp
@@ -41,7 +41,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiaryHierarchicalClusterAlgorithmTest : public CppUnit::TestFixture
+class MultiaryHierarchicalClusterAlgorithmTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryHierarchicalClusterAlgorithmTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiGenericTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiGenericTest.cpp
@@ -39,7 +39,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiaryPoiGenericTest : public CppUnit::TestFixture
+class MultiaryPoiGenericTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryPoiGenericTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCacheTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCacheTest.cpp
@@ -41,7 +41,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiaryPoiMergeCacheTest : public CppUnit::TestFixture
+class MultiaryPoiMergeCacheTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryPoiMergeCacheTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerTest.cpp
@@ -42,7 +42,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiaryPoiMergerTest : public CppUnit::TestFixture
+class MultiaryPoiMergerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryPoiMergerTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryReviewCommandTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryReviewCommandTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryReviewCommandTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryReviewCommandTest.cpp
@@ -27,16 +27,16 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
+#include <hoot/core/io/OsmJsonReader.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/rnd/conflate/multiary/MultiaryReviewCommand.h>
-#include <hoot/core/io/OsmJsonReader.h>
 
 using namespace std;
 
 namespace hoot
 {
 
-class MultiaryReviewCommandTest : public CppUnit::TestFixture
+class MultiaryReviewCommandTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryReviewCommandTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryScoreCacheTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryScoreCacheTest.cpp
@@ -42,7 +42,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiaryScoreCacheTest : public CppUnit::TestFixture
+class MultiaryScoreCacheTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryScoreCacheTest);
   CPPUNIT_TEST(basicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryUtilitiesTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryUtilitiesTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryUtilitiesTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryUtilitiesTest.cpp
@@ -39,7 +39,7 @@ using namespace std;
 namespace hoot
 {
 
-class MultiaryUtilitiesTest : public CppUnit::TestFixture
+class MultiaryUtilitiesTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryUtilitiesTest);
   CPPUNIT_TEST(conflateClusterTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
@@ -26,25 +26,22 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/MapCleaner.h>
+#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/ChainCriterion.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/rnd/conflate/network/IterativeNetworkMatcher.h>
-#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
-
-// Qt
-#include <QDir>
 
 namespace hoot
 {
 
-class IterativeNetworkMatcherTest : public CppUnit::TestFixture
+class IterativeNetworkMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(IterativeNetworkMatcherTest);
   CPPUNIT_TEST(toyTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
@@ -26,25 +26,22 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/MapCleaner.h>
+#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/ChainCriterion.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/rnd/conflate/network/SingleSidedNetworkMatcher.h>
-#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
-
-// Qt
-#include <QDir>
 
 namespace hoot
 {
 
-class SingleSidedNetworkMatcherTest : public CppUnit::TestFixture
+class SingleSidedNetworkMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SingleSidedNetworkMatcherTest);
   CPPUNIT_TEST(toyTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
@@ -38,13 +38,10 @@
 #include <hoot/rnd/conflate/network/VagabondNetworkMatcher.h>
 #include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 
-// Qt
-#include <QDir>
-
 namespace hoot
 {
 
-class VagabondNetworkMatcherTest : public CppUnit::TestFixture
+class VagabondNetworkMatcherTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(VagabondNetworkMatcherTest);
   CPPUNIT_TEST(toyTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/AbstractRegressionTest.h
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/AbstractRegressionTest.h
@@ -31,7 +31,6 @@
 #include <hoot/core/test/AbstractTest.h>
 
 // Qt
-#include <QDir>
 #include <QStringList>
 
 namespace hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/AbstractRegressionTest.h
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/opt/AbstractRegressionTest.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef ABSTRACTREGRESSIONTEST_H
 #define ABSTRACTREGRESSIONTEST_H

--- a/hoot-rnd/src/test/cpp/hoot/rnd/fourpass/FourPassManagerTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/fourpass/FourPassManagerTest.cpp
@@ -32,9 +32,8 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/tile/TileConflator.h>
-#include <hoot/rnd/fourpass/FourPassManager.h>
-#include <hoot/rnd/fourpass/LocalTileWorker2.h>
 #include <hoot/core/ops/OpList.h>
 #include <hoot/core/ops/MapCropper.h>
 #include <hoot/core/ops/MergeNearbyNodes.h>
@@ -45,21 +44,18 @@
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-#include <hoot/core/TestUtils.h>
+#include <hoot/rnd/fourpass/FourPassManager.h>
+#include <hoot/rnd/fourpass/LocalTileWorker2.h>
 
 // Tgs
 #include <tgs/Statistics/Random.h>
-
-// Qt
-#include <QDebug>
-#include <QDir>
 
 using namespace geos::geom;
 
 namespace hoot
 {
 
-class FourPassManagerTest : public CppUnit::TestFixture
+class FourPassManagerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(FourPassManagerTest);
   CPPUNIT_TEST(runToyTest);
@@ -67,17 +63,14 @@ class FourPassManagerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/fourpass");
   }
 
   void runToyTest()
   {
-    Tgs::Random::instance()->seed(0);
-    OsmMap::resetCounters();
-    Settings::getInstance().clear();
-
     FileUtils::removeDir("test-output/fourpass/FourPassManagerTest.osm-cache");
 
     boost::shared_ptr<TileWorker2> worker(new LocalTileWorker2());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/io/MultiaryIngestChangesetReaderTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/io/MultiaryIngestChangesetReaderTest.cpp
@@ -25,17 +25,14 @@
  * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // Hoot
-#include <hoot/rnd/io/MultiaryIngestChangesetReader.h>
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/elements/Node.h>
-
-// Qt
-#include <QDir>
+#include <hoot/rnd/io/MultiaryIngestChangesetReader.h>
 
 namespace hoot
 {
 
-class MultiaryIngestChangesetReaderTest : public CppUnit::TestFixture
+class MultiaryIngestChangesetReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryIngestChangesetReaderTest);
   CPPUNIT_TEST(elementAsJsonTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/io/MultiaryIngestChangesetReaderTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/io/MultiaryIngestChangesetReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 // Hoot
 #include <hoot/core/TestUtils.h>

--- a/hoot-rnd/src/test/cpp/hoot/rnd/io/MultiaryIngestChangesetWriterTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/io/MultiaryIngestChangesetWriterTest.cpp
@@ -24,17 +24,15 @@
  *
  * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
-// Hoot
-#include <hoot/rnd/io/MultiaryIngestChangesetWriter.h>
-#include <hoot/core/TestUtils.h>
 
-//#include <hoot/core/io/GeoNamesReader.h>
-//#include <hoot/rnd/io/MultiaryIngestChangesetReader.h>
+// Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/rnd/io/MultiaryIngestChangesetWriter.h>
 
 namespace hoot
 {
 
-class MultiaryIngestChangesetWriterTest : public CppUnit::TestFixture
+class MultiaryIngestChangesetWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryIngestChangesetWriterTest);
   CPPUNIT_TEST(elementAsJsonTest);
@@ -48,8 +46,9 @@ class MultiaryIngestChangesetWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/MultiaryIngestChangesetWriterTest/");
   }
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/io/SparkChangesetWriterTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/io/SparkChangesetWriterTest.cpp
@@ -24,20 +24,15 @@
  *
  * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
+
 // Hoot
-#include <hoot/rnd/io/SparkChangesetWriter.h>
 #include <hoot/core/TestUtils.h>
-
-//#include <hoot/core/io/GeoNamesReader.h>
-//#include <hoot/rnd/io/MultiaryIngestChangesetReader.h>
-
-// Qt
-#include <QDir>
+#include <hoot/rnd/io/SparkChangesetWriter.h>
 
 namespace hoot
 {
 
-class SparkChangesetWriterTest : public CppUnit::TestFixture
+class SparkChangesetWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(SparkChangesetWriterTest);
   CPPUNIT_TEST(elementAsJsonTest);
@@ -50,8 +45,9 @@ class SparkChangesetWriterTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/io/SparkChangesetWriterTest/");
   }
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyDuplicatePoiOpTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyDuplicatePoiOpTest.cpp
@@ -32,19 +32,19 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/Exception.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/rnd/perty/PertyDuplicatePoiOp.h>
+#include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/perty/PertyDuplicatePoiOp.h>
 
 // tbs
 #include <tbs/stats/SampleStats.h>
 
 // Qt
-#include <QDir>
 #include <QSet>
 
 using namespace std;
@@ -52,7 +52,7 @@ using namespace std;
 namespace hoot
 {
 
-class PertyDuplicatePoiOpTest : public CppUnit::TestFixture
+class PertyDuplicatePoiOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyDuplicatePoiOpTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyMatchScorerTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyMatchScorerTest.cpp
@@ -26,24 +26,19 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
-#include <hoot/rnd/perty/PertyMatchScorer.h>
-#include <hoot/rnd/scoring/MapMatchScoringUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Settings.h>
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/visitors/TagKeyCountVisitor.h>
-
-// Qt
-#include <QString>
-#include <QDir>
-
-#include <hoot/core/TestUtils.h>
+#include <hoot/rnd/perty/PertyMatchScorer.h>
+#include <hoot/rnd/scoring/MapMatchScoringUtils.h>
 
 namespace hoot
 {
 
-class PertyMatchScorerTest : public CppUnit::TestFixture
+class PertyMatchScorerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyMatchScorerTest);
   CPPUNIT_TEST(runLoadReferenceMapTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyNameVisitorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyNameVisitorTest.cpp
@@ -32,26 +32,24 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/Exception.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/rnd/perty/PertyNameVisitor.h>
+#include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/perty/PertyNameVisitor.h>
 
 // tbs
 #include <tbs/stats/SampleStats.h>
-
-// Qt
-#include <QDir>
 
 using namespace std;
 
 namespace hoot
 {
 
-class PertyNameVisitorTest : public CppUnit::TestFixture
+class PertyNameVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyNameVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyOpTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyOpTest.cpp
@@ -32,29 +32,27 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/Exception.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/rnd/perty/PertyOp.h>
+#include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/perty/PertyOp.h>
 
 // tbs
 #include <tbs/stats/SampleStats.h>
 
 // Qt
-#include <QDir>
 #include <QSet>
-
-#include <hoot/core/TestUtils.h>
 
 using namespace std;
 
 namespace hoot
 {
 
-class PertyOpTest : public CppUnit::TestFixture
+class PertyOpTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyOpTest);
   CPPUNIT_TEST(runDirectSequentialSimulationTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyRemoveRandomElementVisitorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyRemoveRandomElementVisitorTest.cpp
@@ -36,23 +36,21 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/Exception.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/rnd/perty/PertyRemoveRandomElementVisitor.h>
+#include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Log.h>
-
-// Qt
-#include <QDir>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/perty/PertyRemoveRandomElementVisitor.h>
 
 using namespace std;
 
 namespace hoot
 {
 
-class PertyRemoveRandomElementVisitorTest : public CppUnit::TestFixture
+class PertyRemoveRandomElementVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyRemoveRandomElementVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyRemoveTagVisitorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyRemoveTagVisitorTest.cpp
@@ -32,18 +32,19 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/util/Exception.h>
 #include <hoot/core/OsmMap.h>
-#include <hoot/rnd/perty/PertyRemoveTagVisitor.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MetadataTags.h>
+#include <hoot/rnd/perty/PertyRemoveTagVisitor.h>
 
 using namespace std;
 
 namespace hoot
 {
 
-class PertyRemoveTagVisitorTest : public CppUnit::TestFixture
+class PertyRemoveTagVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyRemoveTagVisitorTest);
   CPPUNIT_TEST(runBasicTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyTestRunnerTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyTestRunnerTest.cpp
@@ -26,24 +26,19 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
-#include <hoot/rnd/perty/PertyTestRunner.h>
-#include <hoot/rnd/perty/PertyMatchScorer.h>
-#include <hoot/rnd/perty/PertyTestRunResult.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-
-// Qt
-#include <QString>
-#include <QDir>
-
-#include <hoot/core/TestUtils.h>
+#include <hoot/rnd/perty/PertyTestRunner.h>
+#include <hoot/rnd/perty/PertyMatchScorer.h>
+#include <hoot/rnd/perty/PertyTestRunResult.h>
 
 namespace hoot
 {
 
-class PertyTestRunnerTest : public CppUnit::TestFixture
+class PertyTestRunnerTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyTestRunnerTest);
   CPPUNIT_TEST(runDynamicVariablesTest);
@@ -59,8 +54,9 @@ class PertyTestRunnerTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/perty/PertyTestRunnerTest/Dynamic");
     TestUtils::mkpath("test-output/perty/PertyTestRunnerTest/Static");
     TestUtils::mkpath("test-output/perty/PertyTestRunnerTest/Variance");

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyWayGeneralizeVisitorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyWayGeneralizeVisitorTest.cpp
@@ -33,24 +33,22 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/rnd/perty/PertyWayGeneralizeVisitor.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
+#include <hoot/rnd/perty/PertyWayGeneralizeVisitor.h>
 
 // Qt
-#include <QString>
-#include <QDir>
-
-#include <hoot/core/TestUtils.h>
+#include <QFileInfo>
 
 using namespace std;
 
 namespace hoot
 {
 
-class PertyWayGeneralizeVisitorTest : public CppUnit::TestFixture
+class PertyWayGeneralizeVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyWayGeneralizeVisitorTest);
   CPPUNIT_TEST(runTest1);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyWaySplitVisitorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/perty/PertyWaySplitVisitorTest.cpp
@@ -33,24 +33,19 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/rnd/perty/PertyWaySplitVisitor.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-
-// Qt
-#include <QString>
-#include <QDir>
-
-#include <hoot/core/TestUtils.h>
+#include <hoot/rnd/perty/PertyWaySplitVisitor.h>
 
 using namespace std;
 
 namespace hoot
 {
 
-class PertyWaySplitVisitorTest : public CppUnit::TestFixture
+class PertyWaySplitVisitorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(PertyWaySplitVisitorTest);
   CPPUNIT_TEST(runWaySplitTest);
@@ -61,9 +56,9 @@ class PertyWaySplitVisitorTest : public CppUnit::TestFixture
 
 public:
 
-  void setUp()
+  virtual void setUp()
   {
-    TestUtils::resetEnvironment();
+    HootTestFixture::setUp();
     TestUtils::mkpath("test-output/perty/PertyWaySplitVisitorTest/");
   }
 
@@ -72,7 +67,6 @@ public:
     //Log::WarningLevel levelBefore = Log::getInstance().getLevel();
     //Log::getInstance().setLevel(Log::Debug);
 
-    OsmMap::resetCounters();
     OsmXmlReader reader;
     OsmMapPtr map(new OsmMap());
     reader.setDefaultStatus(Status::Unknown1);
@@ -113,7 +107,6 @@ public:
     //Log::WarningLevel levelBefore = Log::getInstance().getLevel();
     //Log::getInstance().setLevel(Log::Debug);
 
-    OsmMap::resetCounters();
     OsmXmlReader reader;
     OsmMapPtr map(new OsmMap());
     reader.setDefaultStatus(Status::Unknown1);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/schema/ImplicitTagRawRulesDeriverTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/schema/ImplicitTagRawRulesDeriverTest.cpp
@@ -26,17 +26,16 @@
  */
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/rnd/schema/ImplicitTagRawRulesDeriver.h>
 #include <hoot/core/io/ImplicitTagRulesSqliteReader.h>
+#include <hoot/rnd/schema/ImplicitTagRawRulesDeriver.h>
 
 // Qt
-#include <QDir>
 #include <QTemporaryFile>
 
 namespace hoot
 {
 
-class ImplicitTagRawRulesDeriverTest : public CppUnit::TestFixture
+class ImplicitTagRawRulesDeriverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ImplicitTagRawRulesDeriverTest);
 
@@ -54,10 +53,14 @@ public:
   static QString inDir() { return "test-files/schema/ImplicitTagRawRulesDeriverTest"; }
   static QString outDir() { return "test-output/schema/ImplicitTagRawRulesDeriverTest"; }
 
+  virtual void setUp()
+  {
+    HootTestFixture::setUp();
+    TestUtils::mkpath(outDir());
+  }
+
   void runBasicPoiTest()
   {
-    TestUtils::mkpath(outDir());
-
     QStringList inputs;
     inputs.append(inDir() + "/yemen-crop-2.osm.pbf");
     const QString outputFile =
@@ -79,8 +82,6 @@ public:
 
   void runMultipleInputsPoiTest()
   {
-    TestUtils::mkpath(outDir());
-
     QStringList inputs;
     inputs.append(inDir() + "/yemen-crop-2.osm.pbf");
     inputs.append(inDir() + "/philippines-1.osm.pbf");
@@ -108,7 +109,6 @@ public:
   void runDuplicateWordKeyCountPoiTest()
   {
     DisableLog dl;
-    TestUtils::mkpath(outDir());
 
     boost::shared_ptr<QTemporaryFile> sortedCountFile(
       new QTemporaryFile(
@@ -155,8 +155,6 @@ public:
     //Case is actually already handled correctly in runBasicTest, but this smaller input dataset
     //will make debugging case problems easier, if needed.
 
-    TestUtils::mkpath(outDir());
-
     QStringList inputs;
     inputs.append(inDir() + "/ImplicitTagRawRulesDeriverTest-runNameCaseTest.osm");
 
@@ -180,8 +178,6 @@ public:
 
   void runTranslateNamesFalsePoiTest()
   {
-    TestUtils::mkpath(outDir());
-
     QStringList inputs;
     inputs.append(inDir() + "/yemen-crop-2.osm.pbf");
     const QString outputFile =
@@ -204,8 +200,6 @@ public:
 
   void runBadInputsTest()
   {
-    TestUtils::mkpath(outDir());
-
     QString exceptionMsg("");
     QStringList inputs;
     QStringList translationScripts;

--- a/hoot-rnd/src/test/cpp/hoot/rnd/schema/ImplicitTagRulesDatabaseDeriverTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/schema/ImplicitTagRulesDatabaseDeriverTest.cpp
@@ -24,18 +24,16 @@
  *
  * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
-// Hoot
-#include <hoot/rnd/schema/ImplicitTagRulesDatabaseDeriver.h>
-#include <hoot/core/io/ImplicitTagRulesSqliteReader.h>
-#include <hoot/core/TestUtils.h>
 
-// Qt
-#include <QDir>
+// Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/ImplicitTagRulesSqliteReader.h>
+#include <hoot/rnd/schema/ImplicitTagRulesDatabaseDeriver.h>
 
 namespace hoot
 {
 
-class ImplicitTagRulesDatabaseDeriverTest : public CppUnit::TestFixture
+class ImplicitTagRulesDatabaseDeriverTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ImplicitTagRulesDatabaseDeriverTest);
   CPPUNIT_TEST(runBasicTest);
@@ -55,6 +53,7 @@ public:
 
   void setUp()
   {
+    HootTestFixture::setUp();
     TestUtils::mkpath(outDir());
   }
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/scoring/GraphComparatorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/scoring/GraphComparatorTest.cpp
@@ -28,19 +28,16 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/splitter/IntersectionSplitter.h>
 #include <hoot/core/io/OsmXmlReader.h>
-#include <hoot/rnd/scoring/GraphComparator.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/OpenCv.h>
-using namespace hoot;
+#include <hoot/rnd/scoring/GraphComparator.h>
 
 // Tgs
 #include <tgs/Statistics/Random.h>
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -48,16 +45,13 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-// Standard
-#include <stdio.h>
-
 using namespace geos::geom;
 using namespace std;
 
-class GraphComparatorTest : public CppUnit::TestFixture
+namespace hoot
+{
+
+class GraphComparatorTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(GraphComparatorTest);
     CPPUNIT_TEST(runTest);
@@ -185,5 +179,5 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(GraphComparatorTest);
 
-
+}
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/scoring/MapScoringStatusAndRefTagValidatorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/scoring/MapScoringStatusAndRefTagValidatorTest.cpp
@@ -27,12 +27,9 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/rnd/scoring/MapScoringStatusAndRefTagValidator.h>
-using namespace hoot;
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -40,16 +37,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-// Standard
-#include <stdio.h>
-
 namespace hoot
 {
 
-class MapScoringStatusAndRefTagValidatorTest : public CppUnit::TestFixture
+class MapScoringStatusAndRefTagValidatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MapScoringStatusAndRefTagValidatorTest);
   CPPUNIT_TEST(runTest);
@@ -105,10 +96,6 @@ public:
 
 };
 
-}
-
 CPPUNIT_TEST_SUITE_REGISTRATION(MapScoringStatusAndRefTagValidatorTest);
 
-
-
-
+}

--- a/hoot-rnd/src/test/cpp/hoot/rnd/scoring/RasterComparatorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/scoring/RasterComparatorTest.cpp
@@ -27,13 +27,9 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/rnd/scoring/RasterComparator.h>
-using namespace hoot;
-
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -41,16 +37,10 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-
-// Standard
-#include <stdio.h>
-
 namespace hoot
 {
 
-class RasterComparatorTest : public CppUnit::TestFixture
+class RasterComparatorTest : public HootTestFixture
 {
     CPPUNIT_TEST_SUITE(RasterComparatorTest);
     CPPUNIT_TEST(runTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/scoring/multiary/MultiaryMatchComparatorTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/scoring/multiary/MultiaryMatchComparatorTest.cpp
@@ -39,7 +39,7 @@ using namespace hoot;
 namespace hoot
 {
 
-class MultiaryMatchComparatorTest : public CppUnit::TestFixture
+class MultiaryMatchComparatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MultiaryMatchComparatorTest);
   CPPUNIT_TEST(runEmptyTest);

--- a/hoot-rnd/src/test/cpp/hoot/rnd/visitors/MatchCandidateCountVisitorRndTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/visitors/MatchCandidateCountVisitorRndTest.cpp
@@ -27,16 +27,13 @@
 
 // Hoot
 #include <hoot/core/OsmMap.h>
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/MatchCandidateCountVisitor.h>
-#include <hoot/core/TestUtils.h>
-
-// Boost
-using namespace boost;
 
 // CPP Unit
 #include <cppunit/extensions/HelperMacros.h>
@@ -44,27 +41,16 @@ using namespace boost;
 #include <cppunit/TestAssert.h>
 #include <cppunit/TestFixture.h>
 
-// Qt
-#include <QDebug>
-#include <QDir>
-#include <QBuffer>
-#include <QByteArray>
-
 namespace hoot
 {
 
-class MatchCandidateCountVisitorRndTest : public CppUnit::TestFixture
+class MatchCandidateCountVisitorRndTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(MatchCandidateCountVisitorRndTest);
   CPPUNIT_TEST(runMatchCandidateCountTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void tearDown()
-  {
-    TestUtils::resetEnvironment();
-  }
 
   void runMatchCandidateCountTest()
   {
@@ -87,7 +73,7 @@ public:
     map->visitRo(uut);
     CPPUNIT_ASSERT_EQUAL((int)36, (int)uut.getStat());
     QMap<QString, long> matchCandidateCountsByMatchCreator =
-      any_cast<QMap<QString, long> >(uut.getData());
+      boost::any_cast<QMap<QString, long> >(uut.getData());
     CPPUNIT_ASSERT_EQUAL(1, matchCandidateCountsByMatchCreator.size());
     CPPUNIT_ASSERT_EQUAL((long)36, matchCandidateCountsByMatchCreator["hoot::PoiPolygonMatchCreator"]);
     CPPUNIT_ASSERT_EQUAL(

--- a/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "PrincipalComponentsAnalysis.h"

--- a/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.cpp
+++ b/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.cpp
@@ -31,13 +31,13 @@
 #include <assert.h>
 #include <iostream>
 
-#include "../RandomForest/DataFrame.h"
-#include "../StreamUtils.h"
+#include <tgs/StreamUtils.h>
+#include <tgs/RandomForest/DataFrame.h>
 
 #define WANT_STREAM
 #define WANT_MATH
 
-#include "Jacobi.h"
+#include <tgs/FeatureReduction/Jacobi.h>
 
 using namespace NEWMAT;
 

--- a/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.h
+++ b/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.h
@@ -40,7 +40,7 @@ namespace NEWMAT {
   class Matrix;
 }
 
-#include "../TgsExport.h"
+#include <tgs/TgsExport.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.h
+++ b/tgs/src/main/cpp/tgs/FeatureReduction/PrincipalComponentsAnalysis.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
  /***************************************************************************
 * Copyright (c) 2005-2007 by SPADAC Inc. (formerly Spatial Data Analytics Corporation).  All rights reserved.

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ProbablePathCalculator.h"

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
@@ -34,11 +34,10 @@
 #include <map>
 #include <sstream>
 
-#include "../StreamUtils.h"
-#include "../Heap/JHeap.h"
-#include "../TgsException.h"
-
 // Tgs
+#include <tgs/StreamUtils.h>
+#include <tgs/TgsException.h>
+#include <tgs/Heap/JHeap.h>
 #include <tgs/Statistics/Random.h>
 
 using namespace std;

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __PROBABLE_PATH_CALCULATOR_H__

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
@@ -34,9 +34,9 @@
 #include <sstream>
 #include <vector>
 
-#include "../HashMap.h"
-#include "../TgsExport.h"
-#include "../RasterOps/Image.hpp"
+#include <tgs/HashMap.h>
+#include <tgs/TgsExport.h>
+#include <tgs/RasterOps/Image.hpp>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/Box.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/Box.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/Box.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/Box.h
@@ -34,7 +34,7 @@
 #include <string.h> // includes memcpy on Linux
 #include <vector>
 
-#include "../TgsExport.h"
+#include <tgs/TgsExport.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "FilePageStore.h"

--- a/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.cpp
@@ -28,8 +28,8 @@
 #include "FilePageStore.h"
 
 #include <errno.h>
-#include "../TgsException.h"
-#include "Page.h"
+#include <tgs/TgsException.h>
+#include <tgs/RStarTree/Page.h>
 
 using namespace std;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.h
@@ -34,8 +34,8 @@
 #include <stdio.h>
 #include <string>
 
-#include "../HashMap.h"
-#include "PageStore.h"
+#include <tgs/HashMap.h>
+#include <tgs/RStarTree/PageStore.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.cpp
@@ -27,9 +27,9 @@
 #include "InternalRStarTreeWrapper.h"
 
 //TGS Includes
-#include "Box.h"
-#include "MemoryPageStore.h"
-#include "../SharedPtr.h"
+#include <tgs/SharedPtr.h>
+#include <tgs/RStarTree/Box.h>
+#include <tgs/RStarTree/MemoryPageStore.h>
 
 //Std Includes
 #include <cassert>

--- a/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "InternalRStarTreeWrapper.h"
 

--- a/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef __INTERNAL_RSTAR_TREE_WRAPPER_H__
 #define __INTERNAL_RSTAR_TREE_WRAPPER_H__

--- a/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.h
@@ -28,11 +28,10 @@
 #define __INTERNAL_RSTAR_TREE_WRAPPER_H__
 
 //TGS Includes
-#include "../TgsExport.h"
-#include "DistanceIterator.h"
-#include "IntersectionIterator.h"
-#include "HilbertRTree.h"
-
+#include <tgs/TgsExport.h>
+#include <tgs/RStarTree/DistanceIterator.h>
+#include <tgs/RStarTree/IntersectionIterator.h>
+#include <tgs/RStarTree/HilbertRTree.h>
 
 //Std Includes
 #include <vector>

--- a/tgs/src/main/cpp/tgs/RStarTree/KnnIterator.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/KnnIterator.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/KnnIterator.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/KnnIterator.h
@@ -38,10 +38,10 @@
 #include <set>
 #include <math.h>
 
-#include "../HashMap.h"
-#include "../SharedPtr.h"
-#include "../TgsExport.h"
-#include "Iterator.h"
+#include <tgs/HashMap.h>
+#include <tgs/SharedPtr.h>
+#include <tgs/TgsExport.h>
+#include <tgs/RStarTree/Iterator.h>
 
 class OGRRawPoint;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/KnnIteratorNd.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/KnnIteratorNd.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/KnnIteratorNd.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/KnnIteratorNd.h
@@ -29,7 +29,6 @@
 #ifndef __TGS__KNN_ITERATOR_ND_H__
 #define __TGS__KNN_ITERATOR_ND_H__
 
-#include "RStarTree.h"
 // Standard Includes
 #include <limits.h>
 #include <list>
@@ -37,10 +36,11 @@
 #include <set>
 #include <math.h>
 
-#include "../HashMap.h"
-#include "../SharedPtr.h"
-#include "../TgsExport.h"
-#include "Iterator.h"
+#include <tgs/HashMap.h>
+#include <tgs/SharedPtr.h>
+#include <tgs/TgsExport.h>
+#include <tgs/RStarTree/Iterator.h>
+#include <tgs/RStarTree/RStarTree.h>
 
 class OGRRawPoint;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __TGS__MEMORY_PAGE_STORE_H__

--- a/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.h
@@ -31,8 +31,8 @@
 // Standard Includes
 #include <vector>
 
-#include "PageStore.h"
-#include "../TgsExport.h"
+#include <tgs/TgsExport.h>
+#include <tgs/RStarTree/PageStore.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/Page.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/Page.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/Page.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/Page.h
@@ -29,7 +29,7 @@
 #ifndef __TGS__PAGE_H__
 #define __TGS__PAGE_H__
 
-#include "../TgsExport.h"
+#include <tgs/TgsExport.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/PageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/PageStore.h
@@ -28,8 +28,8 @@
 #ifndef __TGS__PAGE_STORE_H__
 #define __TGS__PAGE_STORE_H__
 
-#include "Page.h"
-#include "../SharedPtr.h"
+#include <tgs/SharedPtr.h>
+#include <tgs/RStarTree/Page.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/PageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/PageStore.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __TGS__PAGE_STORE_H__

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -34,10 +34,10 @@
 #include <math.h>
 using namespace std;
 
-#include "../TgsException.h"
-#include "PageStore.h"
-#include "RTreeNode.h"
-#include "../StreamUtils.h"
+#include <tgs/StreamUtils.h>
+#include <tgs/TgsException.h>
+#include <tgs/RStarTree/PageStore.h>
+#include <tgs/RStarTree/RTreeNode.h>
 
 using namespace Tgs;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "RStarTree.h"

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
@@ -33,13 +33,9 @@
 #include <set>
 #include <vector>
 
-// Boost Includes
-
-#include "Box.h"
-#include "RTreeNodeStore.h"
-
-#include "../TgsExport.h"
-
+#include <tgs/TgsExport.h>
+#include <tgs/RStarTree/Box.h>
+#include <tgs/RStarTree/RTreeNodeStore.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
@@ -39,8 +39,8 @@
 #include <string>
 #include <vector>
 
-#include "../HashMap.h"
-#include "../TgsExport.h"
+#include <tgs/HashMap.h>
+#include <tgs/TgsExport.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __DATA_FRAME_H__

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
@@ -33,8 +33,8 @@
 #include <limits>
 
 //Urgent Includes
-#include "../HashMap.h"
-#include "../TgsException.h"
+#include <tgs/HashMap.h>
+#include <tgs/TgsException.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "InfoGainCalculator.h"

--- a/tgs/src/main/cpp/tgs/RasterOps/MaxChannelCombiner.h
+++ b/tgs/src/main/cpp/tgs/RasterOps/MaxChannelCombiner.h
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __TGS__MAX_CHANNEL_COMBINER_H__

--- a/tgs/src/main/cpp/tgs/RasterOps/MaxChannelCombiner.h
+++ b/tgs/src/main/cpp/tgs/RasterOps/MaxChannelCombiner.h
@@ -34,8 +34,8 @@
 #include <sstream>
 #include <vector>
 
-#include "../TgsExport.h"
-#include "Image.hpp"
+#include <tgs/TgsExport.h>
+#include <tgs/RasterOps/Image.hpp>
 
 #ifdef SWIG
 %{

--- a/tgs/src/main/cpp/tgs/SpinImage/GroundPlaneRemover.h
+++ b/tgs/src/main/cpp/tgs/SpinImage/GroundPlaneRemover.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __TGS__GROUND_PLANE_REMOVER_H__

--- a/tgs/src/main/cpp/tgs/SpinImage/GroundPlaneRemover.h
+++ b/tgs/src/main/cpp/tgs/SpinImage/GroundPlaneRemover.h
@@ -31,10 +31,10 @@
 // Standard Includes
 #include <queue>
 
-#include "../HashMap.h"
-#include "../SharedPtr.h"
-#include "../TgsExport.h"
-#include "NormalEstimator.h"
+#include <tgs/HashMap.h>
+#include <tgs/SharedPtr.h>
+#include <tgs/TgsExport.h>
+#include <tgs/SpinImage/NormalEstimator.h>
 
 class GroundPlaneRemoverTest;
 

--- a/tgs/src/main/cpp/tgs/SpinImage/NormalEstimator.h
+++ b/tgs/src/main/cpp/tgs/SpinImage/NormalEstimator.h
@@ -31,10 +31,10 @@
 // Standard Includes
 #include <queue>
 
-#include "../HashMap.h"
-#include "../SharedPtr.h"
-#include "../TgsExport.h"
-#include "Points.h"
+#include <tgs/HashMap.h>
+#include <tgs/SharedPtr.h>
+#include <tgs/TgsExport.h>
+#include <tgs/SpinImage/Points.h>
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/SpinImage/NormalEstimator.h
+++ b/tgs/src/main/cpp/tgs/SpinImage/NormalEstimator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __TGS__NORMAL_ESTIMATOR_H__


### PR DESCRIPTION
Refs #2474 
PR consists of a bunch of little things.

- First off created `HootTestFixture` that resets the test environment before and after each test ensuring that all tests are not affected by changes to the environment made by other tests.
- Second updated all occurrences of `TestUtils.h` to use the hoot path instead of relative paths that included `../` potentially multiple times.
- Third alphabetized the includes
- Fourth removed many unnecessary includes
- Finally moved all test inside of the `hoot` namespace.