### PR TITLE
Updates to 'changeset-apply' command

### DIFF
--- a/docs/commands/changeset-apply.asciidoc
+++ b/docs/commands/changeset-apply.asciidoc
@@ -2,11 +2,11 @@
 
 === Description
 
-The +apply-changeset+ command writes an OSM changeset XML file(s) or SQL file that represents the difference between two OSM datasets
+The +apply-changeset+ command writes an OSM changeset XML file(s), OSM XML file(s), or SQL file that represents the difference between two OSM datasets
 to an OSM API database.  The OSM API database URL is   Optional conflict parameters may be passed for SQL files, so that if the target database contains any changesets
 created after the time represented by a timestamp that intersect with a specified AOI, the command will return an error.
 
-* +changeset.osc+     - one or more input XML changeset (e.g. .osc files).
+* +changeset.os*+     - one or more input OSM XML changeset (.osc file) or OSM XML file (.osm) with negative IDs.
 * +targetOsmApiUrl+   - OSM API endpoint the changeset will be written to.
 * +changeset.osc.sql+ - input SQL changeset (e.g. .osc.sql file).
 * +targetDatabaseUrl+ - database the changeset will be written to.
@@ -14,11 +14,13 @@ created after the time represented by a timestamp that intersect with a specifie
                         data (see description)
 * +conflictTimestamp+ - timestamp of the form: "yyyy-MM-dd hh:mm:ss.zzz" used to prevent writing conflicted
                         data (see description)
+* +--stats+           - output statistics (element, node, way, relation, failure, create, modify, and delete counts)
+* +--progress+        - display progress as a percent complete while the upload is working
 
 === Usage
 
 --------------------------------------
-changeset-apply (changeset.osc) [changeset2.osc ...] (targetOsmApiUrl)
+changeset-apply (changeset.os*) [changeset2.os* ...] (targetOsmApiUrl) [--stats] [--progress]
 changeset-apply (changeset.osc.sql) (targetDatabaseUrl) [conflictAoi] [conflictTimestamp]
 --------------------------------------
 
@@ -28,6 +30,8 @@ changeset-apply (changeset.osc.sql) (targetDatabaseUrl) [conflictAoi] [conflictT
 hoot changeset-apply changeset.osc http://username:password@localhost/
 
 hoot changeset-apply changeset.osc changeset-001.osc changeset-002.osc https://username:password@localhost/
+
+hoot changeset-apply sourcedata.osm http://username:password@localhost/ --stats --progress
 
 hoot changeset-apply changeset.osc.sql osmapidb://username:password@localhost:5432/databaseName
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
@@ -26,15 +26,14 @@
  */
 
 //  Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiChangesetElement.h>
 #include <hoot/core/util/FileUtils.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmApiChangesetElementTest : public CppUnit::TestFixture
+class OsmApiChangesetElementTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmApiChangesetElementTest);
   CPPUNIT_TEST(runXmlNodeTest);
