### PR TITLE
Add a conflatable criterion

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
@@ -97,7 +97,8 @@ NodePtr TestUtils::createNode(OsmMapPtr map, Status status, double x, double y,
   return result;
 }
 
-WayPtr TestUtils::createWay(OsmMapPtr map, Status s, Coordinate c[], Meters circularError, const QString& note)
+WayPtr TestUtils::createWay(OsmMapPtr map, Status s, Coordinate c[], Meters circularError,
+                            const QString& note)
 {
   WayPtr result(new Way(s, map->createNextWayId(), circularError));
   for (size_t i = 0; c[i].isNull() == false; i++)
@@ -113,6 +114,21 @@ WayPtr TestUtils::createWay(OsmMapPtr map, Status s, Coordinate c[], Meters circ
   }
   map->addWay(result);
   return result;
+}
+
+WayPtr TestUtils::createWay(OsmMapPtr map, geos::geom::Coordinate c[], Status status,
+                            Meters circularError, Tags tags)
+{
+  WayPtr way(new Way(status, map->createNextWayId(), circularError));
+  for (size_t i = 0; c[i].isNull() == false; i++)
+  {
+    NodePtr n(new Node(status, map->createNextNodeId(), c[i], circularError));
+    map->addNode(n);
+    way->addNode(n->getId());
+  }
+  way->setTags(tags);
+  map->addWay(way);
+  return way;
 }
 
 WayPtr TestUtils::createWay(OsmMapPtr map, const QList<NodePtr>& nodes, Status status,

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
@@ -122,6 +122,11 @@ public:
   static WayPtr createWay(OsmMapPtr map, Status s, geos::geom::Coordinate c[],
     Meters circularError = ConfigOptions().getCircularErrorDefaultValue(), const QString& note = "");
 
+  static WayPtr createWay(OsmMapPtr map, geos::geom::Coordinate c[],
+                          Status status = Status::Unknown1,
+                          Meters circularError = ConfigOptions().getCircularErrorDefaultValue(),
+                          Tags tags = Tags());
+
   static WayPtr createWay(OsmMapPtr map, const QList<NodePtr>& nodes,
                           Status status = Status::Unknown1,
                           Meters circularError = ConfigOptions().getCircularErrorDefaultValue(),

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/ConflatableElementCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/ConflatableElementCriterionTest.cpp
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+// Hoot
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
+#include <hoot/core/TestUtils.h>
+
+namespace hoot
+{
+
+class ConflatableElementCriterionTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(ConflatableElementCriterionTest);
+  CPPUNIT_TEST(runBasicTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void runBasicTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    geos::geom::Coordinate wayCoords[] = {
+      geos::geom::Coordinate(0.0, 0.0),
+      geos::geom::Coordinate(1.0, 0.0),
+      geos::geom::Coordinate(0.0, 1.0),
+      geos::geom::Coordinate(0.0, 0.0),
+      geos::geom::Coordinate::getNull() };
+
+    // This is a bit maintenance-prone as it will require an updating with each new
+    // ConflatableElementCriterion addition/subtraction, but that's a good thing as it will help
+    // us keep track of whenever changes are made to the set of ConflatableElementCriterion.
+    CPPUNIT_ASSERT_EQUAL(9, ConflatableElementCriterion::getConflatableCriteria().size());
+
+    const QStringList poiConflatableCriteria =
+      ConflatableElementCriterion::getConflatableCriteriaForElement(
+        TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, Tags("poi", "yes")));
+    CPPUNIT_ASSERT_EQUAL(2, poiConflatableCriteria.size());
+    CPPUNIT_ASSERT(poiConflatableCriteria.contains("hoot::PoiCriterion"));
+    CPPUNIT_ASSERT(poiConflatableCriteria.contains("hoot::PoiPolygonPoiCriterion"));
+
+    const QStringList buildingConflatableCriteria =
+      ConflatableElementCriterion::getConflatableCriteriaForElement(
+        TestUtils::createWay(map, wayCoords, Status::Unknown1, 15.0, Tags("building", "yes")));
+    CPPUNIT_ASSERT_EQUAL(3, buildingConflatableCriteria.size());
+    CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::AreaCriterion"));
+    CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::BuildingCriterion"));
+    CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::PoiPolygonPolyCriterion"));
+
+    CPPUNIT_ASSERT_EQUAL(
+      0,
+      ConflatableElementCriterion::getConflatableCriteriaForElement(
+        TestUtils::createWay(map, wayCoords, Status::Unknown1, 15.0, Tags("blah", "blah"))).size());
+  }
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ConflatableElementCriterionTest, "quick");
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/NonConflatableCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/NonConflatableCriterionTest.cpp
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+// Hoot
+#include <hoot/core/criterion/NonConflatableCriterion.h>
+#include <hoot/core/TestUtils.h>
+
+namespace hoot
+{
+
+class NonConflatableElementCriterionTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(NonConflatableElementCriterionTest);
+  CPPUNIT_TEST(runBasicTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void runBasicTest()
+  {
+    NonConflatableCriterion uut;
+    OsmMapPtr map(new OsmMap());
+
+    CPPUNIT_ASSERT_EQUAL(9, NonConflatableCriterion::_conflatableCriteria.size());
+
+    CPPUNIT_ASSERT(
+      uut.isSatisfied(
+        TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, Tags("poi", "yes"))));
+    CPPUNIT_ASSERT(
+      !uut.isSatisfied(
+        TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, Tags("poi", "no"))));
+
+    geos::geom::Coordinate buildingCoords[] = {
+      geos::geom::Coordinate(0.0, 0.0),
+      geos::geom::Coordinate(1.0, 0.0),
+      geos::geom::Coordinate(0.0, 1.0),
+      geos::geom::Coordinate(0.0, 0.0),
+      geos::geom::Coordinate::getNull() };
+    CPPUNIT_ASSERT(
+      uut.isSatisfied(
+        TestUtils::createWay(
+          map, buildingCoords, Status::Unknown1, 15.0, Tags("building", "yes"))));
+    CPPUNIT_ASSERT(
+      !uut.isSatisfied(
+        TestUtils::createWay(
+          map, buildingCoords, Status::Unknown1, 15.0, Tags("building", "no"))));
+
+
+  }
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(NonConflatableElementCriterionTest, "quick");
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/NonConflatableCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/NonConflatableCriterionTest.cpp
@@ -27,6 +27,7 @@
 
 // Hoot
 #include <hoot/core/criterion/NonConflatableCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 #include <hoot/core/TestUtils.h>
 
 namespace hoot
@@ -54,7 +55,7 @@ public:
     // This is a bit maintenance-prone as it will require an updating with each new
     // ConflatableElementCriterion addition/subtraction, but that's a good thing as it will help
     // us keep track of whenever changes are made to the set of ConflatableElementCriterion.
-    CPPUNIT_ASSERT_EQUAL(9, NonConflatableCriterion::_conflatableCriteria.size());
+    CPPUNIT_ASSERT_EQUAL(9, ConflatableElementCriterion::getConflatableCriteria().size());
 
     // Criteria satisfaction is negated, as we're checking to see if the element is *not*
     // conflatable.
@@ -62,7 +63,8 @@ public:
     ConstNodePtr poi =
       TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, Tags("poi", "yes"));
     CPPUNIT_ASSERT(!uut.isSatisfied(poi));
