### PR TITLE
OSM with missing nodes fails geometry type handling for closed ways

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2129,6 +2129,15 @@ sequencing of element ID's.
 
 Add a tag with the bounding box for each element
 
+=== osm.map.reader.xml.add.child.refs.when.missing
+
+* Data Type: bool
+* Default Value: `false`
+
+By default, OsmXmlReader will not add child references (node ref, elements members) to parent
+elements if those elements are not present in the data.  For external sorting and translations,
+where partial chunks of elements will be present the setting is changed.
+
 === osm.map.reader.factory.reader
 
 * Data Type: string

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.cpp
@@ -127,7 +127,7 @@ void OsmGeoJsonWriter::_writeGeometry(ConstWayPtr w)
 {
   const vector<long>& nodes = w->getNodeIds();
   bool isPolygon = OsmSchema::getInstance().isArea(w) ||
-                   nodes[0] == nodes[nodes.size() - 1];
+                   (nodes.size() > 0 && nodes[0] == nodes[nodes.size() - 1]);
   _writeGeometry(nodes, (isPolygon) ? "Polygon" : "LineString");
 }
 
@@ -180,6 +180,15 @@ void OsmGeoJsonWriter::_writeGeometry(const vector<long> &nodes, string type)
     if (_map->getNode(*it).get() != NULL)
       temp_nodes.push_back(*it);
   }
+  //  Empty nodes list should output an empty coordinate array
+  if (temp_nodes.size() == 0)
+  {
+    _writeKvp("type", type.c_str());
+    _write(",");
+    _write("\"coordinates\": []");
+    return;
+  }
+  //  Update the geometry type if necessary
   if (temp_nodes.size() < 2 && type.compare("Point") != 0)
     type = "Point";
   if (temp_nodes.size() < 4 && type.compare("Polygon") == 0)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.cpp
@@ -227,7 +227,11 @@ void OsmJsonWriter::_writeTags(ConstElementPtr e)
   {
     for (Tags::const_iterator it = tags.constBegin(); it != tags.constEnd(); ++it)
     {
-      _writeTag(it.key(), it.value(), firstTag);
+      QString key = it.key();
+      QString value = it.value();
+      if (key == "uuid")
+        value = value.replace("{", "").replace("}", "");
+      _writeTag(key, value, firstTag);
     }
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -70,7 +70,7 @@ _useDataSourceId(false),
 _addSourceDateTime(ConfigOptions().getReaderAddSourceDatetime()),
 _inputCompressed(false),
 _preserveAllTags(ConfigOptions().getReaderPreserveAllTags()),
-_addChildRefsWhenMissing(false)
+_addChildRefsWhenMissing(ConfigOptions().getOsmMapReaderXmlAddChildRefsWhenMissing())
 {
 }
 

--- a/plugins/TranslationServer.js
+++ b/plugins/TranslationServer.js
@@ -21,6 +21,8 @@ var availableTranslations = [
 var HOOT_HOME = process.env.HOOT_HOME;
 if (typeof hoot === 'undefined') {
     hoot = require(HOOT_HOME + '/lib/HootJs');
+    hoot.Log.setLogLevel("warn");
+    hoot.Settings.set({"osm.map.reader.xml.add.child.refs.when.missing":"true"});
 }
 
 //Getting schema for fcode, geom type

--- a/plugins/test/runway.js
+++ b/plugins/test/runway.js
@@ -73,7 +73,7 @@ describe('TranslationServer', function () {
     });
 
 
-    it('should fail because it\'s missing node tags', function() {
+    it('should translate Runway (F_CODE=GB055) from osm -> tdsv61 even while missing nodes from the OSM', function() {
 
         var osm_xml = '<osm version="0.6" upload="true" generator="hootenanny">\
                         <way id="-19" action="modify" visible="true">\
@@ -93,15 +93,13 @@ describe('TranslationServer', function () {
             path: '/translateTo'
         });
 
-        console.log(tds_xml);
+        // console.log(tds_xml);
         
         xml = parser.parseFromString(tds_xml);
-        gj = osmtogeojson(xml);
 
         assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "TDSv61");
-
-        var tags = gj.features[0].properties;
-        assert.equal(tags["F_CODE"], 'GB055');
+        assert.equal(xml.getElementsByTagName("tag")[1].getAttribute("k"), "F_CODE");
+        assert.equal(xml.getElementsByTagName("tag")[1].getAttribute("v"), "GB055");
 
     });
 


### PR DESCRIPTION
Refs #2747 
The `OsmXmlReader` class was throwing out node elements referenced from ways that didn't exist in the OSM file so I set the translation server to set `_addChildRefsWhenMissing` to `true` always.  Also updated the JSON/GeoJSON writers to output correct JSON in these cases.  Finally updated the test to not use the `osmtogeojson` function when parsing "bad" GeoJSON.  Technically it is formed correctly but the `osmtogeojson` library doesn't play well with empty geometries.  Below is the output in GeoJSON from Hootenanny that it chokes on:
```
{
  "generator":"Hootenanny",
  "type":"FeatureCollection",
  "bbox":[ 0,0,0,0 ],
  "features":[
    {
      "type":"Feature",
      "properties":{
        "uuid":"b9efe238-98b6-445b-b4f1-b9d7647d94e4",
        "aeroway":"runway"
      },
      "geometry":{
        "type":"Polygon",
        "coordinates":[ ]
      }
    }
  ]
}
```