@@ -44,10 +43,6 @@ class OsmApiChangesetElementTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-  }
 
   void runXmlNodeTest()
   {

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -26,15 +26,14 @@
  */
 
 //  Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiChangeset.h>
 #include <hoot/core/util/FileUtils.h>
-
-#include "../TestUtils.h"
 
 namespace hoot
 {
 
-class OsmApiChangesetTest : public CppUnit::TestFixture
+class OsmApiChangesetTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmApiChangesetTest);
   CPPUNIT_TEST(runXmlChangesetTest);
@@ -45,10 +44,6 @@ class OsmApiChangesetTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-  void setUp()
-  {
-  }
 
   void runXmlChangesetTest()
   {
@@ -136,22 +131,33 @@ public:
     updatedFiles.append("test-files/io/OsmChangesetElementTest/ToyTestASplit3.response.xml");
     updatedFiles.append("test-files/io/OsmChangesetElementTest/ToyTestASplit4.response.xml");
 
+    long processed[] = { 10, 20, 30, 40 };
+
     ChangesetInfoPtr info;
-    int i = 1;
+    int index = 0;
     while (!changeset.isDone())
     {
       info.reset(new ChangesetInfo());
       changeset.calculateChangeset(info);
 
-      QString expectedText = FileUtils::readFully(expectedFiles[i - 1]);
+      QString expectedText = FileUtils::readFully(expectedFiles[index]);
 
-      HOOT_STR_EQUALS(expectedText, changeset.getChangesetString(info, i));
+      HOOT_STR_EQUALS(expectedText, changeset.getChangesetString(info, index + 1));
 
-      QString updatedText = FileUtils::readFully(updatedFiles[i - 1]);
+      QString updatedText = FileUtils::readFully(updatedFiles[index]);
       changeset.updateChangeset(updatedText);
 
-      ++i;
+      CPPUNIT_ASSERT_EQUAL(processed[index], changeset.getProcessedCount());
+
+      ++index;
     }
+    CPPUNIT_ASSERT_EQUAL(40L, changeset.getTotalElementCount());
+    CPPUNIT_ASSERT_EQUAL(36L, changeset.getTotalNodeCount());
+    CPPUNIT_ASSERT_EQUAL(4L, changeset.getTotalWayCount());
+    CPPUNIT_ASSERT_EQUAL(0L, changeset.getTotalRelationCount());
+    CPPUNIT_ASSERT_EQUAL(40L, changeset.getTotalCreateCount());
+    CPPUNIT_ASSERT_EQUAL(0L, changeset.getTotalModifyCount());
+    CPPUNIT_ASSERT_EQUAL(0L, changeset.getTotalDeleteCount());
   }
 
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -25,9 +25,8 @@
  * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
-#include "../TestUtils.h"
-
 //  hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiWriter.h>
 #include <hoot/core/util/Log.h>
 
@@ -37,7 +36,7 @@
 namespace hoot
 {
 
-class OsmApiWriterTest : public CppUnit::TestFixture
+class OsmApiWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmApiWriterTest);
   CPPUNIT_TEST(runParseStatusTest);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -90,25 +90,39 @@ void XmlChangeset::loadChangeset(const QString &changesetPath)
   QXmlStreamReader::TokenType type = reader.readNext();
   if (type == QXmlStreamReader::StartDocument)
     type = reader.readNext();
-  if (type == QXmlStreamReader::StartElement && reader.name() != "osmChange")
+  //  Read the OSC changeset
+  if (changesetPath.endsWith(".osc"))
   {
-    LOG_ERROR("Unknown changeset response format.");
-    return;
-  }
-  //  Iterate all of updates and record them
-  while (!reader.atEnd() && !reader.hasError())
-  {
-    type = reader.readNext();
-    if (type == QXmlStreamReader::StartElement)
+    if (type == QXmlStreamReader::StartElement && reader.name() != "osmChange")
     {
-      QStringRef name = reader.name();
-      if (name == "create")
-        loadElements(reader, ChangesetType::TypeCreate);
-      else if (name == "modify")
-        loadElements(reader, ChangesetType::TypeModify);
-      else if (name == "delete")
-        loadElements(reader, ChangesetType::TypeDelete);
+      LOG_ERROR("Unknown changeset file format.");
+      return;
     }
+    //  Iterate all of updates and record them
+    while (!reader.atEnd() && !reader.hasError())
+    {
+      type = reader.readNext();
+      if (type == QXmlStreamReader::StartElement)
+      {
+        QStringRef name = reader.name();
+        if (name == "create")
+          loadElements(reader, ChangesetType::TypeCreate);
+        else if (name == "modify")
+          loadElements(reader, ChangesetType::TypeModify);
+        else if (name == "delete")
+          loadElements(reader, ChangesetType::TypeDelete);
+      }
+    }
+  }
+  else  //  .osm file
+  {
+    if (type == QXmlStreamReader::StartElement && reader.name() != "osm")
+    {
+      LOG_ERROR("Unknown OSM XML file format.");
+      return;
+    }
+    //  Force load all of the elements as 'create' elements
+    loadElements(reader, ChangesetType::TypeCreate);
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -126,6 +126,51 @@ public:
    * @return true if any elements failed upload
    */
   bool hasFailedElements() { return _failedCount > 0; }
+  /**
+   * @brief getFailedCount
+   * @return number of failed elements
+   */
+  long getFailedCount()         { return _failedCount; }
+  /**
+   * @brief getTotalElementCount
+   * @return total number of elements in the changeset
+   */
+  long getTotalElementCount()   { return _allNodes.size() + _allWays.size() + _allRelations.size(); }
+  /**
+   * @brief getTotalNodeCount
+   * @return total number of nodes in the changeset (create, modify, or delete)
+   */
+  long getTotalNodeCount()      { return _allNodes.size(); }
+  /**
+   * @brief getTotalWayCount
+   * @return total number of ways in the changeset (create, modify, or delete)
+   */
+  long getTotalWayCount()       { return _allWays.size(); }
+  /**
+   * @brief getTotalRelationCount
+   * @return total number of relations in the changeset (create, modify, or delete)
+   */
+  long getTotalRelationCount()  { return _allRelations.size(); }
+  /**
+   * @brief getTotalCreateCount
+   * @return total number of nodes/ways/relations created in the changeset
+   */
+  long getTotalCreateCount()    { return _nodes[TypeCreate].size() + _ways[TypeCreate].size() + _relations[TypeCreate].size(); }
+  /**
+   * @brief getTotalModifyCount
+   * @return total number of nodes/ways/relations modified in the changeset
+   */
+  long getTotalModifyCount()    { return _nodes[TypeModify].size() + _ways[TypeModify].size() + _relations[TypeModify].size(); }
+  /**
+   * @brief getTotalDeleteCount
+   * @return total number of nodes/ways/relations deleted in the changeset
+   */
+  long getTotalDeleteCount()    { return _nodes[TypeDelete].size() + _ways[TypeDelete].size() + _relations[TypeDelete].size(); }
+  /**
+   * @brief getProcessedCount
+   * @return Number of elements processed so far
+   */
+  long getProcessedCount()      { return _processedCount; }
 
 private:
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -36,10 +36,14 @@
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 
+//  Tgs
+#include <tgs/System/Timer.h>
+
 //  Qt
 #include <QXmlStreamReader>
 
 using namespace std;
+using namespace Tgs;
 
 namespace hoot
 {
@@ -47,7 +51,8 @@ namespace hoot
 OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
   : _description(ConfigOptions().getChangesetDescription()),
     _maxWriters(ConfigOptions().getChangesetApidbMaxWriters()),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize())
+    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize()),
+    _showProgress(false)
 {
   _changesets.push_back(changeset);
   if (isSupported(url))
@@ -58,7 +63,8 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
   : _changesets(changesets),
     _description(ConfigOptions().getChangesetDescription()),
     _maxWriters(ConfigOptions().getChangesetApidbMaxWriters()),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize())
+    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize()),
+    _showProgress(false)
 {
   if (isSupported(url))
     _url = url;
@@ -66,6 +72,7 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
 
 bool OsmApiWriter::apply()
 {
+  Timer timer;
   OsmApiNetworkRequestPtr request(new OsmApiNetworkRequest());
   //  Validate API capabilites
   if (!queryCapabilities(request))
@@ -73,12 +80,14 @@ bool OsmApiWriter::apply()
     LOG_ERROR("API Capabilities error");
     return false;
   }
+  _stats.append(SingleStat("API Capabilites Query Time (sec)", timer.getElapsedAndRestart()));
   //  Validate API permissions
   if (!validatePermissions(request))
   {
     LOG_ERROR("API Permissions error");
     return false;
   }
+  _stats.append(SingleStat("API Permissions Query Time (sec)", timer.getElapsedAndRestart()));
   bool success = true;
   //  Load all of the changesets into memory
   _changeset.setMaxSize(_maxChangesetSize);
@@ -86,11 +95,21 @@ bool OsmApiWriter::apply()
   {
     LOG_INFO("Loading changeset: " << _changesets[i]);
     _changeset.loadChangeset(_changesets[i]);
+    _stats.append(SingleStat(QString("Changeset (%1) Time (sec)").arg(_changesets[i]), timer.getElapsedAndRestart()));
   }
   //  Start the writer threads
   LOG_INFO("Starting " << _maxWriters << " processing threads.");
   for (int i = 0; i < _maxWriters; ++i)
     _threadPool.push_back(thread(&OsmApiWriter::_changesetThreadFunc, this));
+  //  Setup the progress indicators
+  long total = _changeset.getTotalElementCount();
+  int progress = 0;
+  int increment = 1;
+  //  Setup the increment
+  if (total < 100000)
+    increment = 10;
+  else if (total < 1000000)
+    increment = 5;
   //  Iterate all changes until there are no more elements to send
   while (_changeset.hasElementsToSend())
   {
@@ -128,10 +147,31 @@ bool OsmApiWriter::apply()
       //  Allow time for the worker threads to complete some work
       this_thread::sleep_for(chrono::milliseconds(10));
     }
+    //  Show the progress
+    if (_showProgress)
+    {
+      //  Actual progress is calculated and once it passes the next increment it is reported
+      if (_changeset.getProcessedCount() / (double)total * 100.0 >= progress + increment)
+      {
+        progress += increment;
+        PROGRESS_INFO("Upload progress: " << progress << "%");
+      }
+    }
   }
