### PR TITLE
Prevent geojson reader from reading from overpass json urls

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2524,8 +2524,8 @@ The default is to write a file even if the map is empty.
 * Data Type: string
 * Default Value: `overpass-api.de`
 
-Overpass API URL host name. Used by the JSON readers to distinguish Overpass JSON sources from
-GeoJSON sources.
+Overpass API URL host name. Used by the JSON readers to distinguish Overpass JSON web sources from
+GeoJSON web sources.
 
 === perty.apply.rubber.sheet
 

--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2519,6 +2519,14 @@ written if the value is not empty.
 If true, the OSM map writer will NOT write a file if the map is empty.
 The default is to write a file even if the map is empty.
 
+=== overpass.api.host
+
+* Data Type: string
+* Default Value: `overpass-api.de`
+
+Overpass API URL host name. Used by the JSON readers to distinguish Overpass JSON sources from
+GeoJSON sources.
+
 === perty.apply.rubber.sheet
 
 * Data Type: bool

--- a/docs/user/SupportedDataFormats.asciidoc
+++ b/docs/user/SupportedDataFormats.asciidoc
@@ -5,10 +5,10 @@
 **Hootenanny can import from:**
 
 * ESRI File Geodatabase (.gdb)
-* GeoJSON (.geojson) (M1)
+* GeoJSON (.geojson file or GeoJSON URL) (M1)
 * geonames.org (.geonames)
 * Hootenanny API Database (hootapidb://)
-* JSON file (.json; similar to Overpass JSON) (M1)
+* JSON (Overpass JSON (http://overpass-api.de/output_formats.html#json): .json file or JSON URL) (M1)
 * OpenStreetMap XML (.osm)
 * OpenStreetMap Protocol Buffers (.osm.pbf)
 * OpenStreetMap API Database (osmapidb://)
@@ -21,7 +21,7 @@
 * ESRI File Geodatabase (.gdb)
 * GeoJSON (.geojson) (M1)
 * Hootenanny API Database (hootapidb://)
-* JSON file (.json; similar to Overpass JSON) (M1)
+* JSON file (Overpass JSON: .json file) (M1)
 * OpenStreetMap XML file (.osm) (M2)
 * OpenStreetMap Protocol Buffers file (.osm.pbf)
 * OpenStreetMap API Database (osmapidb://)

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonReaderTest.cpp
@@ -51,6 +51,7 @@ class OsmGeoJsonReaderTest : public HootTestFixture
   CPPUNIT_TEST(runGenericGeoJsonTest);
   CPPUNIT_TEST(runObjectGeoJsonTest);
   CPPUNIT_TEST(runMultiObjectGeoJsonTest);
+  CPPUNIT_TEST(isSupportedTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -108,6 +109,23 @@ public:
                      _outputPath + output);
   }
 
+  void isSupportedTest()
+  {
+    OsmGeoJsonReader uut;
+    const QString overpassHost = ConfigOptions().getOverpassApiHost();
+
+    // The files passed in must actually exist in order for a postive match.
+    CPPUNIT_ASSERT(!uut.isSupported("test-files/nodes.json"));
+    CPPUNIT_ASSERT(uut.isSupported(_inputPath + "/AllDataTypes.geojson"));
+    CPPUNIT_ASSERT(!uut.isSupported("blah.geojson"));
+    CPPUNIT_ASSERT(!uut.isSupported("http://" + overpassHost));
+    CPPUNIT_ASSERT(!uut.isSupported("https://" + overpassHost));
+    CPPUNIT_ASSERT(!uut.isSupported("ftp://" + overpassHost));
+    CPPUNIT_ASSERT(!uut.isSupported("ftp://blah"));
+    // Non-Overpass API url's with the correct scheme can point to anything for GeoJSON reading.
+    CPPUNIT_ASSERT(uut.isSupported("http://blah"));
+    CPPUNIT_ASSERT(uut.isSupported("https://blah"));
+  }
 };
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmGeoJsonReaderTest, "slow");

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -81,7 +81,7 @@ bool ElementStreamer::areStreamableIo(const QStringList inputs, const QString ou
     {
       LOG_INFO(
         "Unable to stream I/O due to input: " << inputs.at(i).right(25) << " and/or output: " <<
-        output.right(25));
+        output.right(25) << ". Loading entire map...");
       return false;
     }
   }
@@ -98,7 +98,7 @@ bool ElementStreamer::areValidStreamingOps(const QStringList ops)
       // Can this be cleaned up?
 
       const QString unstreamableMsg =
-        "Unable to stream I/O due to criterion op: " + opName + "; loading entire map...";
+        "Unable to stream I/O due to criterion op: " + opName + ". Loading entire map...";
 
       if (Factory::getInstance().hasBase<ElementCriterion>(opName.toStdString()))
       {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
@@ -86,7 +86,8 @@ bool OsmGeoJsonReader::isSupported(QString url)
   }
 
   //  Is it a web address?
-  if ("http" == myUrl.scheme() || "https" == myUrl.scheme())
+  if (myUrl.host().toLower() != ConfigOptions().getOverpassApiHost() &&
+      ("http" == myUrl.scheme() || "https" == myUrl.scheme()))
   {
     return true;
   }
@@ -109,7 +110,7 @@ void OsmGeoJsonReader::read(OsmMapPtr map)
   }
   else
     _readFromHttp();
-  //  Process all of the result strings
+  //  Process all of the result strings;
   for (int i = 0; i < _results.size(); ++i)
   {
     // This will throw a hoot exception if JSON is invalid
@@ -148,7 +149,7 @@ void OsmGeoJsonReader::_parseGeoJson()
   QString type = QString::fromStdString(_propTree.get("type", string("")));
   if (_propTree.not_found() != _propTree.find("bbox"))
   {
-    Envelope env = _parseBbox(_propTree.get_child("bbox"));
+    /*Envelope env = */_parseBbox(_propTree.get_child("bbox"));
   }
 
   // If we don't have a "features" child then we should just have a single feature
@@ -165,7 +166,6 @@ void OsmGeoJsonReader::_parseGeoJson()
     _parseGeoJsonFeature(_propTree);
   }
 }
