### PR TITLE
Expand yum version locks

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -54,6 +54,7 @@ if ! rpm -qa | grep -q ^yum-plugin-versionlock ; then
 else
     # Remove any version locks to allow upgrading when versions have changed.
     sudo yum versionlock delete \
+         armadillo \
          geos \
          geos-devel \
          glpk \
@@ -61,12 +62,16 @@ else
          hoot-gdal \
          hoot-gdal-devel \
          hoot-gdal-python \
+         libgeotiff \
+         libgeotiff-devel \
          liboauthcpp \
          liboauthcpp-devel \
          libphonenumber \
          libphonenumber-devel \
          nodejs \
          nodejs-devel \
+         proj \
+         proj-devel \
          stxxl \
          stxxl-devel
 
@@ -74,6 +79,7 @@ fi
 
 echo "### Installing libraries with locked versions"
 sudo yum install -y \
+     armadillo-$ARMADILLO_VERSION \
      geos-$GEOS_VERSION \
      geos-devel-$GEOS_VERSION \
      glpk-$GLPK_VERSION \
@@ -81,17 +87,22 @@ sudo yum install -y \
      hoot-gdal-$GDAL_VERSION \
      hoot-gdal-devel-$GDAL_VERSION \
      hoot-gdal-python-$GDAL_VERSION \
+     libgeotiff-$LIBGEOTIFF_VERSION \
+     libgeotiff-devel-$LIBGEOTIFF_VERSION \
      libphonenumber-$LIBPHONENUMBER_VERSION \
      libphonenumber-devel-$LIBPHONENUMBER_VERSION \
      liboauthcpp-$LIBOAUTHCPP_VERSION \
      liboauthcpp-devel-$LIBOAUTHCPP_VERSION \
      nodejs-$NODE_VERSION \
      nodejs-devel-$NODE_VERSION \
+     proj-$PROJ_VERSION \
+     proj-devel-$PROJ_VERSION \
      stxxl-$STXXL_VERSION \
      stxxl-devel-$STXXL_VERSION
 
 echo "### Locking versions of libraries"
 sudo yum versionlock add \
+     armadillo-$ARMADILLO_VERSION \
      geos-$GEOS_VERSION \
      geos-devel-$GEOS_VERSION \
      glpk-$GLPK_VERSION \
@@ -99,12 +110,16 @@ sudo yum versionlock add \
      hoot-gdal-$GDAL_VERSION \
      hoot-gdal-devel-$GDAL_VERSION \
      hoot-gdal-python-$GDAL_VERSION \
+     libgeotiff-$LIBGEOTIFF_VERSION \
+     libgeotiff-devel-$LIBGEOTIFF_VERSION \
      libphonenumber-$LIBPHONENUMBER_VERSION \
      libphonenumber-devel-$LIBPHONENUMBER_VERSION \
      liboauthcpp-$LIBOAUTHCPP_VERSION \
      liboauthcpp-devel-$LIBOAUTHCPP_VERSION \
      nodejs-$NODE_VERSION \
      nodejs-devel-$NODE_VERSION \
+     proj-$PROJ_VERSION \
+     proj-devel-$PROJ_VERSION \
      stxxl-$STXXL_VERSION \
      stxxl-devel-$STXXL_VERSION
 

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -6,12 +6,15 @@ export JDK_TAR=jdk-8u161-linux-x64.tar.gz
 export JDK_MD5=99051574a0d90871ed24a91a5d321ed2
 
 # Dependency library versions.
+export ARMADILLO_VERSION=8.300.0
 export GDAL_VERSION=2.1.4
 export GEOS_VERSION=3.6.2
 export GLPK_VERSION=4.64
 export LIBOAUTHCPP_VERSION=0.1.0
+export LIBGEOTIFF_VERSION=1.4.2
 export LIBPHONENUMBER_VERSION=8.9.16
 export NODE_VERSION=8.9.3
+export PROJ_VERSION=4.8.0
 export STXXL_VERSION=1.3.1
 
 # FGDB 1.5 is required to compile using g++ >= 5.1


### PR DESCRIPTION
Fixes #3249, expand yum version locks to:
* `armadillo-8.300.0`
* `libgeotiff-1.4.2`
* `proj-4.8.0`