### PR TITLE
Prevent runaway interpolations during rubber sheeting

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3224,6 +3224,16 @@ met.  e.g less than rubber.sheet.minimum.ties tie points are found.  Otherwise, 
 statement will be logged instead.  This setting is completely ignored if
 rubber.sheet.fail.when.minimum.tie.points.not.found is set to true.
 
+=== rubber.sheet.max.interpolator.iterations
+
+* Data Type: int
+* Default Value: `200`
+
+The maximum number of interpolation optimization iterations, per optimization loop, an interpolator
+is allowed to run during rubber sheeting.  Use -1 for no iteration limit.  Not supported by all
+interpolators.  Can prevent runaway optimizations with some interpolators.  Lower values may result
+in the selection of a suboptimal interpolator.
+
 === rubber.sheet.minimum.ties
 
 * Data Type: int

--- a/conf/services/conflateAdvOps.json
+++ b/conf/services/conflateAdvOps.json
@@ -252,6 +252,16 @@
                 "name":"Minimum Ties Required",
                 "defaultvalue":"4",
                 "hoot_key":"rubber.sheet.minimum.ties"
+            },
+            {
+                "id":"rubber_sheet_max_interpolator_iterations",
+                "minvalue":"1",
+                "elem_type":"int",
+                "description":"The maximum number of interpolation optimization iterations, per optimization loop, an interpolator is allowed to run during rubber sheeting.  Use -1 for no iteration limit.  Not supported by all interpolators.  Can prevent runaway optimizations with some interpolators.  Lower values may result in the selection of a suboptimal interpolator.",
+                "maxvalue":"",
+                "name":"Max Interpolator Iterations",
+                "defaultvalue":"200",
+                "hoot_key":"rubber.sheet.max.interpolator.iterations"
             }
         ]
     },

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.cpp
@@ -112,6 +112,7 @@ void RubberSheet::_addIntersection(long nid, const set<long>& /*wids*/)
     if (aNeighbor->getStatus() == s && it != n2w->end() && it->second.size() >= 2)
     {
       double score = _nm.scorePair(nid, neighbors[i]);
+      LOG_VART(score);
 
       if (score > 0.0)
       {
@@ -240,6 +241,7 @@ boost::shared_ptr<DataFrame> RubberSheet::_buildDataFrame(Status s) const
       d[2] = _ties[i].dx() * multiplier;
       d[3] = _ties[i].dy() * multiplier;
     }
+    LOG_VART(d);
     df->addDataVector("", d);
   }
 
@@ -264,8 +266,19 @@ boost::shared_ptr<Interpolator> RubberSheet::_buildInterpolator(Status s) const
   boost::shared_ptr<Interpolator> bestCandidate;
   for (size_t i = 0; i < candidates.size(); i++)
   {
-    boost::shared_ptr<Interpolator> candidate(Factory::getInstance().constructObject<Interpolator>(
-      candidates[i]));
+    LOG_VARD(candidates[i]);
+    boost::shared_ptr<Interpolator> candidate(
+      Factory::getInstance().constructObject<Interpolator>(candidates[i]));
+    // Setting this upper limit prevents some runaway optimizations.  Those conditions should be
+    // fixed as part of #2893.  The default config value was determined in a way to be high enough
+    // so as not to affect existing tests, as well as accomodate a reasonable runtime based on the
+    // size of the dataset.  Some tweaking to the value may need to occur over time.
+    int maxOptIterations = ConfigOptions().getRubberSheetMaxInterpolatorIterations();
+    if (maxOptIterations == -1)
+    {
+      maxOptIterations = INT_MAX;
+    }
+    candidate->setMaxAllowedPerLoopOptimizationIterations(maxOptIterations);
     vector<string> ind;
     ind.push_back("x");
     ind.push_back("y");
@@ -283,6 +296,8 @@ boost::shared_ptr<Interpolator> RubberSheet::_buildInterpolator(Status s) const
       bestCandidate = candidate;
       bestError = error;
     }
+    LOG_DEBUG(
+      "Max interpolator loop iterations: " << candidate->getMaxOptimizationLoopIterations());
   }
 
   if (bestCandidate.get() == 0)
