### PR TITLE
Some overpass data fails to read in Hootenanny

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -26,18 +26,12 @@
  */
 
 // Hoot
+#include <hoot/core/TestUtils.h>
 #include <hoot/core/io/OsmJsonReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/io/OsmXmlReader.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/schema/MetadataTags.h>
-#include <hoot-core-test/src/test/cpp/hoot/core/TestUtils.h>
-
-// CPP Unit
-#include <cppunit/extensions/HelperMacros.h>
-#include <cppunit/extensions/TestFactoryRegistry.h>
-#include <cppunit/TestAssert.h>
-#include <cppunit/TestFixture.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QDir>

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -420,6 +420,40 @@ public:
         "}";
     OsmJsonReader::scrubQuotes(singleQuoteTest);
     HOOT_STR_EQUALS(doubleQuoteTest, singleQuoteTest);
+
+    QString overpassOriginal =
+    "{\n"
+    "  \"version\": 0.6,\n"
+    "  \"generator\": \"Overpass API\",\n"
+    "  \"osm3s\": {\n"
+    "    \"timestamp_osm_base\": \"some date\",\n"
+    "    \"copyright\": \"copyright\"\n"
+    "  },\n"
+    "  \"elements\": [\n"
+    "{\n"
+    "  \"type\": \"node\",\n"
+    "  \"id\": 824816086,\n"
+    "  \"lat\": 18.5396277,\n"
+    "  \"lon\": -72.5293447,\n"
+    "  \"timestamp\": \"date\",\n"
+    "  \"version\": 2,\n"
+    "  \"changeset\": 2,\n"
+    "  \"tags\": {\n"
+    "    \"amenity\": \"school\",\n"
+    "    \"name\": \"La Prairie d'Yslande\",\n"
+    "    \"operational_status\": \"open\",\n"
+    "    \"operational_status_quality\": \"confirmed\",\n"
+    "    \"school_district\": \"Gressier\",\n"
+    "    \"school_type\": \"kindergarten\",\n"
+    "    \"source\": \"CNIGS/OIM/FOCS\"\n"
+    "  }\n"
+    "}\n"
+    "  ]\n"
+    "}";
+
+    const QString overpassCorrect(overpassOriginal);
+    OsmJsonReader::scrubQuotes(overpassOriginal);
+    HOOT_STR_EQUALS(overpassCorrect, overpassOriginal);
   }
 
   void scrubBigIntsTest()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -433,7 +433,9 @@ void OsmJsonReader::scrubQuotes(QString& jsonStr)
   // test strings into c++. Single quotes within string literals
   // should be escaped as \'
   // Detect if they are using single quotes or doubles
-  if (jsonStr.indexOf("\"features\"", Qt::CaseInsensitive) > -1)
+  //  "features" is GEOJSON while "elements" comes from overpass
+  if (jsonStr.indexOf("\"features\"", Qt::CaseInsensitive) > -1 ||
+      jsonStr.indexOf("\"elements\"", Qt::CaseInsensitive) > -1)
     return; // No need to scrub
   else
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -28,29 +28,28 @@
 #include "OsmJsonReader.h"
 
 // hoot
-#include <hoot/core/Hoot.h>
 #include <hoot/core/io/HootNetworkRequest.h>
+#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/MetadataTags.h>
 
 // Boost
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/foreach.hpp>
+#include <boost/property_tree/json_parser.hpp>
 namespace pt = boost::property_tree;
 
 // Qt
-#include <QTextStream>
 #include <QTextCodec>
+#include <QTextStream>
 #include <QUrlQuery>
 
 // Standard
 #include <fstream>
 #include <iostream>
-#include <thread>
 #include <sstream>
+#include <thread>
 #include <unistd.h>
 using namespace std;
 


### PR DESCRIPTION
The JSON manipulation code wasn't handling overpass data correctly in the `scrubQuotes` function.  This fixes the problem.