### PR TITLE
Changing the chromedriver version to fix Jenkins issues.

### DIFF
--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CHROMEDRIVER_VERSION=73.0.3683.68
+export CHROMEDRIVER_VERSION=72.0.3626.69
 
 export JDK_VERSION=1.8.0_161
 export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.tar.gz


### PR DESCRIPTION
Chromedriver is failing in the ui-tests in Jenkins:
```
Chrome version must be between 70 and 73
  (Driver info: chromedriver=73.0.3683.68 (47787ec04b6e38e22703e856e101e840b65afe72),platform=Linux 3.10.0-957.10.1.el7.x86_64 x86_64)>.
```
Move this back to fall within that magic number.