### PR TITLE
Truncate OSM Tags Destined for OSM API Changesets

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MapComparatorTest.cpp
@@ -33,9 +33,9 @@
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/scoring/MapComparator.h>
-#include <hoot/core/visitors/SetTagValueVisitor.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/OpenCv.h>
+#include <hoot/core/visitors/SetTagValueVisitor.h>
 
 using namespace hoot;
 
@@ -88,7 +88,7 @@ public:
     uut.setUseDateTime();
 
     // Change dates...
-    SetTagValueVisitor vtor("source:datetime", "1989-12-13T12:34:56Z");
+    SetTagValueVisitor vtor(MetadataTags::SourceDateTime(), "1989-12-13T12:34:56Z");
     map2->visitRw(vtor);
 
     // Make sure it fails now!

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/ApiTagTruncateVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/ApiTagTruncateVisitorTest.cpp
@@ -1,0 +1,191 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/elements/OsmUtils.h>
+#include <hoot/core/util/UuidHelper.h>
+#include <hoot/core/visitors/ApiTagTruncateVisitor.h>
+#include <hoot/core/visitors/FindNodesVisitor.h>
+
+namespace hoot
+{
+
+class ApiTagTruncateVisitorTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(ApiTagTruncateVisitorTest);
+  CPPUNIT_TEST(runUUIDTest);
+  CPPUNIT_TEST(runDatesTest);
+  CPPUNIT_TEST(runListTest);
+  CPPUNIT_TEST(runTruncateTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  ApiTagTruncateVisitorTest()
+  {
+  }
+
+  void runUUIDTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    Tags tags;
+    QString value = UuidHelper::createUuid().toString();
+
+    tags["uuid"] = value;
+    tags["note"] = "node1";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, tags);
+
+    tags.appendValue("uuid", UuidHelper::createUuid().toString());
+    tags["note"] = "node2";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 1.0, 15.0, tags);
+
+    QStringList uuids;
+    for (int i = 0; i < 5; ++i)
+      uuids.append(UuidHelper::createUuid().toString());
+    tags.appendValue("uuid", uuids);
+    tags["note"] = "node3";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 2.0, 15.0, tags);
+
+    ApiTagTruncateVisitor v;
+    map->visitRw(v);
+
+    HOOT_STR_EQUALS("Truncated tag key/value pairs for 2 elements", v.getCompletedStatusMessage());
+
+    NodePtr n1 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node1")[0]);
+    NodePtr n2 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node2")[0]);
+    NodePtr n3 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node3")[0]);
+
+    CPPUNIT_ASSERT_EQUAL(38, n1->getTags()["uuid"].length());
+    CPPUNIT_ASSERT_EQUAL(38, n2->getTags()["uuid"].length());
+    CPPUNIT_ASSERT_EQUAL(38, n3->getTags()["uuid"].length());
+  }
+
+  void runDatesTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    Tags tags;
+    QString value = OsmUtils::toTimeString(0);
+
+    tags.insert(MetadataTags::SourceDateTime(), value);
+    tags[MetadataTags::SourceDateTime()] = value;
+    tags["note"] = "node1";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, tags);
+
+    tags.appendValue(MetadataTags::SourceDateTime(), OsmUtils::toTimeString(0));
+    tags["note"] = "node2";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 1.0, 15.0, tags);
+
+    QStringList dates;
+    for (int i = 0; i < 30; ++i)
+      dates.append(OsmUtils::toTimeString(0));
+    tags.appendValue(MetadataTags::SourceIngestDateTime(), dates);
+    tags["note"] = "node3";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 2.0, 15.0, tags);
+
+    ApiTagTruncateVisitor v;
+    map->visitRw(v);
+
+    HOOT_STR_EQUALS("Truncated tag key/value pairs for 2 elements", v.getCompletedStatusMessage());
+
+    NodePtr n1 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node1")[0]);
+    NodePtr n2 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node2")[0]);
+    NodePtr n3 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node3")[0]);
+
+    CPPUNIT_ASSERT_EQUAL(20, n1->getTags()[MetadataTags::SourceDateTime()].length());
+    CPPUNIT_ASSERT_EQUAL(20, n2->getTags()[MetadataTags::SourceDateTime()].length());
+    CPPUNIT_ASSERT_EQUAL(20, n3->getTags()[MetadataTags::SourceIngestDateTime()].length());
+  }
+
+  void runListTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    Tags tags;
+    QString value = "Some random text goes here that is going into a list.";
+
+    tags["some_key"] = value;
+    tags["note"] = "node1";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, tags);
+
+    tags.appendValue("some_key", value);
+    tags["note"] = "node2";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 1.0, 15.0, tags);
+
+    QStringList dates;
+    for (int i = 0; i < 5; ++i)
+      dates.append(value);
+    tags.appendValue("some_key", dates);
+    tags["note"] = "node3";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 2.0, 15.0, tags);
+
+    ApiTagTruncateVisitor v;
+    map->visitRw(v);
+
+    HOOT_STR_EQUALS("Truncated tag key/value pairs for 1 elements", v.getCompletedStatusMessage());
+
+    NodePtr n1 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node1")[0]);
+    NodePtr n2 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node2")[0]);
+    NodePtr n3 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node3")[0]);
+
+    //  value.length() == 53
+    CPPUNIT_ASSERT_EQUAL(53, n1->getTags()["some_key"].length());
+    CPPUNIT_ASSERT_EQUAL(107, n2->getTags()["some_key"].length());
+    CPPUNIT_ASSERT_EQUAL(215, n3->getTags()["some_key"].length());
+  }
+
+  void runTruncateTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    Tags tags;
+    QString value(250, 'B');
+
+    tags["some_key"] = value;
+    tags["note"] = "node1";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, tags);
+
+    QString valueTooLong(400, 'C');
+    tags["some_key"] = valueTooLong;
+    tags["note"] = "node2";
+    TestUtils::createNode(map, Status::Unknown1, 0.0, 1.0, 15.0, tags);
+
+    ApiTagTruncateVisitor v;
+    map->visitRw(v);
+
+    HOOT_STR_EQUALS("Truncated tag key/value pairs for 1 elements", v.getCompletedStatusMessage());
+
+    NodePtr n1 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node1")[0]);
+    NodePtr n2 = map->getNode(FindNodesVisitor::findNodesByTag(map, "note", "node2")[0]);
+
+    CPPUNIT_ASSERT_EQUAL(250, n1->getTags()["some_key"].length());
+    CPPUNIT_ASSERT_EQUAL(255, n2->getTags()["some_key"].length());
+  }
+};
+
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ApiTagTruncateVisitorTest, "current");
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ApiTagTruncateVisitorTest, "quick");
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
@@ -296,7 +296,7 @@ private:
     map->visitRw(removeElementsVisitor);
     _currentTaskNum++;
 
