### PR TITLE
Qube and Makefile updates

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
@@ -219,7 +219,7 @@ public:
     //verify current elements
 
     CPPUNIT_ASSERT_EQUAL((size_t)14, map->getNodes().size());
-    CPPUNIT_ASSERT_EQUAL((int)2, map->getNode(16)->getTags().size());;
+    CPPUNIT_ASSERT_EQUAL((int)2, map->getNode(16)->getTags().size());
 
     CPPUNIT_ASSERT_EQUAL((size_t)5, map->getWays().size());
     CPPUNIT_ASSERT_EQUAL((int)2, map->getWay(6)->getTags().size());
@@ -287,7 +287,7 @@ public:
     //verify current elements
 
     CPPUNIT_ASSERT_EQUAL((size_t)14, map->getNodes().size());
-    CPPUNIT_ASSERT_EQUAL((int)2, map->getNode(3000000016)->getTags().size());;
+    CPPUNIT_ASSERT_EQUAL((int)2, map->getNode(3000000016)->getTags().size());
 
     CPPUNIT_ASSERT_EQUAL((size_t)5, map->getWays().size());
     CPPUNIT_ASSERT_EQUAL((int)2, map->getWay(3000000006)->getTags().size());

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ExternalMergeElementSorter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ExternalMergeElementSorter.cpp
@@ -132,7 +132,7 @@ void ExternalMergeElementSorter::_initElementStream()
   boost::shared_ptr<PartialOsmMapReader> sortedElementsReader =
     boost::dynamic_pointer_cast<PartialOsmMapReader>(
       OsmMapReaderFactory::getInstance().createReader(_sortFinalOutput->fileName()));
-  sortedElementsReader->setUseDataSourceIds(true);;
+  sortedElementsReader->setUseDataSourceIds(true);
   sortedElementsReader->open(_sortFinalOutput->fileName());
   sortedElementsReader->initializePartial();
   _sortedElements = boost::dynamic_pointer_cast<ElementInputStream>(sortedElementsReader);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/schema/ImplicitTagRawRulesDeriver.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/schema/ImplicitTagRawRulesDeriver.cpp
@@ -129,7 +129,7 @@ void ImplicitTagRawRulesDeriver::deriveRawRules(const QStringList inputs,
     "Generating implicit tag rules raw file for inputs: " << inputs <<
     ", translation scripts: " << translationScripts << ".  Writing to output: " << output << "...");
   LOG_VARD(_sortParallelCount);
-  LOG_VARD(_skipFiltering);;
+  LOG_VARD(_skipFiltering);
   LOG_VARD(_translateNamesToEnglish);
 
   _init();

--- a/hoot-services/Makefile
+++ b/hoot-services/Makefile
@@ -9,6 +9,7 @@ SHELL=/bin/bash
 # If the silent flag is passed to make then make Maven quiet too.
 ifneq (,$(findstring s,$(MAKEFLAGS)))
     MVN_QUIET="-q"
+    SCRIPT_QUIET=> /dev/null 2>&1
 endif
 
 default: build
@@ -57,7 +58,7 @@ clean: config clean-coverage
 clean-db: clean-db-force
 
 clean-db-force:
-	../scripts/database/DeleteAllTables.sh
+	../scripts/database/DeleteAllTables.sh $(SCRIPT_QUIET)
 
 coverage:
 	echo "Generating services code coverage report (runs services tests)..."

--- a/test-files/ui/Makefile
+++ b/test-files/ui/Makefile
@@ -6,6 +6,7 @@ ifneq (,$(findstring s,$(MAKEFLAGS)))
   HOOT_OPTS=--warn
   TIME=
   ECHO=true
+  PSQL_QUIET=1>&2
 endif
 
 # Check if we are using a different Tomcat8 port
@@ -76,7 +77,7 @@ clean:
 	fi
 
 	# Remove test user and faux-session data from db
-	PGPASSWORD=$(PGPASSWORD) psql $(AUTH) -c "DELETE FROM users where email='test@test.com' or id=-1" 2>/dev/null || true
+	PGPASSWORD=$(PGPASSWORD) psql $(AUTH) -c "DELETE FROM users where email='test@test.com' or id=-1" 2>/dev/null $(PSQL_QUIET) || true
 
 	# Cleaning up proxy node modules...
 	rm -rf $(HOOT_HOME)/test-files/ui/node_modules >/dev/null 2>&1 || true


### PR DESCRIPTION
Updated make process to quiet the `clean` and `clean-all` targets when requested with the `-s` flag and removed extra semi-colons for the qube.