### PR TITLE
Reorder changesets for HootBot

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -126,7 +126,9 @@ public:
     XmlChangeset changeset;
     changeset.loadChangeset(_inputPath + "ToyTestAInput.osc");
 
-    changeset.setMaxSize(10);
+    //  Four elements max will divide the changeset into four changesets
+    //  one for each way, with its corresponding nodes
+    changeset.setMaxSize(4);
 
     QStringList expectedFiles;
     expectedFiles.append(_inputPath + "ToyTestASplit1.osc");
@@ -140,7 +142,7 @@ public:
     updatedFiles.append(_inputPath + "ToyTestASplit3.response.xml");
     updatedFiles.append(_inputPath + "ToyTestASplit4.response.xml");
 
-    long processed[] = { 10, 20, 30, 40 };
+    long processed[] = { 4, 8, 37, 40 };
 
     ChangesetInfoPtr info;
     int index = 0;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -239,6 +239,7 @@ public:
         "\t\t<node id=\"-1\" version=\"0\" lat=\"38.8549321261880536\" lon=\"-104.8979050333482093\" timestamp=\"\" changeset=\"0\">\n"
         "\t\t\t<tag k=\"node\" v=\"Should fail\"/>\n"
         "\t\t</node>\n"
+        "\t\t<node id=\"2\" version=\"1\" lat=\"38.8549524185660573\" lon=\"-104.8987388916486054\" timestamp=\"\" changeset=\"0\"/>\n"
         "\t</delete>\n"
         "</osmChange>\n",
         writer.getFailedChangeset());

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -37,6 +37,7 @@
 #include <vector>
 
 //  Qt
+#include <QRegularExpression>
 #include <QTextStream>
 
 using namespace std;
@@ -462,10 +463,7 @@ bool XmlChangeset::addWay(ChangesetInfoPtr& changeset, ChangesetType type, XmlWa
 {
   if (canSend(way))
   {
-    //  Add the way
-    changeset->add(ElementType::Way, type, way->id());
-    markBuffered(way);
-    //  Only creates/modifies require more processing
+    //  Only creates/modifies require pre-processing
     if (type != ChangesetType::TypeDelete)
     {
       //  Add any nodes that need to be created
@@ -479,6 +477,9 @@ bool XmlChangeset::addWay(ChangesetInfoPtr& changeset, ChangesetType type, XmlWa
         }
       }
     }
+    //  Add the way last
+    changeset->add(ElementType::Way, type, way->id());
+    markBuffered(way);
     return true;
   }
   else
@@ -487,9 +488,6 @@ bool XmlChangeset::addWay(ChangesetInfoPtr& changeset, ChangesetType type, XmlWa
 
 bool XmlChangeset::moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way)
 {
-  //  Add the way to the destination and remove from the source
-  destination->add(ElementType::Way, type, way->id());
-  source->remove(ElementType::Way, type, way->id());
   //  Don't worry about the contents of a delete operation
   if (type != ChangesetType::TypeDelete)
   {
@@ -504,6 +502,9 @@ bool XmlChangeset::moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destinati
       }
     }
   }
+  //  Add the way to the destination and remove from the source
+  destination->add(ElementType::Way, type, way->id());
+  source->remove(ElementType::Way, type, way->id());
   return true;
 }
 
@@ -536,10 +537,7 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
 {
   if (canSend(relation))
   {
-    //  Add the relation
-    changeset->add(ElementType::Relation, type, relation->id());
-    markBuffered(relation);
-    //  Deletes require no more processing
+    //  Deletes require no pre-processing
     if (type != ChangesetType::TypeDelete)
     {
       //  Add any relation members that need to be added
@@ -580,6 +578,9 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
         }
       }
     }
+    //  Add the relation last
+    changeset->add(ElementType::Relation, type, relation->id());
+    markBuffered(relation);
     return true;
   }
   else
