### PR TITLE
Performance fix for MergeNearbyNodes

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.h
@@ -39,8 +39,8 @@ namespace hoot
 {
 
 /**
- * Creates a hash with the explicit purpose of finding that are within a predefined distance. This
- * is re-entrant, but not thread safe.
+ * Creates a hash with the explicit purpose of finding points which are within a predefined distance.
+ * This is re-entrant, but not thread safe.
  */
 class ClosePointHash
 {


### PR DESCRIPTION
Refs #3060

@bwitham I tried a bunch of stuff, but the performance gain (of factor 100 and more depending on bin/distance size) is all in line 128. Removing the sqrt made almost no difference at all. Looks like hash map lookups are extremely slow.
