### PR TITLE
Change S3 Bucket for Support Files

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -494,13 +494,13 @@ conf/dictionary/words1.sqlite:
 	([ -e /tmp/words1.sqlite.bz2 ] && \
 	 test "`sha1sum /tmp/words1.sqlite.bz2`" == 'cdf47302fec4c8ec6c576849ae877feb1a9cf220  /tmp/words1.sqlite.bz2' && \
 	 bzcat /tmp/words1.sqlite.bz2 > conf/dictionary/words1.sqlite) || \
-	(wget --quiet -N -P /tmp/ https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2 && \
+	(wget --quiet -N -P /tmp/ https://s3.amazonaws.com/hoot-support/words1.sqlite.bz2 && \
 	 bzcat /tmp/words1.sqlite.bz2 > conf/dictionary/words1.sqlite) || \
 	echo "Failure downloading words1.sqlite. Build will continue, but conflation accuracy may suffer."
 
 hoot-services/src/main/resources/language-translation/langdetect-183.bin:
-	if [ ! -f $@ ]; then echo "Downloading OpenNLP language detection model..."; wget --quiet -O $@ https://s3.amazonaws.com/hoot-rpms/support-files/langdetect-183.bin; fi
-	test "`sha1sum hoot-services/src/main/resources/language-translation/langdetect-183.bin`" == 'be8bf56c1b8cb1ecddecc3009c7a3020f149987f  hoot-services/src/main/resources/language-translation/langdetect-183.bin' || echo "OpenNLP language detection not available due to failure downloading model."
+	if [ ! -f $@ ]; then echo "Downloading OpenNLP language detection model..."; wget --quiet -O $@ https://s3.amazonaws.com/hoot-support/langdetect-183.bin; fi
+	echo '2ddf585fac2e02a9dcfb9a4a9cc9417562eaac351be2efb506a2eaa87f19e9d4  hoot-services/src/main/resources/language-translation/langdetect-183.bin' | sha256sum -c || echo "OpenNLP language detection not available due to failure downloading model."
 
 bin/HootEnv.sh: scripts/HootEnv.sh
 	mkdir -p bin

--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3945,7 +3945,7 @@ Location of the word frequency dictionary. If the absolute file path isn't found
 the local `conf` and `$HOOT_HOME/conf` directories will be searched.
 
 This file is typically downloaded from:
-https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2
+https://s3.amazonaws.com/hoot-support/words1.sqlite.bz2
 
 === weighted.word.distance.probability
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/WeightedWordDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/WeightedWordDistance.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "WeightedWordDistance.h"
 
@@ -71,7 +71,7 @@ WeightedWordDistance::WeightedWordDistance()
   {
     LOG_WARN("Unable to locate words.sqlite. This should be downloaded during the make "
       "process. It can be manually downloaded from "
-      "https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2 "
+      "https://s3.amazonaws.com/hoot-support/words1.sqlite.bz2 "
       "or similar. You can also override the default name with the " +
       ConfigOptions().getWeightedWordDistanceDictionaryKey() + " config option.");
     dictPath = ConfPath::search(ConfigOptions().getWeightedWordDistanceAbridgedDictionary());

--- a/scripts/util/Centos7_only_core.sh
+++ b/scripts/util/Centos7_only_core.sh
@@ -29,8 +29,8 @@
 #
 # American-english-insane dictionary & words.sqlite. There isn't a package available for these so we use our own
 # copy stored on S3
-# https://s3.amazonaws.com/hoot-rpms/support-files/american-english-insane.bz2
-# https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2
+# https://s3.amazonaws.com/hoot-support/american-english-insane.bz2
+# https://s3.amazonaws.com/hoot-support/words1.sqlite.bz2
 #
 # Alternate Maven mirror for packages
 # https://repo.maven.apache.org/maven2
@@ -248,7 +248,7 @@ if [ ! -f /usr/share/dict/american-english-insane ]; then
     if [ -f /home/centos/hoot-deps/american-english-insane.bz2 ]
         sudo bash -c "bzcat /home/centos/hoot-deps/american-english-insane.bz2 > /usr/share/dict/american-english-insane"
     else
-        wget --quiet -N https://s3.amazonaws.com/hoot-rpms/support-files/american-english-insane.bz2
+        wget --quiet -N https://s3.amazonaws.com/hoot-support/american-english-insane.bz2
         sudo bash -c "bzcat american-english-insane.bz2 > /usr/share/dict/american-english-insane"
     fi
 fi

--- a/test-files/cmd/quick/ConfigOptionsCmdTest/ConfigOptions.asciidoc
+++ b/test-files/cmd/quick/ConfigOptionsCmdTest/ConfigOptions.asciidoc
@@ -3033,7 +3033,7 @@ Location of the word frequency dictionary. If the absolute file path isn't found
 the local `conf` and `$HOOT_HOME/conf` directories will be searched.
 
 This file is typically downloaded from:
-https://s3.amazonaws.com/hoot-rpms/support-files/words1.sqlite.bz2
+https://s3.amazonaws.com/hoot-support/words1.sqlite.bz2
 
 === weighted.word.distance.probability
 


### PR DESCRIPTION
Fixes #3002; refs ngageoint/hootenanny-rpms#250.  Use the `hoot-support` bucket instead of `hoot-rpms` for support files and improve verification of OpenNLP language file.