### PR TITLE
Prevent Attribute Conflation from dropping multipoly building relations in output

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -364,11 +364,13 @@ void ConflateCmd::_updateConfigOptionsForAttributeConflation()
     // are involved in reviews.
 
     QStringList postConflateOps = ConfigOptions().getConflatePostOps();
+    LOG_DEBUG("Post conflate ops before Attribute Conflation adjustment: " << postConflateOps);
     // Currently, all these things will be true if we're running Attribute Conflation, but I'm
     // specifying them anyway to harden this a bit.
     if (ConfigOptions().getBuildingOutlineUpdateOpRemoveBuildingRelations() &&
         postConflateOps.contains("hoot::RemoveElementsVisitor") &&
-        ConfigOptions().getRemoveElementsVisitorElementCriterion() == "hoot::ReviewRelationCriterion" &&
+        ConfigOptions().getRemoveElementsVisitorElementCriterion() ==
+          "hoot::ReviewRelationCriterion" &&
         postConflateOps.contains("hoot::BuildingOutlineUpdateOp"))
     {
       const int removeElementsVisIndex = postConflateOps.indexOf("hoot::RemoveElementsVisitor");
@@ -388,7 +390,10 @@ void ConflateCmd::_updateConfigOptionsForAttributeConflation()
       conf().set(
         ConfigOptions::getRemoveElementsVisitorElementCriterionKey(), "hoot::ReviewScoreCriterion");
     }
-    LOG_VARD(conf().get(ConfigOptions::getRemoveElementsVisitorElementCriterionKey()));
+
+    LOG_DEBUG(
+      "Post conflate ops after Attribute Conflation adjustment: " <<
+      conf().get("conflate.post.ops").toStringList());
   }
 }
 

