### PR TITLE
Fix when long builds skip the Sonar step

### DIFF
--- a/hoot-core/hoot-core.pro
+++ b/hoot-core/hoot-core.pro
@@ -38,6 +38,7 @@ OTHER_FILES = \
     $$files(../conf/schema/*.json, true) \
     $$files(../docs/*.asciidoc, true) \
     ../conf/core/ConfigOptions.asciidoc \
+    ../scripts/jenkins/Jenkinsfile
 
 include(../Configure.pri)
 

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -65,9 +65,7 @@ pipeline {
             when { 
                 anyOf {
                     expression { return params.Configure_Tests }
-                    // Work around to run certain tests during nightly cron triggers but not on commits to develop.  Logic can be udpated
-                    // once this https://issues.jenkins-ci.org/browse/JENKINS-41272 is implemented
-                    expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 } 
+                    triggeredBy 'cron'
                 }
             }
             steps {
@@ -81,7 +79,7 @@ pipeline {
                     expression { return params.Sonar }
                     changeRequest()
                     allOf {
-                        expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..22 }
+                        triggeredBy 'cron'
                         branch 'develop'
                     }
                 }
@@ -130,7 +128,7 @@ pipeline {
                     expression { return params.Sonar }
                     changeRequest()
                     allOf {
-                        expression { return Calendar.instance.get(Calendar.HOUR_OF_DAY) in 20..23 }
+                        triggeredBy 'cron'
                         branch 'develop'
                     }
                 }


### PR DESCRIPTION
Replaced time checks in Sonar steps with `triggeredBy` checks so that long builds don't cause Sonar to be skipped.
Explanation of the `triggeredBy` option:
https://jenkins.io/doc/book/pipeline/syntax/#when