### PR TITLE
Fix build race condition

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -244,7 +244,7 @@ ifeq ($(BUILD_SERVICES),services)
 endif
 
 # Build automatically generated JS files
-js-make: $(SCHEMA_FILES) plugins/config.js conf/core/ConfigOptions.json
+js-make: $(SCHEMA_FILES) plugins/config.js
 
 # Only PoiModel.rf is being generated this way at this time. The older .arff
 # files don't have the precision to recreate the exact model. That is a

--- a/scripts/database/SetupOsmApiDB.sh
+++ b/scripts/database/SetupOsmApiDB.sh
@@ -40,6 +40,11 @@ if [ "$flag" = "1" ]; then
   db_date_str=${db_date_str#*[}
   db_date_str=${db_date_str%]*}
 
+  # there are times where this file hasn't been created yet, create it
+  if [ -e $HOOT_HOME/scripts/database/blank_osmapidb.sql ]; then
+    $HOOT_HOME/scripts/ReplaceEnvironmentVariables.sh $HOOT_HOME/scripts/database/blank_osmapidb.sql.in $HOOT_HOME/scripts/database/blank_osmapidb.sql
+  fi
+
   # get sql file timestamp
   file_date_str=`stat -c "%y" $HOOT_HOME/scripts/database/blank_osmapidb.sql`;
 


### PR DESCRIPTION
Removed `ConfigOptions.json` from the `js-make` target to remove race condition in build.