-    //we don't want to include review relations
+    //  Truncate tags over 255 characters to push into OSM API
     progress.set(
       (float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Preparing tags for changeset...");
     ApiTagTruncateVisitor truncateTags;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DeriveChangesetCmd.cpp
@@ -26,28 +26,29 @@
  */
 
 // Hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/algorithms/changeset/ChangesetDeriver.h>
-#include <hoot/core/elements/InMemoryElementSorter.h>
-#include <hoot/core/io/OsmXmlChangesetFileWriter.h>
-#include <hoot/core/io/OsmApiDbSqlChangesetFileWriter.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/util/GeometryUtils.h>
-#include <hoot/core/criterion/TagKeyCriterion.h>
-#include <hoot/core/visitors/RemoveElementsVisitor.h>
-#include <hoot/core/visitors/CalculateHashVisitor2.h>
-#include <hoot/core/util/IoUtils.h>
-#include <hoot/core/elements/ExternalMergeElementSorter.h>
-#include <hoot/core/io/ElementCriterionVisitorInputStream.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/criterion/NotCriterion.h>
-#include <hoot/core/io/PartialOsmMapReader.h>
-#include <hoot/core/io/OsmPbfReader.h>
-#include <hoot/core/util/Progress.h>
-#include <hoot/core/ops/NamedOp.h>
+#include <hoot/core/criterion/TagKeyCriterion.h>
+#include <hoot/core/elements/ExternalMergeElementSorter.h>
+#include <hoot/core/elements/InMemoryElementSorter.h>
+#include <hoot/core/io/ElementCriterionVisitorInputStream.h>
 #include <hoot/core/io/ElementStreamer.h>
+#include <hoot/core/io/OsmApiDbSqlChangesetFileWriter.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/io/OsmPbfReader.h>
+#include <hoot/core/io/OsmXmlChangesetFileWriter.h>
+#include <hoot/core/io/PartialOsmMapReader.h>
+#include <hoot/core/ops/NamedOp.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/util/IoUtils.h>
+#include <hoot/core/util/Progress.h>
+#include <hoot/core/visitors/ApiTagTruncateVisitor.h>
+#include <hoot/core/visitors/CalculateHashVisitor2.h>
+#include <hoot/core/visitors/RemoveElementsVisitor.h>
 
 //GEOS
 #include <geos/geom/Envelope.h>
@@ -295,6 +296,13 @@ private:
     map->visitRw(removeElementsVisitor);
     _currentTaskNum++;
 
+    //we don't want to include review relations
+    progress.set(
+      (float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Preparing tags for changeset...");
+    ApiTagTruncateVisitor truncateTags;
+    map->visitRw(truncateTags);
+    _currentTaskNum++;
+
     //node comparisons require hashes be present on the elements
     progress.set(
       (float)(_currentTaskNum - 1) / (float)_numTotalTasks, "Adding element hashes...");
@@ -357,6 +365,8 @@ private:
           new TagKeyCriterion(MetadataTags::HootReviewNeeds()))));
     //node comparisons require hashes be present on the elements
     visitors.append(std::shared_ptr<CalculateHashVisitor2>(new CalculateHashVisitor2()));
+    //  Tags need to be truncated if they are over 255 characters
+    visitors.append(std::shared_ptr<ApiTagTruncateVisitor>(new ApiTagTruncateVisitor()));
 
     std::shared_ptr<PartialOsmMapReader> reader =
       std::dynamic_pointer_cast<PartialOsmMapReader>(

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.cpp
@@ -61,7 +61,7 @@ bool HighwayCriterion::isSatisfied(const ConstElementPtr& element) const
   else
   {
     // Maybe it's a way with nothing but a time tag...
-    it = tags.find("source:datetime");
+    it = tags.find(MetadataTags::SourceDateTime());
     if (type == ElementType::Way && tags.keys().size() < 2 && it != tags.end())
     {
       // We can treat it like a highway

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -36,22 +36,22 @@
 using namespace geos::geom;
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/criterion/AreaCriterion.h>
 #include <hoot/core/elements/ElementIterator.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Tags.h>
 #include <hoot/core/io/OgrUtilities.h>
+#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/schema/PythonSchemaTranslator.h>
 #include <hoot/core/schema/ScriptSchemaTranslator.h>
 #include <hoot/core/schema/ScriptSchemaTranslatorFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-#include <hoot/core/schema/MetadataTags.h>
-#include <hoot/core/criterion/AreaCriterion.h>
 #include <hoot/core/util/StringUtils.h>
-#include <hoot/core/util/GeometryUtils.h>
 
 // Qt
 #include <QDir>
@@ -619,7 +619,7 @@ void OgrReaderInternal::_addFeature(OGRFeature* f)
   if (_addSourceDateTime)
   {
     // Add an ingest datetime tag
-    t.appendValue("source:ingest:datetime",
+    t.appendValue(MetadataTags::SourceIngestDateTime(),
                   QDateTime::currentDateTime().toUTC().toString("yyyy-MM-ddThh:mm:ss.zzzZ"));
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -28,6 +28,7 @@
 #include "OsmApiChangesetElement.h"
 
 #include <hoot/core/util/HootException.h>
+#include <hoot/core/visitors/ApiTagTruncateVisitor.h>
 
 //  Qt
 #include <QTextStream>
@@ -122,9 +123,18 @@ QString XmlElement::toTagString(const QXmlStreamAttributes& attributes) const
   QString buffer;
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
+  QString key(attributes.value("k").toString());
   QString value(attributes.value("v").toString());
+  //  Tag values of length 255 need to be truncated
+  QString newValue(ApiTagTruncateVisitor::truncateTag(key, value));
+
   //  Make sure to XML encode the value
-  ts << "\t\t\t<tag k=\"" << attributes.value("k").toString() << "\" v=\"" << escapeString(value) << "\"/>\n";
+  ts << "\t\t\t<tag k=\"" << attributes.value("k").toString() << "\" v=\"";
+  if (newValue != "")
+    ts << escapeString(newValue);
+  else
+    ts << escapeString(value);
+  ts << "\"/>\n";
   return ts.readAll();
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
@@ -57,6 +57,7 @@ public:
   static const QString ERROR_CIRCULAR;
   inline static const QString& ErrorCircular()          { return ERROR_CIRCULAR; }
   inline static const QString SourceDateTime()          { return "source:datetime"; }
+  inline static const QString SourceIngestDateTime()    { return "source:ingest:datetime"; }
 
   inline static const QString HootBuildingMatch()       { return "hoot:building:match"; }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagInfo.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagInfo.cpp
@@ -28,13 +28,13 @@
 #include "TagInfo.h"
 
 // Hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/cmd/BaseCommand.h>
-#include <hoot/core/io/OgrReader.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/elements/ElementIterator.h>
+#include <hoot/core/io/OgrReader.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/Settings.h>
 
 // Qt
 #include <QFileInfo>
@@ -225,7 +225,7 @@ void TagInfo::_parseElement(const ElementPtr& e, TagInfoHash& result)
     }
 
     // Drop Hoot metadata tags
-    if (it.key() == "source:ingest:datetime")
+    if (it.key() == MetadataTags::SourceIngestDateTime())
     {
       continue;
     }

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MapComparator.cpp
@@ -27,10 +27,10 @@
 #include "MapComparator.h"
 
 // hoot
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
-#include <hoot/core/elements/OsmMap.h>
 
 // Standard
 #include <iomanip>
@@ -116,11 +116,11 @@ public:
     // have the option to ignore it here.
     if (!_useDateTime)
     {
-      in1.set("source:ingest:datetime", "None");  // Wipe out the ingest datetime
-      in2.set("source:ingest:datetime", "None");
+      in1.set(MetadataTags::SourceIngestDateTime(), "None");  // Wipe out the ingest datetime
+      in2.set(MetadataTags::SourceIngestDateTime(), "None");
 
-      in1.set("source:datetime", "None");  // Wipe out the ingest datetime
-      in2.set("source:datetime", "None");
+      in1.set(MetadataTags::SourceDateTime(), "None");  // Wipe out the ingest datetime
+      in2.set(MetadataTags::SourceDateTime(), "None");
     }
 
     if (in1 != in2)

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ApiTagTruncateVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ApiTagTruncateVisitor.cpp
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#include "ApiTagTruncateVisitor.h"
+
+//  Hoot
+#include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/util/Factory.h>
+
+namespace hoot
+{
+
+HOOT_FACTORY_REGISTER(ElementVisitor, ApiTagTruncateVisitor)
+
+void ApiTagTruncateVisitor::visit(const ElementPtr& e)
+{
+  Tags& tags = e->getTags();
+  bool elementAffected = truncateTags(tags);
+  //  Update the statistics
+  _numProcessed++;
+  if (elementAffected)
+    _numAffected++;
+}
+
+bool ApiTagTruncateVisitor::truncateTags(Tags& tags)
+{
+  bool tagsAffected = false;
+  //  Iterate all tags looking for ones that are too long or the special cases
+  for (Tags::iterator it = tags.begin(); it != tags.end(); ++it)
+  {
+    const QString& key = it.key();
+    const QString& value = it.value();
+
+    QString newValue = truncateTag(key, value);
+
+    if (newValue != "")
+    {
+      it.value() = newValue;
+      tagsAffected = true;
+    }
+  }
+  return tagsAffected;
+}
+
+QString ApiTagTruncateVisitor::truncateTag(const QString &key, const QString &value)
+{
+  QString result;
+  //  First check the special cases of lists where only one value is kept
+  if (key == MetadataTags::SourceDateTime() ||
+      key == MetadataTags::SourceIngestDateTime() ||
+      key == "uuid")
+  {
+    //  These are special cases where only the last value in the list is kept
+    QStringList values = value.split(";");
+    if (values.count() > 1)
+      result = values.last();
+  }
+  else if (value.length() > 255)
+  {
+    //  Truncate values greater than 255
+    if (value.contains(";"))
+    {
+      //  These values are lists that will be truncated at a split point before or at the 255 mark
+      int index = value.lastIndexOf(";", 255);
+      if (index == -1)
+        index = 255;
+      //  Truncate at the index
+      result = value.left(index);
+    }
+    else  //  Just truncate after character 255
+      result = value.left(255);
+  }
+  return result;
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ApiTagTruncateVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ApiTagTruncateVisitor.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#ifndef APITAGTRUNCATEVISITOR_H
+#define APITAGTRUNCATEVISITOR_H
+
+//  Hoot
+#include <hoot/core/elements/ElementVisitor.h>
+#include <hoot/core/info/OperationStatusInfo.h>
+
+namespace hoot
+{
+
+class ApiTagTruncateVisitor : public ElementVisitor, public OperationStatusInfo
+{
+public:
+
+  static std::string className() { return "hoot::ApiTagTruncateVisitor"; }
+
+  ApiTagTruncateVisitor() { }
+
+  virtual void visit(const ElementPtr& e) override;
+
+  virtual QString getDescription() const override { return "Truncates tag key/value pairs to the API limit of 255 characters"; }
+
+  virtual QString getInitStatusMessage() const override
+  { return "Truncating tag key/value pairs for OSM API..."; }
+
+  virtual QString getCompletedStatusMessage() const override
+  { return "Truncated tag key/value pairs for " + QString::number(_numAffected) + " elements"; }
+
+  /**
+   * @brief truncateTags Does the actual truncating of tags
+   * @param tags Input and output tags object
+   * @return true if any of the tags were modified
+   */
+  static bool truncateTags(Tags& tags);
+
+  /**
+   * @brief truncateTag
+   * @param key
+   * @param value
+   * @return
+   */
+  static QString truncateTag(const QString& key, const QString& value);
+
+};
+
+}
+#endif  //  APITAGTRUNCATEVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ApiTagTruncateVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ApiTagTruncateVisitor.h
@@ -34,6 +34,16 @@
 namespace hoot
 {
 
+/**
+ * @brief The ApiTagTruncateVisitor class truncates tags that are going to be passed into
+ *  an OSM API database.  The API imposes a 255 character limit to tag values even though
+ *  the database doesn't.  All tags have this limit but three tags (so far) require special
+ *  processing.  First, lists aren't truncated mid-listitem, the last item that starts but
+ *  doesn't end before the 255 limit is removed along with all items after that.  Second,
+ *  `source:datetime` and `source:ingest:datetime` are date lists that are truncated down
+ *  to include only the last date in the list.  Thirdly the `uuid` field is handled the
+ *  same way, only the last UUID in the list is preserved.
+ */
 class ApiTagTruncateVisitor : public ElementVisitor, public OperationStatusInfo
 {
 public:
@@ -44,7 +54,8 @@ public:
 
   virtual void visit(const ElementPtr& e) override;
 
-  virtual QString getDescription() const override { return "Truncates tag key/value pairs to the API limit of 255 characters"; }
+  virtual QString getDescription() const override
+  { return "Truncates tag key/value pairs to the API limit of 255 characters"; }
 
   virtual QString getInitStatusMessage() const override
   { return "Truncating tag key/value pairs for OSM API..."; }
@@ -53,17 +64,17 @@ public:
   { return "Truncated tag key/value pairs for " + QString::number(_numAffected) + " elements"; }
 
   /**
-   * @brief truncateTags Does the actual truncating of tags
+   * @brief truncateTags Iterates all tags calling truncateTag one by one
    * @param tags Input and output tags object
    * @return true if any of the tags were modified
    */
   static bool truncateTags(Tags& tags);
 
   /**
-   * @brief truncateTag
-   * @param key
-   * @param value
-   * @return
+   * @brief truncateTag Does the actual truncating of a tag
+   * @param key Tag key (some tags require special processing)
+   * @param value Tag value to be truncated if > 255 in length
+   * @return Empty string if nothing is changed, truncated string otherwise
    */
   static QString truncateTag(const QString& key, const QString& value);
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/TagCountVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/TagCountVisitor.h
@@ -48,21 +48,21 @@ public:
 
   TagCountVisitor();
 
-  virtual void visit(const ConstElementPtr& e);
+  virtual void visit(const ConstElementPtr& e) override;
 
-  virtual QString getDescription() const { return "Calculates tag count statistics"; }
+  virtual QString getDescription() const override { return "Calculates tag count statistics"; }
 
-  virtual QString getInitStatusMessage() const
+  virtual QString getInitStatusMessage() const override
   { return "Calculating tag count statistics..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  virtual QString getCompletedStatusMessage() const override
   { return "Calculated tag count statistics for " + QString::number(_numAffected) + " elements"; }
 
-  virtual long numWithStat() const { return _numAffected; }
-  virtual double getStat() const { return _totalCount; }
-  virtual double getMin() const { return _smallestCount; }
-  virtual double getMax() const { return _largestCount; }
-  virtual double getAverage() const
+  virtual long numWithStat() const override { return _numAffected; }
+  virtual double getStat() const override { return _totalCount; }
+  virtual double getMin() const override { return _smallestCount; }
+  virtual double getMax() const override { return _largestCount; }
+  virtual double getAverage() const override
   {
     const double average = _numAffected == 0 ? 0.0 : _totalCount / _numAffected;
     return average;

--- a/hoot-services/src/main/java/hoot/services/geo/BoundingBox.java
+++ b/hoot-services/src/main/java/hoot/services/geo/BoundingBox.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 package hoot.services.geo;
 


### PR DESCRIPTION
Refs #3261 
The OSM API sets a limit on tag lengths to 255 characters, `changeset-derive` and `changeset-apply` now impose this rule on changeset operations.