### PR TITLE
Export relation with missing members mangling polygon geometry

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -602,17 +602,16 @@ public:
     OsmMapPtr map(new OsmMap());
     reader.open(ServicesDbTestUtils::getDbReadUrl(mapId).toString());
 
-    reader.setBoundingBox(
-      "-78.02265434416296,38.90089748801109,-77.9224564416296,39.00085678801109");
+    reader.setBoundingBox("-88.1,28.91,-88.0,28.89");
     reader.read(map);
 
     //quick check to see if the element counts are off...consult the test output for more detail
 
     //See explanations for these assertions in ServiceOsmApiDbReaderTest::runReadByBoundsTest
     //(exact same input data)
-    CPPUNIT_ASSERT_EQUAL(6, (int)map->getNodes().size());
-    CPPUNIT_ASSERT_EQUAL(4, (int)map->getWays().size());
-    CPPUNIT_ASSERT_EQUAL(5, (int)map->getRelations().size());
+    CPPUNIT_ASSERT_EQUAL(5, (int)map->getNodes().size());
+    CPPUNIT_ASSERT_EQUAL(2, (int)map->getWays().size());
+    CPPUNIT_ASSERT_EQUAL(2, (int)map->getRelations().size());
 
     //We need to drop to set all the element changeset tags here to empty, which will cause them
     //to be dropped from the file output.  If they aren't dropped, they will increment with each

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -174,23 +174,22 @@ public:
     reader.open(ServicesDbTestUtils::getOsmApiDbUrl().toString());
     OsmMapPtr map(new OsmMap());
 
-    reader.setBoundingBox(
-      "-78.02265434416296,38.90089748801109,-77.9224564416296,39.00085678801109");
+    reader.setBoundingBox("-88.1,28.91,-88.0,28.89");
     reader.read(map);
 
     //quick check to see if the element counts are off...consult the test output for more detail
 
-    //All but one of the seven nodes should be returned.  There are two nodes outside of the
-    //requested bounds, but one of them is referenced by a way within the bounds and the other by a
-    //relation within the bounds.  The node not returned is outside of the requested bounds and not
+    //All but two of the seven nodes should be returned.  There are five nodes outside of the
+    //requested bounds, one of them is referenced by a way within the bounds and the other three by a
+    //relation within the bounds.  The nodes not returned is outside of the requested bounds and not
     //reference by any other element.
-    CPPUNIT_ASSERT_EQUAL(6, (int)map->getNodes().size());
-    //All but one of the five ways should be returned.  The way not returned contains all nodes
+    CPPUNIT_ASSERT_EQUAL(5, (int)map->getNodes().size());
+    //Two of the five ways should be returned.  The ways not returned contain nodes
     //that are out of bounds.
-    CPPUNIT_ASSERT_EQUAL(4, (int)map->getWays().size());
-    //All but one of the six relations should be returned.  The relation not returned contains all
+    CPPUNIT_ASSERT_EQUAL(2, (int)map->getWays().size());
+    //Two of the six relations should be returned.  The relations not returned contain all
     //members that are out of bounds.
-    CPPUNIT_ASSERT_EQUAL(5, (int)map->getRelations().size());
+    CPPUNIT_ASSERT_EQUAL(2, (int)map->getRelations().size());
 
     // Verify timestamps look OK
     WayPtr pWay = map->getWays().begin()->second;

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
@@ -41,6 +41,7 @@
 #include <QSet>
 
 using namespace geos::geom;
+using namespace std;
 
 namespace hoot
 {
@@ -291,6 +292,67 @@ bool ApiDbReader::_isValidBounds(const Envelope& bounds)
   return true;
 }
 
