### PR TITLE
Fix geometry modification in tag-differential

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -186,8 +186,9 @@ int ConflateCmd::runSimple(QStringList args)
 
   // read input 1
   OsmMapPtr map(new OsmMap());
-  IoUtils::loadMap(
-    map, input1, ConfigOptions().getReaderConflateUseDataSourceIds1(), Status::Unknown1);
+  IoUtils::loadMap(map, input1,
+                   ConfigOptions().getReaderConflateUseDataSourceIds1(),
+                   Status::Unknown1);
 
   DiffConflator diffConflator;
   if (isDiffConflate)
@@ -206,8 +207,9 @@ int ConflateCmd::runSimple(QStringList args)
   // read input 2
   if (!input2.isEmpty())
   {
-    IoUtils::loadMap(
-      map, input2, ConfigOptions().getReaderConflateUseDataSourceIds2(), Status::Unknown2);
+    IoUtils::loadMap(map, input2,
+                     ConfigOptions().getReaderConflateUseDataSourceIds2(),
+                     Status::Unknown2);
   }
 
   double inputBytes = IoSingleStat(IoSingleStat::RChar).value - bytesRead;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -194,7 +194,7 @@ int ConflateCmd::runSimple(QStringList args)
   if (isDiffConflate)
   {
     // Store original IDs for tag diff
-    diffConflator.storeOriginalIDs(map);
+    diffConflator.storeOriginalMap(map);
 
     // Mark input1 elements (Use Ref1 visitor, because it's already coded up)
     Settings visitorConf;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -42,6 +42,7 @@
 #include <hoot/core/util/MetadataTags.h>
 #include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/elements/ElementId.h>
+#include <hoot/core/schema/TagComparator.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/criterion/TagKeyCriterion.h>
 #include <hoot/core/visitors/RemoveElementsVisitor.h>
@@ -179,26 +180,8 @@ MemChangesetProviderPtr DiffConflator::getTagDiff()
 
 void DiffConflator::storeOriginalIDs(OsmMapPtr& pMap)
 {
-  // Nodes
-  const NodeMap &nodes = pMap->getNodes();
-  for (HashMap<long, NodePtr>::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
-  {
-    _originalIds.insert(ElementId(ElementType::Node, it->first));
-  }
-
-  // Ways
-  const WayMap &ways = pMap->getWays();
-  for (HashMap<long, WayPtr>::const_iterator it = ways.begin(); it != ways.end(); ++it)
-  {
-    _originalIds.insert(ElementId(ElementType::Way, it->first));
-  }
-
-  // Relations
-  const RelationMap &relations = pMap->getRelations();
-  for (HashMap<long, RelationPtr>::const_iterator it = relations.begin(); it != relations.end(); ++it)
-  {
-    _originalIds.insert(ElementId(ElementType::Relation, it->first));
-  }
+  // Use the copy constructor
+  _pOriginalMap.reset(new OsmMap(pMap));
 }
 
 void DiffConflator::_calcAndStoreTagChanges()
@@ -225,14 +208,14 @@ void DiffConflator::_calcAndStoreTagChanges()
       // the old element
       ConstElementPtr pOldElement;
       ConstElementPtr pNewElement;
-      if (_originalIds.end() != _originalIds.find(pit->first))
+      if (_pOriginalMap->containsElement(pit->first))
       {
-        pOldElement = _pMap->getElement(pit->first);
+        pOldElement = _pOriginalMap->getElement(pit->first);
         pNewElement = _pMap->getElement(pit->second);
       }
-      else if (_originalIds.end() != _originalIds.find(pit->second))
+      else if (_pOriginalMap->containsElement(pit->second))
       {
-        pOldElement = _pMap->getElement(pit->second);
+        pOldElement = _pOriginalMap->getElement(pit->second);
         pNewElement = _pMap->getElement(pit->first);
       }
       else
@@ -283,13 +266,16 @@ Change DiffConflator::_getChange(ConstElementPtr pOldElement,
   // This may seem a little weird, but we want something very specific here.
   // We want the old element as it was... with new tags.
 
-  // Copy the old one
+  // Copy the old one to get the geometry
   ElementPtr pChangeElement (pOldElement->clone());
 
   assert(pChangeElement->getId() == pOldElement->getId());
 
-  // Overwrite all old tags
-  pChangeElement->setTags(pNewElement->getTags());
+  // Need to merge tags into the new element
+  // Keeps all names, chooses tags1 in event of a conflict.
+  Tags newTags = TagComparator::getInstance().overwriteMerge(pNewElement->getTags(),
+                                                             pOldElement->getTags());
+  pChangeElement->setTags(newTags);
 
   // Create the change
   Change newChange(Change::Modify, pChangeElement);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -178,7 +178,7 @@ MemChangesetProviderPtr DiffConflator::getTagDiff()
   return _pTagChanges;
 }
 
-void DiffConflator::storeOriginalIDs(OsmMapPtr& pMap)
+void DiffConflator::storeOriginalMap(OsmMapPtr& pMap)
 {
   // Use the copy constructor
   _pOriginalMap.reset(new OsmMap(pMap));

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
@@ -174,12 +174,12 @@ private:
   // Stores the changes we calculate when doing the tag differential
   MemChangesetProviderPtr _pTagChanges;
 
-  // Set of the elements that came from the "Input1" map
-  // Used when calculating the tag differential
-  // This is important, because elements get modified by map cleaning
-  // operations prior to conflation - and we need this list of IDs to help
-  // us generate a clean changeset output for the tag diff.
-  std::set<ElementId> _originalIds;
+  // A copy of the "Input1" map. This is used when calculating the tag
+  // differential. It's important, because elements get modified by map
+  // cleaning operations prior to conflation - and we need this as a reference
+  // for original IDs and original geometry, so that we can generate a clean
+  // changeset output for the tag diff.
+  OsmMapPtr _pOriginalMap;
 
   template <typename InputCollection>
   void _deleteAll(InputCollection& ic)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
@@ -149,13 +149,12 @@ public:
   MemChangesetProviderPtr getTagDiff();
 
   /**
-   * @brief storeOriginalIDs - Stores the ElementIDs for the original Input1
-   * elements. This is necessary for calculating the tag differential, and it's
-   * important to call this after loading the Input1 map, and before loading the
-   * Input2 map.
+   * @brief storeOriginalMap - Stores the original map. This is necessary
+   * for calculating the tag differential, and it's important to call this
+   * after loading the Input1 map, and before loading the Input2 map.
    * @param pMap - Map that should be holding only the original "Input1" elements
    */
-  void storeOriginalIDs(OsmMapPtr& pMap);
+  void storeOriginalMap(OsmMapPtr& pMap);
 
 private:
 

--- a/test-files/cmd/slow/DiffConflateCmdTest/output.tags.osc
+++ b/test-files/cmd/slow/DiffConflateCmdTest/output.tags.osc
@@ -17,13 +17,23 @@
             <nd ref="8"/>
             <nd ref="34"/>
             <nd ref="9"/>
+            <nd ref="35"/>
+            <nd ref="10"/>
+            <nd ref="36"/>
+            <nd ref="37"/>
+            <nd ref="38"/>
+            <nd ref="11"/>
+            <nd ref="12"/>
+            <nd ref="13"/>
+            <nd ref="14"/>
+            <nd ref="15"/>
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="source:imagery" v="Unknown"/>
             <tag k="source" v="osm"/>
-            <tag k="uuid" v="{23aeaf18-1427-425c-ac42-8ee203b38f65}"/>
+            <tag k="uuid" v="{23aeaf18-1427-425c-ac42-8ee203b38f65};{c535233a-4a32-4a88-acc1-27a4d5a1445b}"/>
             <tag k="name" v="I-15"/>
             <tag k="attribution" v="osm"/>
-            <tag k="source:datetime" v="2018-06-11T16:50:55Z"/>
+            <tag k="source:datetime" v="2018-06-11T16:50:55Z;2018-06-11T16:49:01Z"/>
             <tag k="highway" v="primary"/>
             <tag k="surface" v="paved"/>
             <tag k="error:circular" v="15"/>
@@ -60,10 +70,10 @@
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="source:imagery" v="Unknown"/>
             <tag k="source" v="osm"/>
-            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8}"/>
+            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8};{2fd871c5-751e-40d1-9749-afcf31df94c9}"/>
             <tag k="name" v="Yellow Brick Road"/>
             <tag k="attribution" v="osm"/>
-            <tag k="source:datetime" v="2018-06-11T16:50:55Z"/>
+            <tag k="source:datetime" v="2018-06-11T16:50:55Z;2018-06-11T16:49:01Z"/>
             <tag k="highway" v="primary"/>
             <tag k="surface" v="cobblestone"/>
             <tag k="error:circular" v="15"/>
@@ -124,10 +134,10 @@
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="source:imagery" v="Unknown"/>
             <tag k="source" v="osm"/>
-            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8}"/>
+            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8};{1b31ba72-0a8f-4731-8dba-5a66a55bcec4}"/>
             <tag k="name" v="Yellow Brick Road"/>
             <tag k="attribution" v="osm"/>
