### PR TITLE
Fixed hoot command line parsing issue

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
@@ -465,6 +465,8 @@ void Settings::parseCommonArguments(QStringList& args)
   hootTestCmdsIgnore.append("--names");
   hootTestCmdsIgnore.append("--all-names");
   hootTestCmdsIgnore.append("--diff");
+  hootTestCmdsIgnore.append("--include");
+  hootTestCmdsIgnore.append("--exclude");
 
   const QString optionInputFormatErrorMsg =
     "define must takes the form key=value (or key+=value, key++=value, or key-=value).";
@@ -517,8 +519,7 @@ void Settings::parseCommonArguments(QStringList& args)
       args = args.mid(1);
     }
     //HootTest settings have already been parsed by this point
-    else if (hootTestCmdsIgnore.contains(args[0]) || args[0].contains("--include") ||
-             args[0].contains("--exclude"))
+    else if (hootTestCmdsIgnore.contains(args[0]))
     {
       args = args.mid(1);
     }


### PR DESCRIPTION
Fixed hoot test command parsing causing it to drop other command arguments in some cases 
Refs #2922 

This actually fixes the existing original issue since it no longer does a substring comparison.
However identical parameters (which don't exist at this time) could still be parsed out.