-    const QStringList poiConflatableCriteria = NonConflatableCriterion::conflatableCriteria(poi);
+    const QStringList poiConflatableCriteria =
+      ConflatableElementCriterion::getConflatableCriteriaForElement(poi);
     CPPUNIT_ASSERT_EQUAL(2, poiConflatableCriteria.size());
     CPPUNIT_ASSERT(poiConflatableCriteria.contains("hoot::PoiCriterion"));
     CPPUNIT_ASSERT(poiConflatableCriteria.contains("hoot::PoiPolygonPoiCriterion"));
@@ -72,7 +74,7 @@ public:
         map, wayCoords, Status::Unknown1, 15.0, Tags("building", "yes"));
     CPPUNIT_ASSERT(!uut.isSatisfied(building));
     const QStringList buildingConflatableCriteria =
-      NonConflatableCriterion::conflatableCriteria(building);
+      ConflatableElementCriterion::getConflatableCriteriaForElement(building);
     CPPUNIT_ASSERT_EQUAL(3, buildingConflatableCriteria.size());
     CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::AreaCriterion"));
     CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::BuildingCriterion"));
@@ -81,7 +83,8 @@ public:
     ConstWayPtr nonsense =
       TestUtils::createWay(map, wayCoords, Status::Unknown1, 15.0, Tags("blah", "blah"));
     CPPUNIT_ASSERT(uut.isSatisfied(nonsense));;
-    CPPUNIT_ASSERT_EQUAL(0, NonConflatableCriterion::conflatableCriteria(nonsense).size());
+    CPPUNIT_ASSERT_EQUAL(
+      0, ConflatableElementCriterion::getConflatableCriteriaForElement(nonsense).size());
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/criterion/NonConflatableCriterionTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/criterion/NonConflatableCriterionTest.cpp
@@ -27,7 +27,6 @@
 
 // Hoot
 #include <hoot/core/criterion/NonConflatableCriterion.h>
-#include <hoot/core/criterion/ConflatableElementCriterion.h>
 #include <hoot/core/TestUtils.h>
 
 namespace hoot
@@ -52,39 +51,20 @@ public:
       geos::geom::Coordinate(0.0, 0.0),
       geos::geom::Coordinate::getNull() };
 
-    // This is a bit maintenance-prone as it will require an updating with each new
-    // ConflatableElementCriterion addition/subtraction, but that's a good thing as it will help
-    // us keep track of whenever changes are made to the set of ConflatableElementCriterion.
-    CPPUNIT_ASSERT_EQUAL(9, ConflatableElementCriterion::getConflatableCriteria().size());
-
     // Criteria satisfaction is negated, as we're checking to see if the element is *not*
     // conflatable.
 
-    ConstNodePtr poi =
-      TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, Tags("poi", "yes"));
-    CPPUNIT_ASSERT(!uut.isSatisfied(poi));
-    const QStringList poiConflatableCriteria =
-      ConflatableElementCriterion::getConflatableCriteriaForElement(poi);
-    CPPUNIT_ASSERT_EQUAL(2, poiConflatableCriteria.size());
-    CPPUNIT_ASSERT(poiConflatableCriteria.contains("hoot::PoiCriterion"));
-    CPPUNIT_ASSERT(poiConflatableCriteria.contains("hoot::PoiPolygonPoiCriterion"));
+    CPPUNIT_ASSERT(
+      !uut.isSatisfied(
+        TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, Tags("poi", "yes"))));
 
-    ConstWayPtr building =
-      TestUtils::createWay(
-        map, wayCoords, Status::Unknown1, 15.0, Tags("building", "yes"));
-    CPPUNIT_ASSERT(!uut.isSatisfied(building));
-    const QStringList buildingConflatableCriteria =
-      ConflatableElementCriterion::getConflatableCriteriaForElement(building);
-    CPPUNIT_ASSERT_EQUAL(3, buildingConflatableCriteria.size());
-    CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::AreaCriterion"));
-    CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::BuildingCriterion"));
-    CPPUNIT_ASSERT(buildingConflatableCriteria.contains("hoot::PoiPolygonPolyCriterion"));
+    CPPUNIT_ASSERT(
+      !uut.isSatisfied(
+        TestUtils::createWay(map, wayCoords, Status::Unknown1, 15.0, Tags("building", "yes"))));
 
