### PR TITLE
Upgrade to ChromeDriver 2.41.

### DIFF
--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CHROMEDRIVER_VERSION=2.40
+export CHROMEDRIVER_VERSION=2.41
 
 export JDK_VERSION=1.8.0_161
 export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.tar.gz


### PR DESCRIPTION
Fixes #2574, upgrades the ChromeDriver in preparation for Chrome 69.