### PR TITLE
Add inline conversion opts to changeset-derive command

### DIFF
--- a/docs/commands/changeset-derive.asciidoc
+++ b/docs/commands/changeset-derive.asciidoc
@@ -38,9 +38,14 @@ hoot changeset-derive inputData.osm "" outputChangeset.osc
 hoot changeset-derive inputData.osm "" outputChangeset.osc.sql osmapidb://username:password@localhost:5432/osmApiDatabaseName
 --------------------------------------
 
-=== Notes
+=== Configuration Options
 
-* Element sorting, required by changeset derivation, is performed in memory by default.  To perform sorting in a non-memory bound
+Changset deriviation supports conversion operations with the `convert.ops` configuration option. See the "Configuration Options" section
+of the `convert` command documentation for details.
+
+=== Sorting
+
+Element sorting, required by changeset derivation, is performed in memory by default.  To perform sorting in a non-memory bound
 fashion, set the configuration option element.sorter.element.buffer.size to a value greater than zero.
 
 === See Also

--- a/docs/commands/changeset-derive.asciidoc
+++ b/docs/commands/changeset-derive.asciidoc
@@ -31,6 +31,8 @@ changeset-derive (input1) [input2] (output) [osmApiDatabaseUrl] [--stats]
 --------------------------------------
 hoot changeset-derive inputData1.osm inputData2.osm outputChangeset.osc
 
+hoot changeset-derive -D convert.ops="op1;op2" inputData1.osm inputData2.osm outputChangeset.osc
+
 hoot changeset-derive inputData1.osm inputData2.osm outputChangeset.osc --stats
 
 hoot changeset-derive inputData.osm "" outputChangeset.osc
@@ -40,13 +42,17 @@ hoot changeset-derive inputData.osm "" outputChangeset.osc.sql osmapidb://userna
 
 === Configuration Options
 
-Changset deriviation supports conversion operations with the `convert.ops` configuration option. See the "Configuration Options" section
+Changeset deriviation supports inline conversion operations with the `convert.ops` configuration option. See the "Configuration Options" section
 of the `convert` command documentation for details.
 
 === Sorting
 
-Element sorting, required by changeset derivation, is performed in memory by default.  To perform sorting in a non-memory bound
-fashion, set the configuration option element.sorter.element.buffer.size to a value greater than zero.
+Element sorting, required by changeset derivation, is performed in memory by default. This may cause problems with larger datasets.  To 
+perform sorting in a non-memory bound fashion (to external disk), set the configuration option element.sorter.element.buffer.size to a value 
+greater than zero.
+
+Also, if inline conversion operations are specified in `convert.ops` and any of them do not support streaming (either operations that are an 
+OsmMapOperation or an OsmMapConsumer), in-memory sorting will always occur.
 
 === See Also
 

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/AddAttributesVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/AddAttributesVisitorTest.cpp
@@ -55,8 +55,6 @@ class AddAttributesVisitorTest : public HootTestFixture
 
 public:
 
-
-
   AddAttributesVisitorTest()
     : HootTestFixture("test-files/visitors/AddAttributesVisitorTest/",
                       "test-output/visitors/AddAttributesVisitorTest/")

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
@@ -170,7 +170,6 @@ public:
     }
     _currentTaskNum++;
 