-    ConstWayPtr nonsense =
-      TestUtils::createWay(map, wayCoords, Status::Unknown1, 15.0, Tags("blah", "blah"));
-    CPPUNIT_ASSERT(uut.isSatisfied(nonsense));;
-    CPPUNIT_ASSERT_EQUAL(
-      0, ConflatableElementCriterion::getConflatableCriteriaForElement(nonsense).size());
+    CPPUNIT_ASSERT(
+      uut.isSatisfied(
+        TestUtils::createWay(map, wayCoords, Status::Unknown1, 15.0, Tags("blah", "blah"))));
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/ConflatableCriteriaVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/ConflatableCriteriaVisitorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/ConflatableCriteriaVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/ConflatableCriteriaVisitorTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2014, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+// CPP Unit
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/TestAssert.h>
+#include <cppunit/TestFixture.h>
+
+// hoot
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/visitors/ConflatableCriteriaVisitor.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+
+namespace hoot
+{
+
+class ConflatableCriteriaVisitorTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(ConflatableCriteriaVisitorTest);
+  CPPUNIT_TEST(runBasicTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  ConflatableCriteriaVisitorTest() :
+    HootTestFixture(
+      "test-files/visitors/ConflatableCriteriaVisitorTest/",
+      "test-output/visitors/ConflatableCriteriaVisitorTest/")
+  {
+    setResetType(ResetBasic);
+  }
+
+  void runBasicTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    OsmMapReaderFactory::read(
+      map, "test-files/conflate/unified/AllDataTypesA.osm", false, Status::Unknown1);
+
+    ConflatableCriteriaVisitor uut;
+    map->visitRw(uut);
+
+    const QString outFileName = "ConflatableCriteriaVisitorTest-runBasicTest.osm";
+    OsmMapWriterFactory::write(map, _outputPath + outFileName);
+
+    HOOT_FILE_EQUALS(_inputPath + outFileName, _outputPath + outFileName);
+  }
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ConflatableCriteriaVisitorTest, "quick");
+
+}
+
+

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.cpp
@@ -57,8 +57,11 @@ bool AreaCriterion::isSatisfied(const Tags& tags, const ElementType& elementType
   }
 
   result |= BuildingCriterion().isSatisfied(tags, elementType);
+  LOG_VART(result);
   result |= tags.isTrue(MetadataTags::BuildingPart());
+  LOG_VART(result);
   result |= tags.isTrue("area");
+  LOG_VART(result);
 
   // if at least one of the tags is marked as an area, but not a linestring tag then we consider
   // this to be an area feature.
