### PR TITLE
Throttle OSM API changeset apply speed

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -358,14 +358,7 @@ If true, changesets derived can issue delete statements for the reference datase
 passed to the changeset deriver).  If false, no delete statements will be issued for the reference
 dataset.
 
-=== changeset.apidb.max.writers
-
-* Data Type: long
-* Default Value: `10`
-
-The maximum number of writers to spawn for writing changesets in parallel to an OSM API database.
-
-=== changeset.apidb.max.size
+=== changeset.apidb.size.max
 
 * Data Type: long
 * Default Value: `1000`
@@ -375,6 +368,29 @@ is used when splitting a changeset into smaller pieces.
 
 NOTE: This is different to `changeset.max.size` which is the maximum number of elements that the
 database can handle in a single changeset.
+
+=== changeset.apidb.writers.max
+
+* Data Type: long
+* Default Value: `10`
+
+The maximum number of writers to spawn for writing changesets in parallel to an OSM API database.
+
+=== changeset.apidb.writers.throttle
+
+* Data Type: bool
+* Default Value: `false`
+
+Flag to turn on throttling for OSM API changeset writes.  When turned on, each processing thread
+will wait `changeset.api.writers.throttle.time` seconds after a successful write before submitting
+another changeset to the OSM API.
+
+=== changeset.apidb.writers.throttle.time
+
+* Data Type: long
+* Default Value: `30`
+
+The number of seconds after a successful write before submitting another changeset to the OSM API.
 
 === changeset.buffer
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -28,6 +28,7 @@
 //  hoot
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmApiWriter.h>
+#include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 
 //  Qt
@@ -46,6 +47,7 @@ class OsmApiWriterTest : public HootTestFixture
   /* These tests are for local testing and require additional resources to complete */
 //  CPPUNIT_TEST(runPermissionsTest);
 //  CPPUNIT_TEST(runChangesetTest);
+//  CPPUNIT_TEST(runChangesetTrottleTest);
 //  CPPUNIT_TEST(runChangesetConflictTest);
 //  CPPUNIT_TEST(oauthTest);
   CPPUNIT_TEST_SUITE_END();
@@ -158,8 +160,29 @@ public:
     OsmApiWriter writer(osm, changesets);
 
     Settings s;
-    s.set("changeset.apidb.max.writers", 2);
-    s.set("changeset.apidb.max.size", 10);
+    s.set(ConfigOptions::getChangesetApidbWritersMaxKey(), 2);
+    s.set(ConfigOptions::getChangesetApidbSizeMaxKey(), 10);
+    writer.setConfiguration(s);
+
+    writer.apply();
+  }
+
+  void runChangesetTrottleTest()
+  {
+    QUrl osm;
+    osm.setUrl(ME_API_URL);
+    osm.setUserInfo("test01:hoottest");
+
+    QList<QString> changesets;
+    changesets.append("test-files/io/OsmChangesetElementTest/ToyTestA.osc");
+
+    OsmApiWriter writer(osm, changesets);
+
+    Settings s;
+    s.set(ConfigOptions::getChangesetApidbWritersMaxKey(), 2);
+    s.set(ConfigOptions::getChangesetApidbSizeMaxKey(), 2);
+    s.set(ConfigOptions::getChangesetApidbWritersThrottleKey(), true);
+    s.set(ConfigOptions::getChangesetApidbWritersThrottleTimeKey(), 2);
     writer.setConfiguration(s);
 
     writer.apply();
@@ -180,8 +203,8 @@ public:
 
       Settings s;
       //  Force the changeset to give consistent results with no parallelism
-      s.set("changeset.apidb.max.writers", 1);
-      s.set("changeset.apidb.max.size", 1000);
+      s.set(ConfigOptions::getChangesetApidbWritersMaxKey(), 1);
+      s.set(ConfigOptions::getChangesetApidbSizeMaxKey(), 1000);
       writer.setConfiguration(s);
 
       writer.apply();
@@ -195,8 +218,8 @@ public:
       OsmApiWriter writer(osm, changesets);
 
       Settings s;
-      s.set("changeset.apidb.max.writers", 1);
-      s.set("changeset.apidb.max.size", 10);
+      s.set(ConfigOptions::getChangesetApidbWritersMaxKey(), 1);
+      s.set(ConfigOptions::getChangesetApidbSizeMaxKey(), 10);
       writer.setConfiguration(s);
 
       writer.apply();
@@ -227,12 +250,12 @@ public:
     OsmApiWriter writer(osm, changesets);
 
     Settings s;
-    s.set("changeset.apidb.max.writers",        2);
-    s.set("changeset.apidb.max.size",           10);
-    s.set("hoot.osm.auth.consumer.key",         "<consumer_key_here>");
-    s.set("hoot.osm.auth.consumer.secret",      "<consumer_secret_here>");
-    s.set("hoot.osm.auth.access.token",         "<access_token_here>");
-    s.set("hoot.osm.auth.access.token.secret",  "<access_secret_here>");
+    s.set(ConfigOptions::getChangesetApidbWritersMaxKey(),      2);
+    s.set(ConfigOptions::getChangesetApidbSizeMaxKey(),         10);
+    s.set(ConfigOptions::getHootOsmAuthConsumerKeyKey(),        "<consumer_key_here>");
+    s.set(ConfigOptions::getHootOsmAuthConsumerSecretKey(),     "<consumer_secret_here>");
+    s.set(ConfigOptions::getHootOsmAuthAccessTokenKey(),        "<access_token_here>");
+    s.set(ConfigOptions::getHootOsmAuthAccessTokenSecretKey(),  "<access_secret_here>");
 
     writer.setConfiguration(s);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -48,7 +48,7 @@ XmlChangeset::XmlChangeset()
   : _nodes(ChangesetType::TypeMax),
     _ways(ChangesetType::TypeMax),
     _relations(ChangesetType::TypeMax),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize()),
