### PR TITLE
rework conflation config scripts to remove race condition

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -133,9 +133,7 @@ hoot-core/src/main/cpp/hoot/core/util/ConfigOptions.h: conf/core/ConfigOptions.a
 
 conf/core/ConfigOptions.json: scripts/core/CreateConfigAsJSON.py conf/core/ConfigOptions.asciidoc
 	python $^ $@ || (rm -f $@ ; exit -1)
-
-conf/services/conflationHoot2Ops.json: scripts/services/CreateConflationTypeGroups.py conf/services/conflationTypes.json conf/core/ConfigOptions.json conf/services/conflationTypeDefaults.json
-	python $^ $@ || (rm -f $@ ; exit -1)
+	python scripts/services/CreateConflationTypeGroups.py conf/services/conflationTypes.json $@ conf/services/conflationTypeDefaults.json conf/services/conflationHoot2Ops.json || (rm -f conf/services/conflationHoot2Ops.json ; exit -1)
 
 plugins/config.js: conf/core/ConfigOptions.asciidoc scripts/core/CreateJsConfigCode.py
 	python scripts/core/CreateJsConfigCode.py conf/core/ConfigOptions.asciidoc plugins/config.js


### PR DESCRIPTION
Recent changes to the makefile were causing errors under some build conditions.  It appears to be a race condition caused by a recent change when the compile is run with parallel threads.