-            <tag k="source:datetime" v="2018-06-11T16:50:55Z"/>
+            <tag k="source:datetime" v="2018-06-11T16:50:55Z;2018-06-11T16:49:01Z"/>
             <tag k="highway" v="primary"/>
             <tag k="surface" v="cobblestone"/>
             <tag k="error:circular" v="15"/>
@@ -141,10 +151,11 @@
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="building" v="garage"/>
             <tag k="source" v="Unknown;osm"/>
-            <tag k="uuid" v="{d34e32bc-d084-4368-b7b9-754ef3d349d2}"/>
+            <tag k="uuid" v="{d34e32bc-d084-4368-b7b9-754ef3d349d2};{af7cce29-a47d-4b42-bced-be9152dbaf77}"/>
             <tag k="name" v="Joe's Garage"/>
-            <tag k="amenity" v="fuel"/>
             <tag k="attribution" v="osm"/>
+            <tag k="amenity" v="fuel"/>
+            <tag k="source:datetime" v="2018-06-11T16:49:01Z"/>
             <tag k="error:circular" v="15"/>
         </way>
     </modify>

--- a/test-files/cmd/slow/DiffConflateCmdTest/output_unified.osc
+++ b/test-files/cmd/slow/DiffConflateCmdTest/output_unified.osc
@@ -787,13 +787,23 @@
             <nd ref="8"/>
             <nd ref="34"/>
             <nd ref="9"/>
