### PR TITLE
Sick of always adding $(nproc) to every HootTest call

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -86,19 +86,19 @@ endif
 
 check: test
 test: build services-test plugins-test
-	bin/HootTest $(HOOT_TEST_DIFF) --slow --parallel $$(nproc)
+	bin/HootTest $(HOOT_TEST_DIFF) --slow --parallel
 
 docs: always HOOT_VERSION_FILE services-docs
 	echo Building documentation...
 	cd docs; $(MAKE)
 
 test-quick: build
-	bin/HootTest $(HOOT_TEST_DIFF) --quick --parallel $$(nproc)
+	bin/HootTest $(HOOT_TEST_DIFF) --quick --parallel
 
 test-all-core: services-test-all plugins-test
 	# Don't run services tests at the same time as glacial -- that may stomp
 	# on each other's DB changes.
-	bin/HootTest $(HOOT_TEST_DIFF) --glacial --parallel $$(nproc)
+	bin/HootTest $(HOOT_TEST_DIFF) --glacial --parallel
 
 test-all-no-core: services-test-all plugins-test
 	$(MAKE) ui-test ui2x-test
@@ -106,7 +106,7 @@ test-all-no-core: services-test-all plugins-test
 test-all: test-all-no-core
 	# Don't run services tests at the same time as glacial -- that may stomp
 	# on each other's DB changes.
-	bin/HootTest $(HOOT_TEST_DIFF) --glacial --parallel $$(nproc)
+	bin/HootTest $(HOOT_TEST_DIFF) --glacial --parallel
 
 licenses:
 	scripts/copyright/UpdateAllCopyrightHeaders.sh

--- a/docs/developer/HootenannyTests.asciidoc
+++ b/docs/developer/HootenannyTests.asciidoc
@@ -261,7 +261,9 @@ test routines. At this time the micro tests run as part of _quick_ and up.
 ==== Running Core Unit Tests in Parallel
 
 Hootenanny can run certain unit tests in parallel.  This is accomplished by `--parallel [n]` flag
-where `[n]` specifies the number of worker processes to spawn.
+where the optional `[n]` specifies the number of worker processes to spawn.  Leaving off the `[n]`
+parameter makes an implicit call to the operating system to get the total number of online processing units.
+(The same as +$(nproc)+ )
 
 --------------
 # Runs quick tests serially
@@ -272,10 +274,12 @@ HootTest --quick --parallel 2
 
 # Runs quick tests in parallel with one process per processing unit
 HootTest --quick --parallel $(nproc)
+# Or implicit call to nproc
+HootTest --quick --parallel
 --------------
 
-Initial testing shows using `$(nproc)` is the optimal setting for speed as any more than that causes
-processes to wait for significantly longer for CPU time and give no real benefit.
+Initial testing shows using `$(nproc)` or leaving the parameter empty is the optimal setting for speed
+as any more than that causes processes to wait for significantly longer for CPU time and give no real benefit.
 
 These worker processes are QProcess objects that spawn `HootTest --listen`.  This "listening" process
 accepts single unit test names (similar to `--single`) from standard in, runs the test and then sends

--- a/hoot-test/src/main/cpp/hoot/test/main.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/main.cpp
@@ -67,6 +67,7 @@ using namespace hoot;
 
 // Standard
 #include <iostream>
+#include <unistd.h>
 #include <vector>
 using namespace std;
 
@@ -572,16 +573,18 @@ int main(int argc, char *argv[])
     {
       double start = Tgs::Time::getTime();
 
+      int nproc = 1;
+      //  With no number after --parallel use the number of online processors
+      int nprocs_available = sysconf(_SC_NPROCESSORS_ONLN);
       int i = args.indexOf("--parallel") + 1;
       if (i >= args.size())
+        nproc = nprocs_available;
+      else
       {
-        throw HootException("Expected integer after --parallel.");
-      }
-      bool ok = false;
-      int nproc = args[i].toInt(&ok);
-      if (!ok || nproc < 1)
-      {
-        throw HootException("Expected integer after --parallel");
+        bool ok = false;
+        nproc = args[i].toInt(&ok);
+        if (!ok || nproc < 1)
+          nproc = nprocs_available;
       }
       ProcessPool pool(nproc, listener->getTestTimeout(),
                        (bool)args.contains("--names"),

--- a/scripts/TestConfigure.sh
+++ b/scripts/TestConfigure.sh
@@ -14,7 +14,7 @@ function build_notest {
 function build {
     make -s clean
     make -sj`nproc`
-    HootTest --quick --parallel $(nproc)
+    HootTest --quick --parallel
     make -s clean
 }
 

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
         stage("Core Tests") {
             when { expression { return params.Core_tests } }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel \$(nproc)'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel'"
             }
         }
         stage("Services Tests") {

--- a/scripts/jenkins/TestDevelop.sh
+++ b/scripts/jenkins/TestDevelop.sh
@@ -11,7 +11,7 @@ hoot version --debug
 export HOOT_TEST_DIFF=--diff
 # Run all of the tests - from the "test-all" target
 echo "Running core glacial tests..."
-bin/HootTest $HOOT_TEST_DIFF --glacial --parallel $(nproc)
+bin/HootTest $HOOT_TEST_DIFF --glacial --parallel
 
 echo "Running plugins tests..."
 make -sj`nproc` plugins-test

--- a/scripts/jenkins/TestInitialNightly.sh
+++ b/scripts/jenkins/TestInitialNightly.sh
@@ -14,7 +14,7 @@ make -sj`nproc` plugins-test
 export HOOT_TEST_DIFF=--diff
 # Running glacial tests here because we're not sure core-coverage runs them
 echo "Running glacial tests..."
-bin/HootTest $HOOT_TEST_DIFF --glacial --parallel $(nproc)
+bin/HootTest $HOOT_TEST_DIFF --glacial --parallel
 
 # This is done in VagrantBuild.sh
 # cd $HOOT_HOME/docs

--- a/scripts/jenkins/TestQuick.sh
+++ b/scripts/jenkins/TestQuick.sh
@@ -9,4 +9,4 @@ hoot version --debug
 
 export HOOT_TEST_DIFF=--diff
 make -s -f Makefile.hoot services-test-all
-HootTest --quick --parallel $(nproc)
+HootTest --quick --parallel

--- a/scripts/jenkins/centos67/TestPullRequest_core.sh
+++ b/scripts/jenkins/centos67/TestPullRequest_core.sh
@@ -18,5 +18,5 @@ HootTest --exclude=.*ConflateAverageTest.sh \
          --exclude=.*OsmApiDbHootApiDb.* \
          --exclude=.*MultiaryIngestCmd.* \
          --glacial \
-         --parallel $(nproc) \
+         --parallel \
          --diff


### PR DESCRIPTION
Removed the requirement to always provide a thread count to the `HootTest` executable with `--parallel`.  Now when a thread count is left off the test harness makes an implicit call to `nproc` (actually the equivalent from the `nproc` source code).