+void ApiDbReader::_readWaysByNodeIds(OsmMapPtr map, const QSet<QString>& nodeIds, QSet<QString>& wayIds,
+                                     QSet<QString>& additionalNodeIds, long& nodeCount, long& wayCount)
+{
+  LOG_DEBUG("Retrieving way IDs referenced by the selected nodes...");
+  boost::shared_ptr<QSqlQuery> wayIdItr = _getDatabase()->selectWayIdsByWayNodeIds(nodeIds);
+  while (wayIdItr->next())
+  {
+    const long wayId = (*wayIdItr).value(0).toLongLong();
+    LOG_VART(ElementId(ElementType::Way, wayId));
+    wayIds.insert(QString::number(wayId));
+  }
+  LOG_VARD(wayIds.size());
+  if (wayIds.size() > 0)
+  {
+    LOG_DEBUG("Retrieving ways by way ID...");
+    boost::shared_ptr<QSqlQuery> wayItr =
+      _getDatabase()->selectElementsByElementIdList(wayIds, TableType::Way);
+    while (wayItr->next())
+    {
+      //I'm a little confused why this wouldn't cause a problem in that you could be writing ways
+      //to the map here whose nodes haven't yet been written to the map yet.  Haven't encountered
+      //the problem yet with test data, but will continue to keep an eye on it.
+      WayPtr way = _resultToWay(*wayItr, *map);
+      map->addElement(way);
+      LOG_VART(way);
+      wayCount++;
+    }
+
+    LOG_DEBUG("Retrieving way node IDs referenced by the selected ways...");
+    boost::shared_ptr<QSqlQuery> additionalWayNodeIdItr =
+      _getDatabase()->selectWayNodeIdsByWayIds(wayIds);
+    while (additionalWayNodeIdItr->next())
+    {
+      const long nodeId = (*additionalWayNodeIdItr).value(0).toLongLong();
+      LOG_VART(ElementId(ElementType::Node, nodeId));
+      additionalNodeIds.insert(QString::number(nodeId));
+    }
+
+    //subtract nodeIds from additionalWayNodeIds so no dupes get added
+    LOG_VARD(nodeIds.size());
+    LOG_VARD(additionalNodeIds.size());
+    additionalNodeIds = additionalNodeIds.subtract(nodeIds);
+    LOG_VARD(additionalNodeIds.size());
+
+    if (additionalNodeIds.size() > 0)
+    {
+      LOG_DEBUG(
+        "Retrieving nodes falling outside of the query bounds but belonging to a selected way...");
+      boost::shared_ptr<QSqlQuery> additionalWayNodeItr =
+        _getDatabase()->selectElementsByElementIdList(additionalNodeIds, TableType::Node);
+      while (additionalWayNodeItr->next())
+      {
+        NodePtr node = _resultToNode(*additionalWayNodeItr, *map);
+        map->addElement(node);
+        LOG_VART(node);
+        nodeCount++;
+      }
+    }
+  }
+}
+
 void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
 {
   long boundedNodeCount = 0;
@@ -319,67 +381,12 @@ void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
   {
     if (nodeIds.size() > 0)
     {
-      LOG_DEBUG("Retrieving way IDs referenced by the selected nodes...");
+////////////////////////////
       QSet<QString> wayIds;
-      boost::shared_ptr<QSqlQuery> wayIdItr = _getDatabase()->selectWayIdsByWayNodeIds(nodeIds);
-      while (wayIdItr->next())
-      {
-        const long wayId = (*wayIdItr).value(0).toLongLong();
-        LOG_VART(ElementId(ElementType::Way, wayId));
-        wayIds.insert(QString::number(wayId));
-      }
-      LOG_VARD(wayIds.size());
-
-      if (wayIds.size() > 0)
-      {
-        LOG_DEBUG("Retrieving ways by way ID...");
-        boost::shared_ptr<QSqlQuery> wayItr =
-          _getDatabase()->selectElementsByElementIdList(wayIds, TableType::Way);
-        while (wayItr->next())
-        {
-          //I'm a little confused why this wouldn't cause a problem in that you could be writing ways
-          //to the map here whose nodes haven't yet been written to the map yet.  Haven't encountered
-          //the problem yet with test data, but will continue to keep an eye on it.
-          WayPtr way = _resultToWay(*wayItr, *map);
-          map->addElement(way);
-          LOG_VART(way);
-          boundedWayCount++;
-        }
-
-        LOG_DEBUG("Retrieving way node IDs referenced by the selected ways...");
-        QSet<QString> additionalWayNodeIds;
-        boost::shared_ptr<QSqlQuery> additionalWayNodeIdItr =
-          _getDatabase()->selectWayNodeIdsByWayIds(wayIds);
-        while (additionalWayNodeIdItr->next())
-        {
-          const long nodeId = (*additionalWayNodeIdItr).value(0).toLongLong();
-          LOG_VART(ElementId(ElementType::Node, nodeId));
-          additionalWayNodeIds.insert(QString::number(nodeId));
-        }
-
-        //subtract nodeIds from additionalWayNodeIds so no dupes get added
-        LOG_VARD(nodeIds.size());
-        LOG_VARD(additionalWayNodeIds.size());
-        additionalWayNodeIds = additionalWayNodeIds.subtract(nodeIds);
-        LOG_VARD(additionalWayNodeIds.size());
-
-        if (additionalWayNodeIds.size() > 0)
-        {
-          nodeIds.unite(additionalWayNodeIds);
-          LOG_DEBUG(
-            "Retrieving nodes falling outside of the query bounds but belonging to a selected way...");
-          boost::shared_ptr<QSqlQuery> additionalWayNodeItr =
-            _getDatabase()->selectElementsByElementIdList(additionalWayNodeIds, TableType::Node);
-          while (additionalWayNodeItr->next())
-          {
-            NodePtr node = _resultToNode(*additionalWayNodeItr, *map);
-            map->addElement(node);
-            LOG_VART(node);
-            boundedNodeCount++;
-          }
-        }
-      }
-
+      QSet<QString> additionalWayNodeIds;
+      _readWaysByNodeIds(map, nodeIds, wayIds, additionalWayNodeIds, boundedNodeCount, boundedWayCount);
+      nodeIds.unite(additionalWayNodeIds);
+/////////////////////////////////
       LOG_DEBUG("Retrieving relation IDs referenced by the selected ways and nodes...");
       QSet<QString> relationIds;
       assert(nodeIds.size() > 0);
@@ -403,8 +410,12 @@ void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
       }
       LOG_VARD(relationIds.size());
 
-      if (relationIds.size() > 0)
+      QSet<QString> completedRelationIds;
+      while (relationIds.size() > 0)
       {
+        QSet<QString> newNodes;
+        QSet<QString> newWays;
+        QSet<QString> newRelations;
         LOG_DEBUG("Retrieving relations by relation ID...");
         boost::shared_ptr<QSqlQuery> relationItr =
           _getDatabase()->selectElementsByElementIdList(relationIds, TableType::Relation);
@@ -412,9 +423,92 @@ void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
         {
           RelationPtr relation = _resultToRelation(*relationItr, *map);
           map->addElement(relation);
+          const vector<RelationData::Entry>& members = relation->getMembers();
+          for (vector<RelationData::Entry>::const_iterator it = members.begin(); it != members.end(); ++it)
+          {
+            ElementType type = it->getElementId().getType();
+            QString id = QString::number(it->getElementId().getId());
+            if (type == ElementType::Node)
+              newNodes.insert(id);
+            else if (type == ElementType::Way)
+              newWays.insert(id);
+            else if (type == ElementType::Relation)
+              newRelations.insert(id);
+            else
+            {
+              LOG_WARN("Unknown relation member type");
+            }
+          }
           LOG_VART(relation);
           boundedRelationCount++;
+          completedRelationIds.insert(QString::number(relation->getId()));
         }
+        relationIds.clear();
+        newNodes = newNodes.subtract(nodeIds);
+        if (newNodes.size() > 0)
+        {
+          boost::shared_ptr<QSqlQuery> nodeItr = _getDatabase()->selectElementsByElementIdList(newNodes, TableType::Node);
+          while (nodeItr->next())
+          {
+            const QSqlQuery resultIterator = *nodeItr;
+            NodePtr node = _resultToNode(resultIterator, *map);
+            LOG_VART(node);
+            map->addElement(node);
+            boundedNodeCount++;
+            //Don't use the mapped id from the node object here, b/c we want don't want to use mapped ids
+            //with any queries.  Mapped ids may not exist yet.
+            const long nodeId = resultIterator.value(0).toLongLong();
+            LOG_VART(ElementId(ElementType::Node, nodeId));
+            nodeIds.insert( QString::number(nodeId));
+          }
+        }
+        newWays = newWays.subtract(wayIds);
+        if (newWays.size() > 0)
+        {
+          QSet<QString> additionalNodeIds;
+          LOG_DEBUG("Retrieving ways by way ID...");
+          boost::shared_ptr<QSqlQuery> wayItr =
+            _getDatabase()->selectElementsByElementIdList(newWays, TableType::Way);
+          while (wayItr->next())
+          {
+            WayPtr way = _resultToWay(*wayItr, *map);
+            map->addElement(way);
+            LOG_VART(way);
+            boundedWayCount++;
+          }
+
+          LOG_DEBUG("Retrieving way node IDs referenced by the selected ways...");
+          boost::shared_ptr<QSqlQuery> additionalWayNodeIdItr =
+            _getDatabase()->selectWayNodeIdsByWayIds(newWays);
+          while (additionalWayNodeIdItr->next())
+          {
+            const long nodeId = (*additionalWayNodeIdItr).value(0).toLongLong();
+            LOG_VART(ElementId(ElementType::Node, nodeId));
+            additionalNodeIds.insert(QString::number(nodeId));
+          }
+
+          //subtract nodeIds from additionalWayNodeIds so no dupes get added
+          LOG_VARD(nodeIds.size());
+          LOG_VARD(additionalNodeIds.size());
+          additionalNodeIds = additionalNodeIds.subtract(nodeIds);
+          LOG_VARD(additionalNodeIds.size());
+
+          if (additionalNodeIds.size() > 0)
+          {
+            LOG_DEBUG(
+              "Retrieving nodes falling outside of the query bounds but belonging to a selected way...");
+            boost::shared_ptr<QSqlQuery> additionalWayNodeItr =
+              _getDatabase()->selectElementsByElementIdList(additionalNodeIds, TableType::Node);
+            while (additionalWayNodeItr->next())
+            {
+              NodePtr node = _resultToNode(*additionalWayNodeItr, *map);
+              map->addElement(node);
+              LOG_VART(node);
+              boundedNodeCount++;
+            }
+          }
+        }
+        newRelations.subtract(completedRelationIds);
       }
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
@@ -151,7 +151,8 @@ protected:
    * This is the same logic as in the Map.java query method.
    */
   virtual void _readByBounds(OsmMapPtr map, const geos::geom::Envelope& bounds);
-
+  void _readWaysByNodeIds(OsmMapPtr map, const QSet<QString>& nodeIds, QSet<QString>& wayIds,
+                          QSet<QString>& additionalNodeIds, long& nodeCount, long& wayCount);
   void _updateMetadataOnElement(ElementPtr element);
 
   static bool _isValidBounds(const geos::geom::Envelope& bounds);

--- a/test-files/io/ServiceHootApiDbReaderTest/runReadByBoundsTestInput.osm
+++ b/test-files/io/ServiceHootApiDbReaderTest/runReadByBoundsTestInput.osm
@@ -1,78 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <node visible="true" id="1" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
+    <node visible="true" version="1" id="1" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
         <tag k="node1" v="node1"/>
     </node>
-    <node visible="true" id="2" timestamp="1970-01-01T00:00:00Z" lat="39.0008568" lon="-77.0224564">
+    <node visible="true" version="1" id="2" timestamp="1970-01-01T00:00:00Z" lat="39.0008568" lon="-77.0224564">
 	<tag k="node2" v="node2"/>
     </node>
-    <node visible="true" id="3" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
+    <node visible="true" version="1" id="3" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
 	<tag k="node3" v="node3"/>
     </node>
-    <node visible="true" id="4" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
+    <node visible="true" version="1" id="4" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
 	<tag k="node4" v="node4"/>
     </node>
-    <node visible="true" id="5" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
+    <node visible="true" version="1" id="5" timestamp="1970-01-01T00:00:00Z" lat="38.9008975" lon="-78.0226543">
 	<tag k="node5" v="node5"/>
     </node>
-    <node visible="true" id="6" timestamp="1970-01-01T00:00:00Z" lat="33.9008975" lon="-83.0226543">
+    <node visible="true" version="1" id="6" timestamp="1970-01-01T00:00:00Z" lat="33.9008975" lon="-83.0226543">
 	<tag k="node6" v="node6"/>
     </node>
-    <node visible="true" id="7" timestamp="1970-01-01T00:00:00Z" lat="28.9008975" lon="-88.0226543">
+    <node visible="true" version="1" id="7" timestamp="1970-01-01T00:00:00Z" lat="28.9008975" lon="-88.0226543">
 	<tag k="node7" v="node7"/>
     </node>
-    <way visible="true" id="1" timestamp="1970-01-01T00:00:00Z">
+    <way visible="true" version="1" id="1" timestamp="1970-01-01T00:00:00Z">
         <nd ref="1"/>
         <nd ref="2"/>
         <nd ref="5"/>
 	<tag k="way1" v="way1"/>
     </way>
-    <way visible="true" id="2" timestamp="1970-01-01T00:00:00Z">
+    <way visible="true" version="1" id="2" timestamp="1970-01-01T00:00:00Z">
         <nd ref="3"/>
         <nd ref="2"/>
 	<tag k="way2" v="way2"/>
     </way>
-    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z">
+    <way visible="true" version="1" id="3" timestamp="1970-01-01T00:00:00Z">
         <nd ref="1"/>
         <nd ref="2"/>
 	<tag k="way3" v="way3"/>
     </way>
-    <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z">
+    <way visible="true" version="1" id="4" timestamp="1970-01-01T00:00:00Z">
         <nd ref="6"/>
         <nd ref="7"/>
 	<tag k="way4" v="way4"/>
     </way>
-    <way visible="true" id="5" timestamp="1970-01-01T00:00:00Z">
+    <way visible="true" version="1" id="5" timestamp="1970-01-01T00:00:00Z">
         <nd ref="1"/>
         <nd ref="6"/>
 	<tag k="way5" v="way5"/>
     </way>
-    <relation visible="true" id="1" timestamp="1970-01-01T00:00:00Z">
+    <relation visible="true" version="1" id="1" timestamp="1970-01-01T00:00:00Z">
         <member type="node" ref="1" role="role1"/>
         <member type="way" ref="2" role="role3"/>
         <member type="way" ref="1" role="role2"/>
         <member type="node" ref="3" role="role1"/>
 	<tag k="relation1" v="relation1"/>
     </relation>
-    <relation visible="true" id="2" timestamp="1970-01-01T00:00:00Z">
+    <relation visible="true" version="1" id="2" timestamp="1970-01-01T00:00:00Z">
         <member type="node" ref="5" role="role1"/>
         <member type="relation" ref="1" role="role1"/>
 	<tag k="relation2" v="relation2"/>
     </relation>
-    <relation visible="true" id="3" timestamp="1970-01-01T00:00:00Z">
+    <relation visible="true" version="1" id="3" timestamp="1970-01-01T00:00:00Z">
         <member type="way" ref="2" role="role2"/>
 	<tag k="relation3" v="relation3"/>
     </relation>
-    <relation visible="true" id="4" timestamp="1970-01-01T00:00:00Z">
+    <relation visible="true" version="1" id="4" timestamp="1970-01-01T00:00:00Z">
         <member type="node" ref="3" role="role1"/>
 	<tag k="relation4" v="relation4"/>
     </relation>
-    <relation visible="true" id="5" timestamp="1970-01-01T00:00:00Z">
+    <relation visible="true" version="1" id="5" timestamp="1970-01-01T00:00:00Z">
         <member type="node" ref="7" role="role1"/>
         <member type="way" ref="4" role="role1"/>
 	<tag k="relation5" v="relation5"/>
     </relation>
-    <relation visible="true" id="6" timestamp="1970-01-01T00:00:00Z">
+    <relation visible="true" version="1" id="6" timestamp="1970-01-01T00:00:00Z">
         <member type="node" ref="7" role="role1"/>
         <member type="way" ref="1" role="role1"/>
         <member type="way" ref="4" role="role1"/>

--- a/test-files/io/ServiceHootApiDbReaderTest/runReadByBoundsTestOutput.osm
+++ b/test-files/io/ServiceHootApiDbReaderTest/runReadByBoundsTestOutput.osm
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="33.9008975" minlon="-83.0226543" maxlat="39.0008568" maxlon="-77.0224564"/>
+    <bounds minlat="28.9008975" minlon="-88.0226543" maxlat="39.0008568" maxlon="-77.0224564"/>
+    <node visible="true" id="1" version="1" lat="28.9008974999999992" lon="-88.0226542999999992">
+        <tag k="node7" v="node7"/>
+    </node>
     <node visible="true" id="2" version="1" lat="33.9008974999999992" lon="-83.0226542999999992">
         <tag k="node6" v="node6"/>
     </node>
     <node visible="true" id="3" version="1" lat="38.9008974999999992" lon="-78.0226542999999992">
         <tag k="node5" v="node5"/>
-    </node>
-    <node visible="true" id="4" version="1" lat="38.9008974999999992" lon="-78.0226542999999992">
-        <tag k="node4" v="node4"/>
-    </node>
-    <node visible="true" id="5" version="1" lat="38.9008974999999992" lon="-78.0226542999999992">
-        <tag k="node3" v="node3"/>
     </node>
     <node visible="true" id="6" version="1" lat="39.0008568000000011" lon="-77.0224563999999958">
         <tag k="node2" v="node2"/>
@@ -19,20 +16,10 @@
     <node visible="true" id="7" version="1" lat="38.9008974999999992" lon="-78.0226542999999992">
         <tag k="node1" v="node1"/>
     </node>
-    <way visible="true" id="1" version="1">
-        <nd ref="7"/>
+    <way visible="true" id="2" version="1">
         <nd ref="2"/>
-        <tag k="way5" v="way5"/>
-    </way>
-    <way visible="true" id="3" version="1">
-        <nd ref="7"/>
-        <nd ref="6"/>
-        <tag k="way3" v="way3"/>
-    </way>
-    <way visible="true" id="4" version="1">
-        <nd ref="5"/>
-        <nd ref="6"/>
-        <tag k="way2" v="way2"/>
+        <nd ref="1"/>
+        <tag k="way4" v="way4"/>
     </way>
     <way visible="true" id="5" version="1">
         <nd ref="7"/>
@@ -46,24 +33,9 @@
         <member type="way" ref="2" role="role1"/>
         <tag k="relation6" v="relation6"/>
     </relation>
-    <relation visible="true" id="3" version="1">
-        <member type="node" ref="5" role="role1"/>
-        <tag k="relation4" v="relation4"/>
-    </relation>
-    <relation visible="true" id="4" version="1">
-        <member type="way" ref="4" role="role2"/>
-        <tag k="relation3" v="relation3"/>
-    </relation>
-    <relation visible="true" id="5" version="1">
-        <member type="node" ref="3" role="role1"/>
-        <member type="relation" ref="6" role="role1"/>
-        <tag k="relation2" v="relation2"/>
-    </relation>
-    <relation visible="true" id="6" version="1">
-        <member type="node" ref="7" role="role1"/>
-        <member type="way" ref="4" role="role3"/>
-        <member type="way" ref="5" role="role2"/>
-        <member type="node" ref="5" role="role1"/>
-        <tag k="relation1" v="relation1"/>
+    <relation visible="true" id="2" version="1">
+        <member type="node" ref="1" role="role1"/>
+        <member type="way" ref="2" role="role1"/>
+        <tag k="relation5" v="relation5"/>
     </relation>
 </osm>

--- a/test-files/io/ServiceOsmApiDbReaderTest/runReadByBoundsTest.osm
+++ b/test-files/io/ServiceOsmApiDbReaderTest/runReadByBoundsTest.osm
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="33.9008975" minlon="-83.0226543" maxlat="39.9008568" maxlon="-77.0224564"/>
+    <bounds minlat="28.9008975" minlon="-88.0226543" maxlat="39.9008568" maxlon="-77.0224564"/>
     <node visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1" lat="38.9008974999999992" lon="-78.0226542999999992">
         <tag k="node1" v="node1"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1" lat="39.9008567999999997" lon="-77.0224563999999958">
         <tag k="node2" v="node2"/>
-        <tag k="error:circular" v="15"/>
-    </node>
-    <node visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1" lat="38.9008974999999992" lon="-78.0226542999999992">
-        <tag k="node3" v="node3"/>
-        <tag k="error:circular" v="15"/>
-    </node>
-    <node visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1" lat="38.9008974999999992" lon="-78.0226542999999992">
-        <tag k="node4" v="node4"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1" lat="38.9008974999999992" lon="-78.0226542999999992">
@@ -25,6 +17,10 @@
         <tag k="node6" v="node6"/>
         <tag k="error:circular" v="15"/>
     </node>
+    <node visible="true" id="7" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1" lat="28.9008974999999992" lon="-88.0226542999999992">
+        <tag k="node7" v="node7"/>
+        <tag k="error:circular" v="15"/>
+    </node>
     <way visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
         <nd ref="1"/>
         <nd ref="2"/>
@@ -32,46 +28,16 @@
         <tag k="way1" v="way1"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <nd ref="3"/>
-        <nd ref="2"/>
-        <tag k="way2" v="way2"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <nd ref="1"/>
-        <nd ref="2"/>
-        <tag k="way3" v="way3"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <nd ref="1"/>
+    <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
         <nd ref="6"/>
-        <tag k="way5" v="way5"/>
+        <nd ref="7"/>
+        <tag k="way4" v="way4"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <relation visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <member type="node" ref="1" role="role1"/>
-        <member type="way" ref="2" role="role3"/>
-        <member type="way" ref="1" role="role2"/>
-        <member type="node" ref="3" role="empty"/>
-        <tag k="relation1" v="relation1"/>
-        <tag k="error:circular" v="15"/>
-    </relation>
-    <relation visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <member type="node" ref="5" role="role1"/>
-        <member type="relation" ref="1" role="role1"/>
-        <tag k="relation2" v="relation2"/>
-        <tag k="error:circular" v="15"/>
-    </relation>
-    <relation visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <member type="way" ref="2" role="empty"/>
-        <tag k="relation3" v="relation3"/>
-        <tag k="error:circular" v="15"/>
-    </relation>
-    <relation visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
-        <member type="node" ref="3" role="role1"/>
-        <tag k="relation4" v="relation4"/>
+    <relation visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">
+        <member type="node" ref="7" role="role1"/>
+        <member type="way" ref="4" role="role1"/>
+        <tag k="relation5" v="relation5"/>
         <tag k="error:circular" v="15"/>
     </relation>
     <relation visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="1" changeset="1">


### PR DESCRIPTION
Refs #2505 and #1856

When relations were being exported from the database the process wasn't grabbing relations that were members of relations and so forth.  This code change iterates on each relation and adds all members of the relation to the export.  If that member is a relation itself, then the process is repeated for that sub-relation.