-    // We could make this progress reporting more granular, but for in-memory changesets only.
     progress.set((float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Writing changeset...");
     _streamChangesetOutput(sortedElements1, sortedElements2, output);
     _currentTaskNum++;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
@@ -46,6 +46,8 @@
 #include <hoot/core/io/PartialOsmMapReader.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/util/Progress.h>
+#include <hoot/core/ops/NamedOp.h>
+#include <hoot/core/io/ElementStreamer.h>
 
 //GEOS
 #include <geos/geom/Envelope.h>
@@ -61,12 +63,13 @@ namespace hoot
 /**
  * Derives a set of changes given two map inputs
  *
- * Streaming I/O and external element are available to this command.  However, the in memory input
+ * Streaming I/O and external element are available to this command.  However, the in-memory input
  * reading/sorting has been left in place to support faster I/O in the situation where large inputs
- * are being dealt with and large amounts of memory are available for reading/sorting.  Access to
- * the in memory implementation is controlled by the configuration option,
- * element.sorter.element.buffer.size (size = -1 results in the in memory implementation being
- * used).
+ * are being dealt with and large amounts of memory are available for reading/sorting or when
+ * conversion operations are passed in which require reading an entire map into memory.  Access to
+ * the the sorter implementation is controlled by the configuration option,
+ * element.sorter.element.buffer.size where a size = -1 results in the in-memory implementation
+ * being used and a positive size results in the external sorter being used.
  */
 class DeriveChangesetCmd : public BaseCommand
 {
@@ -82,8 +85,6 @@ public:
   virtual QString getName() const { return "changeset-derive"; }
 
   virtual QString getDescription() const { return "Creates an OSM changeset"; }
-
-  bool _printStats = false;
 
   virtual int runSimple(QStringList args)
   {
@@ -123,11 +124,23 @@ public:
     }
     LOG_VARD(_osmApiDbUrl);
 
+    const bool singleInput = input2.trimmed().isEmpty();
+
     const QString jobSource = "Derive Changeset";
     // The number of steps here must be updated as you add/remove job steps in the logic.
-    const int numTotalTasks = 2;
-    int currentTaskNum = 1;
-    // TODO: update progress
+    _numTotalTasks = 2;
+
+    // for non-streamable convert ops and other inline ops that occur when not streaming
+    if (!_inputIsStreamable(input1))
+    {
+      _numTotalTasks += 3;
+    }
+    if (!singleInput && !_inputIsStreamable(input2))
+    {
+      _numTotalTasks += 3;
+    }
+
+    _currentTaskNum = 1;
     Progress progress(ConfigOptions().getJobId(), jobSource, Progress::JobState::Running);
     const int maxFilePrintLength = ConfigOptions().getProgressVarPrintLengthMax();
 
@@ -138,31 +151,29 @@ public:
 
     _parseBuffer();
 
-    const bool singleInput = input2.trimmed().isEmpty();
-
-    progress.set((float)(currentTaskNum - 1) / (float)numTotalTasks, "Sorting features...");
+    progress.set((float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Sorting features...");
     ElementInputStreamPtr sortedElements1;
     ElementInputStreamPtr sortedElements2;
     if (!singleInput)
     {
       //sortedElements1 is the former state of the data
-      sortedElements1 = _getSortedElements(input1, Status::Unknown1);
+      sortedElements1 = _getSortedElements(input1, Status::Unknown1, progress);
       //sortedElements2 is the newer state of the data
-      sortedElements2 = _getSortedElements(input2, Status::Unknown2);
+      sortedElements2 = _getSortedElements(input2, Status::Unknown2, progress);
     }
     else
     {
       //Here we're passing all the input data through to the output changeset, so put it in the
       //sortedElements2 newer data and leave the first one empty.
       sortedElements1 = _getEmptyInputStream();
-      sortedElements2 = _getSortedElements(input1, Status::Unknown2);
+      sortedElements2 = _getSortedElements(input1, Status::Unknown2, progress);
     }
-    currentTaskNum++;
+    _currentTaskNum++;
 
     // We could make this progress reporting more granular, but for in-memory changesets only.
-    progress.set((float)(currentTaskNum - 1) / (float)numTotalTasks, "Writing changeset...");
+    progress.set((float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Writing changeset...");
     _streamChangesetOutput(sortedElements1, sortedElements2, output);
-    currentTaskNum++;
+    _currentTaskNum++;
 
     progress.set(
       1.0, Progress::JobState::Successful,
@@ -174,6 +185,11 @@ public:
 private:
 
   QString _osmApiDbUrl;
+
+  int _numTotalTasks;
+  int _currentTaskNum;
+
+  bool _printStats = false;
 
   void _parseBuffer()
   {
@@ -234,7 +250,15 @@ private:
     return false;
   }
 
-  OsmMapPtr _readInputFully(const QString& input, const Status& elementStatus)
+  bool _inputIsStreamable(const QString& input) const
+  {
+    LOG_VARD(OsmMapReaderFactory::hasElementInputStream(input));
+    return
+      OsmMapReaderFactory::hasElementInputStream(input) &&
+      ElementStreamer::areValidStreamingOps(ConfigOptions().getConvertOps());
+  }
+
+  OsmMapPtr _readInputFully(const QString& input, const Status& elementStatus, Progress progress)
   {
     LOG_INFO("Reading entire input into memory for " << input.right(25) << "...");
 
@@ -243,36 +267,40 @@ private:
     OsmMapPtr map(new OsmMap());
     IoUtils::loadMap(map, input, true, elementStatus);
 
-    // TODO: apply ops
-    /*
-     *if (_convertOps.size() > 0)
+    if (ConfigOptions().getConvertOps().size() > 0)
     {
-      NamedOp convertOps(_convertOps);
+      NamedOp convertOps(ConfigOptions().getConvertOps());
       convertOps.setProgress(
         Progress(
           ConfigOptions().getJobId(), JOB_SOURCE, Progress::JobState::Running,
-          (float)(currentStep - 1) / (float)numSteps, 1.0 / (float)numSteps));
+          (float)(_currentTaskNum - 1) / (float)_numTotalTasks, 1.0 / (float)_numTotalTasks));
       convertOps.apply(map);
-      currentStep++;
+      _currentTaskNum++;
     }
-     */
 
     //we don't want to include review relations
+    progress.set(
+      (float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Removing review relations...");
     std::shared_ptr<TagKeyCriterion> elementCriterion(
       new TagKeyCriterion(MetadataTags::HootReviewNeeds()));
     RemoveElementsVisitor removeElementsVisitor;
     removeElementsVisitor.setRecursive(false);
     removeElementsVisitor.addCriterion(elementCriterion);
     map->visitRw(removeElementsVisitor);
+    _currentTaskNum++;
 
     //node comparisons require hashes be present on the elements
+    progress.set(
+      (float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Adding element hashes...");
     CalculateHashVisitor2 hashVis;
     map->visitRw(hashVis);
+    _currentTaskNum++;
 
     return map;
   }
 
-  ElementInputStreamPtr _getSortedElements(const QString& input, const Status& status)
+  ElementInputStreamPtr _getSortedElements(const QString& input, const Status& status,
+                                           Progress progress)
   {
     ElementInputStreamPtr sortedElements;
 
@@ -284,32 +312,18 @@ private:
     //Only sort if input isn't already sorted.
     if (!inputSorted)
     {
-      /*
-       * TODO: add streamable check
-       * TODO: change buffer size default
-       *
-       * const bool isStreamable =
-    ElementStreamer::areValidStreamingOps(_convertOps) &&
-    ElementStreamer::areStreamableIo(inputs, output);
-       */
-
-      //If external sorting is enabled and both inputs are streamable, externally sort the elements
+      //If external sorting is enabled and the input is streamable, externally sort the elements
       //to avoid potential memory issues.
       LOG_VARD(ConfigOptions().getElementSorterElementBufferSize());
-      LOG_VARD(OsmMapReaderFactory::hasElementInputStream(input));
-      if (OsmMapReaderFactory::hasElementInputStream(input) &&
-          ConfigOptions().getElementSorterElementBufferSize() != -1)
+      if (_inputIsStreamable(input) && ConfigOptions().getElementSorterElementBufferSize() != -1)
       {
         sortedElements = _sortElementsExternally(input);
       }
       else
       {
-        // TODO: get rid of in memory sorter and _readInputFully (or factory implementation; do
-        // performance comparison first)?
-
         //Otherwise, since currently not all input formats are supported as streamable, switch over
         //to memory bound sorting.
-        sortedElements = _sortElementsInMemory(_readInputFully(input, status));
+        sortedElements = _sortElementsInMemory(_readInputFully(input, status, progress));
       }
     }
     else
@@ -339,8 +353,6 @@ private:
     //node comparisons require hashes be present on the elements
     visitors.append(std::shared_ptr<CalculateHashVisitor2>(new CalculateHashVisitor2()));
 
-    // TODO: add streaming ops in the pipeline
-
     std::shared_ptr<PartialOsmMapReader> reader =
       std::dynamic_pointer_cast<PartialOsmMapReader>(
         OsmMapReaderFactory::createReader(input));
@@ -350,7 +362,9 @@ private:
     ElementInputStreamPtr filteredInputStream(
       new ElementCriterionVisitorInputStream(inputStream, elementCriterion, visitors));
 
-    return filteredInputStream;
+    // Add streaming ops in the pipeline, if there are any.
+    return
+      ElementStreamer::getFilteredInputStream(filteredInputStream, ConfigOptions().getConvertOps());
   }
 
   ElementInputStreamPtr _sortElementsInMemory(OsmMapPtr map)

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
@@ -46,6 +46,8 @@
 #include <hoot/core/io/PartialOsmMapReader.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/util/Progress.h>
+#include <hoot/core/ops/NamedOp.h>
+#include <hoot/core/io/ElementStreamer.h>
 
 //GEOS
 #include <geos/geom/Envelope.h>
@@ -226,7 +228,7 @@ private:
     //Streaming db inputs actually do not come back sorted, despite the order by id clause
     //in the query (see ApiDb::selectElements).  Otherwise, we'd skip sorting them too.
 
-    //pbf sets a sort flag
+    //pbf sets a sorted flag
     if (OsmPbfReader().isSupported(input) && OsmPbfReader().isSorted(input))
     {
       return true;
@@ -243,19 +245,16 @@ private:
     OsmMapPtr map(new OsmMap());
     IoUtils::loadMap(map, input, true, elementStatus);
 
-    // TODO: apply ops
-    /*
-     *if (_convertOps.size() > 0)
+    if (ConfigOptions().getConvertOps().size() > 0)
     {
-      NamedOp convertOps(_convertOps);
-      convertOps.setProgress(
-        Progress(
-          ConfigOptions().getJobId(), JOB_SOURCE, Progress::JobState::Running,
-          (float)(currentStep - 1) / (float)numSteps, 1.0 / (float)numSteps));
+      NamedOp convertOps(ConfigOptions().getConvertOps());
+//      convertOps.setProgress(
+//        Progress(
+//          ConfigOptions().getJobId(), JOB_SOURCE, Progress::JobState::Running,
+//          (float)(currentStep - 1) / (float)numSteps, 1.0 / (float)numSteps));
       convertOps.apply(map);
-      currentStep++;
+      //currentStep++;
     }
-     */
 
     //we don't want to include review relations
     std::shared_ptr<TagKeyCriterion> elementCriterion(
@@ -284,29 +283,18 @@ private:
     //Only sort if input isn't already sorted.
     if (!inputSorted)
     {
-      /*
-       * TODO: add streamable check
-       * TODO: change buffer size default
-       *
-       * const bool isStreamable =
-    ElementStreamer::areValidStreamingOps(_convertOps) &&
-    ElementStreamer::areStreamableIo(inputs, output);
-       */
-
       //If external sorting is enabled and both inputs are streamable, externally sort the elements
       //to avoid potential memory issues.
       LOG_VARD(ConfigOptions().getElementSorterElementBufferSize());
       LOG_VARD(OsmMapReaderFactory::hasElementInputStream(input));
       if (OsmMapReaderFactory::hasElementInputStream(input) &&
-          ConfigOptions().getElementSorterElementBufferSize() != -1)
+          ConfigOptions().getElementSorterElementBufferSize() != -1 &&
+          ElementStreamer::areValidStreamingOps(ConfigOptions().getConvertOps()))
       {
         sortedElements = _sortElementsExternally(input);
       }
       else
       {
-        // TODO: get rid of in memory sorter and _readInputFully (or factory implementation; do
-        // performance comparison first)?
-
         //Otherwise, since currently not all input formats are supported as streamable, switch over
         //to memory bound sorting.
         sortedElements = _sortElementsInMemory(_readInputFully(input, status));
@@ -340,6 +328,14 @@ private:
     visitors.append(std::shared_ptr<CalculateHashVisitor2>(new CalculateHashVisitor2()));
 
     // TODO: add streaming ops in the pipeline
+
+    /*
+     * ElementStreamer::stream(
+      inputs, output, _convertOps,
+      Progress(
+        ConfigOptions().getJobId(), JOB_SOURCE, Progress::JobState::Running,
+        (float)(currentTask - 1) / (float)numTasks, taskWeight));
+     */
 
     std::shared_ptr<PartialOsmMapReader> reader =
       std::dynamic_pointer_cast<PartialOsmMapReader>(
@@ -413,5 +409,3 @@ private:
 HOOT_FACTORY_REGISTER(Command, DeriveChangesetCmd)
 
 }
-
-

--- a/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.cpp
@@ -96,7 +96,7 @@ void ExternalMergeElementSorter::sort(ElementInputStreamPtr input)
 
 void ExternalMergeElementSorter::_sort(ElementInputStreamPtr input)
 {
-  LOG_INFO("Sorting input by element ID and type...");
+  LOG_INFO("Sorting elements on external disk...");
 
   //if only one file was written, skip merging
   _createSortedFileOutputs(input);

--- a/hoot-core/src/main/cpp/hoot/core/elements/InMemoryElementSorter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/InMemoryElementSorter.cpp
@@ -43,8 +43,12 @@ InMemoryElementSorter::InMemoryElementSorter(ConstOsmMapPtr source) :
 {
   if (source)
   {
-    LOG_INFO(
-      "Sorting elements by element type for map with element count: " << source->getElementCount());
+    // Its possible an empty map was sent back just for obtaining an empty stream...let's not
+    // log that.
+    if (source->getElementCount() > 0)
+    {
+      LOG_INFO("Sorting " << source->getElementCount() << " elements in-memory...");
+    }
 
     _source = source;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -213,14 +213,13 @@ ElementInputStreamPtr ElementStreamer::_getFilteredInputStream(
 }
 
 void ElementStreamer::stream(const QString& input, const QString& out, const QStringList& convertOps,
-                             ElementInputStreamPtr customInputStream, Progress progress)
+                             Progress progress)
 {
-  stream(QStringList(input), out, convertOps, customInputStream, progress);
+  stream(QStringList(input), out, convertOps, progress);
 }
 
 void ElementStreamer::stream(const QStringList& inputs, const QString& out,
-                             const QStringList& convertOps, ElementInputStreamPtr customInputStream,
-                             Progress progress)
+                             const QStringList& convertOps, Progress progress)
 {
   QElapsedTimer timer;
   timer.start();
@@ -257,11 +256,6 @@ void ElementStreamer::stream(const QStringList& inputs, const QString& out,
     // add visitor/criterion operations if any of the convert ops are visitors.
     LOG_VARD(convertOps);
     ElementInputStreamPtr streamReader = _getFilteredInputStream(reader, convertOps);
-
-    if (customInputStream)
-    {
-      //streamReader.reset(new ElementInputStream())
-    }
 
     ElementOutputStream::writeAllElements(*streamReader, *streamWriter);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -213,13 +213,14 @@ ElementInputStreamPtr ElementStreamer::_getFilteredInputStream(
 }
 
 void ElementStreamer::stream(const QString& input, const QString& out, const QStringList& convertOps,
-                             Progress progress)
+                             ElementInputStreamPtr customInputStream, Progress progress)
 {
-  stream(QStringList(input), out, convertOps, progress);
+  stream(QStringList(input), out, convertOps, customInputStream, progress);
 }
 
 void ElementStreamer::stream(const QStringList& inputs, const QString& out,
-                             const QStringList& convertOps, Progress progress)
+                             const QStringList& convertOps, ElementInputStreamPtr customInputStream,
+                             Progress progress)
 {
   QElapsedTimer timer;
   timer.start();
@@ -256,6 +257,11 @@ void ElementStreamer::stream(const QStringList& inputs, const QString& out,
     // add visitor/criterion operations if any of the convert ops are visitors.
     LOG_VARD(convertOps);
     ElementInputStreamPtr streamReader = _getFilteredInputStream(reader, convertOps);
+
+    if (customInputStream)
+    {
+      //streamReader.reset(new ElementInputStream())
+    }
 
     ElementOutputStream::writeAllElements(*streamReader, *streamWriter);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
@@ -105,11 +105,11 @@ public:
   static bool areValidStreamingOps(const QStringList& ops);
 
   /**
-   * TODO
+   * Get an input stream set up to be filtered by operations
    *
-   * @param streamToFilter
-   * @param ops
-   * @return
+   * @param streamToFilter the stream to be filtered
+   * @param ops a list of Hoot operation class names to use for inline filtering on the input stream
+   * @return an input stream
    */
   static ElementInputStreamPtr getFilteredInputStream(
     ElementInputStreamPtr streamToFilter, const QStringList& ops);

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
@@ -55,10 +55,13 @@ public:
    * @param inputs data sources
    * @param out data destination
    * @param convertOps a list of map ops/visitors to perform against the data during conversion
+   * @param customInputStream TODO
    * @param progress optional for tracking I/O job progress
    */
   static void stream(const QStringList& inputs, const QString& out,
-                     const QStringList& convertOps = QStringList(), Progress progress = Progress());
+                     const QStringList& convertOps = QStringList(),
+                     ElementInputStreamPtr customInputStream = ElementInputStreamPtr(),
+                     Progress progress = Progress());
 
   /**
    * Streams a data source from input to output.
@@ -68,10 +71,13 @@ public:
    * @param input data source
    * @param out data destination
    * @param convertOps a list of map ops/visitors to perform against the data during conversion
+   * @param customInputStream TODO
    * @param progress optional for tracking I/O job progress
    */
   static void stream(const QString& input, const QString& out,
-                     const QStringList& convertOps = QStringList(), Progress progress = Progress());
+                     const QStringList& convertOps = QStringList(),
+                     ElementInputStreamPtr customInputStream = ElementInputStreamPtr(),
+                     Progress progress = Progress());
 
   /**
    * Determines whether both input and output are streamable data sources (associated

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
@@ -55,13 +55,10 @@ public:
    * @param inputs data sources
    * @param out data destination
    * @param convertOps a list of map ops/visitors to perform against the data during conversion
-   * @param customInputStream TODO
    * @param progress optional for tracking I/O job progress
    */
   static void stream(const QStringList& inputs, const QString& out,
-                     const QStringList& convertOps = QStringList(),
-                     ElementInputStreamPtr customInputStream = ElementInputStreamPtr(),
-                     Progress progress = Progress());
+                     const QStringList& convertOps = QStringList(), Progress progress = Progress());
 
   /**
    * Streams a data source from input to output.
@@ -71,13 +68,10 @@ public:
    * @param input data source
    * @param out data destination
    * @param convertOps a list of map ops/visitors to perform against the data during conversion
-   * @param customInputStream TODO
    * @param progress optional for tracking I/O job progress
    */
   static void stream(const QString& input, const QString& out,
-                     const QStringList& convertOps = QStringList(),
-                     ElementInputStreamPtr customInputStream = ElementInputStreamPtr(),
-                     Progress progress = Progress());
+                     const QStringList& convertOps = QStringList(), Progress progress = Progress());
 
   /**
    * Determines whether both input and output are streamable data sources (associated

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
@@ -104,10 +104,15 @@ public:
    */
   static bool areValidStreamingOps(const QStringList& ops);
 
-private:
-
-  static ElementInputStreamPtr _getFilteredInputStream(
-    std::shared_ptr<OsmMapReader> reader, const QStringList& ops);
+  /**
+   * TODO
+   *
+   * @param streamToFilter
+   * @param ops
+   * @return
+   */
+  static ElementInputStreamPtr getFilteredInputStream(
+    ElementInputStreamPtr streamToFilter, const QStringList& ops);
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
@@ -171,7 +171,7 @@ bool OsmMapReaderFactory::isSupportedFormat(const QString& url)
 void OsmMapReaderFactory::read(const OsmMapPtr& map, const QString& url, bool useDataSourceIds,
                                Status defaultStatus)
 {
-  LOG_INFO("Loading map from " << url.right(50) << "...");
+  LOG_INFO("Loading map from ..." << url.right(50) << "...");
   std::shared_ptr<OsmMapReader> reader = createReader(url, useDataSourceIds, defaultStatus);
   _read(map, reader, url);
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveWayOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveWayOp.cpp
@@ -39,13 +39,13 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(OsmMapOperation, RemoveWayOp)
 
-RemoveWayOp::RemoveWayOp(bool removeFully):
+RemoveWayOp::RemoveWayOp(bool removeFully) :
 _wayIdToRemove(-std::numeric_limits<int>::max()),
 _removeFully(removeFully)
 {
 }
 
-RemoveWayOp::RemoveWayOp(long wId, bool removeFully):
+RemoveWayOp::RemoveWayOp(long wId, bool removeFully) :
 _wayIdToRemove(wId),
 _removeFully(removeFully)
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddAttributesVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddAttributesVisitor.cpp
@@ -53,7 +53,9 @@ void AddAttributesVisitor::setConfiguration(const Settings& conf)
 {
   ConfigOptions configOptions(conf);
   _attributes = configOptions.getAddAttributesVisitorKvps();
+  LOG_VARD(_attributes);
   _addOnlyIfEmpty = configOptions.getAddAttributesVisitorAddOnlyIfEmpty();
+  LOG_VARD(_addOnlyIfEmpty);
 }
 
 void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
@@ -62,6 +64,7 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
   {
     QString attributeValue;
     const ElementAttributeType attrType = _getAttributeType(_attributes.at(i), attributeValue);
+    LOG_VART(attrType);
 
     bool ok = false;
     switch (attrType.getEnum())
@@ -75,6 +78,7 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
             throw IllegalArgumentException("Invalid attribute value: " + attributeValue);
           }
           LOG_TRACE("Added " << attrType.toString() << "=" << attributeValue);
+          _numAffected++;
         }
         break;
 
@@ -83,6 +87,7 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
         {
           e->setTimestamp(OsmUtils::fromTimeString(attributeValue));
           LOG_TRACE("Added " << attrType.toString() << "=" << attributeValue);
+          _numAffected++;
         }
         break;
 
@@ -92,6 +97,7 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
           e->setUser(attributeValue);
         }
         LOG_TRACE("Added " << attrType.toString() << "=" << attributeValue);
+        _numAffected++;
         break;
 
       case ElementAttributeType::Uid:
@@ -103,6 +109,7 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
             throw IllegalArgumentException("Invalid attribute value: " + attributeValue);
           }
           LOG_TRACE("Added " << attrType.toString() << "=" << attributeValue);
+          _numAffected++;
         }
         break;
 
@@ -115,6 +122,7 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
             throw IllegalArgumentException("Invalid attribute value: " + attributeValue);
           }
           LOG_TRACE("Added " << attrType.toString() << "=" << attributeValue);
+          _numAffected++;
         }
         break;
 
@@ -127,14 +135,16 @@ void AddAttributesVisitor::visit(const std::shared_ptr<Element>& e)
 ElementAttributeType::Type AddAttributesVisitor::_getAttributeType(const QString& attribute,
                                                                    QString& attributeValue)
 {
-  //LOG_VART(attribute);
+  LOG_VART(attribute);
   const QStringList attributeParts = attribute.split("=");
   if (attributeParts.size() != 2)
   {
     throw IllegalArgumentException("Invalid attribute: " + attribute);
   }
   const QString attributeName = attributeParts[0];
+  LOG_VART(attributeName);
   attributeValue = attributeParts[1].trimmed();
+  LOG_VART(attributeValue);
   if (attributeValue.isEmpty())
   {
     throw IllegalArgumentException("Invalid empty attribute.");

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddAttributesVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddAttributesVisitor.h
@@ -31,6 +31,7 @@
 #include <hoot/core/util/Configurable.h>
 #include <hoot/core/elements/ElementAttributeType.h>
 #include <hoot/core/elements/ElementVisitor.h>
+#include <hoot/core/info/OperationStatusInfo.h>
 
 namespace hoot
 {
@@ -39,7 +40,7 @@ namespace hoot
  * Adds one or more attributes to elements.  Only common OSM attributes may be added
  * (see ElementAttributeType).
  */
-class AddAttributesVisitor : public ElementVisitor, public Configurable
+class AddAttributesVisitor : public ElementVisitor, public Configurable, public OperationStatusInfo
 {
 
 public:
@@ -58,6 +59,11 @@ public:
 
   virtual QString getDescription() const
   { return "Adds one or more common OSM attributes to features"; }
+
+  virtual QString getInitStatusMessage() const { return "Adding attributes..."; }
+
+  virtual QString getCompletedStatusMessage() const
+  { return "Added " + QString::number(_numAffected) + " attributes"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CalculateHashVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CalculateHashVisitor.cpp
@@ -100,9 +100,7 @@ QString CalculateHashVisitor::toJsonString(const ConstElementPtr& e)
 QByteArray CalculateHashVisitor::toHash(const ConstElementPtr& e)
 {
   QCryptographicHash hash(QCryptographicHash::Sha1);
-
   hash.addData(toJsonString(e).toLatin1().constData());
-
   return hash.result();
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReplaceTagVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReplaceTagVisitor.cpp
@@ -73,7 +73,6 @@ void ReplaceTagVisitor::setConfiguration(const Settings& conf)
     _matchKey = matchTagParts[0];
     _matchValue = matchTagParts[1];
 
-
     if (!replaceTag.contains("="))
     {
       throw IllegalArgumentException("Invalid replace tag: " + replaceTag);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
@@ -43,7 +43,7 @@ namespace hoot
  * shouldn't contain missing references.
  */
 class ReportMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumer,
-    public Configurable, public OperationStatusInfo
+  public Configurable, public OperationStatusInfo
 {
 public:
 

--- a/test-files/cmd/slow/DeriveChangesetCmdTest.sh
+++ b/test-files/cmd/slow/DeriveChangesetCmdTest.sh
@@ -6,7 +6,7 @@ OUTPUT_DIR=test-output/cmd/slow/DeriveChangesetCmdTest
 rm -rf $OUTPUT_DIR
 mkdir -p $OUTPUT_DIR
 
-# IN MEMORY SORTING
+# IN MEMORY SORTING (default)
 
 hoot changeset-derive -C Testing.conf $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-1.osc
 diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-1.osc 
@@ -14,12 +14,12 @@ diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-1.osc
 hoot changeset-derive -C Testing.conf $INPUT_DIR/map1.osm "" $OUTPUT_DIR/changeset-2.osc
 diff $INPUT_DIR/changeset-2.osc $OUTPUT_DIR/changeset-2.osc 
 
-# Add at least one map consumer in the convert ops to force in memory sorting.
-hoot changeset-derive -C Testing.conf -D convert.ops="hoot::NoInformationElementRemover;hoot::ElementCountVisitor" $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-3.osc
+# Add at least one map consumer in the convert ops to force in memory sorting when no element buffer size is specified.
+hoot changeset-derive -C Testing.conf -D convert.ops="hoot::MapCropper;hoot::SetTagValueVisitor" -D crop.bounds="104.8948,38.8519,104.9003,38.85545" -D set.tag.value.visitor.key=test_key -D set.tag.value.visitor.value=test_val $INPUT_DIR/map1.osm "" $OUTPUT_DIR/changeset-3.osc
 diff $INPUT_DIR/changeset-3.osc $OUTPUT_DIR/changeset-3.osc 
 
 # A set of all streamable convert ops should work with in memory sorting as well.
-hoot changeset-derive -C Testing.conf -D convert.ops="hoot::ElementCountVisitor;hoot::BuildingLevelsVisitor" $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-3.osc
+hoot changeset-derive -C Testing.conf -D convert.ops="hoot::SetTagValueVisitor;hoot::ReplaceTagVisitor" -D set.tag.value.visitor.key=test_key -D set.tag.value.visitor.value=test_val -D replace.tag.visitor.match.tag="highway=road" -D replace.tag.visitor.replace.tag="highway=primary" $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-4.osc
 diff $INPUT_DIR/changeset-4.osc $OUTPUT_DIR/changeset-4.osc 
 
 # EXTERNAL MERGE SORTING
@@ -28,8 +28,8 @@ hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 $I
 diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-5.osc 
 
 hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 $INPUT_DIR/map1.osm "" $OUTPUT_DIR/changeset-6.osc
-diff $INPUT_DIR/changeset-6.osc $OUTPUT_DIR/changeset-6.osc 
+diff $INPUT_DIR/changeset-2.osc $OUTPUT_DIR/changeset-6.osc 
 
-# If all convert ops are streamable (not map consumers), then external merge sorting will occur.
-hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 -D convert.ops="hoot::ElementCountVisitor;hoot::BuildingLevelsVisitor"  $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-7.osc
-diff $INPUT_DIR/changeset-7.osc $OUTPUT_DIR/changeset-7.osc 
+# If all convert ops are streamable (not map consumers), then external merge sorting will occur if a proper element buffer size was specified.
+hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 -D convert.ops="hoot::SetTagValueVisitor;hoot::ReplaceTagVisitor" -D set.tag.value.visitor.key=test_key -D set.tag.value.visitor.value=test_val -D replace.tag.visitor.match.tag="highway=road" -D replace.tag.visitor.replace.tag="highway=primary" $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-7.osc
+diff $INPUT_DIR/changeset-4.osc $OUTPUT_DIR/changeset-7.osc 

--- a/test-files/cmd/slow/DeriveChangesetCmdTest.sh
+++ b/test-files/cmd/slow/DeriveChangesetCmdTest.sh
@@ -6,7 +6,7 @@ OUTPUT_DIR=test-output/cmd/slow/DeriveChangesetCmdTest
 rm -rf $OUTPUT_DIR
 mkdir -p $OUTPUT_DIR
 
-# in memory sorting tests
+# IN MEMORY SORTING
 
 hoot changeset-derive -C Testing.conf $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-1.osc
 diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-1.osc 
@@ -14,10 +14,22 @@ diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-1.osc
 hoot changeset-derive -C Testing.conf $INPUT_DIR/map1.osm "" $OUTPUT_DIR/changeset-2.osc
 diff $INPUT_DIR/changeset-2.osc $OUTPUT_DIR/changeset-2.osc 
 
-# external merge sorting tests
+# Add at least one map consumer in the convert ops to force in memory sorting.
+hoot changeset-derive -C Testing.conf -D convert.ops="hoot::NoInformationElementRemover;hoot::ElementCountVisitor" $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-3.osc
+diff $INPUT_DIR/changeset-3.osc $OUTPUT_DIR/changeset-3.osc 
 
-hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-3.osc
-diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-3.osc 
+# A set of all streamable convert ops should work with in memory sorting as well.
+hoot changeset-derive -C Testing.conf -D convert.ops="hoot::ElementCountVisitor;hoot::BuildingLevelsVisitor" $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-3.osc
+diff $INPUT_DIR/changeset-4.osc $OUTPUT_DIR/changeset-4.osc 
 
-hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 $INPUT_DIR/map1.osm "" $OUTPUT_DIR/changeset-4.osc
-diff $INPUT_DIR/changeset-2.osc $OUTPUT_DIR/changeset-4.osc 
+# EXTERNAL MERGE SORTING
+
+hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-5.osc
+diff $INPUT_DIR/changeset-1.osc $OUTPUT_DIR/changeset-5.osc 
+
+hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 $INPUT_DIR/map1.osm "" $OUTPUT_DIR/changeset-6.osc
+diff $INPUT_DIR/changeset-6.osc $OUTPUT_DIR/changeset-6.osc 
+
+# If all convert ops are streamable (not map consumers), then external merge sorting will occur.
+hoot changeset-derive -C Testing.conf -D element.sorter.element.buffer.size=5 -D convert.ops="hoot::ElementCountVisitor;hoot::BuildingLevelsVisitor"  $INPUT_DIR/map1.osm $INPUT_DIR/map2.osm $OUTPUT_DIR/changeset-7.osc
+diff $INPUT_DIR/changeset-7.osc $OUTPUT_DIR/changeset-7.osc 

--- a/test-files/cmd/slow/DeriveChangesetCmdTest/changeset-3.osc
+++ b/test-files/cmd/slow/DeriveChangesetCmdTest/changeset-3.osc
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+    <create>
+        <node id="-1" version="0" lat="38.8549379688307894" lon="104.9003000000000014" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-2" version="0" lat="38.8542605775610568" lon="104.9003000000000014" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-3" version="0" lat="38.8541670018907581" lon="104.8997069874790355" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-4" version="0" lat="38.8549614373988845" lon="104.8997124086258452" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-5" version="0" lat="38.8545785045938388" lon="104.8997171368440888" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-6" version="0" lat="38.8542618470630714" lon="104.8997171368440888" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-7" version="0" lat="38.8539525522998730" lon="104.8996840393162842" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-8" version="0" lat="38.8536248456666229" lon="104.8996934957527998" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-9" version="0" lat="38.8532583477841484" lon="104.8997542928851772" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-10" version="0" lat="38.8532424272016641" lon="104.8996868263970015" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-11" version="0" lat="38.8533001490996028" lon="104.8994528828182951" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-12" version="0" lat="38.8533470481072030" lon="104.8993671807151884" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-13" version="0" lat="38.8535166057996975" lon="104.8992698972467963" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-14" version="0" lat="38.8535689160700528" lon="104.8990568001256065" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-15" version="0" lat="38.8535508780501431" lon="104.8988321216391171" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-16" version="0" lat="38.8536194225014810" lon="104.8987070428940598" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-17" version="0" lat="38.8537204352567329" lon="104.8987232568054679" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-18" version="0" lat="38.8539585361836473" lon="104.8989155074691695" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-19" version="0" lat="38.8541335037809361" lon="104.8988900284655159" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-20" version="0" lat="38.8541767946664436" lon="104.8987070428940598" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-21" version="0" lat="38.8542327120211866" lon="104.8983109602013855" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-22" version="0" lat="38.8544293243065937" lon="104.8980654352573794" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-23" version="0" lat="38.8546042907457476" lon="104.8977759011253141" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-24" version="0" lat="38.8547197322843374" lon="104.8973219116062410" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-25" version="0" lat="38.8548604264061623" lon="104.8968586569948798" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-26" version="0" lat="38.8549019130812496" lon="104.8964394115716487" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-27" version="0" lat="38.8549073243849037" lon="104.8961823052623856" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <way id="-1" version="0" timestamp="">
+            <nd ref="-1"/>
+            <nd ref="-4"/>
+            <nd ref="-5"/>
+            <nd ref="-6"/>
+            <nd ref="-3"/>
+            <nd ref="-7"/>
+            <nd ref="-8"/>
+            <nd ref="-9"/>
+            <nd ref="-10"/>
+            <nd ref="-11"/>
+            <nd ref="-12"/>
+            <nd ref="-13"/>
+            <nd ref="-14"/>
+            <nd ref="-15"/>
+            <nd ref="-16"/>
+            <nd ref="-17"/>
+            <nd ref="-18"/>
+            <nd ref="-19"/>
+            <nd ref="-20"/>
+            <nd ref="-21"/>
+            <nd ref="-22"/>
+            <nd ref="-23"/>
+            <nd ref="-24"/>
+            <nd ref="-25"/>
+            <nd ref="-26"/>
+            <nd ref="-27"/>
+            <tag k="test_key" v="test_val"/>
+            <tag k="highway" v="road"/>
+            <tag k="note" v="0"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+        <way id="-2" version="0" timestamp="">
+            <nd ref="-2"/>
+            <nd ref="-6"/>
+            <tag k="test_key" v="test_val"/>
+            <tag k="highway" v="road"/>
+            <tag k="note" v="2"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </create>
+</osmChange>

--- a/test-files/cmd/slow/DeriveChangesetCmdTest/changeset-4.osc
+++ b/test-files/cmd/slow/DeriveChangesetCmdTest/changeset-4.osc
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+    <create>
+        <node id="-1" version="0" lat="38.8549524185660573" lon="104.8987388916486054" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <node id="-2" version="0" lat="38.8549321261880536" lon="104.8979050333482093" timestamp="">
+            <tag k="test_key" v="test_val"/>
+            <tag k="error:circular" v="15"/>
+        </node>
+        <way id="-1" version="0" timestamp="">
+            <nd ref="1669731"/>
+            <nd ref="-1"/>
+            <nd ref="-2"/>
+            <tag k="test_key" v="test_val"/>
+            <tag k="highway" v="primary"/>
+            <tag k="note" v="1"/>
+            <tag k="error:circular" v="15"/>
+        </way>
+    </create>
+</osmChange>


### PR DESCRIPTION
* Adds `convert.ops` to the `changeset-derive` command
* All ops must support streaming to take advantage of the non-memory bound disk element sorting that occur before changeset derivation, otherwise the in-memory sorting implementation is always used.