### PR TITLE
Removed duplicate code in ReviewMarker::mark() functions

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.cpp
@@ -27,8 +27,8 @@
 #include "ReviewMarker.h"
 
 #include <hoot/core/ops/RemoveElementOp.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/util/Log.h>
 
 // Tgs
 #include <tgs/RStarTree/HilbertCurve.h>
@@ -159,58 +159,40 @@ bool ReviewMarker::isReviewUid(const ConstOsmMapPtr &map, ReviewUid uid)
   return isReview(map->getElement(uid));
 }
 
-// TODO: consolidate the duplicate code in these mark methods, if possible
-
 void ReviewMarker::mark(const OsmMapPtr &map, const ElementPtr& e1, const ElementPtr& e2,
   const QString& note, const QString& reviewType, double score, vector<QString> choices)
 {
-  LOG_TRACE("Marking review...");
-
-  LOG_VART(reviewType);
-  LOG_VART(note);
-  LOG_VART(score);
-
-  if (note.isEmpty())
-  {
-    LOG_VART(e1->toString());
-    LOG_VART(e2->toString());
-    throw IllegalArgumentException("You must specify a review note.");
-  }
-
-  RelationPtr r(
-    new Relation(
-      Status::Conflated, map->createNextRelationId(), 0, MetadataTags::RelationReview()));
-  r->getTags().set(MetadataTags::HootReviewNeeds(), true);
-  if (_addReviewTagsToFeatures)
-  {
-    e1->getTags().set(MetadataTags::HootReviewNeeds(), true);
-    e2->getTags().set(MetadataTags::HootReviewNeeds(), true);
-  }
-  r->getTags().appendValueIfUnique(MetadataTags::HootReviewType(), reviewType);
-  if (ConfigOptions().getWriterIncludeConflateReviewDetailTags())
-  {
-    r->getTags().appendValueIfUnique(MetadataTags::HootReviewNote(), note.simplified());
-    r->getTags().set(MetadataTags::HootReviewScore(), score);
-  }
-  r->addElement(MetadataTags::RoleReviewee(), e1->getElementId());
-  r->addElement(MetadataTags::RoleReviewee(), e2->getElementId());
-  r->getTags().set(MetadataTags::HootReviewMembers(), (int)r->getMembers().size());
-  r->setCircularError(ElementData::CIRCULAR_ERROR_EMPTY);
-
-  LOG_VART(r->getId());
-  LOG_VART(e1->getElementId());
-  LOG_VART(e2->getElementId());
-
-  for (unsigned int i = 0; i < choices.size(); i++)
-  {
-    r->getTags()[MetadataTags::HootReviewChoices() + ":" + QString::number(i+1)] = choices[i];
-  }
-
-  map->addElement(r);
+  if (!e1 || !e2)
+    return;
+  //  Insert the IDs into a vector and call mark
+  vector<ElementId> ids;
+  ids.push_back(e1->getElementId());
+  ids.push_back(e2->getElementId());
+  mark(map, ids, note, reviewType, score, choices);
 }
 
