### PR TITLE
Removed the 'rule of five' check from SonarQube as we are not using it.

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.github.repository=ngageoint/hootenanny
 sonar.host.url=https://sonarcloud.io
 sonar.sources=./hoot-core/src/main,./hoot-js/src/main,./hoot-rnd/src/main,./tbs/src/main,./tgs/src/main
 
-sonar.issue.ignore.multicriteria=cout1,cout2,cout3,cout4,cout5,cout6,cout7,protected1,undef1,empty1,explicit1,override1
+sonar.issue.ignore.multicriteria=cout1,cout2,cout3,cout4,cout5,cout6,cout7,protected1,undef1,empty1,explicit1,override1,ruleOf5
 
 # Only the command, test, and selected other classes should output to standard out
 sonar.issue.ignore.multicriteria.cout1.ruleKey=cpp:S106
@@ -42,3 +42,7 @@ sonar.issue.ignore.multicriteria.explicit1.resourceKey=**/*
 # Don't care about constructor/destructor calling overridable methods
 sonar.issue.ignore.multicriteria.override1.ruleKey=cpp:S1699
 sonar.issue.ignore.multicriteria.override1.resourceKey=**/*
+
+# Ignore the rule-of-5 rule
+sonar.issue.ignore.multicriteria.ruleOf5.ruleKey=cpp:S3624
+sonar.issue.ignore.multicriteria.ruleOf5.resourceKey=**/*


### PR DESCRIPTION
Refs #2657
The classes listed that are failing the "rule of 5" don't require explicit copy constructors, assignment operators, etc.  These rulings are false positives.  Turn it off.