--- a/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Expected.osm
@@ -1,0 +1,771 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="10.24470824009" minlon="-67.59244220783999" maxlat="10.24774693597" maxlon="-67.59026216936"/>
+    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455528500799975" lon="-67.5919206810900022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-129"/>
+    </node>
+    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454282894799977" lon="-67.5912685530000061">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-128"/>
+    </node>
+    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454490062699985" lon="-67.5912645195400046">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-127"/>
+    </node>
+    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453964175100012" lon="-67.5909891965900016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-126"/>
+    </node>
+    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452861327500013" lon="-67.5910106688100001">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-125"/>
+    </node>
+    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453365262600009" lon="-67.5912744966200023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-124"/>
+    </node>
+    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453086517699994" lon="-67.5912799231300028">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-123"/>
+    </node>
+    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453559615100005" lon="-67.5915276081099989">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-122"/>
+    </node>
+    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453145045600014" lon="-67.5915356795299829">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-121"/>
+    </node>
+    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452844321300010" lon="-67.5913782379199972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-120"/>
+    </node>
+    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2451705680700016" lon="-67.5914004070999965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-119"/>
+    </node>
+    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452809193800007" lon="-67.5919781423800003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-118"/>
+    </node>
+    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453176216100008" lon="-67.5919709963600042">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-117"/>
+    </node>
+    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453231524400010" lon="-67.5919999554299977">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-116"/>
+    </node>
+    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453901852099989" lon="-67.5919869044700050">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-115"/>
+    </node>
+    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453839690899979" lon="-67.5919543607100053">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-114"/>
+    </node>
+    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454023251600024" lon="-67.5919507867999982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-113"/>
+    </node>
+    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453825373700003" lon="-67.5918471893999993">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-112"/>
+    </node>
+    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454384248399997" lon="-67.5918363084999925">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-111"/>
+    </node>
+    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454580651399993" lon="-67.5919391351799987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-110"/>
+    </node>
+    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2451024947799993" lon="-67.5918882335599989">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-109"/>
+    </node>
+    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450982796600023" lon="-67.5918428087999956">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-108"/>
+    </node>
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450101613900024" lon="-67.5918511437200067">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-107"/>
+    </node>
+    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450143774100013" lon="-67.5918965693699931">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-106"/>
+    </node>
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457179799999984" lon="-67.5918839275999943">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-105"/>
+    </node>
+    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455272814599994" lon="-67.5909240299200036">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-104"/>
+    </node>
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454290602000011" lon="-67.5909439202300035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-103"/>
+    </node>
+    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456197587400002" lon="-67.5919038179099942">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-102"/>
+    </node>
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456772542000003" lon="-67.5908318952800045">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-101"/>
+    </node>
+    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457106010600025" lon="-67.5908259075900020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-100"/>
+    </node>
+    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457023785600008" lon="-67.5907792282799846">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-99"/>
+    </node>
+    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456690317000021" lon="-67.5907852159599969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-98"/>
+    </node>
+    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456648147799996" lon="-67.5907612778100031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-97"/>
+    </node>
+    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454878578800006" lon="-67.5907930508600003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-96"/>
+    </node>
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455059063699991" lon="-67.5908955160199838">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-95"/>
+    </node>
+    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456828641700000" lon="-67.5908637429700008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-94"/>
+    </node>
+    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458831827599983" lon="-67.5918641263299946">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-93"/>
+    </node>
+    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456876998300022" lon="-67.5908899456099874">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-92"/>
+    </node>
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455775841400030" lon="-67.5909124682400062">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-91"/>
+    </node>
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457730670699991" lon="-67.5918866498499966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-90"/>
+    </node>
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2461908111599982" lon="-67.5917447620099949">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-89"/>
+    </node>
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2460060184599975" lon="-67.5907854327000024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-88"/>
+    </node>
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2459004956099999" lon="-67.5908061521799937">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-87"/>
+    </node>
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2460852883099971" lon="-67.5917654805899986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-86"/>
+    </node>
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463518410599992" lon="-67.5917154432100062">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-85"/>
+    </node>
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2461634978500005" lon="-67.5907543413400020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-84"/>
+    </node>
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2460479232700017" lon="-67.5907774269399795">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-83"/>
+    </node>
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2462362664899977" lon="-67.5917385288099979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-82"/>
+    </node>
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465183073699979" lon="-67.5917147084699934">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-81"/>
+    </node>
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464801887100005" lon="-67.5915003181900005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-80"/>
+    </node>
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463735210200007" lon="-67.5915196509100014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-79"/>
+    </node>
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464116396900007" lon="-67.5917340402900066">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-78"/>
+    </node>
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466811386200014" lon="-67.5916925329800051">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-77"/>
+    </node>
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464927333499993" lon="-67.5907171264900057">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-76"/>
+    </node>
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463910964699991" lon="-67.5907371382100024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-75"/>
+    </node>
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465795017399994" lon="-67.5917125447000018">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-74"/>
+    </node>
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467138919299963" lon="-67.5910773220600021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-73"/>
+    </node>
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466343756799976" lon="-67.5907093491599937">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-72"/>
+    </node>
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465580349300005" lon="-67.5907261646800066">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-71"/>
+    </node>
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466375520799993" lon="-67.5910941375800007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-70"/>
+    </node>
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2471659199699996" lon="-67.5915866899699864">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-69"/>
+    </node>
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470590193600017" lon="-67.5910293099500024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-68"/>
+    </node>
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469525531199999" lon="-67.5910501238600006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-67"/>
+    </node>
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470594546299996" lon="-67.5916075038799988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-66"/>
+    </node>
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469422819600009" lon="-67.5915351444299972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-65"/>
+    </node>
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470418432100008" lon="-67.5915156803999935">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-64"/>
+    </node>
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470270376699997" lon="-67.5914384843999869">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-63"/>
+    </node>
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469274764199980" lon="-67.5914579493200023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-62"/>
+    </node>
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469574004599995" lon="-67.5916139709099895">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-61"/>
+    </node>
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470569617100011" lon="-67.5915945068799999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-60"/>
+    </node>
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467914584600006" lon="-67.5910779066200007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-59"/>
+    </node>
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467820632399995" lon="-67.5910347850300042">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-58"/>
+    </node>
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467163623699999" lon="-67.5910493765299947">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-57"/>
+    </node>
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467257575899993" lon="-67.5910924981200054">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-56"/>
+    </node>
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458232240600005" lon="-67.5908547533399968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-55"/>
+    </node>
+    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458117666999993" lon="-67.5908091055599982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-54"/>
+    </node>
+    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457548090400010" lon="-67.5908236781699969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-53"/>
+    </node>
+    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457662664000004" lon="-67.5908693259600000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-52"/>
+    </node>
+    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467481821799993" lon="-67.5908972939700021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-51"/>
+    </node>
+    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467397195600025" lon="-67.5908419865699983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-50"/>
+    </node>
+    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466790548900004" lon="-67.5908514474400022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-49"/>
+    </node>
+    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466875175100025" lon="-67.5909067557399936">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-48"/>
+    </node>
+    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465167272700004" lon="-67.5902785217400037">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-47"/>
+    </node>
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465190331300029" lon="-67.5902904818200057">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-46"/>
+    </node>
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452717121199974" lon="-67.5905355695600036">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-45"/>
+    </node>
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2447082400900005" lon="-67.5918273647399985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-44"/>
+    </node>
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2447957603199988" lon="-67.5923359772200030">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-43"/>
+    </node>
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449746129899975" lon="-67.5924422078399942">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-42"/>
+    </node>
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450295201999992" lon="-67.5924347875400002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-41"/>
+    </node>
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450275308999998" lon="-67.5924197778499831">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-40"/>
+    </node>
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464631267699993" lon="-67.5921367648000029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-39"/>
+    </node>
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464607120900002" lon="-67.5921242831099960">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-38"/>
+    </node>
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476332364800005" lon="-67.5918931294600043">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-37"/>
+    </node>
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477469359699978" lon="-67.5917258528699847">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-36"/>
+    </node>
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477389679799984" lon="-67.5916769450300023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-35"/>
+    </node>
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477275564800028" lon="-67.5916788408100047">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-34"/>
+    </node>
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477069089500006" lon="-67.5915521083399966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-33"/>
+    </node>
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477212675199993" lon="-67.5915497242399965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-32"/>
+    </node>
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477059655599980" lon="-67.5914557999499834">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-31"/>
+    </node>
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476835202800007" lon="-67.5914595276399979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-30"/>
+    </node>
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476468998799959" lon="-67.5912347519799965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-29"/>
+    </node>
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476181737399994" lon="-67.5911991990799805">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-28"/>
+    </node>
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466139484699994" lon="-67.5902621693600025">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-27"/>
+    </node>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450212230499975" lon="-67.5916578335399976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-26"/>
+    </node>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449718628599999" lon="-67.5916367336500059">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-25"/>
+    </node>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453800012900000" lon="-67.5906785383799900">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-24"/>
+    </node>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458482863700020" lon="-67.5905748834200040">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-23"/>
+    </node>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458527793799981" lon="-67.5905955768199931">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-22"/>
+    </node>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2459350196900001" lon="-67.5905773727500048">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-21"/>
+    </node>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2459333694300021" lon="-67.5905697716799949">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-20"/>
+    </node>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465866972199997" lon="-67.5904251571000003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-19"/>
+    </node>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466356365299998" lon="-67.5904784904899998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-18"/>
+    </node>
+    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466065947199994" lon="-67.5905056545099825">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-17"/>
+    </node>
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466811017499992" lon="-67.5905868524999960">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-16"/>
+    </node>
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467087586000005" lon="-67.5905609843999997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-15"/>
+    </node>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2474966015899991" lon="-67.5913090575700011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-14"/>
+    </node>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2475753228400013" lon="-67.5916866181400025">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-13"/>
+    </node>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2475404129599976" lon="-67.5917431809999982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-12"/>
+    </node>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463518509599982" lon="-67.5919804815100065">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-11"/>
+    </node>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463533600200023" lon="-67.5919881869100010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-10"/>
+    </node>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450073618000008" lon="-67.5922569169199932">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-9"/>
+    </node>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449458931399988" lon="-67.5922234432599964">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-8"/>
+    </node>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2448848975200004" lon="-67.5918525250699957">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-7"/>
+    </node>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449035971200004" lon="-67.5917971250400029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-6"/>
+    </node>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449538062699990" lon="-67.5918185882599971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-5"/>
+    </node>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464099381700002" lon="-67.5912184508700022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-4"/>
+    </node>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464036087399997" lon="-67.5911761647499958">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-3"/>
+    </node>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463481691300018" lon="-67.5911846246700065">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-2"/>
+    </node>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463544994599989" lon="-67.5912269107899988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-1"/>
+    </node>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-129"/>
+        <nd ref="-128"/>
+        <nd ref="-127"/>
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-123"/>
+        <nd ref="-122"/>
+        <nd ref="-121"/>
+        <nd ref="-120"/>
+        <nd ref="-119"/>
+        <nd ref="-118"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-115"/>
+        <nd ref="-114"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-110"/>
+        <nd ref="-129"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-19"/>
+    </way>
+    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-109"/>
+        <nd ref="-108"/>
+        <nd ref="-107"/>
+        <nd ref="-106"/>
+        <nd ref="-109"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-18"/>
+    </way>
+    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-105"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-102"/>
+        <nd ref="-105"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-17"/>
+    </way>
+    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-99"/>
+        <nd ref="-98"/>
+        <nd ref="-97"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-101"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-16"/>
+    </way>
+    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-93"/>
+        <nd ref="-92"/>
+        <nd ref="-91"/>
+        <nd ref="-90"/>
+        <nd ref="-93"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-15"/>
+    </way>
+    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-89"/>
+        <nd ref="-88"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-89"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-14"/>
+    </way>
+    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-85"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-13"/>
+    </way>
+    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-81"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-12"/>
+    </way>
+    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-77"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-11"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-73"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-10"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-69"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-9"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-65"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-8"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-64"/>
+        <nd ref="-65"/>
+        <nd ref="-61"/>
+        <nd ref="-60"/>
+        <nd ref="-64"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-7"/>
+    </way>
+    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
+        <nd ref="-59"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-6"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-55"/>
+        <nd ref="-54"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-55"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-5"/>
+    </way>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-51"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <nd ref="-48"/>
+        <nd ref="-51"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-4"/>
+    </way>
+    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-44"/>
+        <nd ref="-43"/>
+        <nd ref="-42"/>
+        <nd ref="-41"/>
+        <nd ref="-40"/>
+        <nd ref="-39"/>
+        <nd ref="-38"/>
+        <nd ref="-37"/>
+        <nd ref="-36"/>
+        <nd ref="-35"/>
+        <nd ref="-34"/>
+        <nd ref="-33"/>
+        <nd ref="-32"/>
+        <nd ref="-31"/>
+        <nd ref="-30"/>
+        <nd ref="-29"/>
+        <nd ref="-28"/>
+        <nd ref="-27"/>
+        <nd ref="-47"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-3"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-25"/>
+        <nd ref="-24"/>
+        <nd ref="-23"/>
+        <nd ref="-22"/>
+        <nd ref="-21"/>
+        <nd ref="-20"/>
+        <nd ref="-19"/>
+        <nd ref="-18"/>
+        <nd ref="-17"/>
+        <nd ref="-16"/>
+        <nd ref="-15"/>
+        <nd ref="-14"/>
+        <nd ref="-13"/>
+        <nd ref="-12"/>
+        <nd ref="-11"/>
+        <nd ref="-10"/>
+        <nd ref="-9"/>
+        <nd ref="-8"/>
+        <nd ref="-7"/>
+        <nd ref="-6"/>
+        <nd ref="-5"/>
+        <nd ref="-26"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-2"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-4"/>
+        <nd ref="-3"/>
+        <nd ref="-2"/>
+        <nd ref="-1"/>
+        <nd ref="-4"/>
+        <tag k="building" v="yes"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-1"/>
+    </way>
+    <relation visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="way" ref="-3" role="outer"/>
+        <member type="way" ref="-2" role="inner"/>
+        <tag k="building" v="yes"/>
+        <tag k="type" v="multipolygon"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-4"/>
+    </relation>
+</osm>