@@ -588,9 +589,6 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
 
 bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation)
 {
-  //  Add the way to the destination and remove from the source
-  destination->add(ElementType::Relation, type, relation->id());
-  source->remove(ElementType::Relation, type, relation->id());
   //  Don't worry about the contents of a delete operation
   if (type != ChangesetType::TypeDelete)
   {
@@ -627,6 +625,9 @@ bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& dest
       }
     }
   }
+  //  Add the way to the destination and remove from the source
+  destination->add(ElementType::Relation, type, relation->id());
+  source->remove(ElementType::Relation, type, relation->id());
   return true;
 }
 
@@ -838,10 +839,11 @@ bool XmlChangeset::calculateChangeset(ChangesetInfoPtr& changeset)
      *  Changesets are created by first adding nodes, then ways, and
      *  finally relations. In testing this order was found to be 4%-7%
      *  faster than any other interpolation of the ordering of nodes,
-     *  ways, and relations.
+     *  ways, and relations.  BUT deleting must go in the opposite order
+     *  so we'll do relations, ways, and finally nodes.
      */
-    //  Start with the nodes
-    addNodes(changeset, type);
+    //  Start with the relations
+    addRelations(changeset, type);
     //  Break out of the loop once the changeset is big enough
     if (changeset->size() >= (size_t)_maxChangesetSize)
       continue;
@@ -850,8 +852,8 @@ bool XmlChangeset::calculateChangeset(ChangesetInfoPtr& changeset)
     //  Break out of the loop once the changeset is big enough
     if (changeset->size() >= (size_t)_maxChangesetSize)
       continue;
-    //  Then the relations
-    addRelations(changeset, type);
+    //  Finally the nodes
+    addNodes(changeset, type);
     //  Break out of the loop once the changeset is big enough
     if (changeset->size() >= (size_t)_maxChangesetSize)
       continue;
