### PR TITLE
Silence the Hoot UI 2x build

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -2,7 +2,7 @@
 # If the silent flag is passed to make then make Maven and npm quiet too.
 ifneq (,$(findstring s,$(MAKEFLAGS)))
 	MVN_QUIET='-q'
-	NPM_QUIET='-s' # > /dev/null'
+	NPM_QUIET=-s > /dev/null 2>&1
 else
 	HOOT_TEST_DIFF='--diff'
 endif


### PR DESCRIPTION
Refs #2721 and #2641 
Make the Hoot UI 2x quiet without breaking the build.  The single quotes were causing the parameter to not function correctly.  The best way to tell that the build happened and wasn't skipped is that it modifies files in the `hoot-ui-2x` directory when it builds.
```
$ git status
# On branch silent_2721
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#   (commit or discard the untracked or modified content in submodules)
#
#	modified:   hoot-ui-2x (modified content)
```
It is more than an annoyance but for now it will show that the build was successful.  We should open another ticket to fix this modification problem later.