@@ -66,14 +69,15 @@ bool AreaCriterion::isSatisfied(const Tags& tags, const ElementType& elementType
   {
     const SchemaVertex& tv = OsmSchema::getInstance().getTagVertex(it.key() + "=" + it.value());
     uint16_t g = tv.geometries;
+    LOG_VART(g);
     if (g & OsmGeometries::Area && !(g & (OsmGeometries::LineString | OsmGeometries::ClosedWay)))
     {
       //LOG_TRACE("Area: " << it.key() << "=" << it.value());
       result = true;
+      LOG_VART(result);
       break;
     }
   }
-  //LOG_VART(result);
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.h
@@ -30,7 +30,7 @@
 // hoot
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/ConstOsmMapConsumer.h>
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 namespace hoot
 {
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * A criterion to identify buildings
  */
-class BuildingCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class BuildingCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.cpp
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#include "ConflatableElementCriterion.h"
+
+// hoot
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/Factory.h>
+
+namespace hoot
+{
+
+QMap<QString, ElementCriterionPtr> ConflatableElementCriterion::_conflatableCriteria;
+
+QMap<QString, ElementCriterionPtr> ConflatableElementCriterion::getConflatableCriteria()
+{
+  LOG_VART(_conflatableCriteria.isEmpty());
+  if (_conflatableCriteria.isEmpty())
+  {
+    _createConflatableCriteria();
+  }
+  LOG_VART(_conflatableCriteria.size());
+  return _conflatableCriteria;
+}
+
+void ConflatableElementCriterion::_createConflatableCriteria()
+{
+  const std::vector<std::string> criterionClassNames =
+    Factory::getInstance().getObjectNamesByBase(ElementCriterion::className());
+  LOG_VART(criterionClassNames);
+  for (std::vector<std::string>::const_iterator itr = criterionClassNames.begin();
+       itr != criterionClassNames.end(); ++itr)
+  {
+    ElementCriterionPtr crit(Factory::getInstance().constructObject<ElementCriterion>(*itr));
+    if (std::dynamic_pointer_cast<ConflatableElementCriterion>(crit) != 0)
+    {
+      _conflatableCriteria[QString::fromStdString(*itr)] = crit;
+    }
+  }
+  LOG_VART(_conflatableCriteria.size());
+}
+
+QStringList ConflatableElementCriterion::getConflatableCriteriaForElement(const ConstElementPtr& e)
+{
+  if (_conflatableCriteria.isEmpty())
+  {
+    _createConflatableCriteria();
+  }
+
+  QStringList conflatableCriteriaForElement;
+  for (QMap<QString, ElementCriterionPtr>::const_iterator itr = _conflatableCriteria.begin();
+       itr != _conflatableCriteria.end(); ++itr)
+  {
+    if (itr.value()->isSatisfied(e))
+    {
+      // It is something we can conflate.
+      conflatableCriteriaForElement.append(itr.key());
+    }
+  }
+  return conflatableCriteriaForElement;
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.h
@@ -45,6 +45,24 @@ public:
   static std::string className() { return "hoot::ConflatableElementCriterion"; }
 
   virtual ~ConflatableElementCriterion() {}
+
+  /**
+   * Determines which criteria consider an element as conflatable
+   *
+   * @param e the element to determine conflatability of
+   * @return a list of ConflatableElementCriterion class names that consider the element as
+   * conflatable
+   */
+  static QStringList getConflatableCriteriaForElement(const ConstElementPtr& e);
+
+  static QMap<QString, ElementCriterionPtr> getConflatableCriteria();
+
+private:
+
+  // criterion class names to criterion objects
+  static QMap<QString, ElementCriterionPtr> _conflatableCriteria;
+
+  static void _createConflatableCriteria();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.h
@@ -22,37 +22,31 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
-#ifndef AREACRITERION_H
-#define AREACRITERION_H
+#ifndef CONFLATABLE_ELEMENT_CRITERION_H
+#define CONFLATABLE_ELEMENT_CRITERION_H
 
 // hoot
-#include <hoot/core/criterion/ConflatableElementCriterion.h>
+#include <hoot/core/criterion/ElementCriterion.h>
 
 namespace hoot
 {
 
 /**
- * A criterion that will either keep or remove areas.
+ * Simple abstract base class that signifies an ElementCriterion that describes conflatable feature
+ * types; e.g. BuildingCriterion.  All ElementCriterion used for identifying conflatable features
+ * should inherit from this class
  */
-class AreaCriterion : public ConflatableElementCriterion
+class ConflatableElementCriterion : public ElementCriterion
 {
 public:
 
-  static std::string className() { return "hoot::AreaCriterion"; }
+  static std::string className() { return "hoot::ConflatableElementCriterion"; }
 
-  AreaCriterion();
-
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
-
-  bool isSatisfied(const Tags& tags, const ElementType& elementType) const;
-
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new AreaCriterion()); }
-
-  virtual QString getDescription() const { return "Identifies areas"; }
+  virtual ~ConflatableElementCriterion() {}
 };
 
 }
 
-#endif // AREACRITERION_H
+#endif // CONFLATABLE_ELEMENT_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ConflatableElementCriterion.h
@@ -34,9 +34,9 @@ namespace hoot
 {
 
 /**
- * Simple abstract base class that signifies an ElementCriterion that describes conflatable feature
- * types; e.g. BuildingCriterion.  All ElementCriterion used for identifying conflatable features
- * should inherit from this class
+ * Simple abstract base class that signifies an ElementCriterion that describes a conflatable
+ * feature type; e.g. BuildingCriterion.  All ElementCriterion used for identifying conflatable
+ * features should inherit from this class
  */
 class ConflatableElementCriterion : public ElementCriterion
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ElementCriterion.h
@@ -30,10 +30,6 @@
 // hoot
 #include <hoot/core/elements/Element.h>
 #include <hoot/core/info/ApiEntityInfo.h>
-#include <hoot/core/util/NotImplementedException.h>
-
-// Standard
-#include <memory>
 
 namespace hoot
 {
@@ -53,6 +49,8 @@ class Element;
  * should only use the criteria in a positive sense. (e.g. apply something to the elements that
  * meet the criteria, rather than apply it to those that don't meet the criteria). Look at the
  * NotCriterion for an example to negate criterion.
+ *
+ * Also see: ConflatableElementCriterion.
  */
 class ElementCriterion : public ApiEntityInfo
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.h
@@ -29,7 +29,7 @@
 
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/ConstOsmMapConsumer.h>
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 namespace hoot
 {
@@ -37,7 +37,7 @@ namespace hoot
 /**
  * A criterion that will either keep or remove road matches.
  */
-class HighwayCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class HighwayCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/LinearWaterwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/LinearWaterwayCriterion.h
@@ -28,7 +28,7 @@
 #ifndef LINEAR_WATERWAY_CRITERION_H
 #define LINEAR_WATERWAY_CRITERION_H
 
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 namespace hoot
 {
@@ -36,7 +36,7 @@ namespace hoot
 /**
  * Identifies linear bodies of water
  */
-class LinearWaterwayCriterion : public ElementCriterion
+class LinearWaterwayCriterion : public ConflatableElementCriterion
 {
 public:
   static std::string className() { return "hoot::LinearWaterwayCriterion"; }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
@@ -42,11 +42,11 @@ NonConflatableCriterion::NonConflatableCriterion()
 {
   if (_conflatableCriteria.isEmpty())
   {
-    _initConflatableCriterion();
+    _createConflatableCriteria();
   }
 }
 
-void NonConflatableCriterion::_initConflatableCriterion()
+void NonConflatableCriterion::_createConflatableCriteria()
 {
   const std::vector<std::string> criterionClassNames =
     Factory::getInstance().getObjectNamesByBase(ElementCriterion::className());
@@ -79,17 +79,17 @@ bool NonConflatableCriterion::isSatisfied(const ConstElementPtr& e) const
 
 QStringList NonConflatableCriterion::conflatableCriteria(const ConstElementPtr& e)
 {
-  QStringList conflatableCriteria;
+  QStringList conflatableCriteriaForElement;
   for (QMap<QString, ElementCriterionPtr>::const_iterator itr = _conflatableCriteria.begin();
        itr != _conflatableCriteria.end(); ++itr)
   {
     if (itr.value()->isSatisfied(e))
     {
       // It is something we can conflate.
-      conflatableCriteria.append(itr.key());
+      conflatableCriteriaForElement.append(itr.key());
     }
   }
-  return conflatableCriteria;
+  return conflatableCriteriaForElement;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
@@ -34,38 +34,18 @@
 namespace hoot
 {
 
-QMap<QString, ElementCriterionPtr> NonConflatableCriterion::_conflatableCriteria;
-
 HOOT_FACTORY_REGISTER(ElementCriterion, NonConflatableCriterion)
 
 NonConflatableCriterion::NonConflatableCriterion()
 {
-  if (_conflatableCriteria.isEmpty())
-  {
-    _createConflatableCriteria();
-  }
-}
-
-void NonConflatableCriterion::_createConflatableCriteria()
-{
-  const std::vector<std::string> criterionClassNames =
-    Factory::getInstance().getObjectNamesByBase(ElementCriterion::className());
-  for (std::vector<std::string>::const_iterator itr = criterionClassNames.begin();
-       itr != criterionClassNames.end(); ++itr)
-  {
-    ElementCriterionPtr crit(Factory::getInstance().constructObject<ElementCriterion>(*itr));
-    if (std::dynamic_pointer_cast<ConflatableElementCriterion>(crit) != 0)
-    {
-      _conflatableCriteria[QString::fromStdString(*itr)] = crit;
-    }
-  }
-  LOG_VART(_conflatableCriteria.size());
 }
 
 bool NonConflatableCriterion::isSatisfied(const ConstElementPtr& e) const
 {
-  for (QMap<QString, ElementCriterionPtr>::const_iterator itr = _conflatableCriteria.begin();
-       itr != _conflatableCriteria.end(); ++itr)
+  const QMap<QString, ElementCriterionPtr> conflatableCriteria =
+    ConflatableElementCriterion::getConflatableCriteria();
+  for (QMap<QString, ElementCriterionPtr>::const_iterator itr = conflatableCriteria.begin();
+       itr != conflatableCriteria.end(); ++itr)
   {
     if (itr.value()->isSatisfied(e))
     {
@@ -75,21 +55,6 @@ bool NonConflatableCriterion::isSatisfied(const ConstElementPtr& e) const
   }
   // It is not something we can conflate
   return true;
-}
-
-QStringList NonConflatableCriterion::conflatableCriteria(const ConstElementPtr& e)
-{
-  QStringList conflatableCriteriaForElement;
-  for (QMap<QString, ElementCriterionPtr>::const_iterator itr = _conflatableCriteria.begin();
-       itr != _conflatableCriteria.end(); ++itr)
-  {
-    if (itr.value()->isSatisfied(e))
-    {
-      // It is something we can conflate.
-      conflatableCriteriaForElement.append(itr.key());
-    }
-  }
-  return conflatableCriteriaForElement;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -58,11 +58,20 @@ public:
 
   virtual QString getDescription() const { return "Identifies features that are not conflatable"; }
 
+  /**
+   * TODO
+   *
+   * @param e
+   * @return
+   */
+  static QStringList conflatableCriteria(const ConstElementPtr& e);
+
 private:
 
-  friend class NonConflatableElementCriterionTest;
+  friend class NonConflatableCriterionTest;
 
-  static QList<ElementCriterionPtr> _conflatableCriteria;
+  // criterion class names to criterion objects
+  static QMap<QString, ElementCriterionPtr> _conflatableCriteria;
 
   static void _initConflatableCriterion();
 };

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -57,24 +57,6 @@ public:
   }
 
   virtual QString getDescription() const { return "Identifies features that are not conflatable"; }
-
-  /**
-   * Determines which criteria consider an element as conflatable
-   *
-   * @param e the element to determine conflatability of
-   * @return a list of ConflatableElementCriterion class names that consider the element as
-   * conflatable
-   */
-  static QStringList conflatableCriteria(const ConstElementPtr& e);
-
-private:
-
-  friend class NonConflatableCriterionTest;
-
-  // criterion class names to criterion objects
-  static QMap<QString, ElementCriterionPtr> _conflatableCriteria;
-
-  static void _createConflatableCriteria();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -29,16 +29,16 @@
 
 // hoot
 #include <hoot/core/criterion/ElementCriterion.h>
-#include <hoot/core/util/Configurable.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/schema/MetadataTags.h>
+
+// Qt
+#include <QList>
 
 namespace hoot
 {
 
 /**
- * A filter that will remove elements that aren't conflatable by hootenanny.
- * These are elements for which we have no matchers defined.
+ * A filter that will remove elements that aren't conflatable by hootenanny. These are elements
+ * for which we have no matchers defined.
  */
 class NonConflatableCriterion : public ElementCriterion
 {
@@ -47,7 +47,7 @@ public:
 
   static std::string className() { return "hoot::NonConflatableCriterion"; }
 
-  NonConflatableCriterion() { }
+  NonConflatableCriterion();
 
   virtual bool isSatisfied(const ConstElementPtr& e) const override;
 
@@ -57,6 +57,14 @@ public:
   }
 
   virtual QString getDescription() const { return "Identifies features that are not conflatable"; }
+
+private:
+
+  friend class NonConflatableElementCriterionTest;
+
+  static QList<ElementCriterionPtr> _conflatableCriteria;
+
+  static void _initConflatableCriterion();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -37,7 +37,7 @@ namespace hoot
 {
 
 /**
- * A filter that will remove elements that aren't conflatable by hootenanny. These are elements
+ * A filter that will remove elements that aren't conflatable by Hootenanny. These are elements
  * for which we have no matchers defined.
  */
 class NonConflatableCriterion : public ElementCriterion
@@ -59,10 +59,11 @@ public:
   virtual QString getDescription() const { return "Identifies features that are not conflatable"; }
 
   /**
-   * TODO
+   * Determines which criteria consider an element as conflatable
    *
-   * @param e
-   * @return
+   * @param e the element to determine conflatability of
+   * @return a list of ConflatableElementCriterion class names that consider the element as
+   * conflatable
    */
   static QStringList conflatableCriteria(const ConstElementPtr& e);
 
@@ -73,7 +74,7 @@ private:
   // criterion class names to criterion objects
   static QMap<QString, ElementCriterionPtr> _conflatableCriteria;
 
-  static void _initConflatableCriterion();
+  static void _createConflatableCriteria();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PoiCriterion.h
@@ -27,7 +27,7 @@
 #ifndef POICRITERION_H
 #define POICRITERION_H
 
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 namespace hoot
 {
@@ -35,7 +35,7 @@ namespace hoot
 /**
  * A criterion that is only satisified with POIs.
  */
-class PoiCriterion : public ElementCriterion
+class PoiCriterion : public ConflatableElementCriterion
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PowerLineCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PowerLineCriterion.h
@@ -27,7 +27,7 @@
 #ifndef POWERLINECRITERION_H
 #define POWERLINECRITERION_H
 
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 namespace hoot
 {
@@ -35,7 +35,7 @@ namespace hoot
 /**
  * A criterion that will either keep or remove power line utilities.
  */
-class PowerLineCriterion : public ElementCriterion
+class PowerLineCriterion : public ConflatableElementCriterion
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RailwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RailwayCriterion.h
@@ -29,7 +29,7 @@
 #define RAILWAYCRITERION_H
 
 // hoot
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 namespace hoot
 {
@@ -37,7 +37,7 @@ namespace hoot
 /**
  * A criterion that will keep railways.
  */
-class RailwayCriterion : public ElementCriterion
+class RailwayCriterion : public ConflatableElementCriterion
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h
@@ -28,7 +28,7 @@
 #define POI_POLYGON_POI_CRITERION_H
 
 // hoot
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 #include <hoot/core/conflate/address/AddressParser.h>
 
 // Qt
@@ -40,7 +40,7 @@ namespace hoot
 /**
  * Identifies POIs for use with POI/Polygon conflation
  */
-class PoiPolygonPoiCriterion : public ElementCriterion
+class PoiPolygonPoiCriterion : public ConflatableElementCriterion
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h
@@ -28,7 +28,7 @@
 #define POI_POLYGON_POLY_CRITERION_H
 
 // hoot
-#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
 
 // Qt
 #include <QStringList>
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Identifies polygons for use with POI/Polygon conflation
  */
-class PoiPolygonPolyCriterion : public ElementCriterion
+class PoiPolygonPolyCriterion : public ConflatableElementCriterion
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
@@ -45,6 +45,17 @@ namespace hoot
 QStringList Tags::_nameKeys;
 QStringList Tags::_pseudoNameKeys;
 
+Tags::Tags() :
+QHash<QString, QString>()
+{
+}
+
+Tags::Tags(const QString& key, const QString& value) :
+QHash<QString, QString>()
+{
+  set(key, value);
+}
+
 void Tags::addTags(const Tags& t)
 {
   for (Tags::const_iterator it = t.constBegin(); it != t.constEnd(); ++it)

--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.h
@@ -60,6 +60,9 @@ public:
   static std::string className() { return "hoot::Tags"; }
   static QString uuidKey() { return "uuid"; }
 
+  Tags();
+  Tags(const QString& key, const QString& value);
+
   void addNote(const QString& note);
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
@@ -157,8 +157,15 @@ public:
 
   inline static const QString HootSnappedWayNode()      { return "hoot:snapped"; }
 
-  // identifies multilinestring relations hoot adds during conflation
-  inline static const QString HootMultilineString()      { return "hoot:multilinestring"; }
+  /**
+   * identifies multilinestring relations hoot adds during conflation
+   */
+  inline static const QString HootMultilineString()     { return "hoot:multilinestring"; }
+
+  /**
+   * identifies ElementConflatableCriteria that consider an element conflatable
+   */
+  inline static const QString HootConflatableCriteria() { return "hoot:conflatable:criteria"; }
 
   /**
    * ID Unique to a training data set with multiary training data.

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.cpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#include "ConflatableCriteriaVisitor.h"
+
+// hoot
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/criterion/ConflatableElementCriterion.h>
+
+namespace hoot
+{
+
+HOOT_FACTORY_REGISTER(ElementVisitor, ConflatableCriteriaVisitor)
+
+ConflatableCriteriaVisitor::ConflatableCriteriaVisitor()
+{
+}
+
+void ConflatableCriteriaVisitor::visit(const std::shared_ptr<Element>& e)
+{
+  const QStringList conflatableCriteria =
+    ConflatableElementCriterion::getConflatableCriteriaForElement(e);
+  QString conflatableCriteriaStr;
+  for (int i = 0; i < conflatableCriteria.size(); i++)
+  {
+    conflatableCriteriaStr += conflatableCriteria.at(i) + ";";
+  }
+  conflatableCriteriaStr.chop(1);
+  e->getTags()[MetadataTags::HootConflatableCriteria()] =  conflatableCriteriaStr;
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ConflatableCriteriaVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#ifndef CONFLATABLE_CRITERIA_VISITOR_H
+#define CONFLATABLE_CRITERIA_VISITOR_H
+
+// hoot
+#include <hoot/core/elements/ElementVisitor.h>
+
+namespace hoot
+{
+
+class ConflatableCriteriaVisitor : public ElementVisitor
+{
+
+public:
+
+  static std::string className() { return "hoot::ConflatableCriteriaVisitor"; }
+
+  ConflatableCriteriaVisitor();
+
+  virtual void visit(const std::shared_ptr<Element>& e);
+
+  virtual QString getDescription() const
+  { return "Marks elements with all criterion classes that consider them conflatable"; }
+};
+
+}
+
+#endif // CONFLATABLE_CRITERIA_VISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef CONFLATABLE_CRITERIA_VISITOR_H
 #define CONFLATABLE_CRITERIA_VISITOR_H

--- a/test-files/visitors/ConflatableCriteriaVisitorTest/ConflatableCriteriaVisitorTest-runBasicTest.osm
+++ b/test-files/visitors/ConflatableCriteriaVisitorTest/ConflatableCriteriaVisitorTest-runBasicTest.osm
@@ -1,0 +1,408 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.84672181207975" minlon="-104.9197586162136" maxlat="39.59441940337849" maxlon="-104.7145693652068"/>
+    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918538057342388" lon="-104.8049653120718006"/>
+    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918839666917890" lon="-104.8049694320074394"/>
+    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918855541102559" lon="-104.8048623136804309"/>
+    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918712673428601" lon="-104.8048664336160698"/>
+    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918744421802984" lon="-104.8047263558038367"/>
+    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918601554105933" lon="-104.8047366556429552"/>
+    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918617428296216" lon="-104.8047634352247144"/>
+    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918268196031988" lon="-104.8047613752569163"/>
+    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5910470002864514" lon="-104.8048703722634372"/>
+    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5910402653585791" lon="-104.8049927281098803"/>
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918132861614396" lon="-104.8045340418683224"/>
+    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918282304716129" lon="-104.8044494796687758"/>
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918267091370168" lon="-104.8043483519689971"/>
+    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918141225920408" lon="-104.8041645223572687"/>
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918253473461093" lon="-104.8042606517369109"/>
+    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918227535863068" lon="-104.8041632446121127"/>
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918139002840164" lon="-104.8042640972780504"/>
+    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918147640879994" lon="-104.8043460390379522"/>
+    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918175070261000" lon="-104.8044472273774375"/>
+    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918275295324804" lon="-104.8045322894089963"/>
+    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5931191349798937" lon="-104.8065292974913660"/>
+    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5931528497740288" lon="-104.8060931452853168"/>
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5933066733141175" lon="-104.8061245919960953"/>
+    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5932771729356574" lon="-104.8065566424572665"/>
+    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5917678695682369" lon="-104.8066608840727696"/>
+    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5914711576245608" lon="-104.8066874362091028"/>
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5914386771047546" lon="-104.8069965303088082"/>
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5917260674373566" lon="-104.8070473857991374"/>
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5911643488569496" lon="-104.8058709287899717"/>
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5909605614554110" lon="-104.8058031214695376"/>
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5909631741181940" lon="-104.8062404786862061"/>
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5911460602684713" lon="-104.8062709919803979"/>
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5913550724204910" lon="-104.8062777727124342"/>
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5912610170301207" lon="-104.8059183939142542"/>
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5915248943297016" lon="-104.8058675384239393"/>
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5915353448951350" lon="-104.8062438690522384"/>
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918880505540258" lon="-104.8058777095220080"/>
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5916816526456614" lon="-104.8058641480579070"/>
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5916576244285636" lon="-104.8062067543027354"/>
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918305727172637" lon="-104.8062370883201879"/>
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918985010646765" lon="-104.8061964039279133"/>
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5911094830770551" lon="-104.8062303075881090"/>
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5911042577624173" lon="-104.8066235900464847"/>
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918723747851047" lon="-104.8065964671183394"/>
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5910792485870715" lon="-104.8052266791553677"/>
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5910882284857166" lon="-104.8049954826725241"/>
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5909358810389094" lon="-104.8048575559457305"/>
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5909370229654272" lon="-104.8037828099171946"/>
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5917973193579158" lon="-104.8037828099171946"/>
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918025834933829" lon="-104.8038622197304051"/>
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918623451759117" lon="-104.8038646558332658"/>
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918593259945553" lon="-104.8040583838280213"/>
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918184557514508" lon="-104.8040643213816736"/>
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918284296655827" lon="-104.8046324666495792"/>
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918168975692382" lon="-104.8046309493925747"/>
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5918538712206569" lon="-104.8052113027000161"/>
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5934971733042431" lon="-104.8050061945212263"/>
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5934971733042431" lon="-104.8048403015620806"/>
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5937003389047391" lon="-104.8048343768135453"/>
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5937026216609027" lon="-104.8049113985445473"/>
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5937665388031519" lon="-104.8049143609188434"/>
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5937642560490914" lon="-104.8050032321469587"/>
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5935816354801773" lon="-104.8043811335501374"/>
+    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5935793527200275" lon="-104.8041352564856936"/>
+    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5938121938686507" lon="-104.8041234069886087"/>
+    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5938099111160895" lon="-104.8043722464273344"/>
+    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5940359032546780" lon="-104.8041411812342432"/>
+    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5942459154902124" lon="-104.8039041912925882"/>
+    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5944194033784882" lon="-104.8041559931055815"/>
+    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5942139571476162" lon="-104.8043781711758697"/>
+    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8593025332214523" lon="-104.9197586162135565">
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Manitou Springs"/>
+        <tag k="poi" v="yes"/>
+        <tag k="place" v="town"/>
+        <tag k="error:circular" v="2000"/>
+    </node>
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8885119273824316" lon="-104.7175564929962519">
+        <tag k="amenity" v="cafe"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="note" v="1-c"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="1000"/>
+    </node>
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8751955295816245" lon="-104.7179399970222704">
+        <tag k="amenity" v="cafe"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="note" v="1-d"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="1000"/>
+    </node>
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8571566428667481" lon="-104.9070371581716046">
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Manitou Springs"/>
+        <tag k="poi" v="yes"/>
+        <tag k="place" v="town"/>
+        <tag k="error:circular" v="1500"/>
+    </node>
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8940860705601636" lon="-104.7174958015344259">
+        <tag k="amenity" v="cafe"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="note" v="1-b"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="200"/>
+    </node>
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8618557942462957" lon="-104.8786905089454109">
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Garden of the Gods"/>
+        <tag k="leisure" v="park"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="1000"/>
+    </node>
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8745941427828896" lon="-104.7196458819557705">
+        <tag k="amenity" v="cafe"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="note" v="1-e"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="1000"/>
+    </node>
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8580512412840235" lon="-104.7869287551585984">
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion"/>
+        <tag k="name" v="Colorado Springs"/>
+        <tag k="poi" v="yes"/>
+        <tag k="place" v="city"/>
+        <tag k="error:circular" v="20000"/>
+    </node>
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9239774040227218" lon="-104.8439481192893510">
+        <tag k="amenity" v="cafe"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="50"/>
+    </node>
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8467218120797497" lon="-104.8852148410949496">
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Red Rock Canyon"/>
+        <tag k="leisure" v="park"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="1000"/>
+    </node>
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9109692767935371" lon="-104.7145693652068132">
+        <tag k="amenity" v="cafe"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::PoiCriterion;hoot::PoiPolygonPoiCriterion"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="note" v="1-a"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="100"/>
+    </node>
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747341" lon="-104.9005795104799432"/>
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856"/>
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938388" lon="-104.8997171368440888"/>
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598"/>
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700528" lon="-104.8990568001256065"/>
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954272" lon="-104.9005253172435630"/>
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121"/>
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016641" lon="-104.8996868263970015"/>
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061623" lon="-104.8968586569948798"/>
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809361" lon="-104.8988900284655159"/>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054"/>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481072030" lon="-104.8993671807151884"/>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666229" lon="-104.8996934957527998"/>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457476" lon="-104.8977759011253141"/>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679"/>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703"/>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630714" lon="-104.8997171368440888"/>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013855"/>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501431" lon="-104.8988321216391171"/>
+    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564655"/>
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715179" lon="-104.9010788637033329"/>
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951"/>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812496" lon="-104.8964394115716487"/>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452"/>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880536" lon="-104.8979050333482093"/>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057996975" lon="-104.8992698972467963"/>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605240" lon="-104.9005693264316363"/>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907581" lon="-104.8997069874790355"/>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841484" lon="-104.8997542928851772"/>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410"/>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836473" lon="-104.8989155074691695"/>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998730" lon="-104.8996840393162842"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794"/>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788"/>
+    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-94"/>
+        <nd ref="-95"/>
+        <nd ref="-96"/>
+        <nd ref="-97"/>
+        <nd ref="-94"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Panera Bread"/>
+        <tag k="alt_name" v="Maid-Rite"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Panera"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-90"/>
+        <nd ref="-91"/>
+        <nd ref="-92"/>
+        <nd ref="-93"/>
+        <nd ref="-90"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Bad Pair"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Convoluted No Match 2"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-86"/>
+        <nd ref="-87"/>
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <nd ref="-86"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Bad Pair"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Convoluted No Match 2"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-82"/>
+        <nd ref="-83"/>
+        <nd ref="-84"/>
+        <nd ref="-85"/>
+        <nd ref="-82"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Bad Pair"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Convoluted No Match 2"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-78"/>
+        <nd ref="-79"/>
+        <nd ref="-80"/>
+        <nd ref="-81"/>
+        <nd ref="-78"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Bad Pair"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Convoluted No Match 2"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-74"/>
+        <nd ref="-75"/>
+        <nd ref="-76"/>
+        <nd ref="-79"/>
+        <nd ref="-77"/>
+        <nd ref="-74"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Convoluted Example"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Convoluted No Match 1"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-62"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-115"/>
+        <nd ref="-114"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-110"/>
+        <nd ref="-63"/>
+        <nd ref="-64"/>
+        <nd ref="-98"/>
+        <nd ref="-107"/>
+        <nd ref="-99"/>
+        <nd ref="-106"/>
+        <nd ref="-105"/>
+        <nd ref="-100"/>
+        <nd ref="-101"/>
+        <nd ref="-103"/>
+        <nd ref="-102"/>
+        <nd ref="-104"/>
+        <nd ref="-65"/>
+        <nd ref="-66"/>
+        <nd ref="-67"/>
+        <nd ref="-68"/>
+        <nd ref="-69"/>
+        <nd ref="-70"/>
+        <nd ref="-71"/>
+        <nd ref="-109"/>
+        <nd ref="-108"/>
+        <nd ref="-72"/>
+        <nd ref="-73"/>
+        <nd ref="-62"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Target"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Target"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-56"/>
+        <nd ref="-57"/>
+        <nd ref="-58"/>
+        <nd ref="-59"/>
+        <nd ref="-60"/>
+        <nd ref="-61"/>
+        <nd ref="-56"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Freddy's"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Freddy's"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-52"/>
+        <nd ref="-53"/>
+        <nd ref="-54"/>
+        <nd ref="-55"/>
+        <nd ref="-52"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Biondi"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-48"/>
+        <nd ref="-49"/>
+        <nd ref="-50"/>
+        <nd ref="-51"/>
+        <nd ref="-48"/>
+        <tag k="amenity" v="restaurant"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::AreaCriterion;hoot::BuildingCriterion;hoot::PoiPolygonPolyCriterion"/>
+        <tag k="name" v="Cheddar's Casual Cafe"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Cheddar's"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="-21"/>
+        <nd ref="-1"/>
+        <nd ref="-17"/>
+        <nd ref="-31"/>
+        <nd ref="-13"/>
+        <nd ref="-34"/>
+        <nd ref="-20"/>
+        <nd ref="-9"/>
+        <nd ref="-4"/>
+        <nd ref="-24"/>
+        <nd ref="-8"/>
+        <nd ref="-29"/>
+        <nd ref="-15"/>
+        <nd ref="-25"/>
+        <nd ref="-11"/>
+        <nd ref="-32"/>
+        <nd ref="-18"/>
+        <nd ref="-2"/>
+        <nd ref="-22"/>
+        <nd ref="-6"/>
+        <nd ref="-27"/>
+        <nd ref="-33"/>
+        <nd ref="-19"/>
+        <nd ref="-3"/>
+        <nd ref="-23"/>
+        <nd ref="-7"/>
+        <nd ref="-28"/>
+        <nd ref="-14"/>
+        <nd ref="-35"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::HighwayCriterion"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-13"/>
+        <nd ref="-26"/>
+        <nd ref="-12"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::HighwayCriterion"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-16"/>
+        <nd ref="-36"/>
+        <nd ref="-20"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::HighwayCriterion"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36"/>
+        <nd ref="-10"/>
+        <nd ref="-31"/>
+        <tag k="hoot:conflatable:criteria" v="hoot::HighwayCriterion"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+</osm>


### PR DESCRIPTION
* Established a base class for `ElementCriterion` to inherit from for criterion that are used to identify conflatable features. This also cleans up the static addition of `ElementCriterion` classes to NonConflatableCriterion, thus reducing future maintenance.
* Added a visitor, `ConflatableCriteriaVisitor`, useful in debugging instances where it isn't clear which criterion is identifying a feature as a conflatable.