### PR TITLE
Fix language environment in name frequencies test

### DIFF
--- a/test-files/cmd/quick/NameFrequenciesCmdTest.sh
+++ b/test-files/cmd/quick/NameFrequenciesCmdTest.sh
@@ -3,4 +3,4 @@ set -e
 
 inputfile=$HOOT_HOME/test-files/DcGisRoads.osm
 
-hoot name-frequencies $inputfile | LANG=C sort
+hoot name-frequencies $inputfile | LC_ALL=C sort


### PR DESCRIPTION
Fixes #2528.  Use `LC_ALL=C` instead of `LANG=C` for consistent sorting.