### PR TITLE
Roundabout unit tests implode when IDs aren't regenerated

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.cpp
@@ -85,7 +85,7 @@ NodePtr Roundabout::getNewCenter(OsmMapPtr pMap)
   NodePtr pNewNode(new Node(_status,
                    pMap->createNextNodeId(),
                    lon, lat, 15));
-  pNewNode->setTag("hoot:special", "RoundaboutCenter");
+  pNewNode->setTag(MetadataTags::HootSpecial(), MetadataTags::RoundaboutCenter());
 
   return pNewNode;
 }
@@ -194,7 +194,7 @@ void Roundabout::handleCrossingWays(boost::shared_ptr<OsmMap> pMap)
                                   15));
               pWay->addNode(pCenterNode->getId());
               pWay->setTag("highway", "unclassified");
-              pWay->setTag("hoot:special", "roundabout_connector");
+              pWay->setTag(MetadataTags::HootSpecial(), MetadataTags::RoundaboutConnector());
 
               // Take the new way. Whichever is closest, first node or last,
               // connect it to our center point.
@@ -284,7 +284,7 @@ void Roundabout::removeRoundabout(boost::shared_ptr<OsmMap> pMap)
     pWay->setTag("highway", "unclassified");
 
     // Add special hoot tag
-    pWay->setTag("hoot:special", "roundabout_connector");
+    pWay->setTag(MetadataTags::HootSpecial(), MetadataTags::RoundaboutConnector());
 
     pMap->addWay(pWay);
     _tempWays.push_back(pWay);

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
@@ -74,26 +74,31 @@ void RemoveRoundabouts::removeRoundabouts(std::vector<RoundaboutPtr> &removed)
 
   // Mangle (in a good way) ways that may cross our roundabouts, provided there
   // is no 'sibling' roundabout in the secondary dataset
+  QVector<bool> foundSibling(removed.size(), false);
   for (size_t i = 0; i < removed.size() - 1; i++)
   {
-    geos::geom::Coordinate c1 = removed[i]->getCenter()->toCoordinate();
-    bool hasSibling = false;
-    for (size_t j = i + 1; j < removed.size() && !hasSibling; j++)
+    //  If a sibling has already been found for this way, skip it
+    if (!foundSibling[i])
     {
-      geos::geom::Coordinate c2 = removed[j]->getCenter()->toCoordinate();
-      double distance = c1.distance(c2);
-      if (distance <= removed[i]->getCenter()->getCircularError())
-        hasSibling = true;
-    }
+      geos::geom::Coordinate c1 = removed[i]->getCenter()->toCoordinate();
+      for (size_t j = i + 1; j < removed.size() && !foundSibling[i]; j++)
+      {
+        geos::geom::Coordinate c2 = removed[j]->getCenter()->toCoordinate();
+        double distance = c1.distance(c2);
+        //  If the two centers are within the circular error, mark both as siblings
+        if (distance <= removed[i]->getCenter()->getCircularError())
+          foundSibling[i] = foundSibling[j] = true;
+      }
 
-    // If no sibling, do the mangle
-    if (!hasSibling)
-      removed[i]->handleCrossingWays(_pMap);
+      // If no sibling, do the mangle
+      if (!foundSibling[i])
+        removed[i]->handleCrossingWays(_pMap);
+    }
   }
 
-  //  Catch the case where there is only one way to "remove", mangle it
-  if (removed.size() == 1)
-    removed[0]->handleCrossingWays(_pMap);
+  //  Mangle the last way if it doesn't have a sibling
+  if (!foundSibling[removed.size() - 1])
+    removed[removed.size() - 1]->handleCrossingWays(_pMap);
 
   // Now remove roundabouts
   for (size_t i = 0; i < removed.size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
@@ -91,6 +91,10 @@ void RemoveRoundabouts::removeRoundabouts(std::vector<RoundaboutPtr> &removed)
       removed[i]->handleCrossingWays(_pMap);
   }
 
+  //  Catch the case where there is only one way to "remove", mangle it
+  if (removed.size() == 1)
+    removed[0]->handleCrossingWays(_pMap);
+
   // Now remove roundabouts
   for (size_t i = 0; i < removed.size(); i++)
     removed[i]->removeRoundabout(_pMap);

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
@@ -74,11 +74,11 @@ void RemoveRoundabouts::removeRoundabouts(std::vector<RoundaboutPtr> &removed)
 
   // Mangle (in a good way) ways that may cross our roundabouts, provided there
   // is no 'sibling' roundabout in the secondary dataset
