### PR TITLE
Lock Library Versions on Vagrant

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -54,15 +54,57 @@ if ! rpm -qa | grep -q ^yum-plugin-versionlock ; then
     # Install the versionlock plugin version first.
     sudo yum install -y yum-plugin-versionlock
 else
-    # Remove any NodeJS version locks to allow upgrading to $NODE_VERSION.
-    sudo yum versionlock delete nodejs nodejs-devel
+    # Remove any version locks to allow upgrading when versions have changed.
+    sudo yum versionlock delete \
+         geos \
+         geos-devel \
+         glpk \
+         glpk-devel \
+         hoot-gdal \
+         hoot-gdal-devel \
+         hoot-gdal-python \
+         liboauthcpp \
+         liboauthcpp-devel \
+         libphonenumber \
+         libphonenumber-devel \
+         nodejs \
+         nodejs-devel \
+         stxxl \
+         stxxl-devel
+
 fi
 
-echo "### Installing NodeJS ${NODE_VERSION}"
-sudo yum install -y nodejs-$NODE_VERSION nodejs-devel-$NODE_VERSION
+echo "### Installing libraries with locked versions"
+sudo yum install -y \
+     geos-$GEOS_VERSION \
+     geos-devel-$GEOS_VERSION \
+     glpk-$GLPK_VERSION \
+     glpk-devel-$GLPK_VERSION \
+     hoot-gdal-$GDAL_VERSION \
+     hoot-gdal-devel-$GDAL_VERSION \
+     hoot-gdal-python-$GDAL_VERSION \
+     libphonenumber-$LIBPHONENUMBER_VERSION \
+     libphonenumber-devel-$LIBPHONENUMBER_VERSION \
+     liboauthcpp-$LIBOAUTHCPP_VERSION \
+     liboauthcpp-devel-$LIBOAUTHCPP_VERSION \
+     nodejs-$NODE_VERSION \
+     nodejs-devel-$NODE_VERSION \
+     stxxl-$STXXL_VERSION \
+     stxxl-devel-$STXXL_VERSION
 
-echo "### Locking version of NodeJS"
-sudo yum versionlock add nodejs-$NODE_VERSION nodejs-devel-$NODE_VERSION
+echo "### Locking versions of libraries"
+sudo yum versionlock add \
+     geos-$GEOS_VERSION \
+     geos-devel-$GEOS_VERSION \
+     glpk-$GLPK_VERSION \
+     glpk-devel-$GLPK_VERSION \
+     hoot-gdal-$GDAL_VERSION \
+     hoot-gdal-devel-$GDAL_VERSION \
+     hoot-gdal-python-$GDAL_VERSION \
+     nodejs-$NODE_VERSION \
+     nodejs-devel-$NODE_VERSION \
+     stxxl-$STXXL_VERSION \
+     stxxl-devel-$STXXL_VERSION
 
 # install useful and needed packages for working with hootenanny
 echo "### Installing dependencies from repos..."
@@ -82,20 +124,11 @@ sudo yum -y install \
     gcc \
     gcc-c++ \
     gdb \
-    geos \
-    geos-devel \
     git \
     git-core \
-    glpk \
-    glpk-devel \
     gnuplot \
-    hoot-gdal \
-    hoot-gdal-devel \
-    hoot-gdal-python \
     lcov \
     libicu-devel \
-    liboauthcpp \
-    liboauthcpp-devel \
     libpng-devel \
     libtool \
     m4 \
@@ -109,7 +142,6 @@ sudo yum -y install \
     java-1.8.0-openjdk \
     perl-XML-LibXML \
     hoot-postgis24_95 \
-    libphonenumber-devel \
     libpostal-data \
     libpostal-devel \
     postgresql95 \
@@ -132,8 +164,6 @@ sudo yum -y install \
     qtwebkit \
     qtwebkit-devel \
     redhat-lsb-core \
-    stxxl \
-    stxxl-devel \
     swig \
     tex-fonts-hebrew \
     texlive \

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -101,6 +101,10 @@ sudo yum versionlock add \
      hoot-gdal-$GDAL_VERSION \
      hoot-gdal-devel-$GDAL_VERSION \
      hoot-gdal-python-$GDAL_VERSION \
+     libphonenumber-$LIBPHONENUMBER_VERSION \
+     libphonenumber-devel-$LIBPHONENUMBER_VERSION \
+     liboauthcpp-$LIBOAUTHCPP_VERSION \
+     liboauthcpp-devel-$LIBOAUTHCPP_VERSION \
      nodejs-$NODE_VERSION \
      nodejs-devel-$NODE_VERSION \
      stxxl-$STXXL_VERSION \

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -7,14 +7,19 @@ export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165b
 export JDK_TAR=jdk-8u161-linux-x64.tar.gz
 export JDK_MD5=99051574a0d90871ed24a91a5d321ed2
 
+# Dependency library versions.
 export GDAL_VERSION=2.1.4
+export GEOS_VERSION=3.6.2
+export GLPK_VERSION=4.64
+export LIBOAUTHCPP_VERSION=0.1.0
+export LIBPHONENUMBER_VERSION=8.9.16
+export NODE_VERSION=8.9.3
+export STXXL_VERSION=1.3.1
 
 # FGDB 1.5 is required to compile using g++ >= 5.1
 # https://trac.osgeo.org/gdal/wiki/FileGDB#HowtodealwithGCC5.1C11ABIonLinux
 export FGDB_VERSION=1.5.1
 export FGDB_URL=https://github.com/Esri/file-geodatabase-api/raw/master/FileGDB_API_${FGDB_VERSION}/
-
-export NODE_VERSION=8.9.3
 
 # Ruby versions and locations.
 export BUNDLER_VERSION=1.16.1
@@ -25,5 +30,3 @@ export RVM_BASE_URL=https://github.com/rvm/rvm
 export RVM_BINARIES_URL="${RUBY_BASE_URL}/binaries"
 export RVM_HOME="${RVM_HOME:-${HOME}/.rvm}"
 export RVM_VERSION=1.29.4
-
-export GLPK_VERSION=4.64


### PR DESCRIPTION
Fixes #2821, adds variables and locks versions for the following hoot libraries:

* `geos`
* `glpk`
* `hoot-gdal`
* `liboauthcpp`
* `libphonenumber`
* `stxxl`