+  PROGRESS_INFO("Upload progress: 100%");
   //  Wait for the threads to shutdown
   for (int i = 0; i < _maxWriters; ++i)
     _threadPool[i].join();
+  //  Keep some stats
+  _stats.append(SingleStat("API Upload Time (sec)", timer.getElapsedAndRestart()));
+  _stats.append(SingleStat("Total Nodes in Changeset", _changeset.getTotalNodeCount()));
+  _stats.append(SingleStat("Total Ways in Changeset", _changeset.getTotalWayCount()));
+  _stats.append(SingleStat("Total Relations in Changeset", _changeset.getTotalRelationCount()));
+  _stats.append(SingleStat("Total Elements Created", _changeset.getTotalCreateCount()));
+  _stats.append(SingleStat("Total Elements Modified", _changeset.getTotalModifyCount()));
+  _stats.append(SingleStat("Total Elements Deleted", _changeset.getTotalDeleteCount()));
+  _stats.append(SingleStat("Total Errors", _changeset.getFailedCount()));
+  //  Return successfully
   return success;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -33,6 +33,7 @@
 #include <hoot/core/io/OsmApiChangeset.h>
 #include <hoot/core/io/OsmApiChangesetElement.h>
 #include <hoot/core/io/OsmApiNetworkRequest.h>
+#include <hoot/core/ops/stats/SingleStat.h>
 #include <hoot/core/util/Configurable.h>
 
 //  Standard
@@ -108,6 +109,16 @@ public:
    * @return true if the current user has write permission for the OSM API
    */
   bool validatePermissions(OsmApiNetworkRequestPtr request);
+  /**
+   * @brief getStats Get the stats object
+   * @return
+   */
+  QList<SingleStat> getStats() const { return _stats; }
+  /**
+   * @brief showProgress Set the show progress flag for progress during upload
+   * @param show True shows an adaptive, granular progress
+   */
+  void showProgress(bool show) { _showProgress = show; }
 
 private:
   /**
@@ -184,6 +195,10 @@ private:
   long _maxChangesetSize;
   /** Queried capabilities from the target OSM API */
   OsmApiCapabilites _capabilities;
+  /** Actual statistics */
+  QList<SingleStat> _stats;
+  /** Progress flag */
+  bool _showProgress;
   /** Default constructor for testing purposes only */
   OsmApiWriter() {}
   //  for white box testing


### PR DESCRIPTION
Refs #2518 
Added `--stats` and `--progress` options to the command line for `changeset-apply`.  Also allowed for reading `.osm` files directly as an all-create changeset.