### PR TITLE
Fix for the Qt warning during vagrant provisioning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ m4_include([m4/boost.m4])
 AX_LIB_BOOST()
 
 # Qt
-AC_CHECK_HEADERS([qt5/QtCore/QXmlStreamWriter])
+AC_CHECK_HEADERS([qt5/QtCore/QtCoreVersion])
 
 # Protocol Buffers
 AC_SEARCH_LIBS([_ZTIN6google8protobuf20FieldDescriptorProtoE], [protobuf], [], [AC_MSG_ERROR([Protocol buffers library was not found])])

--- a/hoot-core/src/main/cpp/hoot/core/ops/GeometryModifierOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/GeometryModifierOp.cpp
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "GeometryModifierOp.h"
+
+// Hoot
+#include <hoot/core/util/Factory.h>
+
+// Boost
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/foreach.hpp>
+namespace boostPropTree = boost::property_tree;
+
+namespace hoot
+{
+
+HOOT_FACTORY_REGISTER(OsmMapOperation, GeometryModifierOp)
+
+GeometryModifierOp::GeometryModifierOp()
+{
+}
+
+void GeometryModifierOp::apply(boost::shared_ptr<OsmMap>& map)
+{
+  _geometryModifierVisitor.setOsmMap(map.get());
+
+  map->visitRw(_geometryModifierVisitor);
+
+  _numAffected = _geometryModifierVisitor._numAffected;
+  _numProcessed = _geometryModifierVisitor._numProcessed;
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/ops/GeometryModifierOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/GeometryModifierOp.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef GEOMETRYMODIFIEROP_H
+#define GEOMETRYMODIFIEROP_H
+
+// Hoot
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/ops/OsmMapOperation.h>
+#include <hoot/core/info/OperationStatusInfo.h>
+#include <hoot/core/visitors/GeometryModifierVisitor.h>
+
+namespace hoot
+{
+
+  class GeometryModifierOp : public OsmMapOperation, public OperationStatusInfo
+  {
+  public:
+
+    GeometryModifierOp();
+
+    // OsmMapOperation
+    static std::string className() { return "hoot::GeometryModifierOp"; }
+    void apply(boost::shared_ptr<OsmMap>& map);
+    QString getDescription() const { return "Modifies map geometry as specified"; }
+
+    // OperationStatusInfo
+    virtual QString getInitStatusMessage() const { return "Modifying geometry..."; }
+    virtual QString getCompletedStatusMessage() const { return "Modified " + QString::number(_numAffected) + " elements"; }
+
+  private:
+    GeometryModifierVisitor _geometryModifierVisitor;
+  };
+
+}
+
+#endif // GEOMETRYMODIFIEROP_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/GeometryModifierVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/GeometryModifierVisitor.cpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "GeometryModifierVisitor.h"
+
+// Hoot
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/Log.h>
+
+using namespace geos::geom;
+using namespace std;
+
+namespace hoot
+{
+
+HOOT_FACTORY_REGISTER(ElementVisitor, GeometryModifierVisitor)
+
+GeometryModifierVisitor::GeometryModifierVisitor()
+{
+}
+
+void GeometryModifierVisitor::visit(const ElementPtr& pElement)
+{
+  _numProcessed++;
+
+  // only process Ways
+  if( pElement->getElementType() != ElementType::Way ) return;
+
+  Tags& tags = pElement->getTags();
+
+  // for now use a hardocded filter to get a basic framework going
+  if( tags.find("aeroway") == tags.end() ) return;
+
+  if( tags["aeroway"] == "runway")
+  {
+    extrude( boost::dynamic_pointer_cast<Way>(pElement));
+
+    tags["Test"] = "GeometryModifierVisitor";
+    _numAffected++;
+  }
+}
+
+void GeometryModifierVisitor::extrude(const WayPtr& pWay)
+{
+  int nodeCount = pWay->getNodeCount();
+
+  // too small, nothing to do
+  if( nodeCount < 2 ) return;
+
+  // create poly way and add it to map
+  WayPtr pPoly( new Way(Status::Unknown1, _pMap->createNextWayId(), -1) );
+  pPoly->setTag("name", "GeneratedPoly");
+  _pMap->addElement(pPoly);
+
+  // build poly by extruding existing nodes
+  const std::vector<long> nodeIds = pWay->getNodeIds();
+  for (uint i = 0; i < nodeIds.size(); i++)
+  {
+    const NodePtr pNode = _pMap->getNode(nodeIds[i]);
+
+    // Coordinate c = pNode->toCoordinate();
+    // boost::shared_ptr<geos::geom::Point> p = pNode->toPoint();
+    // ...
+  }
+
+  LOG_VAR(nodeCount);
+}
+
+} // namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/visitors/GeometryModifierVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/GeometryModifierVisitor.h
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef GEOMETRYMODIFIERVISITOR_H
+#define GEOMETRYMODIFIERVISITOR_H
+
+// hoot
+#include <hoot/core/elements/ElementVisitor.h>
+#include <hoot/core/elements/Way.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/info/OperationStatusInfo.h>
+
+namespace hoot
+{
+
+class GeometryModifierVisitor : public ElementVisitor, public OperationStatusInfo
+{
+  friend class GeometryModifierOp;
+
+public:
+  GeometryModifierVisitor();
+
+  virtual void setOsmMap(OsmMap* pMap) { _pMap = pMap; }
+
+  // ElementVisitor
+  static std::string className() { return "hoot::GeometryModifierVisitor"; }
+  virtual void visit(const ElementPtr& e);
+  QString getDescription() const { return "Modifies map geometry as specified"; }
+
+  // OperationStatusInfo
+  virtual QString getInitStatusMessage() const { return "Modifying geometry..."; }
+  virtual QString getCompletedStatusMessage() const { return "Modified " + QString::number(_numAffected) + " elements"; }
+
+private:
+  void extrude(const WayPtr& pWay);
+
+  OsmMap* _pMap;
+
+};
+
+}
+
+#endif // GEOMETRYMODIFIERVISITOR_H


### PR DESCRIPTION
Changed Qt header to be checked to one that can be compiled without prerequisites

Refs #3097 