### PR TITLE
Chrome driver failure

### DIFF
--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CHROMEDRIVER_VERSION=73.0.3683.68
+export CHROMEDRIVER_VERSION=72.0.3626.69
 
 export JDK_VERSION=1.8.0_161
 export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.tar.gz

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CHROMEDRIVER_VERSION=72.0.3626.69
+export CHROMEDRIVER_VERSION=74.0.3729.6
 
 export JDK_VERSION=1.8.0_161
 export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.tar.gz


### PR DESCRIPTION
Need to upgrade chrome driver because chrome was updated to 74.  This is just a bandaid and we need to rethink our chrome/chromedriver installs now that the versions are semi-synchronized.  The current chrome version is `74.0.3729.108` and chromedriver is `74.0.3729.6`.