### PR TITLE
Throw error when encountering ways with duplicate ids and clear id maps when reusing reader

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -189,6 +189,11 @@ void OsmXmlReader::_createWay(const QXmlAttributes &attributes)
 {
   _wayId = _parseLong(attributes.value("id"));
 
+  if( _wayIdMap.contains(_wayId) )
+  {
+    throw HootException(QString("Duplicate way id %1 in map %2 encountered.").arg(_wayId).arg(_path));
+  }
+
   long newId;
   if (_useDataSourceId)
   {
@@ -300,6 +305,11 @@ void OsmXmlReader::read(OsmMapPtr map)
   LOG_VART(_useFileStatus);
   LOG_VART(_keepStatusTag);
   LOG_VART(_preserveAllTags);
+
+  // clear node id maps in case the reader is used for mulitple files
+  _nodeIdMap.clear();
+  _relationIdMap.clear();
+  _wayIdMap.clear();
 
   _numRead = 0;
   finalizePartial();


### PR DESCRIPTION
Refs #2079 

With this change hoot throws an error when multiple way nodes with identical ids are encountered in the same osm file.

When that happened the previously saved id in the way id map was overwritten. This could also happen when loading multiple osm files with the same reader in which case it would add the ids of multiple osm maps to the internal id map causing arbitrary id mapping results leading to crashes.

Now when reusing a reader, all id maps are cleared ahead of time.