+            <nd ref="35"/>
+            <nd ref="10"/>
+            <nd ref="36"/>
+            <nd ref="37"/>
+            <nd ref="38"/>
+            <nd ref="11"/>
+            <nd ref="12"/>
+            <nd ref="13"/>
+            <nd ref="14"/>
+            <nd ref="15"/>
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="source:imagery" v="Unknown"/>
             <tag k="source" v="osm"/>
-            <tag k="uuid" v="{23aeaf18-1427-425c-ac42-8ee203b38f65}"/>
+            <tag k="uuid" v="{23aeaf18-1427-425c-ac42-8ee203b38f65};{c535233a-4a32-4a88-acc1-27a4d5a1445b}"/>
             <tag k="name" v="I-15"/>
             <tag k="attribution" v="osm"/>
-            <tag k="source:datetime" v="2018-06-11T16:50:55Z"/>
+            <tag k="source:datetime" v="2018-06-11T16:50:55Z;2018-06-11T16:49:01Z"/>
             <tag k="highway" v="primary"/>
             <tag k="surface" v="paved"/>
             <tag k="error:circular" v="15"/>
@@ -830,10 +840,10 @@
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="source:imagery" v="Unknown"/>
             <tag k="source" v="osm"/>
-            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8}"/>
+            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8};{2fd871c5-751e-40d1-9749-afcf31df94c9}"/>
             <tag k="name" v="Yellow Brick Road"/>
             <tag k="attribution" v="osm"/>
-            <tag k="source:datetime" v="2018-06-11T16:50:55Z"/>
+            <tag k="source:datetime" v="2018-06-11T16:50:55Z;2018-06-11T16:49:01Z"/>
             <tag k="highway" v="primary"/>
             <tag k="surface" v="cobblestone"/>
             <tag k="error:circular" v="15"/>
@@ -894,10 +904,10 @@
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="source:imagery" v="Unknown"/>
             <tag k="source" v="osm"/>
-            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8}"/>
+            <tag k="uuid" v="{71756076-65b1-4e09-ad86-53b3f6483bf8};{1b31ba72-0a8f-4731-8dba-5a66a55bcec4}"/>
             <tag k="name" v="Yellow Brick Road"/>
             <tag k="attribution" v="osm"/>
-            <tag k="source:datetime" v="2018-06-11T16:50:55Z"/>
+            <tag k="source:datetime" v="2018-06-11T16:50:55Z;2018-06-11T16:49:01Z"/>
             <tag k="highway" v="primary"/>
             <tag k="surface" v="cobblestone"/>
             <tag k="error:circular" v="15"/>
@@ -911,10 +921,11 @@
             <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
             <tag k="building" v="garage"/>
             <tag k="source" v="Unknown;osm"/>
-            <tag k="uuid" v="{d34e32bc-d084-4368-b7b9-754ef3d349d2}"/>
+            <tag k="uuid" v="{d34e32bc-d084-4368-b7b9-754ef3d349d2};{af7cce29-a47d-4b42-bced-be9152dbaf77}"/>
             <tag k="name" v="Joe's Garage"/>
-            <tag k="amenity" v="fuel"/>
             <tag k="attribution" v="osm"/>
+            <tag k="amenity" v="fuel"/>
+            <tag k="source:datetime" v="2018-06-11T16:49:01Z"/>
             <tag k="error:circular" v="15"/>
         </way>
     </modify>


### PR DESCRIPTION
Refs #2551

These changes should stop geometries from being modified when applying the tag-diff.

They might not, however, keep your roads from turning into bicycle paths @mattjdnv .