### PR TITLE
remove conflate post ops from default, update UI with +=

### DIFF
--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -454,24 +454,6 @@
         ]
     },
     {
-        "id":"hoot_post_conflation_options",
-        "elem_type":"group",
-        "description":"A list of map operations to be applied to a map after conflation has run",
-        "name":"Post Conlation Options",
-        "hoot_key":"conflate.post.ops",
-        "members":[
-
-            {
-                "id":"unknown_2_remover",
-                "elem_type":"checkbox",
-                "description":"Remove unmatched features in secondary dataset.",
-                "name":"Remove Unmatched Secondary Features",
-                "hoot_val":"hoot::RemoveUnknown2Visitor",
-                "defaultvalue":"false"
-            }
-        ]
-    },
-    {
         "id":"hoot_road_options",
         "elem_type":"group",
         "description":"Hootenanny road options",

--- a/conf/services/conflationAttributeOps.json
+++ b/conf/services/conflationAttributeOps.json
@@ -6,33 +6,7 @@
     "required":"true",
     "members": [
       {
-        "id": "attribute_override_conflate_enable_old_roads",
-        "elem_type": "bool",
-        "override":{
-                    "elem_type":"bool"
-                },
-        "description": "Disable the old road conflation. This is only necessary when using the `--conflate` command. See the _Command Line Reference_ for details on the `--conflate` command. By default the `--conflate` command will first conflate roads using the circa 2012 conflation algorithm and then conflate using the newer (circa 2014) unifying algorithm. If the unifying algorithm has road conflation enable then the results could get interesting.",
-        "name": "Conflate Enable Old Roads",
-        "defaultvalue": "false",
-        "hoot_key": "conflate.enable.old.roads",
-        "required":"true",
-        "members": [
-          {
-            "isDefault": "false",
-            "description": "Enable the old road conflation. This is only necessary when using the `--conflate` command. See the _Command Line Reference_ for details on the `--conflate` command",
-            "name": "true",
-            "hoot_val": "true"
-          },
-          {
-            "isDefault": "true",
-            "description": "Disable the old road conflation. This is only necessary when using the `--conflate` command. See the _Command Line Reference_ for details on the `--conflate` command",
-            "name": "false",
-            "hoot_val": "false"
-          }
-        ]
-      },
-      {
-        "id": "hoot_road_opt_engine",
+        "id": "attribute_override_hoot_road_opt_engine",
         "elem_type": "list",
         "description": "A list of road engines",
         "name": "Engines",


### PR DESCRIPTION
this has many more options not exposed to the ui
doesn't make sense to expose just this one
update UI to += conflate.post.ops