+    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
     _sentCount(0),
     _processedCount(0),
     _failedCount(0)
@@ -59,7 +59,7 @@ XmlChangeset::XmlChangeset(const QList<QString> &changesets)
   : _nodes(ChangesetType::TypeMax),
     _ways(ChangesetType::TypeMax),
     _relations(ChangesetType::TypeMax),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize()),
+    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
     _sentCount(0),
     _processedCount(0),
     _failedCount(0)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -51,7 +51,7 @@ namespace hoot
 OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
   : _description(ConfigOptions().getChangesetDescription()),
     _maxWriters(ConfigOptions().getChangesetApidbWritersMax()),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize()),
+    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
     _throttleWriters(ConfigOptions().getChangesetApidbWritersThrottle()),
     _throttleTime(ConfigOptions().getChangesetApidbWritersThrottleTime()),
     _showProgress(false)
@@ -65,7 +65,7 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
   : _changesets(changesets),
     _description(ConfigOptions().getChangesetDescription()),
     _maxWriters(ConfigOptions().getChangesetApidbWritersMax()),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbMaxSize()),
+    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
     _throttleWriters(ConfigOptions().getChangesetApidbWritersThrottle()),
     _throttleTime(ConfigOptions().getChangesetApidbWritersThrottleTime()),
     _showProgress(false),
@@ -317,7 +317,7 @@ void OsmApiWriter::setConfiguration(const Settings& conf)
 {
   ConfigOptions options(conf);
   _description = options.getChangesetDescription();
-  _maxChangesetSize = options.getChangesetApidbMaxSize();
+  _maxChangesetSize = options.getChangesetApidbSizeMax();
   _maxWriters = options.getChangesetApidbWritersMax();
   _throttleWriters = options.getChangesetApidbWritersThrottle();
   _throttleTime = options.getChangesetApidbWritersThrottleTime();

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -235,6 +235,10 @@ private:
    *  the entirety of a way or relation, loaded with 'changeset.apidb.max.size' option
    */
   long _maxChangesetSize;
+  /** Flag to turn on OSM API writer throttling */
+  bool _throttleWriters;
+  /** Number of seconds for a writer thread to wait after a successful API writer before continuing, if enabled */
+  int _throttleTime;
   /** Queried capabilities from the target OSM API */
   OsmApiCapabilites _capabilities;
   /** Actual statistics */


### PR DESCRIPTION
Refs #3041 
Added ability to throttle OSM API changeset uploads.