### PR TITLE
Performance fix

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateAreaVisitor.cpp
@@ -198,7 +198,8 @@ void RemoveDuplicateAreaVisitor::visit(const boost::shared_ptr<Element>& e1)
 
       // check to see if e2 is null, it is possible that we removed it w/ a previous call to remove
       // a parent.
-      if (e2 != 0 && areaCrit.isSatisfied(e2) && _equals(e1, e2))
+      // run _equals() first as it is much faster than isSatisfied() (which ends up doing lots of regex matching)
+      if (e2 != 0 && _equals(e1, e2) && areaCrit.isSatisfied(e2) )
       {
         LOG_TRACE("e2 is area and e1/e2 equal.");
         // remove the crummier one.


### PR DESCRIPTION
Refs #2742, removal time comes down to 00m24s from 03m25s 

This took a while for rearranging a single line, but I think I have a reasonable workflow now to track down these slowdowns.
I made an attempt to speed up the regex matching by using the boost version, but that was way slower and caused the tests to fail.
There is surely more to gain but I'm still trying to understand what the code is actually doing.