### PR TITLE
Remove auto-disabling of rubber sheeting when using Unify roads alg from UI

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
@@ -244,27 +244,6 @@ void MatchFactory::_tempFixDefaults()
     conf().set("conflate.match.highway.classifier", "hoot::HighwayRfClassifier");
   }
   LOG_VARD(ConfigOptions().getConflateMatchHighwayClassifier());
-
-  //fix use of rubber sheeting and corner splitter - default value coming in from UI with network
-  //will be correct, so just fix for unifying - https://github.com/ngageoint/hootenanny-ui/issues/969
-  QStringList mapCleanerTransforms = ConfigOptions().getMapCleanerTransforms();
-  if (matchCreators.contains("hoot::HighwayMatchCreator") &&
-      (mapCleanerTransforms.contains("hoot::CornerSplitter") ||
-       mapCleanerTransforms.contains("hoot::RubberSheet")))
-  {
-    if (mapCleanerTransforms.contains("hoot::CornerSplitter") &&
-        !ConfigOptions().getHighwayMergeTagsOnly())
-    {
-      mapCleanerTransforms.removeAll("hoot::CornerSplitter");
-    }
-    if (mapCleanerTransforms.contains("hoot::RubberSheet"))
-    {
-      mapCleanerTransforms.removeAll("hoot::RubberSheet");
-    }
-    LOG_DEBUG("Temp fixing map.cleaner.transforms...");
-    conf().set("map.cleaner.transforms", mapCleanerTransforms.join(";"));
-  }
-  LOG_VARD(ConfigOptions().getMapCleanerTransforms());
 }
 
 void MatchFactory::setConfiguration(const Settings& s)


### PR DESCRIPTION
Rubbersheeting with the Unifying alg was originally disabled b/c rubbersheeting was occurring, even when unselected, from the UI.  Now, some users would like to use it with the Unifying alg so removing the hardcode that disabled it.  If it still is being applied regardless, then we can open a UI bug issue to fix.