### PR TITLE
Remove branch specifier from submodule.  Not providing much utility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "hoot-ui"]
 	path = hoot-ui
 	url = https://github.com/ngageoint/hootenanny-ui.git
-	branch = release_test


### PR DESCRIPTION
I'm proposing we remove the branch specifier from our submodule .gitmodules file.  As I understand it, it's only relevant when using the --remote flag with a submodule update, which causes the submodule code to update to the SHA1 of the latest commit on the branch specified.  I'm not sure that's a use case we really care that much about.

Since it's not defined how to use the branch specifier across different branches of hoot, would require fragile logic to adhere to a defined pattern, and even then could easily get changed without anyone really noticing I propose we just not use it.

I added several reviewers to get diverse opinions on this matter since it can be fairly confusing and I wanted to see if people are actively using the --remote flag with submodule update for some purpose.