### PR TITLE
Implement `writer.include.circular.error.tags` for shapefile writer

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -64,21 +64,6 @@ public:
 
   static int logWarnCount;
 
-  /**
-   * A true/false value to determine whether or not all layers are created.
-   * @sa setCreateAllLayers
-   */
-  static QString createAllLayersKey() { return "ogr.writer.create.all.layers"; }
-  /**
-   * Prepends this onto each of the layer names.
-   */
-  static QString preLayerNameKey() { return "ogr.writer.pre.layer.name"; }
-  static QString scriptKey() { return "ogr.writer.script"; }
-  /**
-   * Valid values are "on", "off" and "warn"
-   */
-  static QString strictCheckingKey() { return "ogr.strict.checking"; }
-
   OgrWriter();
 
   /**
@@ -130,8 +115,8 @@ public:
    */
   void translateToFeatures(ElementProviderPtr& provider,
                            const ConstElementPtr& e,
-                           std::shared_ptr<geos::geom::Geometry> &g,
-                           std::vector<ScriptToOgrTranslator::TranslatedFeature> &tf);
+                           std::shared_ptr<geos::geom::Geometry>& g,
+                           std::vector<ScriptToOgrTranslator::TranslatedFeature>& tf);
 
   void writeTranslatedFeature(const std::shared_ptr<geos::geom::Geometry>& g,
                               const std::vector<ScriptToOgrTranslator::TranslatedFeature>& tf);

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
@@ -30,13 +30,12 @@
 
 // hoot
 #include <hoot/core/io/OsmMapWriter.h>
+#include <hoot/core/util/Configurable.h>
 
 // Qt
 #include <QDir>
-#include <QHash>
 #include <QString>
 #include <QStringList>
-#include <QXmlDefaultHandler>
 
 // Standard
 #include <vector>
@@ -49,16 +48,15 @@ class Way;
 class Relation;
 
 /**
- * Reads in a .osm file into an OsmMap data structure. During this process all IDs are mapped from
- * the .osm node/way ID to a new ID.
+ * Writes an OsmMap to Shapefile file format.
  */
-class ShapefileWriter : public OsmMapWriter
+class ShapefileWriter : public OsmMapWriter, public Configurable
 {
 public:
 
   static std::string className() { return "hoot::ShapefileWriter"; }
 
-  ShapefileWriter() { _includeInfo = true; _includeIds = false; _circularErrorIndex = -1; }
+  ShapefileWriter();
 
   virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".shp"); }
 
@@ -68,14 +66,11 @@ public:
 
   void setColumns(QStringList columns) { _columns = columns; }
 
-  void setIncludeIds(bool includeIds) { _includeIds = includeIds; }
-
-  void setIncludeHootInfo(bool includeInfo) { _includeInfo = includeInfo; }
-
   /**
    * Will write out up to three files:
-   * path + "Polygon.shp"
-   * path + "Line.shp"
+   * path + "Points.shp"
+   * path + "Lines.shp"
+   * path + "Polygons.shp"
    */
   virtual void write(const ConstOsmMapPtr& map) override;
 
@@ -92,18 +87,22 @@ public:
 
   virtual QString supportedFormats() override { return ".shp"; }
 
+  /**
+   * Set the configuration for this object.
+   */
+  virtual void setConfiguration(const Settings& conf) override;
+
 protected:
 
   QStringList _columns;
-  bool _includeIds;
-  bool _includeInfo;
+  bool _includeCircularError;
   QDir _outputDir;
   int _circularErrorIndex;
 
   void _removeShapefile(const QString& path);
 
-  void _writeRelationPolygon(const ConstOsmMapPtr& map, const RelationPtr &relation,
-    OGRLayer *poLayer, const QStringList &columns, const QStringList &shpColumns);
+  void _writeRelationPolygon(const ConstOsmMapPtr& map, const RelationPtr& relation,
+    OGRLayer* poLayer, const QStringList& columns, const QStringList& shpColumns);
 
   void _writeWayPolygon(const ConstOsmMapPtr& map, const WayPtr& way, OGRLayer *poLayer,
     const QStringList& columns, const QStringList &shpColumns);


### PR DESCRIPTION
Refs #3232 
Implemented Configurable in the ShapefileWriter class and cleaned up OgrWriter class a little.