--- a/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Input1.osm
+++ b/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Input1.osm
@@ -1,0 +1,356 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <bounds minlat='10.244633' minlon='-67.5931' maxlat='10.2485' maxlon='-67.5893' origin='hootenanny' />
+  <node id='-18509452' visible='true' lat='10.24635449946' lon='-67.59122691079' />
+  <node id='-18509454' visible='true' lat='10.24634816913' lon='-67.59118462467' />
+  <node id='-18509456' visible='true' lat='10.24640360874' lon='-67.59117616475' />
+  <node id='-18509458' visible='true' lat='10.24640993817' lon='-67.59121845087' />
+  <node id='-18509536' visible='true' lat='10.24495380627' lon='-67.59181858826' />
+  <node id='-18509538' visible='true' lat='10.24490359712' lon='-67.59179712504' />
+  <node id='-18509540' visible='true' lat='10.24488489752' lon='-67.59185252507' />
+  <node id='-18509542' visible='true' lat='10.24494589314' lon='-67.59222344326' />
+  <node id='-18509544' visible='true' lat='10.2450073618' lon='-67.59225691692' />
+  <node id='-18509546' visible='true' lat='10.24635336002' lon='-67.59198818691' />
+  <node id='-18509548' visible='true' lat='10.24635185096' lon='-67.59198048151' />
+  <node id='-18509550' visible='true' lat='10.24754041296' lon='-67.591743181' />
+  <node id='-18509552' visible='true' lat='10.24757532284' lon='-67.59168661814' />
+  <node id='-18509554' visible='true' lat='10.24749660159' lon='-67.59130905757' />
+  <node id='-18509556' visible='true' lat='10.2467087586' lon='-67.5905609844' />
+  <node id='-18509558' visible='true' lat='10.24668110175' lon='-67.5905868525' />
+  <node id='-18509560' visible='true' lat='10.24660659472' lon='-67.59050565451' />
+  <node id='-18509562' visible='true' lat='10.24663563653' lon='-67.59047849049' />
+  <node id='-18509564' visible='true' lat='10.24658669722' lon='-67.5904251571' />
+  <node id='-18509566' visible='true' lat='10.24593336943' lon='-67.59056977168' />
+  <node id='-18509568' visible='true' lat='10.24593501969' lon='-67.59057737275' />
+  <node id='-18509570' visible='true' lat='10.24585277938' lon='-67.59059557682' />
+  <node id='-18509572' visible='true' lat='10.24584828637' lon='-67.59057488342' />
+  <node id='-18509574' visible='true' lat='10.24538000129' lon='-67.59067853838' />
+  <node id='-18509576' visible='true' lat='10.24497186286' lon='-67.59163673365' />
+  <node id='-18509578' visible='true' lat='10.24502122305' lon='-67.59165783354' />
+  <node id='-18509580' visible='true' lat='10.24661394847' lon='-67.59026216936' />
+  <node id='-18509582' visible='true' lat='10.24761817374' lon='-67.59119919908' />
+  <node id='-18509584' visible='true' lat='10.24764689988' lon='-67.59123475198' />
+  <node id='-18509586' visible='true' lat='10.24768352028' lon='-67.59145952764' />
+  <node id='-18509588' visible='true' lat='10.24770596556' lon='-67.59145579995' />
+  <node id='-18509590' visible='true' lat='10.24772126752' lon='-67.59154972424' />
+  <node id='-18509592' visible='true' lat='10.24770690895' lon='-67.59155210834' />
+  <node id='-18509594' visible='true' lat='10.24772755648' lon='-67.59167884081' />
+  <node id='-18509596' visible='true' lat='10.24773896798' lon='-67.59167694503' />
+  <node id='-18509598' visible='true' lat='10.24774693597' lon='-67.59172585287' />
+  <node id='-18509600' visible='true' lat='10.24763323648' lon='-67.59189312946' />
+  <node id='-18509602' visible='true' lat='10.24646071209' lon='-67.59212428311' />
+  <node id='-18509604' visible='true' lat='10.24646312677' lon='-67.5921367648' />
+  <node id='-18509606' visible='true' lat='10.2450275309' lon='-67.59241977785' />
+  <node id='-18509608' visible='true' lat='10.2450295202' lon='-67.59243478754' />
+  <node id='-18509610' visible='true' lat='10.24497461299' lon='-67.59244220784' />
+  <node id='-18509612' visible='true' lat='10.24479576032' lon='-67.59233597722' />
+  <node id='-18509614' visible='true' lat='10.24470824009' lon='-67.59182736474' />
+  <node id='-18509616' visible='true' lat='10.24527171212' lon='-67.59053556956' />
+  <node id='-18509618' visible='true' lat='10.24651903313' lon='-67.59029048182' />
+  <node id='-18509620' visible='true' lat='10.24651672727' lon='-67.59027852174' />
+  <node id='-18509622' visible='true' lat='10.24668751751' lon='-67.59090675574' />
+  <node id='-18509624' visible='true' lat='10.24667905489' lon='-67.59085144744' />
+  <node id='-18509626' visible='true' lat='10.24673971956' lon='-67.59084198657' />
+  <node id='-18509628' visible='true' lat='10.24674818218' lon='-67.59089729397' />
+  <node id='-18509630' visible='true' lat='10.2457662664' lon='-67.59086932596' />
+  <node id='-18509632' visible='true' lat='10.24575480904' lon='-67.59082367817' />
+  <node id='-18509634' visible='true' lat='10.2458117667' lon='-67.59080910556' />
+  <node id='-18509636' visible='true' lat='10.24582322406' lon='-67.59085475334' />
+  <node id='-18509638' visible='true' lat='10.24672575759' lon='-67.59109249812' />
+  <node id='-18509640' visible='true' lat='10.24671636237' lon='-67.59104937653' />
+  <node id='-18509642' visible='true' lat='10.24678206324' lon='-67.59103478503' />
+  <node id='-18509644' visible='true' lat='10.24679145846' lon='-67.59107790662' />
+  <node id='-18509810' visible='true' lat='10.24705696171' lon='-67.59159450688' />
+  <node id='-18509812' visible='true' lat='10.24695740046' lon='-67.59161397091' />
+  <node id='-18509814' visible='true' lat='10.24692747642' lon='-67.59145794932' />
+  <node id='-18509816' visible='true' lat='10.24702703767' lon='-67.5914384844' />
+  <node id='-18509818' visible='true' lat='10.24704184321' lon='-67.5915156804' />
+  <node id='-18509820' visible='true' lat='10.24694228196' lon='-67.59153514443' />
+  <node id='-18509822' visible='true' lat='10.24705945463' lon='-67.59160750388' />
+  <node id='-18509824' visible='true' lat='10.24695255312' lon='-67.59105012386' />
+  <node id='-18509826' visible='true' lat='10.24705901936' lon='-67.59102930995' />
+  <node id='-18509828' visible='true' lat='10.24716591997' lon='-67.59158668997' />
+  <node id='-18509830' visible='true' lat='10.24663755208' lon='-67.59109413758' />
+  <node id='-18509832' visible='true' lat='10.24655803493' lon='-67.59072616468' />
+  <node id='-18509834' visible='true' lat='10.24663437568' lon='-67.59070934916' />
+  <node id='-18509836' visible='true' lat='10.24671389193' lon='-67.59107732206' />
+  <node id='-18509838' visible='true' lat='10.24657950174' lon='-67.5917125447' />
+  <node id='-18509840' visible='true' lat='10.24639109647' lon='-67.59073713821' />
+  <node id='-18509842' visible='true' lat='10.24649273335' lon='-67.59071712649' />
+  <node id='-18509844' visible='true' lat='10.24668113862' lon='-67.59169253298' />
+  <node id='-18509846' visible='true' lat='10.24641163969' lon='-67.59173404029' />
+  <node id='-18509848' visible='true' lat='10.24637352102' lon='-67.59151965091' />
+  <node id='-18509850' visible='true' lat='10.24648018871' lon='-67.59150031819' />
+  <node id='-18509852' visible='true' lat='10.24651830737' lon='-67.59171470847' />
+  <node id='-18509862' visible='true' lat='10.24623626649' lon='-67.59173852881' />
+  <node id='-18509864' visible='true' lat='10.24604792327' lon='-67.59077742694' />
+  <node id='-18509866' visible='true' lat='10.24616349785' lon='-67.59075434134' />
+  <node id='-18509868' visible='true' lat='10.24635184106' lon='-67.59171544321' />
+  <node id='-18509870' visible='true' lat='10.24608528831' lon='-67.59176548059' />
+  <node id='-18509872' visible='true' lat='10.24590049561' lon='-67.59080615218' />
+  <node id='-18509874' visible='true' lat='10.24600601846' lon='-67.5907854327' />
+  <node id='-18509876' visible='true' lat='10.24619081116' lon='-67.59174476201' />
+  <node id='-18509878' visible='true' lat='10.24577306707' lon='-67.59188664985' />
+  <node id='-18509880' visible='true' lat='10.24557758414' lon='-67.59091246824' />
+  <node id='-18509882' visible='true' lat='10.24568769983' lon='-67.59088994561' />
+  <node id='-18509884' visible='true' lat='10.24588318276' lon='-67.59186412633' />
+  <node id='-18509886' visible='true' lat='10.24568286417' lon='-67.59086374297' />
+  <node id='-18509888' visible='true' lat='10.24550590637' lon='-67.59089551602' />
+  <node id='-18509890' visible='true' lat='10.24548785788' lon='-67.59079305086' />
+  <node id='-18509892' visible='true' lat='10.24566481478' lon='-67.59076127781' />
+  <node id='-18509894' visible='true' lat='10.2456690317' lon='-67.59078521596' />
+  <node id='-18509896' visible='true' lat='10.24570237856' lon='-67.59077922828' />
+  <node id='-18509898' visible='true' lat='10.24571060106' lon='-67.59082590759' />
+  <node id='-18509900' visible='true' lat='10.2456772542' lon='-67.59083189528' />
+  <node id='-18509902' visible='true' lat='10.24561975874' lon='-67.59190381791' />
+  <node id='-18509904' visible='true' lat='10.2454290602' lon='-67.59094392023' />
+  <node id='-18509906' visible='true' lat='10.24552728146' lon='-67.59092402992' />
+  <node id='-18509908' visible='true' lat='10.24571798' lon='-67.5918839276' />
+  <node id='-18509910' visible='true' lat='10.24501437741' lon='-67.59189656937' />
+  <node id='-18509912' visible='true' lat='10.24501016139' lon='-67.59185114372' />
+  <node id='-18509914' visible='true' lat='10.24509827966' lon='-67.5918428088' />
+  <node id='-18509916' visible='true' lat='10.24510249478' lon='-67.59188823356' />
+  <node id='-18509918' visible='true' lat='10.24545806514' lon='-67.59193913518' />
+  <node id='-18509920' visible='true' lat='10.24543842484' lon='-67.5918363085' />
+  <node id='-18509922' visible='true' lat='10.24538253737' lon='-67.5918471894' />
+  <node id='-18509924' visible='true' lat='10.24540232516' lon='-67.5919507868' />
+  <node id='-18509926' visible='true' lat='10.24538396909' lon='-67.59195436071' />
+  <node id='-18509928' visible='true' lat='10.24539018521' lon='-67.59198690447' />
+  <node id='-18509930' visible='true' lat='10.24532315244' lon='-67.59199995543' />
+  <node id='-18509932' visible='true' lat='10.24531762161' lon='-67.59197099636' />
+  <node id='-18509934' visible='true' lat='10.24528091938' lon='-67.59197814238' />
+  <node id='-18509936' visible='true' lat='10.24517056807' lon='-67.5914004071' />
+  <node id='-18509938' visible='true' lat='10.24528443213' lon='-67.59137823792' />
+  <node id='-18509940' visible='true' lat='10.24531450456' lon='-67.59153567953' />
+  <node id='-18509942' visible='true' lat='10.24535596151' lon='-67.59152760811' />
+  <node id='-18509944' visible='true' lat='10.24530865177' lon='-67.59127992313' />
+  <node id='-18509946' visible='true' lat='10.24533652626' lon='-67.59127449662' />
+  <node id='-18509948' visible='true' lat='10.24528613275' lon='-67.59101066881' />
+  <node id='-18509950' visible='true' lat='10.24539641751' lon='-67.59098919659' />
+  <node id='-18509952' visible='true' lat='10.24544900627' lon='-67.59126451954' />
+  <node id='-18509954' visible='true' lat='10.24542828948' lon='-67.591268553' />
+  <node id='-18509956' visible='true' lat='10.24555285008' lon='-67.59192068109' />
+  <way id='-18510211' visible='true'>
+    <nd ref='-18509458' />
+    <nd ref='-18509456' />
+    <nd ref='-18509454' />
+    <nd ref='-18509452' />
+    <nd ref='-18509458' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510217' visible='true'>
+    <nd ref='-18509578' />
+    <nd ref='-18509576' />
+    <nd ref='-18509574' />
+    <nd ref='-18509572' />
+    <nd ref='-18509570' />
+    <nd ref='-18509568' />
+    <nd ref='-18509566' />
+    <nd ref='-18509564' />
+    <nd ref='-18509562' />
+    <nd ref='-18509560' />
+    <nd ref='-18509558' />
+    <nd ref='-18509556' />
+    <nd ref='-18509554' />
+    <nd ref='-18509552' />
+    <nd ref='-18509550' />
+    <nd ref='-18509548' />
+    <nd ref='-18509546' />
+    <nd ref='-18509544' />
+    <nd ref='-18509542' />
+    <nd ref='-18509540' />
+    <nd ref='-18509538' />
+    <nd ref='-18509536' />
+    <nd ref='-18509578' />
+  </way>
+  <way id='-18510218' visible='true'>
+    <nd ref='-18509620' />
+    <nd ref='-18509618' />
+    <nd ref='-18509616' />
+    <nd ref='-18509614' />
+    <nd ref='-18509612' />
+    <nd ref='-18509610' />
+    <nd ref='-18509608' />
+    <nd ref='-18509606' />
+    <nd ref='-18509604' />
+    <nd ref='-18509602' />
+    <nd ref='-18509600' />
+    <nd ref='-18509598' />
+    <nd ref='-18509596' />
+    <nd ref='-18509594' />
+    <nd ref='-18509592' />
+    <nd ref='-18509590' />
+    <nd ref='-18509588' />
+    <nd ref='-18509586' />
+    <nd ref='-18509584' />
+    <nd ref='-18509582' />
+    <nd ref='-18509580' />
+    <nd ref='-18509620' />
+  </way>
+  <way id='-18510219' visible='true'>
+    <nd ref='-18509628' />
+    <nd ref='-18509626' />
+    <nd ref='-18509624' />
+    <nd ref='-18509622' />
+    <nd ref='-18509628' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510220' visible='true'>
+    <nd ref='-18509636' />
+    <nd ref='-18509634' />
+    <nd ref='-18509632' />
+    <nd ref='-18509630' />
+    <nd ref='-18509636' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510221' visible='true'>
+    <nd ref='-18509644' />
+    <nd ref='-18509642' />
+    <nd ref='-18509640' />
+    <nd ref='-18509638' />
+    <nd ref='-18509644' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510236' visible='true'>
+    <nd ref='-18509818' />
+    <nd ref='-18509820' />
+    <nd ref='-18509812' />
+    <nd ref='-18509810' />
+    <nd ref='-18509818' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510237' visible='true'>
+    <nd ref='-18509820' />
+    <nd ref='-18509818' />
+    <nd ref='-18509816' />
+    <nd ref='-18509814' />
+    <nd ref='-18509820' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510238' visible='true'>
+    <nd ref='-18509828' />
+    <nd ref='-18509826' />
+    <nd ref='-18509824' />
+    <nd ref='-18509822' />
+    <nd ref='-18509828' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510239' visible='true'>
+    <nd ref='-18509836' />
+    <nd ref='-18509834' />
+    <nd ref='-18509832' />
+    <nd ref='-18509830' />
+    <nd ref='-18509836' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510240' visible='true'>
+    <nd ref='-18509844' />
+    <nd ref='-18509842' />
+    <nd ref='-18509840' />
+    <nd ref='-18509838' />
+    <nd ref='-18509844' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510241' visible='true'>
+    <nd ref='-18509852' />
+    <nd ref='-18509850' />
+    <nd ref='-18509848' />
+    <nd ref='-18509846' />
+    <nd ref='-18509852' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510243' visible='true'>
+    <nd ref='-18509868' />
+    <nd ref='-18509866' />
+    <nd ref='-18509864' />
+    <nd ref='-18509862' />
+    <nd ref='-18509868' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510244' visible='true'>
+    <nd ref='-18509876' />
+    <nd ref='-18509874' />
+    <nd ref='-18509872' />
+    <nd ref='-18509870' />
+    <nd ref='-18509876' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510245' visible='true'>
+    <nd ref='-18509884' />
+    <nd ref='-18509882' />
+    <nd ref='-18509880' />
+    <nd ref='-18509878' />
+    <nd ref='-18509884' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510246' visible='true'>
+    <nd ref='-18509900' />
+    <nd ref='-18509898' />
+    <nd ref='-18509896' />
+    <nd ref='-18509894' />
+    <nd ref='-18509892' />
+    <nd ref='-18509890' />
+    <nd ref='-18509888' />
+    <nd ref='-18509886' />
+    <nd ref='-18509900' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510247' visible='true'>
+    <nd ref='-18509908' />
+    <nd ref='-18509906' />
+    <nd ref='-18509904' />
+    <nd ref='-18509902' />
+    <nd ref='-18509908' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510248' visible='true'>
+    <nd ref='-18509916' />
+    <nd ref='-18509914' />
+    <nd ref='-18509912' />
+    <nd ref='-18509910' />
+    <nd ref='-18509916' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-18510249' visible='true'>
+    <nd ref='-18509956' />
+    <nd ref='-18509954' />
+    <nd ref='-18509952' />
+    <nd ref='-18509950' />
+    <nd ref='-18509948' />
+    <nd ref='-18509946' />
+    <nd ref='-18509944' />
+    <nd ref='-18509942' />
+    <nd ref='-18509940' />
+    <nd ref='-18509938' />
+    <nd ref='-18509936' />
+    <nd ref='-18509934' />
+    <nd ref='-18509932' />
+    <nd ref='-18509930' />
+    <nd ref='-18509928' />
+    <nd ref='-18509926' />
+    <nd ref='-18509924' />
+    <nd ref='-18509922' />
+    <nd ref='-18509920' />
+    <nd ref='-18509918' />
+    <nd ref='-18509956' />
+    <tag k='building' v='yes' />
+  </way>
+  <relation id='-18510270' action='modify' visible='true'>
+    <tag k='building' v='yes' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='-18510271' action='modify' visible='true'>
+    <tag k='building' v='yes' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='-18510272' action='modify' visible='true'>
+    <tag k='building' v='yes' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='-18510273' visible='true'>
+    <member type='way' ref='-18510218' role='outer' />
+    <member type='way' ref='-18510217' role='inner' />
+    <tag k='building' v='yes' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+</osm>

--- a/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Input2.osm
+++ b/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Input2.osm
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <bounds minlat='10.248326' minlon='-67.5931' maxlat='10.2485' maxlon='-67.5900111' origin='hootenanny' />
+</osm>

--- a/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/README.txt
+++ b/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/README.txt
@@ -1,0 +1,2 @@
+This is an Attribute Conflation test to ensure that multipoly building relations in the reference layer do not get dropped in the output.  Note
+that the secondary layer is empty.


### PR DESCRIPTION
will cherry pick this back into develop for nightly build purposes

Changes were previously made to Attribute Conflation to remove building relations after conflation when they had already had a corresponding unioned multipoly relation created for them after conflation.  However, BuildingOutlineUpdateOp was incorrectly removing all multipoly relations, regardless of whether they had been conflated and then unioned with anything.  So, multipoly building relations were disappearing from the output.  These changes fix that.