### PR TITLE
Upgrade PostGIS

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -105,7 +105,7 @@ sudo yum -y install \
     osmosis \
     java-1.8.0-openjdk \
     perl-XML-LibXML \
-    hoot-postgis23_95 \
+    hoot-postgis24_95 \
     postgresql95 \
     postgresql95-contrib \
     postgresql95-devel \

--- a/docker/hootcore/Dockerfile
+++ b/docker/hootcore/Dockerfile
@@ -63,7 +63,7 @@ RUN yum install -q -y \
     osmosis \
     java-1.8.0-openjdk \
     perl-XML-LibXML \
-    hoot-postgis23_95 \
+    hoot-postgis24_95 \
     postgresql95 \
     postgresql95-contrib \
     postgresql95-devel \

--- a/scripts/hoot-repo/yum-configure.sh
+++ b/scripts/hoot-repo/yum-configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HOOT_BASEURL=${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/upgrade}
+HOOT_BASEURL="${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/release}"
 HOOT_KEY=/etc/pki/rpm-gpg/RPM-GPG-KEY-Hoot
 
 cat > $HOOT_KEY <<EOF

--- a/scripts/hoot-repo/yum-configure.sh
+++ b/scripts/hoot-repo/yum-configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HOOT_BASEURL=${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/release}
+HOOT_BASEURL=${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/upgrade}
 HOOT_KEY=/etc/pki/rpm-gpg/RPM-GPG-KEY-Hoot
 
 cat > $HOOT_KEY <<EOF


### PR DESCRIPTION
Fixes #2638.  Uses upgraded dependencies (PostGIS 2.4.4 and Tomcat 8.5.34), currently hosted in the release dependency repository.