-void ReviewMarker::mark(const OsmMapPtr& map, set<ElementId> ids, const QString& note,
-   const QString& reviewType, double score, vector<QString> choices)
+void ReviewMarker::mark(const OsmMapPtr& map, const std::set<ElementId>& ids, const QString& note,
+  const QString& reviewType, double score, vector<QString> choices)
+{
+  //  Copy element IDs into a vector to preserve ordering used by other overloads of mark() function
+  vector<ElementId> vids(ids.begin(), ids.end());
+  mark(map, vids, note, reviewType, score, choices);
+}
+
+void ReviewMarker::mark(const OsmMapPtr& map, const ElementPtr& e, const QString& note,
+  const QString& reviewType, double score, vector<QString> choices)
+{
+  if (!e)
+    return;
+  //  Insert the ID into a vector and call mark
+  vector<ElementId> ids;
+  ids.push_back(e->getElementId());
+  mark(map, ids, note, reviewType, score, choices);
+  LOG_TRACE("Marking review with note: " << note);
+}
+
+void ReviewMarker::mark(const OsmMapPtr &map, const std::vector<ElementId>& ids, const QString& note,
+  const QString& reviewType, double score, vector<QString> choices)
 {
   LOG_TRACE("Marking review...");
 
@@ -229,7 +211,7 @@ void ReviewMarker::mark(const OsmMapPtr& map, set<ElementId> ids, const QString&
   r->getTags().set(MetadataTags::HootReviewNeeds(), true);
   if (_addReviewTagsToFeatures)
   {
-    for (set<ElementId>::iterator itr = ids.begin(); itr != ids.end(); ++itr)
+    for (vector<ElementId>::const_iterator itr = ids.begin(); itr != ids.end(); ++itr)
     {
       map->getElement(*itr)->getTags().set(MetadataTags::HootReviewNeeds(), true);
     }
@@ -240,7 +222,7 @@ void ReviewMarker::mark(const OsmMapPtr& map, set<ElementId> ids, const QString&
     r->getTags().appendValueIfUnique(MetadataTags::HootReviewNote(), note.simplified());
     r->getTags().set(MetadataTags::HootReviewScore(), score);
   }
-  for (set<ElementId>::iterator it = ids.begin(); it != ids.end(); ++it)
+  for (vector<ElementId>::const_iterator it = ids.begin(); it != ids.end(); ++it)
   {
     ElementId id = *it;
     r->addElement(MetadataTags::RoleReviewee(), id);
@@ -250,50 +232,6 @@ void ReviewMarker::mark(const OsmMapPtr& map, set<ElementId> ids, const QString&
 
   LOG_VART(r->getId());
   LOG_VART(ids);
-
-  for (unsigned int i = 0; i < choices.size(); i++)
-  {
-    r->getTags()[MetadataTags::HootReviewChoices() + ":" + QString::number(i+1)] = choices[i];
-  }
-
-  map->addElement(r);
-}
-
-void ReviewMarker::mark(const OsmMapPtr& map, const ElementPtr& e, const QString& note,
-  const QString& reviewType, double score, vector<QString> choices)
-{
-  LOG_TRACE("Marking review with note: " << note);
-
-  LOG_VART(reviewType);
-  LOG_VART(note);
-  LOG_VART(score);
-
-  if (note.isEmpty())
-  {
-    LOG_VART(e->toString())
-    throw IllegalArgumentException("You must specify a review note.");
-  }
-
-  RelationPtr r(
-    new Relation(
-      Status::Conflated, map->createNextRelationId(), 0, MetadataTags::RelationReview()));
-  r->getTags().set(MetadataTags::HootReviewNeeds(), true);
-  if (_addReviewTagsToFeatures)
-  {
-    e->getTags().set(MetadataTags::HootReviewNeeds(), true);
-  }
-  r->getTags().appendValueIfUnique(MetadataTags::HootReviewType(), reviewType);
-  if (ConfigOptions().getWriterIncludeConflateReviewDetailTags())
-  {
-    r->getTags().appendValueIfUnique(MetadataTags::HootReviewNote(), note.simplified());
-    r->getTags().set(MetadataTags::HootReviewScore(), score);
-  }
-  r->addElement(MetadataTags::RoleReviewee(), e->getElementId());
-  r->getTags().set(MetadataTags::HootReviewMembers(), (int)r->getMembers().size());
-  r->setCircularError(ElementData::CIRCULAR_ERROR_EMPTY);
-
-  LOG_VART(r->getId());
-  LOG_VART(e->getElementId());
 
   for (unsigned int i = 0; i < choices.size(); i++)
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.h
@@ -22,13 +22,13 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef REVIEWMARKER_H
 #define REVIEWMARKER_H
 
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Element.h>
+#include <hoot/core/elements/OsmMap.h>
 
 namespace hoot
 {
@@ -110,7 +110,7 @@ public:
    * @param reviewType A human readable review type. Typically this is a one word description of
    *  the feature being reviewed. E.g. "Highway" or "Building".
    */
-  void mark(const OsmMapPtr &map, std::set<ElementId> ids, const QString& note,
+  void mark(const OsmMapPtr &map, const std::set<ElementId>& ids, const QString& note,
             const QString& reviewType, double score = -1,
             std::vector<QString> choices = std::vector<QString>());
 
@@ -118,6 +118,18 @@ public:
    * Marks a single element as needing review.
    */
   void mark(const OsmMapPtr &map, const ElementPtr& e, const QString& note,
+            const QString& reviewType, double score = -1,
+            std::vector<QString> choices = std::vector<QString>());
+
+  /**
+   * Marks a vector of elements as needing review and sets them to reference each other. If the score
+   * is negative then the score is omitted.
+   *
+   * @param note A human readable note describing the review.
+   * @param reviewType A human readable review type. Typically this is a one word description of
+   *  the feature being reviewed. E.g. "Highway" or "Building".
+   */
+  void mark(const OsmMapPtr &map, const std::vector<ElementId>& ids, const QString& note,
             const QString& reviewType, double score = -1,
             std::vector<QString> choices = std::vector<QString>());
 

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 // Load shared libraries
 @Library('radiant-pipeline-library')_
 


### PR DESCRIPTION
refs #2997 
Created new `std::vector` based `ReviewMarker::mark` function because vectors keep ordering while `std::set` does not.  This is important for unit testing.  All other versions push `ElementId`s into a vector, preserving ordering, and then pass it into the `std::vector` overload.