### PR TITLE
Schema changes for geometries

### DIFF
--- a/conf/schema/REF1.json
+++ b/conf/schema/REF1.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 1,
         "name": "REF1",
         "objectType": "tag"

--- a/conf/schema/REF2.json
+++ b/conf/schema/REF2.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 1,
         "name": "REF2",
         "objectType": "tag"

--- a/conf/schema/address.json
+++ b/conf/schema/address.json
@@ -1,12 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "area",
-            "way",
-            "relation"
-        ],
         "influence": 2,
         "mismatchScore": 0.25,
         "name": "abstract_address",

--- a/conf/schema/colour.json
+++ b/conf/schema/colour.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "colour",
         "objectType": "tag"
     }

--- a/conf/schema/contact.json
+++ b/conf/schema/contact.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "contact:phone",
         "objectType": "tag"
     }

--- a/conf/schema/destination.json
+++ b/conf/schema/destination.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "destination",
         "objectType": "tag"
     }

--- a/conf/schema/ele.json
+++ b/conf/schema/ele.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "real",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "ele",
         "objectType": "tag"
     }

--- a/conf/schema/email.json
+++ b/conf/schema/email.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "email",
         "objectType": "tag"
     }

--- a/conf/schema/frequency.json
+++ b/conf/schema/frequency.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "real",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "frequency",
         "objectType": "tag"
     }

--- a/conf/schema/gauge.json
+++ b/conf/schema/gauge.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "real",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "gauge",
         "objectType": "tag"
     }

--- a/conf/schema/height.json
+++ b/conf/schema/height.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "real",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "height",
         "objectType": "tag"
     }

--- a/conf/schema/hoot_tags.json
+++ b/conf/schema/hoot_tags.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 1,
         "isA": "metadata",
         "name": "hoot:hash",

--- a/conf/schema/is_in.json
+++ b/conf/schema/is_in.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-	    "relation"
-        ],
         "name": "abstract_is_in",
         "influence": 1,
         "objectType": "tag"

--- a/conf/schema/lanes.json
+++ b/conf/schema/lanes.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "int",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "lanes",
         "objectType": "tag"
     }

--- a/conf/schema/maxspeed.json
+++ b/conf/schema/maxspeed.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "real",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "maxspeed",
         "objectType": "tag"
     }

--- a/conf/schema/metadata.json
+++ b/conf/schema/metadata.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 0,
         "name": "metadata",
         "objectType": "tag"

--- a/conf/schema/name.json
+++ b/conf/schema/name.json
@@ -4,11 +4,6 @@
             "name"
         ],
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 2,
         "name": "abstract_name",
         "objectType": "tag"
@@ -58,11 +53,6 @@
             "pseudoname"
         ],
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 1,
         "name": "pseudo_name",
         "objectType": "tag"

--- a/conf/schema/note.json
+++ b/conf/schema/note.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 0,
         "name": "note",
         "objectType": "tag"

--- a/conf/schema/source.json
+++ b/conf/schema/source.json
@@ -6,11 +6,6 @@
     },
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "influence": 1,
         "isA": "metadata",
         "name": "source",

--- a/conf/schema/url.json
+++ b/conf/schema/url.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "url",
         "objectType": "tag"
     }

--- a/conf/schema/website.json
+++ b/conf/schema/website.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "website",
         "objectType": "tag"
     }

--- a/conf/schema/width.json
+++ b/conf/schema/width.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "real",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "width",
         "objectType": "tag"
     }

--- a/conf/schema/wikipedia.json
+++ b/conf/schema/wikipedia.json
@@ -1,11 +1,6 @@
 [
     {
         "dataType": "text",
-        "geometries": [
-            "node",
-            "way",
-            "relation"
-        ],
         "name": "wikipedia",
         "objectType": "tag"
     }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -1783,7 +1783,7 @@ bool OsmSchema::allowsFor(const Tags& t, const ElementType& /*type*/, OsmGeometr
   {
     const SchemaVertex& tv = getTagVertex(it.key() + "=" + it.value());
     //  Unknown vertex types aren't usable tags
-    if (tv.getType() != SchemaVertex::UnknownVertexType)
+    if (tv.getType() != SchemaVertex::UnknownVertexType && tv.geometries != OsmGeometries::Empty)
     {
       value = static_cast<OsmGeometries::Type>(value & tv.geometries);
       usableTags++;

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.cpp
@@ -64,6 +64,7 @@ void SchemaChecker::checkUnknownVertexType()
 
 void SchemaChecker::checkEmptyGeometry()
 {
+  return;
   for (unsigned int i = 0; i < _schemaVertexList.size(); i++)
   {
     SchemaVertex schemaVertex = _schemaVertexList[i];

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "SchemaChecker.h"
@@ -64,23 +64,8 @@ void SchemaChecker::checkUnknownVertexType()
 
 void SchemaChecker::checkEmptyGeometry()
 {
+  //  Empty geometries are ok
   return;
-  for (unsigned int i = 0; i < _schemaVertexList.size(); i++)
-  {
-    SchemaVertex schemaVertex = _schemaVertexList[i];
-    if (schemaVertex.geometries == 0)
-    {
-      if (logWarnCount < Log::getWarnMessageLimit())
-      {
-        LOG_WARN("Warning: empty geometries. " << schemaVertex.name);
-      }
-      else if (logWarnCount == Log::getWarnMessageLimit())
-      {
-        LOG_WARN(className() << ": " << Log::LOG_WARN_LIMIT_REACHED_MESSAGE);
-      }
-      logWarnCount++;
-    }
-  }
 }
 
 void SchemaChecker::check()


### PR DESCRIPTION
Removed geometry from schema that don't describe geometries and updated `OsmSchema::allowsFor()` code to ignore empty geometries
Refs #2693 
Merge into branch `2693` for https://github.com/ngageoint/hootenanny/pull/2734