### PR TITLE
Turn on debugging tags with 'debug.maps.write' setting

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriter.h
@@ -39,7 +39,7 @@ public:
 
   static std::string className() { return "hoot::OsmMapWriter"; }
 
-  OsmMapWriter() {}
+  OsmMapWriter() : _debug(false) {}
 
   virtual ~OsmMapWriter() {}
 
@@ -69,6 +69,20 @@ public:
    * @return a formats string
    */
   virtual QString supportedFormats() = 0;
+
+  /**
+   * Sets flag indicating the writer is writing a debug map so that extra debugging metadata is
+   * included in the output
+   */
+  void setIsDebugMap(const bool is_debug = false) { _debug = is_debug; }
+  /**
+   * Gets flag indicating the writer is writing a debug map so that extra debugging metadata can
+   * be included in each implementation of the output formats
+   */
+  bool getIsDebugMap() { return _debug; }
+
+private:
+  bool _debug;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMMAPWRITER_H
 #define OSMMAPWRITER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.cpp
@@ -121,7 +121,7 @@ bool OsmMapWriterFactory::hasElementOutputStream(QString url)
 }
 
 void OsmMapWriterFactory::write(const boost::shared_ptr<const OsmMap>& map, QString url,
-                                const bool silent)
+                                const bool silent, const bool is_debug)
 {
   bool skipEmptyMap = map->isEmpty() && ConfigOptions().getOsmMapWriterSkipEmptyMap();
 
@@ -134,6 +134,7 @@ void OsmMapWriterFactory::write(const boost::shared_ptr<const OsmMap>& map, QStr
   if (!skipEmptyMap)
   {
     boost::shared_ptr<OsmMapWriter> writer = createWriter(url);
+    writer->setIsDebugMap(is_debug);
     writer->open(url);
     writer->write(map);
     LOG_INFO(
@@ -172,7 +173,7 @@ void OsmMapWriterFactory::writeDebugMap(const ConstOsmMapPtr& map, const QString
     }
 
     MapProjector::projectToWgs84(copy);
-    write(copy, debugMapFileName, true);
+    write(copy, debugMapFileName, true, true);
     _debugMapCount++;
   }
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.h
@@ -53,7 +53,7 @@ public:
   static bool hasElementOutputStream(QString url);
 
   static void write(const boost::shared_ptr<const OsmMap>& map, QString url,
-                    const bool silent = false);
+                    const bool silent = false, const bool is_debug = false);
 
   static QString getWriterName(const QString url);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -225,6 +225,10 @@ void OsmXmlWriter::write(ConstOsmMapPtr map)
     _initWriter();
   }
 
+  //  Debug maps get a bunch of debug settings setup here
+  if (getIsDebugMap())
+    _overrideDebugSettings();
+
   // The coord sys and schema entries don't get written to streamed output b/c we don't have
   // the map object to read the coord sys from.
 
@@ -246,6 +250,7 @@ void OsmXmlWriter::write(ConstOsmMapPtr map)
     _writer->writeAttribute("schema", _osmSchema);
   }
 
+  //  Osmosis chokes on the bounds being written at the end of the file, do it first
   const geos::geom::Envelope bounds = CalculateMapBoundsVisitor::getGeosBounds(map);
   _writeBounds(bounds);
 
@@ -665,9 +670,21 @@ void OsmXmlWriter::writePartial(const ConstRelationPtr& r)
 
 void OsmXmlWriter::finalizePartial()
 {
-  //osmosis chokes on the bounds being written at the end of the file, so not writing it at all
-  //_writeBounds(_bounds);
   close();
+}
+
+void OsmXmlWriter::_overrideDebugSettings()
+{
+  //  Include Hoot ID tag
+  _includeIds = true;
+  //  Include parent ID tag
+  _includePid = true;
+  //  Include debug tags
+  _includeDebug = true;
+  //  Output the status as text
+  _textStatus = true;
+  //  Output circular error
+  _includeCircularErrorTags = true;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -160,6 +160,12 @@ private:
    * @param bounds the bounds to write
    */
   void _writeBounds(const geos::geom::Envelope& bounds);
+
+  /**
+   * Sets debug settings to add extra metadata to output map for debugging purposes
+   * enabled with `debug.maps.write` setting
+   */
+  void _overrideDebugSettings();
 };
 
 }


### PR DESCRIPTION
refs #3078 
When debug maps are written, override the following settings to make sure that they are included:
* Hoot ID tag
* Parent ID tag
* Debug tags
* Status as text
* Circular error