### PR TITLE
Use Pre-provisioned Box in Testing Again

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         booleanParam(name: 'UI_hoot1_tests', defaultValue: true)
         booleanParam(name: 'UI_hoot2_tests', defaultValue: true)
         booleanParam(name: 'Sonar', defaultValue: false)
-        string(name: 'Box', defaultValue: 'hoot_centos7', description: 'Vagrant Box')
+        string(name: 'Box', defaultValue: 'default', description: 'Vagrant Box')
     }
 
     stages {


### PR DESCRIPTION
Switch back to pre-provisioned box that we changed in #3121 now that the `hoot/centos7-hoot` box has been updated (including on Jenkins).