-
 
 void OsmGeoJsonReader::_parseGeoJsonFeature(const boost::property_tree::ptree& feature)
 {
@@ -234,7 +234,6 @@ void OsmGeoJsonReader::_parseGeoJsonFeature(const boost::property_tree::ptree& f
   }
 }
 
-
 geos::geom::Envelope OsmGeoJsonReader::_parseBbox(const boost::property_tree::ptree& bbox)
 {
   pt::ptree::const_iterator bboxIt = bbox.begin();
@@ -250,7 +249,8 @@ geos::geom::Envelope OsmGeoJsonReader::_parseBbox(const boost::property_tree::pt
   return Envelope(minX, maxX, minY, maxY);
 }
 
-void OsmGeoJsonReader::_parseGeoJsonNode(const string& id, const pt::ptree& properties, const pt::ptree& geometry)
+void OsmGeoJsonReader::_parseGeoJsonNode(const string& id, const pt::ptree& properties,
+                                         const pt::ptree& geometry)
 {
   //  Get info we need to construct our node
   long node_id = -1;
@@ -288,7 +288,8 @@ void OsmGeoJsonReader::_parseGeoJsonNode(const string& id, const pt::ptree& prop
   _map->addNode(pNode);
 }
 
-void OsmGeoJsonReader::_parseGeoJsonWay(const string& id, const pt::ptree& properties, const pt::ptree& geometry)
+void OsmGeoJsonReader::_parseGeoJsonWay(const string& id, const pt::ptree& properties,
+                                        const pt::ptree& geometry)
 {
   vector<Coordinate> coords = _parseGeometry(geometry);
 
@@ -341,7 +342,8 @@ void OsmGeoJsonReader::_parseGeoJsonWay(const string& id, const pt::ptree& prope
   _map->addWay(way);
 }
 
-void OsmGeoJsonReader::_parseGeoJsonRelation(const string& id, const pt::ptree& properties, const pt::ptree& geometry)
+void OsmGeoJsonReader::_parseGeoJsonRelation(const string& id, const pt::ptree& properties,
+                                             const pt::ptree& geometry)
 {
   //  Get info we need to construct our relation
   long relation_id = -1;
@@ -504,7 +506,8 @@ void OsmGeoJsonReader::_parseGeoJsonRelation(const string& id, const pt::ptree& 
   _map->addRelation(relation);
 }
 
-void OsmGeoJsonReader::_parseMultiPointGeometry(const boost::property_tree::ptree& geometry, const RelationPtr& relation)
+void OsmGeoJsonReader::_parseMultiPointGeometry(const boost::property_tree::ptree& geometry,
+                                                const RelationPtr& relation)
 {
   vector<JsonCoordinates> multigeo = _parseMultiGeometry(geometry);
   vector<JsonCoordinates>::const_iterator multi = multigeo.begin();
@@ -521,7 +524,8 @@ void OsmGeoJsonReader::_parseMultiPointGeometry(const boost::property_tree::ptre
   }
 }
 
-void OsmGeoJsonReader::_parseMultiLineGeometry(const boost::property_tree::ptree& geometry, const RelationPtr& relation)
+void OsmGeoJsonReader::_parseMultiLineGeometry(const boost::property_tree::ptree& geometry,
+                                               const RelationPtr& relation)
 {
   vector<JsonCoordinates> multigeo = _parseMultiGeometry(geometry);
   for (vector<JsonCoordinates>::const_iterator multi = multigeo.begin(); multi != multigeo.end(); ++multi)
@@ -543,7 +547,8 @@ void OsmGeoJsonReader::_parseMultiLineGeometry(const boost::property_tree::ptree
   }
 }
 
-void OsmGeoJsonReader::_parseMultiPolygonGeometry(const boost::property_tree::ptree& geometry, const RelationPtr& relation)
+void OsmGeoJsonReader::_parseMultiPolygonGeometry(const boost::property_tree::ptree& geometry,
+                                                  const RelationPtr& relation)
 {
   vector<JsonCoordinates> multigeo = _parseMultiGeometry(geometry);
   for (vector<JsonCoordinates>::const_iterator multi = multigeo.begin(); multi != multigeo.end(); ++multi)
@@ -668,7 +673,6 @@ vector<JsonCoordinates> OsmGeoJsonReader::_parseMultiGeometry(const pt::ptree& g
   return results;
 }
 
-
 void OsmGeoJsonReader::_addTags(const pt::ptree &item, ElementPtr element)
 {
   //  Starts with the "properties" tree, use the "tags" subtree if it exists
@@ -745,5 +749,5 @@ boost::shared_ptr<Coordinate> OsmGeoJsonReader::ReadCoordinate( const pt::ptree&
   return pCoord;
 }
 
-} //  namespace hoot
+}
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
@@ -73,16 +73,17 @@ bool OsmGeoJsonReader::isSupported(QString url)
 {
   QUrl myUrl(url);
 
-  bool isRelativeUrl = myUrl.isRelative();
-  bool isLocalFile =  myUrl.isLocalFile();
+  const bool isRelativeUrl = myUrl.isRelative();
+  const bool isLocalFile =  myUrl.isLocalFile();
 
   //  Is it a file?
   if (isRelativeUrl || isLocalFile)
   {
-    QString filename = isRelativeUrl ? myUrl.toString() : myUrl.toLocalFile();
-
+    const QString filename = isRelativeUrl ? myUrl.toString() : myUrl.toLocalFile();
     if (QFile::exists(filename) && url.endsWith(".geojson", Qt::CaseInsensitive))
+    {
       return true;
+    }
   }
 
   //  Is it a web address?

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
@@ -198,9 +198,9 @@ private:
    */
   std::queue<std::string> _roles;
 
-  boost::shared_ptr<geos::geom::Coordinate> ReadCoordinate( const boost::property_tree::ptree& coordsIt );
+  boost::shared_ptr<geos::geom::Coordinate> ReadCoordinate(const boost::property_tree::ptree& coordsIt);
 };
 
-} // end namespace hoot
+}
 
 #endif // OSM_GEOJSON_READER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -89,13 +89,17 @@ bool OsmJsonReader::isSupported(QString url)
 {
   QUrl myUrl(url);
 
-  // Is it a file?
-  if (myUrl.isLocalFile())
-  {
-    QString filename = myUrl.toLocalFile();
+  const bool isRelativeUrl = myUrl.isRelative();
+  const bool isLocalFile =  myUrl.isLocalFile();
 
+  // Is it a file?
+  if (isRelativeUrl || isLocalFile)
+  {
+    const QString filename = isRelativeUrl ? myUrl.toString() : myUrl.toLocalFile();
     if (QFile::exists(filename) && url.endsWith(".json", Qt::CaseInsensitive))
+    {
       return true;
+    }
   }
 
   // Is it a web address?

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -530,8 +530,6 @@ void OsmJsonReader::_readFromHttp()
     LOG_VART(response.left(200));
     _results.append(response);
   }
-
-  LOG_DEBUG("end _readFromHttp");
 }
 
 void OsmJsonReader::_doHttpRequestFunc()


### PR DESCRIPTION
Before this change there wasn't anyway to disambiguate an Overpass JSON URL from a GeoJSON URL.  Added a config option to specify the Overpass host in use to prevent the GeoJSON reader from trying to read from such URL's. Callers can update the config option based on their Overpass source.