### PR TITLE
Make some Singleton constructors private

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/Hoot.h
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.h
@@ -67,6 +67,7 @@ public:
   void reinit();
 
 private:
+
   static boost::shared_ptr<Hoot> _theInstance;
 
   Hoot();

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.h
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.h
@@ -42,7 +42,7 @@ namespace hoot
 {
 
 /**
- * A singleton to initialize hootenanny. You should call getInstance() on this before any other
+ * A Singleton to initialize hootenanny. You should call getInstance() on this before any other
  * use of hoot. You can call getInstance multiple times without any ill effects.
  */
 class Hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
@@ -40,10 +40,12 @@
 namespace hoot
 {
 
+/**
+ * (Singleton)
+ */
 class ProbabilityOfMatch
 {
 public:
-  ProbabilityOfMatch();
 
   static ProbabilityOfMatch& getInstance();
 
@@ -70,6 +72,9 @@ public:
   static bool debug;
 
 private:
+
+  ProbabilityOfMatch();
+
   static boost::shared_ptr<ProbabilityOfMatch> _theInstance;
   double _parallelExp;
   double _dMax;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MostEnglishName.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MostEnglishName.h
@@ -71,8 +71,6 @@ public:
 
   static unsigned int logWarnCount;
 
-  MostEnglishName();
-
   static const MostEnglishNamePtr& getInstance();
 
   /**
@@ -119,6 +117,14 @@ public:
   bool isEnglishText(const QString text);
 
 private:
+
+  // This class is unique in that it 1) is a Singleton, 2) is configurable, and 3) and gets called
+  // from hoot-js.  hoot-js isn't set up to treat treat configurable classes as Singletons, so
+  // so this is here to limit that calling behavior just to MostEnglishNameJs.  Possibly,
+  // MostEnglishNameJs could be changed to use it as a Singleton at some point.
+  friend class MostEnglishNameJs;
+
+  MostEnglishName();
 
   static MostEnglishNamePtr _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MostEnglishName.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MostEnglishName.h
@@ -49,8 +49,8 @@ class Tags;
 typedef boost::shared_ptr<MostEnglishName> MostEnglishNamePtr;
 
 /**
- * Return a best guess at the "most english" name in the list. There are no guarantees. This is
- * an ad-hoc routine that should be better than taking the first choice in most cases.
+ * Return a best guess at the "most english" name in the list (Singleton). There are no guarantees.
+ * This is an ad-hoc routine that should be better than taking the first choice in most cases.
  *
  * If there are no names then an empty string is returned.
  *

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
@@ -42,13 +42,11 @@ class AddressTagKeys;
 typedef boost::shared_ptr<AddressTagKeys> AddressTagKeysPtr;
 
 /**
- * Allows for mapping an address part type to a range of valid OSM tag keys
+ * Allows for mapping an address part type to a range of valid OSM tag keys (Singleton)
  */
 class AddressTagKeys
 {
 public:
-
-  AddressTagKeys();
 
   static const AddressTagKeysPtr& getInstance();
 
@@ -84,6 +82,8 @@ public:
   QSet<QString> getAdditionalTagKeys() const { return _additionalTagKeys; }
 
 private:
+
+  AddressTagKeys();
 
   friend class PoiPolygonAddressScoreExtractorTest;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -40,6 +40,9 @@ namespace hoot
 class Match;
 class MatchThreshold;
 
+/**
+ * (Singleton)
+ */
 class MatchFactory
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -44,8 +44,6 @@ class MatchFactory
 {
 public:
 
-  MatchFactory();
-
   ~MatchFactory();
 
   /**
@@ -100,6 +98,8 @@ public:
   long getMatchCandidateCount(const ConstOsmMapPtr& map, const geos::geom::Envelope& bounds);
 
 private:
+
+  MatchFactory();
 
   void _checkMatchCreatorBoundable(boost::shared_ptr<MatchCreator> matchCreator,
                                    const geos::geom::Envelope& bounds) const;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
@@ -46,7 +46,7 @@ class Match;
 class Merger;
 
 /**
- * A factory for creating a merge from a set of matches.
+ * A factory for creating a merge from a set of matches (Singleton).
  */
 class MergerFactory
 {
@@ -57,11 +57,6 @@ public:
   static unsigned int logWarnCount;
 
   static QString mergerCreatorsKey() { return "merger.creators"; }
-
-  /**
-   * A custom merge factory can be created or the global singleton can be used.
-   */
-  MergerFactory();
 
   ~MergerFactory();
 
@@ -101,6 +96,14 @@ public:
   void reset() { _creators.clear(); }
 
 private:
+
+  // Since this is a Singleton, we shouldn't be accessing its constructor, but there are a some
+  // spots where are.  This is here to limit any further constructor access.
+  friend class UnifyingConflator;
+  friend class MultiaryUtilities;
+
+  MergerFactory();
+
   static boost::shared_ptr<MergerFactory> _theInstance;
 
   std::vector<MergerCreator*> _creators;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h
@@ -34,14 +34,12 @@ namespace hoot
 {
 
 /**
- * Reads tag ignore lists for POI/Polygon conflation
+ * Reads tag ignore lists for POI/Polygon conflation (Singleton)
  */
 class PoiPolygonTagIgnoreListReader
 {
 
 public:
-
-  PoiPolygonTagIgnoreListReader();
 
   static PoiPolygonTagIgnoreListReader& getInstance();
 
@@ -49,6 +47,8 @@ public:
   QStringList getPolyTagIgnoreList() const { return _polyTagIgnoreList; }
 
 private:
+
+  PoiPolygonTagIgnoreListReader();
 
   static boost::shared_ptr<PoiPolygonTagIgnoreListReader> _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractor.cpp
@@ -27,7 +27,6 @@
 #include "PoiPolygonAddressScoreExtractor.h"
 
 // hoot
-#include <hoot/core/algorithms/string/MostEnglishName.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/extractors/PoiPolygonTypeScoreExtractor.cpp
@@ -27,7 +27,6 @@
 #include "PoiPolygonTypeScoreExtractor.h"
 
 // hoot
-#include <hoot/core/algorithms/string/MostEnglishName.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonDistanceTruthRecorder.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonNameScoreExtractor.h>
 #include <hoot/core/conflate/poi-polygon/extractors/PoiPolygonAddressScoreExtractor.h>

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -67,6 +67,9 @@ public:
   unsigned int _driverType;
 };
 
+/**
+ * (Singleton)
+ */
 class OgrUtilities
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.h
@@ -35,13 +35,11 @@ namespace hoot
 class OsmChangeWriter;
 
 /**
- * A factory for constructing changeset writers based on the URL.
+ * A factory for constructing changeset writers based on the URL (Singleton).
  */
 class OsmChangeWriterFactory
 {
 public:
-
-  OsmChangeWriterFactory();
 
   boost::shared_ptr<OsmChangeWriter> createWriter(
     QString url, QString elementPayloadFormat = "json");
@@ -51,6 +49,8 @@ public:
   static OsmChangeWriterFactory& getInstance();
 
 private:
+
+  OsmChangeWriterFactory();
 
   static boost::shared_ptr<OsmChangeWriterFactory> _theInstance;
 };

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
@@ -43,14 +43,12 @@ class OsmMap;
 class OsmMapReader;
 
 /**
- * A factory for constructing readers based on the URL.
+ * A factory for constructing readers based on the URL (Singleton).
  */
 class OsmMapReaderFactory
 {
 
 public:
-
-  OsmMapReaderFactory();
 
   boost::shared_ptr<OsmMapReader> createReader(QString url, bool useFileId = true,
                                                Status defaultStatus = Status::Invalid);
@@ -78,6 +76,8 @@ public:
   static bool isSupportedFormat(const QString url);
 
 private:
+
+  OsmMapReaderFactory();
 
   static boost::shared_ptr<OsmMapReaderFactory> _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.h
@@ -39,13 +39,11 @@ class OsmMap;
 class OsmMapWriter;
 
 /**
- * A factory for constructing writers based on the URL.
+ * A factory for constructing writers based on the URL (Singleton).
  */
 class OsmMapWriterFactory
 {
 public:
-
-  OsmMapWriterFactory();
 
   boost::shared_ptr<OsmMapWriter> createWriter(QString url);
 
@@ -60,6 +58,8 @@ public:
   static bool isSupportedFormat(const QString url);
 
 private:
+
+  OsmMapWriterFactory();
 
   static boost::shared_ptr<OsmMapWriterFactory> _theInstance;
 };

--- a/hoot-core/src/main/cpp/hoot/core/io/ScriptTranslatorFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ScriptTranslatorFactory.h
@@ -42,6 +42,9 @@ namespace hoot
 
 class ScriptTranslator;
 
+/**
+ * (Singleton)
+ */
 class ScriptTranslatorFactory
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/io/ScriptTranslatorFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ScriptTranslatorFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SCRIPTTRANSLATORFACTORY_H
 #define SCRIPTTRANSLATORFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/language/TranslateDictionary.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/TranslateDictionary.h
@@ -45,12 +45,12 @@ namespace hoot
 {
 
 /**
+ * (Singleton)
  */
 class TranslateDictionary
 {
 public:
 
-  TranslateDictionary();
   ~TranslateDictionary();
 
   static TranslateDictionary& getInstance();
@@ -68,6 +68,8 @@ public:
   bool transliterationCachingEnabled() const { return _transliterationCachingEnabled; }
 
 private:
+
+  TranslateDictionary();
 
   static boost::shared_ptr<TranslateDictionary> _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
@@ -249,7 +249,7 @@ class Relation;
 class Way;
 
 /**
- * This class is reentrant, but not thread safe.
+ * This class is reentrant, but not thread safe (Singleton).
  */
 class OsmSchema
 {

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
@@ -255,8 +255,6 @@ class OsmSchema
 {
 public:
 
-  OsmSchema();
-
   virtual ~OsmSchema();
 
   void addAssociatedWith(QString name1, QString name2);
@@ -412,6 +410,11 @@ public:
   bool containsTagFromList(const Tags& tags, const QStringList tagList) const;
 
 private:
+
+  friend class OsmSchemaTest;
+  friend class SchemaCheckerTest;
+
+  OsmSchema();
 
   // the templates we're including take a crazy long time to include, so I'm isolating the
   // implementation.

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.h
@@ -55,7 +55,8 @@ enum EdgeType
   CompoundComponent,
 };
 
-struct OsmSchemaCategory {
+struct OsmSchemaCategory
+{
   enum Type
   {
     Empty =           0x00,

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
@@ -40,16 +40,21 @@ namespace hoot
 
 class OsmSchemaLoader;
 
+/**
+ * (Singleton)
+ */
 class OsmSchemaLoaderFactory
 {
 public:
-  OsmSchemaLoaderFactory() {}
 
   static OsmSchemaLoaderFactory& getInstance();
 
   boost::shared_ptr<OsmSchemaLoader> createLoader(QString url);
 
 private:
+
+  OsmSchemaLoaderFactory() {}
+
   static boost::shared_ptr<OsmSchemaLoaderFactory> _theInstance;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMSCHEMALOADERFACTORY_H
 #define OSMSCHEMALOADERFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagComparator.h
@@ -44,11 +44,12 @@ namespace hoot
 
 class Tags;
 
+/**
+ * (Singleton)
+ */
 class TagComparator
 {
 public:
-
-  TagComparator();
 
   /**
    * @param keepAllUnknownTags If this is set to true then all unknown tags will simply be
@@ -132,6 +133,8 @@ public:
   void mergeText(Tags& t1, Tags& t2, Tags& result);
 
 private:
+
+  TagComparator();
 
   static boost::shared_ptr<TagComparator> _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef TAGMERGERFACTORY_H
 #define TAGMERGERFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
@@ -41,11 +41,12 @@ class TagMerger;
 class Tags;
 class ElementType;
 
+/**
+ * (Singleton)
+ */
 class TagMergerFactory
 {
 public:
-
-  TagMergerFactory();
 
   ~TagMergerFactory();
 
@@ -74,6 +75,9 @@ public:
   void reset();
 
 private:
+
+  TagMergerFactory();
+
   QHash<QString, boost::shared_ptr<const TagMerger> > _mergers;
   boost::shared_ptr<const TagMerger> _default;
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.h
@@ -95,6 +95,9 @@ private:
   std::string _name, _baseName;
 };
 
+/**
+ * (Singleton)
+ */
 class Factory
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -76,6 +76,8 @@ private:
 };
 
 /**
+ * (Singleton)
+ *
  * Cliff Notes for adding an exception:
  * 1. Add a HOOT_DEFINE_EXCEPTION[_STR] in your .h (possibly here).
  * 2. Add a HOOT_REGISTER_EXCEPTION in your .cpp (possibly HootException.cpp).

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -70,6 +70,7 @@ public:
   virtual const char* what() const throw() { _tmp = _what.toAscii(); return _tmp.constData(); }
 
 private:
+
   QString _what;
   mutable QByteArray _tmp;
 };
@@ -100,6 +101,9 @@ private:
 class HootExceptionThrower
 {
 public:
+
+  HootExceptionThrower() {}
+
   typedef void (*ThrowMethod)(HootException* e);
 
   static HootExceptionThrower& getInstance();
@@ -117,6 +121,7 @@ public:
   void rethrowPointer(HootException* e);
 
 private:
+
   QVector<ThrowMethod> _throwMethods;
   static HootExceptionThrower* _theInstance;
 };
@@ -129,6 +134,7 @@ template<class T>
 class AutoRegisterException
 {
 public:
+
   AutoRegisterException()
   {
     HootExceptionThrower::getInstance().registerException(tryThrow);

--- a/hoot-core/src/main/cpp/hoot/core/util/LibPostalInit.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/LibPostalInit.h
@@ -38,18 +38,19 @@ class LibPostalInit;
 typedef boost::shared_ptr<LibPostalInit> LibPostalInitPtr;
 
 /**
- * Singleton access for initializing/destroying libpostal
+ * Singleton access for initializing/destroying libpostal (Singleton)
  */
 class LibPostalInit
 {
 public:
 
-  LibPostalInit();
   ~LibPostalInit();
 
   static const LibPostalInitPtr& getInstance();
 
 private:
+
+  LibPostalInit();
 
   static LibPostalInitPtr _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -135,6 +135,7 @@ public:
   static std::string ellipsisStr(const std::string& str, uint count = 33);
 
 private:
+
   WarningLevel _level;
   static boost::shared_ptr<Log> _theInstance;
   static unsigned int _warnMessageLimit;
@@ -149,6 +150,7 @@ private:
 class DisableLog
 {
 public:
+
   DisableLog(Log::WarningLevel tmpLevel = Log::Error)
   {
     _oldLevel = Log::getInstance().getLevel();
@@ -168,6 +170,7 @@ public:
   }
 
 private:
+
   Log::WarningLevel _oldLevel;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -54,7 +54,7 @@ namespace hoot
 
 /**
  * This class is here to abstract out the logging interface. I only have mild confidence in log4cxx
- * and I don't really need all the complicated goodies.
+ * and I don't really need all the complicated goodies (Singleton).
  */
 class Log
 {

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef __MAP_PROJECTOR_H__
 #define __MAP_PROJECTOR_H__

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
@@ -56,6 +56,9 @@ namespace hoot
 
 class OsmMap;
 
+/**
+ * (Singleton)
+ */
 class MapProjector
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -43,7 +43,7 @@ namespace hoot
 {
 
 /**
- * Stores Hootenanny configuration options
+ * Stores Hootenanny configuration options (Singleton)
  *
  * This class favors convenience over performance so use it appropriately outside performance
  * critical code sections.
@@ -55,6 +55,12 @@ namespace hoot
 class Settings
 {
 public:
+
+  // Technically, this is a Singleton and this constructor should not be publicly accessible.  There
+  // does seem to be a use case for passing around temporary settings, though, which then makes
+  // sense for it to remain public.  Possibly, we need a separate class for HootSettings that would
+  // then be a true Singleton?
+  Settings();
 
   typedef QHash<QString, QVariant> SettingsMap;
 
@@ -157,8 +163,6 @@ public:
   QString toString() const;
 
 private:
-
-  Settings();
 
   static boost::shared_ptr<Settings> _theInstance;
   SettingsMap _settings;

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -58,8 +58,6 @@ public:
 
   typedef QHash<QString, QVariant> SettingsMap;
 
-  Settings();
-
   void append(const QString& key, const QStringList& values);
 
   /**
@@ -159,6 +157,8 @@ public:
   QString toString() const;
 
 private:
+
+  Settings();
 
   static boost::shared_ptr<Settings> _theInstance;
   SettingsMap _settings;

--- a/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
@@ -42,14 +42,13 @@ namespace hoot
 
 /**
  * A super simple wrapper around boost's object pool and shared pointers. This should provide
- * more efficient allocation/deleting when dealing with large numbers of elements. E.g. nodes.
+ * more efficient allocation/deleting when dealing with large numbers of elements (Singleton).
+ * E.g. nodes.
  */
 template <class T>
 class SharedPtrPool
 {
 public:
-
-  SharedPtrPool() {}
 
   boost::shared_ptr<T> allocate()
   {
@@ -62,6 +61,8 @@ public:
   static SharedPtrPool<T>& getInstance() { return _theInstance; }
 
 private:
+
+  SharedPtrPool() {}
 
   static SharedPtrPool<T> _theInstance;
   boost::fast_pool_allocator<T> _pool;

--- a/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SHAREDPTRPOOL_H
 #define SHAREDPTRPOOL_H

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
@@ -71,6 +71,9 @@ public:
   }
 };
 
+/**
+ * (Singleton)
+ */
 class JsRegistrar
 {
 public:

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
@@ -58,6 +58,7 @@ template<class T>
 class ClassInitializerTemplate : public ClassInitializer
 {
 public:
+
   ClassInitializerTemplate()
   {
   }
@@ -68,14 +69,11 @@ public:
   {
     T::Init(exports);
   }
-
-private:
 };
 
 class JsRegistrar
 {
 public:
-  JsRegistrar();
 
   static JsRegistrar& getInstance();
 
@@ -89,6 +87,8 @@ private:
 
   std::vector<boost::shared_ptr<ClassInitializer> > _initializers;
   static boost::shared_ptr<JsRegistrar> _theInstance;
+
+  JsRegistrar();
 };
 
 template<class T>

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/string/MostEnglishNameJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/string/MostEnglishNameJs.h
@@ -46,6 +46,7 @@ class OsmMapOperation;
 class MostEnglishNameJs : public node::ObjectWrap
 {
 public:
+
   static void Init(v8::Handle<v8::Object> target);
 
   MostEnglishNamePtr getPtr() { return _sd; }
@@ -53,6 +54,7 @@ public:
   static v8::Handle<v8::Object> New(const MostEnglishNamePtr& sd);
 
 private:
+
   MostEnglishNameJs();
   MostEnglishNameJs(MostEnglishNamePtr sd) { _sd = sd; }
   ~MostEnglishNameJs();

--- a/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.h
@@ -48,6 +48,7 @@ namespace hoot
 class TagsJs : public node::ObjectWrap
 {
 public:
+
   static void Init(v8::Handle<v8::Object> target);
 
   Tags& getTags() { return _tags; }
@@ -55,6 +56,7 @@ public:
   static v8::Handle<v8::Object> New(const Tags& t);
 
 private:
+
   TagsJs(ConstNodePtr n);
   TagsJs();
   ~TagsJs();

--- a/hoot-js/src/main/cpp/hoot/js/v8Engine.h
+++ b/hoot-js/src/main/cpp/hoot/js/v8Engine.h
@@ -33,8 +33,8 @@ namespace hoot
 {
 
 /**
- * A singleton to initialize v8 JavaScript library. You should call getInstance() on this before any other
- * use of v8Engine. You can call getInstance multiple times without any ill effects.
+ * A singleton to initialize v8 JavaScript library. You should call getInstance() on this before
+ * any other use of v8Engine. You can call getInstance multiple times without any ill effects.
  */
 class v8Engine
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
@@ -45,11 +45,13 @@ namespace hoot
 class SearchBoundsCalculator;
 
 /**
- * A simple class to represent relationships between nodes.
+ * A simple class to represent relationships between nodes (Singleton).
  */
 class MultiarySimpleMatch
 {
+
 public:
+
   MultiarySimpleMatch() {}
 
   MultiarySimpleMatch(int nIndex, double s) : neighborIndex(nIndex), score(s) {}
@@ -67,7 +69,9 @@ public:
  */
 class MultiaryElement
 {
+
 public:
+
   MultiaryElement() {}
 
 #ifndef SWIG
@@ -102,7 +106,9 @@ private:
  */
 class MultiaryUtilities
 {
+
 public:
+
 // OsmMap hasn't been wrapped, yet.
 #ifndef SWIG
   /**
@@ -140,6 +146,9 @@ public:
   static MultiaryUtilities& getInstance();
 
 private:
+
+  MultiaryUtilities() {}
+
   static boost::shared_ptr<MultiaryUtilities> _theInstance;
 
   boost::shared_ptr<SearchBoundsCalculator> _searchBoundsCalculator;

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
@@ -102,7 +102,7 @@ private:
 };
 
 /**
- * Centralize some operations that occur over and over when using Multiary Conflation.
+ * Centralize some operations that occur over and over when using Multiary Conflation (Singleton).
  */
 class MultiaryUtilities
 {

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef STXXL_H
 #define STXXL_H

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
@@ -38,7 +38,7 @@ namespace Tgs
 {
 
 /**
- * A convenience class for initializing STXXL in a multiple processes safe way.
+ * A convenience class for initializing STXXL in a multiple processes safe way (Singleton).
  */
 class Stxxl
 {

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
@@ -61,6 +61,7 @@ public:
   void setConfig(QString configFile);
 
 private:
+
   static boost::shared_ptr<Stxxl> _theInstance;
   QTemporaryFile _configFileTmp;
 


### PR DESCRIPTION
* All Singleton constructors are now private with the exception of Settings.
* Settings is instantiated for temporary use in a few places.  Its debatable whether a separate, non-Singleton class should be made for passing around temp settings instead.
* MostEnglishName's constructor is private but a friend addition was made to accommodate a constructor call from hoot-js.  Possibly, this access could be removed at some point.
* Similar to MostEnglishName, MergerFactory has situations where its constructor needs to be called externally.  I'm not sure if this can be changed w/o significant refactoring at this point.