@@ -480,6 +495,7 @@ const RubberSheet::Match& RubberSheet::_findMatch(long nid1, long nid2)
 
   for (list<Match>::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
+    LOG_VART(it->nid2);
     if (it->nid2 == nid2)
     {
       return *it;
@@ -554,6 +570,7 @@ vector<double> RubberSheet::calculateTiePointDistances()
   for (vector<Tie>::const_iterator it = _ties.begin(); it != _ties.end(); ++it)
   {
     Tie tiePoint = *it;
+    LOG_TRACE(tiePoint.toString());
     tiePointDistances.push_back(tiePoint.c1.distance(tiePoint.c2));
   }
   return tiePointDistances;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef RUBBERSHEET_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.h
@@ -140,6 +140,7 @@ private:
   class Tie
   {
     public:
+
       // Unknown1 coordinate
       geos::geom::Coordinate c1;
       // Unknown2 coordinate
@@ -148,6 +149,8 @@ private:
       double dx() const { return c1.x - c2.x; }
 
       double dy() const { return c1.y - c2.y; }
+
+      QString toString() { return "dx: " + QString::number(dx()) + ", dy: " + QString::number(dy()); }
   };
 
   boost::shared_ptr<OsmMap> _map;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -403,7 +403,7 @@ bool OsmXmlReader::startElement(const QString & /* namespaceURI */,
       }
       else
       {
-        LOG_DEBUG("Node " << attributes.value("id") << " set to delete.");
+        LOG_TRACE("Node " << attributes.value("id") << " set to delete.");
         _element.reset();
       }
     }
@@ -415,7 +415,7 @@ bool OsmXmlReader::startElement(const QString & /* namespaceURI */,
       }
       else
       {
-        LOG_DEBUG("Way " << attributes.value("id") << " set to delete.");
+        LOG_TRACE("Way " << attributes.value("id") << " set to delete.");
         _element.reset();
       }
     }
@@ -427,7 +427,7 @@ bool OsmXmlReader::startElement(const QString & /* namespaceURI */,
       }
       else
       {
-        LOG_DEBUG("Relation " << attributes.value("id") << " set to delete.");
+        LOG_TRACE("Relation " << attributes.value("id") << " set to delete.");
         _element.reset();
       }
     }

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
@@ -46,7 +46,9 @@ using namespace std;
 namespace Tgs
 {
 
-BaseInterpolator::BaseInterpolator()
+BaseInterpolator::BaseInterpolator() :
+_maxAllowedPerLoopOptimizationIterations(INT_MAX),
+_iterations(0)
 {
 }
 

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "BaseInterpolator.h"
 

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef BASEINTERPOLATOR_H
 #define BASEINTERPOLATOR_H

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.h
@@ -39,6 +39,7 @@ class HilbertRTree;
 class BaseInterpolator : public Interpolator
 {
 public:
+
   BaseInterpolator();
 
   virtual ~BaseInterpolator() {}
@@ -55,7 +56,13 @@ public:
 
   virtual void writeInterpolator(QIODevice& os) const;
 
+  virtual void setMaxAllowedPerLoopOptimizationIterations(int maxIterations)
+  { _maxAllowedPerLoopOptimizationIterations = maxIterations; }
+
+  virtual int getMaxOptimizationLoopIterations() { return _iterations; }
+
 protected:
+
   std::vector<int> _indColumns;
   std::vector<std::string> _indColumnsLabels;
   mutable boost::shared_ptr<HilbertRTree> _index;
@@ -64,6 +71,8 @@ protected:
   // A temp variable used to return the result of interpolate()
   mutable std::vector<double> _result;
   boost::shared_ptr<const DataFrame> _df;
+  int _maxAllowedPerLoopOptimizationIterations;
+  mutable int _iterations;
 
   virtual void _buildModel() = 0;
 
@@ -88,7 +97,6 @@ protected:
    * The data frame and columns are serialized automatically.
    */
   virtual void _writeInterpolator(QIODevice& os) const = 0;
-
 };
 
 }

--- a/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "IdwInterpolator.h"
 

--- a/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef IDWINTERPOLATOR_H
 #define IDWINTERPOLATOR_H

--- a/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.h
@@ -43,6 +43,7 @@ namespace Tgs
 class IdwInterpolator : public BaseInterpolator
 {
 public:
+
   static std::string className() { return "Tgs::IdwInterpolator"; }
 
   /**
@@ -67,6 +68,7 @@ public:
   virtual std::string toString() const;
 
 protected:
+
   double _p;
   double _stopDelta;
 

--- a/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
@@ -93,7 +93,14 @@ public:
    */
   virtual void writeInterpolator(QIODevice& os) const = 0;
 
+  /**
+   * The max number of optimization loop iterations to allow per loop.  Some interplolators may
+   * take an extraordinary time to find a solution (or never find one).  This is meant to possibly
+   * be a temporary solution until such issues can be solved.  See hoot #2893.
+   */
+  virtual void setMaxAllowedPerLoopOptimizationIterations(int maxIterations) = 0;
 
+  virtual int getMaxOptimizationLoopIterations() = 0;
 };
 
 }

--- a/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef INTERPOLATOR_H
 #define INTERPOLATOR_H

--- a/tgs/src/main/cpp/tgs/Interpolation/KernelEstimationInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/KernelEstimationInterpolator.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "KernelEstimationInterpolator.h"
 


### PR DESCRIPTION
Adds a config option to cap per loop iterations for applicable interpolators during rubber sheeting