### PR TITLE
Unifying conflation changing direction of one way streets - Maldives

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwaySnapMerger.cpp
@@ -33,24 +33,26 @@
 #include <geos/geom/LineString.h>
 
 // hoot
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
+#include <hoot/core/algorithms/DirectionFinder.h>
+#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
 #include <hoot/core/algorithms/splitter/MultiLineStringSplitter.h>
+#include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
 #include <hoot/core/conflate/NodeToWayMap.h>
 #include <hoot/core/conflate/highway/HighwayMatch.h>
+#include <hoot/core/criterion/OneWayCriterion.h>
+#include <hoot/core/elements/ElementConverter.h>
 #include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
 #include <hoot/core/ops/RemoveReviewsByEidOp.h>
 #include <hoot/core/ops/ReplaceElementOp.h>
 #include <hoot/core/schema/TagMergerFactory.h>
-#include <hoot/core/elements/ElementConverter.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/Validate.h>
 #include <hoot/core/visitors/ElementOsmMapVisitor.h>
 #include <hoot/core/visitors/LengthOfWaysVisitor.h>
 #include <hoot/core/visitors/ExtractWaysVisitor.h>
-#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/ops/RemoveElementOp.h>
 
 // Qt
@@ -249,6 +251,9 @@ bool HighwaySnapMerger::_mergePair(const OsmMapPtr& map, ElementId eid1, Element
       boost::dynamic_pointer_cast<Way>(scraps1)->setPid(w1->getPid());
     if (scraps2 && scraps2->getElementType() == ElementType::Way)
       boost::dynamic_pointer_cast<Way>(scraps2)->setPid(w2->getPid());
+    // Reverse the way if w2 is one way and w1 isn't the similar direction as w2
+    if (OneWayCriterion().isSatisfied(w2) && !DirectionFinder::isSimilarDirection(map->shared_from_this(), w1, w2))
+      wMatch->reverseOrder();
   }
 
   LOG_VART(e1Match->getElementId());

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayTagOnlyMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayTagOnlyMerger.cpp
@@ -27,6 +27,8 @@
 #include "HighwayTagOnlyMerger.h"
 
 // hoot
+#include <hoot/core/algorithms/DirectionFinder.h>
+#include <hoot/core/criterion/OneWayCriterion.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
 #include <hoot/core/ops/ReplaceElementOp.h>
 #include <hoot/core/schema/TagMergerFactory.h>
@@ -89,6 +91,16 @@ bool HighwayTagOnlyMerger::_mergePair(const OsmMapPtr& map, ElementId eid1, Elem
       elementToRemove = e1;
     }
 
+    // Reverse the way if way to remove is one way and the two ways aren't similar directions
+    if (elementToKeep->getElementType() == ElementType::Way &&
+        elementToRemove->getElementType() == ElementType::Way)
+    {
+      WayPtr wayToKeep = boost::dynamic_pointer_cast<Way>(elementToKeep);
+      WayPtr wayToRemove = boost::dynamic_pointer_cast<Way>(elementToRemove);
+      if (OneWayCriterion().isSatisfied(wayToRemove) &&
+          !DirectionFinder::isSimilarDirection(map->shared_from_this(), wayToKeep, wayToRemove))
+        wayToKeep->reverseOrder();
+    }
     // There actually could be a relation in here, but the default tag merging doesn't use the
     // element type anyway, so not worrying about it for now.
     elementToKeep->setTags(


### PR DESCRIPTION
Refs #2884 
Added way reversal for one-way streets to prevent them from being merged in reverse order.