-  for (size_t i = 0; i < removed.size(); i++)
+  for (size_t i = 0; i < removed.size() - 1; i++)
   {
     geos::geom::Coordinate c1 = removed[i]->getCenter()->toCoordinate();
     bool hasSibling = false;
-    for (size_t j = i+1; j < removed.size() && !hasSibling; j++)
+    for (size_t j = i + 1; j < removed.size() && !hasSibling; j++)
     {
       geos::geom::Coordinate c2 = removed[j]->getCenter()->toCoordinate();
       double distance = c1.distance(c2);

--- a/hoot-core/src/main/cpp/hoot/core/ops/SmallWayMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SmallWayMerger.cpp
@@ -91,8 +91,9 @@ void SmallWayMerger::apply(boost::shared_ptr<OsmMap>& map)
     {
       boost::shared_ptr<Way> w = it->second;
 
-      // if the way is smaller than the threshold
+      // if the way is smaller than the threshold, that isn't a `hoot:special` way
       if (highwayCrit.isSatisfied(w) &&
+          !w->getTags().contains(MetadataTags::HootSpecial()) &&
           ElementConverter(map).convertToLineString(w)->getLength() <= _threshold)
       {
         _mergeNeighbors(w);

--- a/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
@@ -114,6 +114,10 @@ public:
 
   inline static const QString HootSource()              { return "hoot:source"; }
 
+  inline static const QString HootSpecial()             { return "hoot:special"; }
+  inline static const QString RoundaboutCenter()        { return "roundabout_center"; }
+  inline static const QString RoundaboutConnector()     { return "roundabout_connector"; }
+
   inline static const QString HootSplitParentId()       { return "hoot:split_parent_id"; }
 
   inline static const QString HootStub()                { return "hoot:stub"; }

--- a/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
@@ -161,7 +161,7 @@ void ProcessThread::processJobs(JobQueue* queue)
           {
             _proc.reset(createProcess());
             _outMutex->lock();
-            cout << test.toStdString() << " failed, requeued." << endl;
+            cout << test.toStdString() << " failed to launch, requeued." << endl;
             _outMutex->unlock();
             output.clear();
           }

--- a/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ProcessPool.h"
 

--- a/test-files/cases/roundabouts/rcase-002/Expected.osm
+++ b/test-files/cases/roundabouts/rcase-002/Expected.osm
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="18.544216" minlon="-72.34875099833999" maxlat="18.549036" maxlon="-72.340941"/>
-    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457702303256262" lon="-72.3442470443381751">
+    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457692657415727" lon="-72.3442418399442175">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
+        <tag k="hoot:id" v="-131"/>
     </node>
     <node visible="true" id="-41" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465998999999968" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
@@ -169,9 +169,9 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="-1"/>
     </node>
-    <way visible="true" id="-175" timestamp="2017-06-07T15:16:56Z" version="1">
+    <way visible="true" id="-183" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="-35"/>
-        <nd ref="-95"/>
+        <nd ref="-131"/>
         <nd ref="-31"/>
         <nd ref="-30"/>
         <nd ref="-29"/>
@@ -182,7 +182,7 @@
         <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-175"/>
+        <tag k="hoot:id" v="-183"/>
     </way>
     <way visible="true" id="-6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="-6"/>

--- a/test-files/cases/roundabouts/rcase-002/Expected.osm
+++ b/test-files/cases/roundabouts/rcase-002/Expected.osm
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="18.544216" minlon="-72.34875099833999" maxlat="18.549036" maxlon="-72.340941"/>
-    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457692657415727" lon="-72.3442418399442175">
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457702303256262" lon="-72.3442470443381751">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-131"/>
+        <tag k="hoot:id" v="-95"/>
     </node>
     <node visible="true" id="-41" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465998999999968" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
@@ -169,9 +169,9 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="-1"/>
     </node>
-    <way visible="true" id="-183" timestamp="2017-06-07T15:16:56Z" version="1">
+    <way visible="true" id="-175" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="-35"/>
-        <nd ref="-131"/>
+        <nd ref="-95"/>
         <nd ref="-31"/>
         <nd ref="-30"/>
         <nd ref="-29"/>
@@ -182,7 +182,7 @@
         <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-183"/>
+        <tag k="hoot:id" v="-175"/>
     </way>
     <way visible="true" id="-6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="-6"/>

--- a/test-files/cases/roundabouts/rcase-003/Expected.osm
+++ b/test-files/cases/roundabouts/rcase-003/Expected.osm
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="18.544216" minlon="-72.34882018686" maxlat="18.549036" maxlon="-72.340941"/>
-    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457702303256262" lon="-72.3442470443381893">
+    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457702303256262" lon="-72.3442470443381893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
+        <tag k="hoot:id" v="-126"/>
     </node>
     <node visible="true" id="-45" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465998999999968" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
@@ -187,7 +187,7 @@
     </node>
     <way visible="true" id="-154" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="-38"/>
-        <nd ref="-127"/>
+        <nd ref="-126"/>
         <nd ref="-34"/>
         <nd ref="-33"/>
         <nd ref="-32"/>


### PR DESCRIPTION
Refs #3049 
I found that when ordering of ways was reversed in roundabout unit tests that they failed.  Some even failed to restore the original roundabout.  It was a mess.  This fixes those issues.