@@ -872,18 +874,20 @@ bool XmlChangeset::matchesPlaceholderFailure(const QString& hint,
 {
   //  Placeholder node not found for reference -145213 in way -5687
   //  Placeholder Way not found for reference -12257 in relation -51
-  QRegExp regPlaceholder("Placeholder (node|way|relation) not found for reference (-?[0-9]+) in (node|way|relation) (-?[0-9]+)", Qt::CaseInsensitive);
-  if (hint.contains(regPlaceholder) && regPlaceholder.captureCount() == 4)
+  QRegularExpression reg("Placeholder (node|way|relation) not found for reference (-?[0-9]+) in (node|way|relation) (-?[0-9]+)",
+                         QRegularExpression::CaseInsensitiveOption);
+  QRegularExpressionMatch match = reg.match(hint);
+  if (match.hasMatch())
   {
     //  Get the node/way/relation type and id that caused the failure
-    member_type = ElementType::fromString(regPlaceholder.cap(1));
+    member_type = ElementType::fromString(match.captured(1));
     bool success = false;
-    member_id = regPlaceholder.cap(2).toLong(&success);
+    member_id = match.captured(2).toLong(&success);
     if (!success)
       return success;
     //  Get the node/way/relation type and id that failed
-    element_type = ElementType::fromString(regPlaceholder.cap(3));
-    element_id = regPlaceholder.cap(4).toLong(&success);
+    element_type = ElementType::fromString(match.captured(3));
+    element_id = match.captured(4).toLong(&success);
     return success;
   }
   return false;
@@ -892,20 +896,45 @@ bool XmlChangeset::matchesPlaceholderFailure(const QString& hint,
 bool XmlChangeset::matchesRelationFailure(const QString& hint, long& element_id, long& member_id, ElementType::Type& member_type)
 {
   //  Relation with id  cannot be saved due to Relation with id 1707699
-  QRegExp regRelation("Relation with id (-?[0-9]+)? cannot be saved due to (nodes|way|relation) with id (-?[0-9]+)", Qt::CaseInsensitive);
-  if (hint.contains(regRelation))
+  QRegularExpression reg("Relation with id (-?[0-9]+)? cannot be saved due to (nodes|way|relation) with id (-?[0-9]+)",
+                         QRegularExpression::CaseInsensitiveOption);
+  QRegularExpressionMatch match = reg.match(hint);
+  if (match.hasMatch())
   {
-    QString error = regRelation.cap(1);
+    QString error = match.captured(1);
     if (error != "")
       element_id = error.toLong();
     //  Get the node/way/relation type and id that failed
-    member_type = ElementType::fromString(regRelation.cap(2));
+    member_type = ElementType::fromString(match.captured(2));
     bool success = false;
-    member_id = regRelation.cap(3).toLong(&success);
+    member_id = match.captured(3).toLong(&success);
     return success;
   }
   return false;
 }
+
+bool XmlChangeset::matchesChangesetPreconditionFailure(const QString& hint,
+                                                       long& member_id, ElementType::Type& member_type,
+                                                       long& element_id, ElementType::Type& element_type)
+{
+  QRegularExpression reg(
+        "Precondition failed: (Node|Way|Relation) (-?[0-9]+) is still used by (node|way|relation)s (-?[0-9]+)",
+        QRegularExpression::CaseInsensitiveOption);
+  QRegularExpressionMatch match = reg.match(hint);
+  if (match.hasMatch())
+  {
+    bool success = false;
+    member_type = ElementType::fromString(match.captured(1).toLower());
+    member_id = match.captured(2).toLong(&success);
+    if (!success)
+      return success;
+    element_type = ElementType::fromString(match.captured(3).toLower());
+    element_id = match.captured(4).toLong(&success);
+    return success;
+  }
+  return false;
+}
+
 
 ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const QString& splitHint)
 {
@@ -927,11 +956,11 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
     if (matchesPlaceholderFailure(splitHint, member_id, member_type, element_id, element_type))
     {
       //  Use the type and id to split the changeset
-      if (element_type == ElementType::Way)
+      for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
       {
-        for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
+        if (changeset->contains(element_type, (ChangesetType)current_type, element_id))
         {
-          if (changeset->contains(element_type, (ChangesetType)current_type, element_id))
+          if (element_type == ElementType::Way)
           {
             XmlWay* way = dynamic_cast<XmlWay*>(_allWays[element_id].get());
             //  Add the way to the split and remove from the changeset
@@ -939,13 +968,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
             changeset->remove(element_type, (ChangesetType)current_type, way->id());
             return split;
           }
-        }
-      }
-      else if (element_type == ElementType::Relation)
-      {
-        for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
-        {
-          if (changeset->contains(element_type, (ChangesetType)current_type, element_id))
+          else if (element_type == ElementType::Relation)
           {
             XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[element_id].get());
             //  Add the relation to the split and remove from the changeset
@@ -957,7 +980,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
       }
     }
     //  See if the hint is something like: Relation with id  cannot be saved due to Relation with id 1707699
-    if (matchesRelationFailure(splitHint, element_id, member_id, member_type))
+    else if (matchesRelationFailure(splitHint, element_id, member_id, member_type))
     {
       if (element_id != 0)
       {
@@ -992,6 +1015,45 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
               return split;
             }
           }
+        }
+      }
+    }
+    //  See if the hint is something like: Changeset precondition failed: Precondition failed: Node 5 is still used by ways 67
+    else if (matchesChangesetPreconditionFailure(splitHint, member_id, member_type, element_id, element_type))
+    {
+      //  In this case the node 5 cannot be deleted because way 67 is still using it.  Way 67 must be modified or deleted first
+      //  here we figure out how to make that happen
+      for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
+      {
+        if (changeset->contains(member_type, (ChangesetType)current_type, member_id))
+        {
+          //  Remove the offending change from this changeset
+          split->add(member_type, (ChangesetType)current_type, member_id);
+          changeset->remove(member_type, (ChangesetType)current_type, member_id);
+          //  Try to add the blocking element to the split changeset
+          for (int blocking_type = ChangesetType::TypeCreate; blocking_type != ChangesetType::TypeMax; ++blocking_type)
+          {
+            if (element_type == ElementType::Way)
+            {
+              //  Add the way to the split so that they can be processed together
+              if (_allWays.find(element_id) != _allWays.end())
+              {
+                XmlWay* way = dynamic_cast<XmlWay*>(_allWays[element_id].get());
+                addWay(split, (ChangesetType)blocking_type, way);
+              }
+            }
+            else if (element_type == ElementType::Relation)
+            {
+              //  Add the relation to the split so that they can be processed together
+              if (_allRelations.find(element_id) != _allRelations.end())
+              {
+                XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[element_id].get());
+                addRelation(split, (ChangesetType)blocking_type, relation);
+              }
+            }
+          }
+          //  Split out the offending element and the associated blocking element if possible
+          return split;
         }
       }
     }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -346,6 +346,18 @@ private:
    * @return True if the message matches and was parsed
    */
   bool matchesRelationFailure(const QString& hint, long& element_id, long& member_id, ElementType::Type& member_type);
