### PR TITLE
Fix for JSON parsing issue when big ints are embedded in value string

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonReaderTest.cpp
@@ -118,8 +118,10 @@ public:
     CPPUNIT_ASSERT(!uut.isSupported("test-files/nodes.json"));
     CPPUNIT_ASSERT(uut.isSupported(_inputPath + "/AllDataTypes.geojson"));
     CPPUNIT_ASSERT(!uut.isSupported("blah.geojson"));
+    // We skip Overpass urls to let the OsmJsonReader handle them.
     CPPUNIT_ASSERT(!uut.isSupported("http://" + overpassHost));
     CPPUNIT_ASSERT(!uut.isSupported("https://" + overpassHost));
+    // wrong scheme
     CPPUNIT_ASSERT(!uut.isSupported("ftp://" + overpassHost));
     CPPUNIT_ASSERT(!uut.isSupported("ftp://blah"));
     // Non-Overpass API url's with the correct scheme can point to anything for GeoJSON reading.

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -514,6 +514,19 @@ public:
 
     OsmJsonReader::scrubBigInts(bigIntMultiline);
     HOOT_STR_EQUALS(bigIntMultilineCorrect, bigIntMultiline);
+
+    // One of the regex's to clean big ints originally had a leading semicolon in it (see related
+    // note in OsmJsonReader::scrubBigInts), which would add double quotes to the text below within
+    // a single json value and break it. Haven't encountered any data instances to be cleaned so far
+    // that would require the semicolon to be in the regex, so removed it. If any instances do exist,
+    // then we need to rethink that regex to correctly parse this.
+    QString bigIntEmbedded =
+      "{\n"
+      " \"fixme\": \"DUPLICATE [Facebook:1477777628952292, Facebook:1477777665618955]\"\n"
+      "}";
+    const QString bigIntEmbeddedCorrect(bigIntEmbedded);
+    OsmJsonReader::scrubBigInts(bigIntEmbedded);
+    HOOT_STR_EQUALS(bigIntEmbeddedCorrect, bigIntEmbedded);
   }
 
   void isSupportedTest()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -190,11 +190,15 @@ void OsmJsonReader::_loadJSON(QString jsonStr)
   // Clear out anything that might be hanging around
   _propTree.clear();
 
+  LOG_TRACE("JSON before cleaning: " << jsonStr.left(100));
+
   // Handle single or double quotes
   scrubQuotes(jsonStr);
 
   // Handle IDs
   scrubBigInts(jsonStr);
+
+  LOG_TRACE("JSON after cleaning: " << jsonStr.left(100));
 
   // Convert string to stringstream
   stringstream ss(jsonStr.toUtf8().constData(), ios::in);
@@ -422,7 +426,7 @@ void OsmJsonReader::_addTags(const boost::property_tree::ptree &item, hoot::Elem
   }
 }
 
-void OsmJsonReader::scrubQuotes(QString &jsonStr)
+void OsmJsonReader::scrubQuotes(QString& jsonStr)
 {
   // We allow the use of single quotes, for ease of coding
   // test strings into c++. Single quotes within string literals
@@ -442,14 +446,15 @@ void OsmJsonReader::scrubQuotes(QString &jsonStr)
   }
 }
 
-void OsmJsonReader::scrubBigInts(QString &jsonStr)
+void OsmJsonReader::scrubBigInts(QString& jsonStr)
 {
   // Boost 1.41 property tree json parser has trouble with
   // integers bigger than 2^31. So we put quotes around big
   // numbers, and that makes it all better
   QRegExp rx1("(\"[^\"]+\"\\s*:\\s*)(-?\\d{8,})");
   jsonStr.replace(rx1, "\\1\"\\2\"");
-  QRegExp rx2("([\\[:,\\s]\\s*)(-?\\d{8,})([,\\}\\]\\n])");
+  // see related note in OsmJsonReaderTest::scrubBigIntsTest about changes made to this regex
+  QRegExp rx2("([\\[,\\s]\\s*)(-?\\d{8,})([,\\}\\]\\n])");
   jsonStr.replace(rx2, "\\1\"\\2\"\\3");
 }
 


### PR DESCRIPTION
The regex used to replace large integers in JSON values to address Boost JSON parser bug was causing certain large integers embedded in JSON text values not to parse (see OsmJsonReaderTest::scrubBigIntsTest). A simple solution was to slightly relax the regex by removing a semicolon to match, as no test data has been found that needs that level of strictness. If such data exists, then a different solution would need to be found.