+  /**
+   * @brief matchesChangesetPreconditionFailure
+   * @param hint Error message from OSM API
+   * @param member_id ID of the member element that caused the element to fail
+   * @param member_type Type of the member element that caused the element to fail
+   * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
+   * @return True if the message matches and was parsed
+   */
+  bool matchesChangesetPreconditionFailure(const QString& hint,
+                                           long& member_id, ElementType::Type& member_type,
+                                           long& element_id, ElementType::Type& element_type);
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
   XmlElementMap _allNodes;
   /** Sorted map of all ways, original node ID and a pointer to the element object */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -31,6 +31,7 @@
 //  Qt
 #include <QList>
 #include <QString>
+#include <QTextStream>
 #include <QVector>
 #include <QXmlStreamReader>
 
@@ -225,11 +226,11 @@ private:
   /**
    * @brief getChangeset Get all of the elements' XML for the given type
    * @param changeset Subset of the changeset to render
-   * @param id ID of the changeset
+   * @param changeset_id ID of the changeset
    * @param type Type of operation (create/modify/delete)
    * @return XML string for a particular
    */
-  QString getChangeset(ChangesetInfoPtr changeset, long id, ChangesetType type);
+  QString getChangeset(ChangesetInfoPtr changeset, long changeset_id, ChangesetType type);
   /**
    * @brief addNodes/Ways/Relations Add nodes/ways/relations of a type to the subset
    * @param changeset Subset of the changeset to add to
@@ -358,6 +359,16 @@ private:
   bool matchesChangesetPreconditionFailure(const QString& hint,
                                            long& member_id, ElementType::Type& member_type,
                                            long& element_id, ElementType::Type& element_type);
+  /**
+   * @brief getNodes/Ways/Relations Output node/way/relation text to the text stream
+   * @param changeset Pointer to the changeset to output
+   * @param ts TextStream to output the element to
+   * @param type Changeset type (create, modify, delete)
+   * @param changeset_id ID of the changeset to write to the element attribute
+   */
+  void getNodes(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
+  void getWays(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
+  void getRelations(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
   XmlElementMap _allNodes;
   /** Sorted map of all ways, original node ID and a pointer to the element object */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -60,7 +60,7 @@ class OsmApiWriter : public Configurable, public ProgressReporter
   const QString API_PATH_CREATE_CHANGESET = "/api/0.6/changeset/create/";
   const QString API_PATH_CLOSE_CHANGESET = "/api/0.6/changeset/%1/close/";
   const QString API_PATH_UPLOAD_CHANGESET = "/api/0.6/changeset/%1/upload/";
-  const QString API_PATH_GET_ELEMENT = "api/0.6/%1/%2";
+  const QString API_PATH_GET_ELEMENT = "/api/0.6/%1/%2/";
   /**
    *  Max number of jobs waiting in the work queue = multiplier * number of threads,
    *  this keeps the producer thread from creating too many sub-changesets too early

--- a/test-files/io/OsmChangesetElementTest/ChangesetErrorFixErrors.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetErrorFixErrors.osc
@@ -16,7 +16,12 @@
 		</way>
 	</modify>
 	<delete>
-		<node id="-16" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
+		<relation id="-10" version="0" timestamp="" changeset="0">
+			<member type="node" ref="17" role="role1"/>
+			<member type="way" ref="13" role="role2"/>
+			<tag k="key2" v="value2"/>
+			<tag k="error:circular" v="15"/>
+		</relation>
 		<way id="-12" version="0" timestamp="" changeset="0">
 			<nd ref="14"/>
 			<nd ref="15"/>
@@ -29,11 +34,6 @@
 			<tag k="key1" v="value1"/>
 			<tag k="error:circular" v="15"/>
 		</way>
-		<relation id="-10" version="0" timestamp="" changeset="0">
-			<member type="node" ref="17" role="role1"/>
-			<member type="way" ref="13" role="role2"/>
-			<tag k="key2" v="value2"/>
-			<tag k="error:circular" v="15"/>
-		</relation>
+		<node id="-16" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
 	</delete>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ChangesetMergeExpected.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetMergeExpected.osc
@@ -26,7 +26,12 @@
 		</way>
 	</modify>
 	<delete>
-		<node id="16" version="0" lat="-44.0000000000000000" lon="-7.0000000000000000" timestamp="" changeset="1"/>
+		<relation id="1" version="0" timestamp="" changeset="1">
+			<member type="node" ref="7" role="role1"/>
+			<member type="way" ref="3" role="role2"/>
+			<tag k="key2" v="value2"/>
+			<tag k="error:circular" v="15"/>
+		</relation>
 		<way id="2" version="0" timestamp="" changeset="1">
 			<nd ref="4"/>
 			<nd ref="5"/>
@@ -39,11 +44,6 @@
 			<tag k="key1" v="value1"/>
 			<tag k="error:circular" v="15"/>
 		</way>
-		<relation id="1" version="0" timestamp="" changeset="1">
-			<member type="node" ref="7" role="role1"/>
-			<member type="way" ref="3" role="role2"/>
-			<tag k="key2" v="value2"/>
-			<tag k="error:circular" v="15"/>
-		</relation>
+		<node id="16" version="0" lat="-44.0000000000000000" lon="-7.0000000000000000" timestamp="" changeset="1"/>
 	</delete>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ToyTestAConflicts.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestAConflicts.osc
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
     <create>
-	<node id="-37" version="0" lat="38.8545553856" lon="-104.9005792841" timestamp=""/>
+        <node id="-37" version="0" lat="38.8545553856" lon="-104.9005792841" timestamp=""/>
         <way id="-5" version="0" timestamp="">
             <nd ref="-37"/>
             <nd ref="31"/>
@@ -23,5 +23,6 @@
         <node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="">
           <tag k="node" v="Should fail"/>
         </node>
+        <node id="2" version="1" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp=""/>
     </delete>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit1.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit1.osc
@@ -3,13 +3,13 @@
 	<create>
 		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="1"/>
 		<node id="-2" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="1"/>
-		<node id="-3" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp="" changeset="1"/>
-		<node id="-4" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp="" changeset="1"/>
-		<node id="-5" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp="" changeset="1"/>
-		<node id="-6" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp="" changeset="1"/>
-		<node id="-7" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp="" changeset="1"/>
-		<node id="-8" version="0" lat="38.8548514075605240" lon="-104.9005693264316363" timestamp="" changeset="1"/>
-		<node id="-9" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp="" changeset="1"/>
-		<node id="-10" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp="" changeset="1"/>
+		<node id="-32" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp="" changeset="1"/>
+		<way id="-1" version="0" timestamp="" changeset="1">
+			<nd ref="-32"/>
+			<nd ref="-2"/>
+			<nd ref="-1"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
 	</create>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit1.response.xml
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit1.response.xml
@@ -1,12 +1,6 @@
 <diffResult generator="OpenStreetMap Server" version="0.6">
   <node old_id="-1" new_id="1" new_version="1"/>
   <node old_id="-2" new_id="2" new_version="1"/>
-  <node old_id="-3" new_id="3" new_version="1"/>
-  <node old_id="-4" new_id="4" new_version="1"/>
-  <node old_id="-5" new_id="5" new_version="1"/>
-  <node old_id="-6" new_id="6" new_version="1"/>
-  <node old_id="-7" new_id="7" new_version="1"/>
-  <node old_id="-8" new_id="8" new_version="1"/>
-  <node old_id="-9" new_id="9" new_version="1"/>
-  <node old_id="-10" new_id="10" new_version="1"/>
+  <node old_id="-32" new_id="32" new_version="1"/>
+  <way old_id="-1" new_id="1" new_version="1"/>
 </diffResult>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit2.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit2.osc
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
 	<create>
-		<node id="-11" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp="" changeset="2"/>
-		<node id="-12" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp="" changeset="2"/>
-		<node id="-13" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp="" changeset="2"/>
-		<node id="-14" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp="" changeset="2"/>
-		<node id="-15" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp="" changeset="2"/>
-		<node id="-16" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp="" changeset="2"/>
-		<node id="-17" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp="" changeset="2"/>
-		<node id="-18" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp="" changeset="2"/>
-		<node id="-19" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp="" changeset="2"/>
-		<node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp="" changeset="2"/>
+		<node id="-7" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp="" changeset="2"/>
+		<node id="-8" version="0" lat="38.8548514075605240" lon="-104.9005693264316363" timestamp="" changeset="2"/>
+		<node id="-33" version="0" lat="38.8542599687747341" lon="-104.9005795104799432" timestamp="" changeset="2"/>
+		<way id="-2" version="0" timestamp="" changeset="2">
+			<nd ref="-33"/>
+			<nd ref="-8"/>
+			<nd ref="-7"/>
+			<tag k="note" v="3"/>
+			<tag k="highway" v="road"/>
+		</way>
 	</create>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit2.response.xml
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit2.response.xml
@@ -1,12 +1,6 @@
 <diffResult generator="OpenStreetMap Server" version="0.6">
-  <node old_id="-11" new_id="11" new_version="1"/>
-  <node old_id="-12" new_id="12" new_version="1"/>
-  <node old_id="-13" new_id="13" new_version="1"/>
-  <node old_id="-14" new_id="14" new_version="1"/>
-  <node old_id="-15" new_id="15" new_version="1"/>
-  <node old_id="-16" new_id="16" new_version="1"/>
-  <node old_id="-17" new_id="17" new_version="1"/>
-  <node old_id="-18" new_id="18" new_version="1"/>
-  <node old_id="-19" new_id="19" new_version="1"/>
-  <node old_id="-20" new_id="20" new_version="1"/>
+  <node old_id="-7" new_id="7" new_version="1"/>
+  <node old_id="-8" new_id="8" new_version="1"/>
+  <node old_id="-33" new_id="33" new_version="1"/>
+  <way old_id="-2" new_id="2" new_version="1"/>
 </diffResult>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit3.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit3.osc
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
 	<create>
+		<node id="-3" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp="" changeset="3"/>
+		<node id="-4" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp="" changeset="3"/>
+		<node id="-5" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp="" changeset="3"/>
+		<node id="-6" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp="" changeset="3"/>
+		<node id="-9" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp="" changeset="3"/>
+		<node id="-10" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp="" changeset="3"/>
+		<node id="-11" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp="" changeset="3"/>
+		<node id="-12" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp="" changeset="3"/>
+		<node id="-13" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp="" changeset="3"/>
+		<node id="-14" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp="" changeset="3"/>
+		<node id="-15" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp="" changeset="3"/>
+		<node id="-16" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp="" changeset="3"/>
+		<node id="-17" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp="" changeset="3"/>
+		<node id="-18" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp="" changeset="3"/>
+		<node id="-19" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp="" changeset="3"/>
+		<node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp="" changeset="3"/>
 		<node id="-21" version="0" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp="" changeset="3"/>
 		<node id="-22" version="0" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp="" changeset="3"/>
 		<node id="-23" version="0" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp="" changeset="3"/>
@@ -11,5 +27,41 @@
 		<node id="-28" version="0" lat="38.8536248456666229" lon="-104.8996934957527998" timestamp="" changeset="3"/>
 		<node id="-29" version="0" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp="" changeset="3"/>
 		<node id="-30" version="0" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp="" changeset="3"/>
+		<node id="-31" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp="" changeset="3"/>
+		<node id="-36" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="3"/>
+		<way id="-3" version="0" timestamp="" changeset="3">
+			<nd ref="-3"/>
+			<nd ref="-4"/>
+			<nd ref="-5"/>
+			<nd ref="-6"/>
+			<nd ref="7"/>
+			<nd ref="32"/>
+			<nd ref="-31"/>
+			<nd ref="-30"/>
+			<nd ref="-36"/>
+			<nd ref="-29"/>
+			<nd ref="-28"/>
+			<nd ref="-27"/>
+			<nd ref="-26"/>
+			<nd ref="-25"/>
+			<nd ref="-24"/>
+			<nd ref="-23"/>
+			<nd ref="-22"/>
+			<nd ref="-21"/>
+			<nd ref="-20"/>
+			<nd ref="-19"/>
+			<nd ref="-18"/>
+			<nd ref="-17"/>
+			<nd ref="-16"/>
+			<nd ref="-15"/>
+			<nd ref="-14"/>
+			<nd ref="-13"/>
+			<nd ref="-12"/>
+			<nd ref="-11"/>
+			<nd ref="-10"/>
+			<nd ref="-9"/>
+			<tag k="note" v="0"/>
+			<tag k="highway" v="road"/>
+		</way>
 	</create>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit3.response.xml
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit3.response.xml
@@ -1,4 +1,20 @@
 <diffResult generator="OpenStreetMap Server" version="0.6">
+  <node old_id="-3" new_id="3" new_version="1"/>
+  <node old_id="-4" new_id="4" new_version="1"/>
+  <node old_id="-5" new_id="5" new_version="1"/>
+  <node old_id="-6" new_id="6" new_version="1"/>
+  <node old_id="-9" new_id="9" new_version="1"/>
+  <node old_id="-10" new_id="10" new_version="1"/>
+  <node old_id="-11" new_id="11" new_version="1"/>
+  <node old_id="-12" new_id="12" new_version="1"/>
+  <node old_id="-13" new_id="13" new_version="1"/>
+  <node old_id="-14" new_id="14" new_version="1"/>
+  <node old_id="-15" new_id="15" new_version="1"/>
+  <node old_id="-16" new_id="16" new_version="1"/>
+  <node old_id="-17" new_id="17" new_version="1"/>
+  <node old_id="-18" new_id="18" new_version="1"/>
+  <node old_id="-19" new_id="19" new_version="1"/>
+  <node old_id="-20" new_id="20" new_version="1"/>
   <node old_id="-21" new_id="21" new_version="1"/>
   <node old_id="-22" new_id="22" new_version="1"/>
   <node old_id="-23" new_id="23" new_version="1"/>
@@ -9,4 +25,7 @@
   <node old_id="-28" new_id="28" new_version="1"/>
   <node old_id="-29" new_id="29" new_version="1"/>
   <node old_id="-30" new_id="30" new_version="1"/>
+  <node old_id="-31" new_id="31" new_version="1"/>
+  <node old_id="-36" new_id="36" new_version="1"/>
+  <way old_id="-3" new_id="3" new_version="1"/>
 </diffResult></diffResult>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit4.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit4.osc
@@ -1,64 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
 	<create>
-		<node id="-31" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp="" changeset="4"/>
-		<node id="-32" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp="" changeset="4"/>
-		<node id="-33" version="0" lat="38.8542599687747341" lon="-104.9005795104799432" timestamp="" changeset="4"/>
 		<node id="-34" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="4"/>
 		<node id="-35" version="0" lat="38.8540851073630833" lon="-104.9014476647277121" timestamp="" changeset="4"/>
-		<node id="-36" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="4"/>
-		<way id="-1" version="0" timestamp="" changeset="4">
-			<nd ref="-32"/>
-			<nd ref="2"/>
-			<nd ref="1"/>
-			<tag k="note" v="1"/>
-			<tag k="highway" v="road"/>
-		</way>
-		<way id="-2" version="0" timestamp="" changeset="4">
-			<nd ref="-33"/>
-			<nd ref="8"/>
-			<nd ref="7"/>
-			<tag k="note" v="3"/>
-			<tag k="highway" v="road"/>
-		</way>
-		<way id="-3" version="0" timestamp="" changeset="4">
-			<nd ref="3"/>
-			<nd ref="4"/>
-			<nd ref="5"/>
-			<nd ref="6"/>
-			<nd ref="7"/>
-			<nd ref="-32"/>
-			<nd ref="-31"/>
-			<nd ref="30"/>
-			<nd ref="-36"/>
-			<nd ref="29"/>
-			<nd ref="28"/>
-			<nd ref="27"/>
-			<nd ref="26"/>
-			<nd ref="25"/>
-			<nd ref="24"/>
-			<nd ref="23"/>
-			<nd ref="22"/>
-			<nd ref="21"/>
-			<nd ref="20"/>
-			<nd ref="19"/>
-			<nd ref="18"/>
-			<nd ref="17"/>
-			<nd ref="16"/>
-			<nd ref="15"/>
-			<nd ref="14"/>
-			<nd ref="13"/>
-			<nd ref="12"/>
-			<nd ref="11"/>
-			<nd ref="10"/>
-			<nd ref="9"/>
-			<tag k="note" v="0"/>
-			<tag k="highway" v="road"/>
-		</way>
 		<way id="-4" version="0" timestamp="" changeset="4">
 			<nd ref="-35"/>
 			<nd ref="-34"/>
-			<nd ref="-33"/>
+			<nd ref="33"/>
 			<nd ref="30"/>
 			<tag k="note" v="2"/>
 			<tag k="highway" v="road"/>

--- a/test-files/io/OsmChangesetElementTest/ToyTestASplit4.response.xml
+++ b/test-files/io/OsmChangesetElementTest/ToyTestASplit4.response.xml
@@ -1,12 +1,5 @@
 <diffResult generator="OpenStreetMap Server" version="0.6">
-  <node old_id="-31" new_id="31" new_version="1"/>
-  <node old_id="-32" new_id="32" new_version="1"/>
-  <node old_id="-33" new_id="33" new_version="1"/>
   <node old_id="-34" new_id="34" new_version="1"/>
   <node old_id="-35" new_id="35" new_version="1"/>
-  <node old_id="-36" new_id="36" new_version="1"/>
-  <way old_id="-1" new_id="1" new_version="1"/>
-  <way old_id="-2" new_id="2" new_version="1"/>
-  <way old_id="-3" new_id="3" new_version="1"/>
   <way old_id="-4" new_id="4" new_version="1"/>
 </diffResult>


### PR DESCRIPTION
Changed order of changesets to relation/way/node and accounted for the 'precondition failed:' message.