### PR TITLE
Updated all 'cases' expected files to new ordering for Qt5

### DIFF
--- a/test-files/cases/attribute/network/highway-2888-reviews-by-score/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2888-reviews-by-score/Expected.osm
@@ -118,7 +118,6 @@
         <tag k="source:datetime" v="2014-10-08T02:06:40.000Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-1287" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1780915598090109" lon="73.5059929203423366">
         <tag k="hoot:status" v="2"/>
@@ -3713,7 +3712,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="28910"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-891"/>
@@ -3733,7 +3731,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-663"/>
@@ -3754,7 +3751,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="554.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-323"/>
@@ -3779,7 +3775,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="557.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-521"/>
@@ -3804,7 +3799,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-466"/>
@@ -3838,7 +3832,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-484" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-199"/>
@@ -3882,7 +3875,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="676.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-167"/>
@@ -3915,7 +3907,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="412.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
@@ -3933,7 +3924,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="124.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
@@ -3949,7 +3939,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="125.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-377" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-237"/>
@@ -4018,7 +4007,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="19486.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
@@ -4038,7 +4026,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="156"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-31"/>
@@ -4071,7 +4058,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1341.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-355" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800">
         <nd ref="-1287"/>
@@ -4089,7 +4075,6 @@
         <tag k="source:datetime" v="2014-11-28T17:34:21.000Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-296" timestamp="2019-01-14T12:12:36Z" version="1">
         <nd ref="-1734"/>
@@ -4141,7 +4126,6 @@
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-185" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1097"/>
@@ -4158,7 +4142,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="67.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-184" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1099"/>
@@ -4174,7 +4157,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="31.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-183" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1102"/>
@@ -4195,7 +4177,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="138.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-182" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1159"/>
@@ -4214,7 +4195,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-181" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-925"/>
@@ -4243,7 +4223,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1710.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-180" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-898"/>
@@ -4260,7 +4239,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="125.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-179" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-999"/>
@@ -4270,7 +4248,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="143.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-178" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1037"/>
@@ -4286,7 +4263,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="657.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-177" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-998"/>
@@ -4309,7 +4285,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="458.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-176" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1084"/>
@@ -4331,7 +4306,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="108.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-175" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-891"/>
@@ -4356,7 +4330,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="112.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-174" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1082"/>
@@ -4377,7 +4350,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="890.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-173" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1029"/>
@@ -4409,7 +4381,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1118.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-172" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1088"/>
@@ -4439,7 +4410,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="643.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-171" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1024"/>
@@ -4457,7 +4427,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="22.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-169" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-988"/>
@@ -4490,7 +4459,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1254.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-168" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-291"/>
@@ -4509,7 +4477,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="64.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-167" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-995"/>
@@ -4526,7 +4493,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="188.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-166" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-669"/>
@@ -4560,7 +4526,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="3636"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-165" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1022"/>
@@ -4569,7 +4534,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="41.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-164" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1070"/>
@@ -4596,7 +4560,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1284"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-163" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-959"/>
@@ -4607,7 +4570,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="191.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-162" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1048"/>
@@ -4632,7 +4594,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="685.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-161" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1018"/>
@@ -4648,7 +4609,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="43.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-160" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-975"/>
@@ -4673,7 +4633,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="597"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-159" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-976"/>
@@ -4703,7 +4662,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="2836"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-158" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1114"/>
@@ -4744,7 +4702,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="353.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-157" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-968"/>
@@ -4763,7 +4720,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="666"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-156" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-949"/>
@@ -4781,7 +4737,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="87.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-155" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-921"/>
@@ -4827,7 +4782,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="12850.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-154" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-898"/>
@@ -4861,7 +4815,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="3546.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-153" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-893"/>
@@ -4879,7 +4832,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-152" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-895"/>
@@ -4896,7 +4848,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="54.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-150" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-201"/>
@@ -4913,7 +4864,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="35.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-149" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-297"/>
@@ -4937,7 +4887,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="69.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-148" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1176"/>
@@ -4963,7 +4912,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="238.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-147" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-763"/>
@@ -4986,7 +4934,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="263.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-146" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-217"/>
@@ -5010,7 +4957,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="182.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-145" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-862"/>
@@ -5019,7 +4965,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="66.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-144" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-987"/>
@@ -5040,7 +4985,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="132.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-143" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1099"/>
@@ -5062,7 +5006,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-142" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-21"/>
@@ -5085,7 +5028,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="617.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-141" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-828"/>
@@ -5104,7 +5046,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="62.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-140" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-19"/>
@@ -5131,7 +5072,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="900.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-139" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-822"/>
@@ -5143,7 +5083,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="217.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-138" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-822"/>
@@ -5154,7 +5093,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="83.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-137" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-763"/>
@@ -5172,7 +5110,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-136" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1176"/>
@@ -5189,7 +5126,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-135" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-560"/>
@@ -5212,7 +5148,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="128.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-134" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1106"/>
@@ -5226,7 +5161,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="201"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-132" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-807"/>
@@ -5235,7 +5169,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="55.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-131" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-924"/>
@@ -5254,7 +5187,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="137.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-130" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-372"/>
@@ -5286,7 +5218,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="623.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-129" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-66"/>
@@ -5315,7 +5246,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="2073.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-128" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-921"/>
@@ -5335,7 +5265,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="528.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-127" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-251"/>
@@ -5344,7 +5273,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="44.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-126" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-808"/>
@@ -5354,7 +5282,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="67.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-125" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-67"/>
@@ -5378,7 +5305,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="828.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-124" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-782"/>
@@ -5387,7 +5313,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="50.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-123" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-268"/>
@@ -5413,7 +5338,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1944.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-122" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-743"/>
@@ -5422,7 +5346,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="26.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-121" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-745"/>
@@ -5431,7 +5354,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="53.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-119" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-930"/>
@@ -5454,7 +5376,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="204.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-117" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-840"/>
@@ -5480,7 +5401,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="600.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-116" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-197"/>
@@ -5499,7 +5419,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="58.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-115" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1139"/>
@@ -5519,7 +5438,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="507.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-114" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-335"/>
@@ -5536,7 +5454,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="67.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-113" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-750"/>
@@ -5553,7 +5470,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="31.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-112" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1008"/>
@@ -5562,7 +5478,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="23.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-111" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-189"/>
@@ -5583,7 +5498,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="133.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-109" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1155"/>
@@ -5601,7 +5515,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-108" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-615"/>
@@ -5620,7 +5533,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="62.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-107" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-521"/>
@@ -5639,7 +5551,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="148.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-106" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-912"/>
@@ -5680,7 +5591,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="196.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-105" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-707"/>
@@ -5699,7 +5609,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="117.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-104" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-448"/>
@@ -5721,7 +5630,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="83.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-101" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-237"/>
@@ -5730,7 +5638,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="41.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-100" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-615"/>
@@ -5748,7 +5655,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="45.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-99" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-636"/>
@@ -5769,7 +5675,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="269.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-98" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-655"/>
@@ -5788,7 +5693,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="132.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-97" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-633"/>
@@ -5812,7 +5716,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="175.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-96" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-544"/>
@@ -5851,7 +5754,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="669.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-95" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-908"/>
@@ -5879,7 +5781,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="411.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-94" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-160"/>
@@ -5891,7 +5792,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="207.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-93" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-38"/>
@@ -5908,7 +5808,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="133.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-92" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1094"/>
@@ -5921,7 +5820,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="69.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-91" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-396"/>
@@ -5943,7 +5841,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="262.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-90" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1098"/>
@@ -5965,7 +5862,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="485.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-89" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1080"/>
@@ -5990,7 +5886,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="238"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-88" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-577"/>
@@ -6014,7 +5909,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="723.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-87" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-999"/>
@@ -6025,7 +5919,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="68.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-86" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-49"/>
@@ -6047,7 +5940,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="473.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-50"/>
@@ -6074,7 +5966,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="228.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-84" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1056"/>
@@ -6109,7 +6000,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="685"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-83" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-540"/>
@@ -6131,7 +6021,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="231.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-588"/>
@@ -6150,7 +6039,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="85.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-80" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-514"/>
@@ -6168,7 +6056,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="48.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-79" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-979"/>
@@ -6187,7 +6074,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="103.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-78" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-932"/>
@@ -6205,7 +6091,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="94.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-77" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-504"/>
@@ -6215,7 +6100,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="55.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-76" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-423"/>
@@ -6240,7 +6124,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-75" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-405"/>
@@ -6251,7 +6134,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="31.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-74" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-909"/>
@@ -6289,7 +6171,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="627"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-72" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-438"/>
@@ -6318,7 +6199,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="378.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-71" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-408"/>
@@ -6332,7 +6212,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="265"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-68" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-427"/>
@@ -6351,7 +6230,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="73.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-67" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1063"/>
@@ -6377,7 +6255,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1802.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-65" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1040"/>
@@ -6401,7 +6278,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="530.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-64" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-968"/>
@@ -6411,7 +6287,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="102.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-63" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-934"/>
@@ -6435,7 +6310,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="608.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-62" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1152"/>
@@ -6453,7 +6327,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="45.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-61" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1129"/>
@@ -6479,7 +6352,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="404.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-60" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-378"/>
@@ -6501,7 +6373,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="537.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-59" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-328"/>
@@ -6518,7 +6389,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="35.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-58" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1131"/>
@@ -6530,7 +6400,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="64.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-57" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-948"/>
@@ -6543,7 +6412,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="17.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-56" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-352"/>
@@ -6574,7 +6442,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="276.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-55" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-252"/>
@@ -6597,7 +6464,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="7586"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-54" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-345"/>
@@ -6618,7 +6484,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="85.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-52" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-105"/>
@@ -6646,7 +6511,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1908"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-50" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-876"/>
@@ -6657,7 +6521,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="147.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-49" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-313"/>
@@ -6676,7 +6539,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="411"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-48" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-7"/>
@@ -6693,7 +6555,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="1021.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-47" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1147"/>
@@ -6702,7 +6563,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="72.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-46" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-324"/>
@@ -6711,7 +6571,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="67.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-45" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-915"/>
@@ -6727,7 +6586,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="663.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-44" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-184"/>
@@ -6744,7 +6602,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="43.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-43" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-31"/>
@@ -6765,7 +6622,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="73.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-42" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-260"/>
@@ -6785,7 +6641,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="142.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-40" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-191"/>
@@ -6802,7 +6657,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="108.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-39" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-217"/>
@@ -6827,7 +6681,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="189.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-38" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-238"/>
@@ -6845,7 +6698,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="137.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-37" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-219"/>
@@ -6882,7 +6734,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1647.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-36" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-271"/>
@@ -6896,7 +6747,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="86.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-35" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1044"/>
@@ -6923,7 +6773,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="102.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-34" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-899"/>
@@ -6946,7 +6795,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-33" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-98"/>
@@ -6963,7 +6811,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="69.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-32" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-126"/>
@@ -6979,7 +6826,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="71.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-31" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-919"/>
@@ -7002,7 +6848,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1032.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-30" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-185"/>
@@ -7011,7 +6856,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="68.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-164"/>
@@ -7030,7 +6874,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="269.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-28" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-202"/>
@@ -7051,7 +6894,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1237.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-27" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-163"/>
@@ -7074,7 +6916,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="86.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-26" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-67"/>
@@ -7109,7 +6950,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="3865.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-25" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-156"/>
@@ -7120,7 +6960,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="272.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-954"/>
@@ -7148,7 +6987,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="403.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-23" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-143"/>
@@ -7158,7 +6996,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="60.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-120"/>
@@ -7173,7 +7010,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="283.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-141"/>
@@ -7194,7 +7030,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="822.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-128"/>
@@ -7212,7 +7047,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="276.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-154"/>
@@ -7226,7 +7060,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="1868"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-148"/>
@@ -7235,7 +7068,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="101.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-13" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-110"/>
@@ -7244,7 +7076,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="42.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-12" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1149"/>
@@ -7270,7 +7101,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="273"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-11" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-13"/>
@@ -7289,7 +7119,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="335.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-10" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-493"/>
@@ -7309,7 +7138,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="2674.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-93"/>
@@ -7330,7 +7158,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="50.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-8" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-87"/>
@@ -7356,7 +7183,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="796"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-94"/>
@@ -7372,7 +7198,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="21.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1112"/>
@@ -7382,7 +7207,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="68.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-139"/>
@@ -7408,7 +7232,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1230.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-964"/>
@@ -7437,7 +7260,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="1833.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
@@ -7476,7 +7298,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="20645.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-23"/>
@@ -7504,7 +7325,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="2682.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1151"/>
@@ -7527,7 +7347,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="717"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1139" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-296" role="reviewee"/>

--- a/test-files/cases/attribute/network/highway-2888/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2888/Expected.osm
@@ -3585,7 +3585,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="28910"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-891"/>
@@ -3605,7 +3604,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-663"/>
@@ -3626,7 +3624,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="554.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-323"/>
@@ -3651,7 +3648,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="557.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-521"/>
@@ -3676,7 +3672,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-466"/>
@@ -3710,7 +3705,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-484" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-199"/>
@@ -3754,7 +3748,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="676.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-167"/>
@@ -3787,7 +3780,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="412.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
@@ -3805,7 +3797,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="124.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
@@ -3821,7 +3812,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="125.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-377" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-237"/>
@@ -3890,7 +3880,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="19486.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
@@ -3910,7 +3899,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="156"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-31"/>
@@ -3943,7 +3931,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1341.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-185" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1097"/>
@@ -3960,7 +3947,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="67.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-184" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1099"/>
@@ -3976,7 +3962,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="31.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-183" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1102"/>
@@ -3997,7 +3982,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="138.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-182" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1159"/>
@@ -4016,7 +4000,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-181" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-925"/>
@@ -4045,7 +4028,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1710.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-180" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-898"/>
@@ -4062,7 +4044,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="125.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-179" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-999"/>
@@ -4072,7 +4053,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="143.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-178" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1037"/>
@@ -4088,7 +4068,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="657.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-177" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-998"/>
@@ -4111,7 +4090,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="458.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-176" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1084"/>
@@ -4133,7 +4111,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="108.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-175" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-891"/>
@@ -4158,7 +4135,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="112.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-174" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1082"/>
@@ -4179,7 +4155,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="890.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-173" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1029"/>
@@ -4211,7 +4186,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1118.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-172" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1088"/>
@@ -4241,7 +4215,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="643.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-171" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1024"/>
@@ -4259,7 +4232,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="22.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-169" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-988"/>
@@ -4292,7 +4264,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1254.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-168" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-291"/>
@@ -4311,7 +4282,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="64.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-167" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-995"/>
@@ -4328,7 +4298,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="188.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-166" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-669"/>
@@ -4362,7 +4331,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="3636"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-165" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1022"/>
@@ -4371,7 +4339,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="41.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-164" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1070"/>
@@ -4398,7 +4365,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1284"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-163" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-959"/>
@@ -4409,7 +4375,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="191.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-162" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1048"/>
@@ -4434,7 +4399,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="685.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-161" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1018"/>
@@ -4450,7 +4414,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="43.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-160" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-975"/>
@@ -4475,7 +4438,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="597"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-159" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-976"/>
@@ -4505,7 +4467,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="2836"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-158" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1114"/>
@@ -4546,7 +4507,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="353.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-157" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-968"/>
@@ -4565,7 +4525,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="666"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-156" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-949"/>
@@ -4583,7 +4542,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="87.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-155" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-921"/>
@@ -4629,7 +4587,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="12850.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-154" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-898"/>
@@ -4663,7 +4620,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="3546.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-153" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-893"/>
@@ -4681,7 +4637,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-152" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-895"/>
@@ -4698,7 +4653,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="54.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-150" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-201"/>
@@ -4715,7 +4669,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="35.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-149" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-297"/>
@@ -4739,7 +4692,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="69.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-148" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1176"/>
@@ -4765,7 +4717,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="238.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-147" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-763"/>
@@ -4788,7 +4739,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="263.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-146" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-217"/>
@@ -4812,7 +4762,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="182.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-145" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-862"/>
@@ -4821,7 +4770,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="66.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-144" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-987"/>
@@ -4842,7 +4790,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="132.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-143" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1099"/>
@@ -4864,7 +4811,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-142" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-21"/>
@@ -4887,7 +4833,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="617.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-141" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-828"/>
@@ -4906,7 +4851,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="62.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-140" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-19"/>
@@ -4933,7 +4877,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="900.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-139" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-822"/>
@@ -4945,7 +4888,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="217.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-138" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-822"/>
@@ -4956,7 +4898,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="83.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-137" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-763"/>
@@ -4974,7 +4915,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-136" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1176"/>
@@ -4991,7 +4931,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-135" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-560"/>
@@ -5014,7 +4953,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="128.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-134" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1106"/>
@@ -5028,7 +4966,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="201"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-132" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-807"/>
@@ -5037,7 +4974,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="55.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-131" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-924"/>
@@ -5056,7 +4992,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="137.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-130" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-372"/>
@@ -5088,7 +5023,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="623.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-129" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-66"/>
@@ -5117,7 +5051,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="2073.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-128" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-921"/>
@@ -5137,7 +5070,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="528.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-127" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-251"/>
@@ -5146,7 +5078,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="44.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-126" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-808"/>
@@ -5156,7 +5087,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="67.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-125" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-67"/>
@@ -5180,7 +5110,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="828.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-124" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-782"/>
@@ -5189,7 +5118,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="50.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-123" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-268"/>
@@ -5215,7 +5143,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1944.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-122" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-743"/>
@@ -5224,7 +5151,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="26.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-121" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-745"/>
@@ -5233,7 +5159,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="53.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-119" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-930"/>
@@ -5256,7 +5181,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="204.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-117" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-840"/>
@@ -5282,7 +5206,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="600.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-116" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-197"/>
@@ -5301,7 +5224,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="58.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-115" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1139"/>
@@ -5321,7 +5243,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="507.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-114" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-335"/>
@@ -5338,7 +5259,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="67.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-113" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-750"/>
@@ -5355,7 +5275,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="31.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-112" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1008"/>
@@ -5364,7 +5283,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="23.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-111" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-189"/>
@@ -5385,7 +5303,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="133.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-109" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1155"/>
@@ -5403,7 +5320,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="68.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-108" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-615"/>
@@ -5422,7 +5338,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="62.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-107" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-521"/>
@@ -5441,7 +5356,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="148.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-106" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-912"/>
@@ -5482,7 +5396,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="196.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-105" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-707"/>
@@ -5501,7 +5414,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="117.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-104" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-448"/>
@@ -5523,7 +5435,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="83.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-101" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-237"/>
@@ -5532,7 +5443,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="41.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-100" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-615"/>
@@ -5550,7 +5460,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="45.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-99" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-636"/>
@@ -5571,7 +5480,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="269.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-98" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-655"/>
@@ -5590,7 +5498,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="132.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-97" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-633"/>
@@ -5614,7 +5521,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="175.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-96" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-544"/>
@@ -5653,7 +5559,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="669.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-95" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-908"/>
@@ -5681,7 +5586,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="411.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-94" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-160"/>
@@ -5693,7 +5597,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="207.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-93" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-38"/>
@@ -5710,7 +5613,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="133.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-92" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1094"/>
@@ -5723,7 +5625,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="69.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-91" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-396"/>
@@ -5745,7 +5646,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="262.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-90" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1098"/>
@@ -5767,7 +5667,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="485.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-89" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1080"/>
@@ -5792,7 +5691,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="238"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-88" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-577"/>
@@ -5816,7 +5714,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="723.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-87" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-999"/>
@@ -5827,7 +5724,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="68.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-86" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-49"/>
@@ -5849,7 +5745,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="473.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-50"/>
@@ -5876,7 +5771,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="228.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-84" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1056"/>
@@ -5911,7 +5805,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="685"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-83" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-540"/>
@@ -5933,7 +5826,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="231.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-588"/>
@@ -5952,7 +5844,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="85.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-80" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-514"/>
@@ -5970,7 +5861,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="48.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-79" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-979"/>
@@ -5989,7 +5879,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="103.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-78" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-932"/>
@@ -6007,7 +5896,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="94.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-77" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-504"/>
@@ -6017,7 +5905,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="55.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-76" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-423"/>
@@ -6042,7 +5929,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-75" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-405"/>
@@ -6053,7 +5939,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="31.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-74" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-909"/>
@@ -6091,7 +5976,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="627"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-72" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-438"/>
@@ -6120,7 +6004,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="378.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-71" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-408"/>
@@ -6134,7 +6017,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="265"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-68" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-427"/>
@@ -6153,7 +6035,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="73.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-67" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1063"/>
@@ -6179,7 +6060,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1802.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-65" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1040"/>
@@ -6203,7 +6083,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="530.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-64" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-968"/>
@@ -6213,7 +6092,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="102.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-63" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-934"/>
@@ -6237,7 +6115,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="608.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-62" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1152"/>
@@ -6255,7 +6132,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="45.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-61" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1129"/>
@@ -6281,7 +6157,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="404.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-60" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-378"/>
@@ -6303,7 +6178,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="537.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-59" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-328"/>
@@ -6320,7 +6194,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="35.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-58" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1131"/>
@@ -6332,7 +6205,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="64.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-57" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-948"/>
@@ -6345,7 +6217,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="17.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-56" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-352"/>
@@ -6376,7 +6247,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="276.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-55" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-252"/>
@@ -6399,7 +6269,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="7586"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-54" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-345"/>
@@ -6420,7 +6289,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="85.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-52" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-105"/>
@@ -6448,7 +6316,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1908"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-50" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-876"/>
@@ -6459,7 +6326,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="147.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-49" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-313"/>
@@ -6478,7 +6344,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="411"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-48" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-7"/>
@@ -6495,7 +6360,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="1021.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-47" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1147"/>
@@ -6504,7 +6368,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="72.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-46" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-324"/>
@@ -6513,7 +6376,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="67.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-45" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-915"/>
@@ -6529,7 +6391,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="663.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-44" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-184"/>
@@ -6546,7 +6407,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="43.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-43" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-31"/>
@@ -6567,7 +6427,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="73.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-42" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-260"/>
@@ -6587,7 +6446,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="142.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-40" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-191"/>
@@ -6604,7 +6462,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="108.0"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-39" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-217"/>
@@ -6629,7 +6486,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="189.9"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-38" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-238"/>
@@ -6647,7 +6503,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="137.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-37" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-219"/>
@@ -6684,7 +6539,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1647.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-36" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-271"/>
@@ -6698,7 +6552,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="86.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-35" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1044"/>
@@ -6725,7 +6578,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="102.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-34" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-899"/>
@@ -6748,7 +6600,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-33" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-98"/>
@@ -6765,7 +6616,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="69.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-32" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-126"/>
@@ -6781,7 +6631,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="71.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-31" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-919"/>
@@ -6804,7 +6653,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1032.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-30" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-185"/>
@@ -6813,7 +6661,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="68.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-164"/>
@@ -6832,7 +6679,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="269.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-28" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-202"/>
@@ -6853,7 +6699,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1237.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-27" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-163"/>
@@ -6876,7 +6721,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="86.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-26" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-67"/>
@@ -6911,7 +6755,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="3865.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-25" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-156"/>
@@ -6922,7 +6765,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="272.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-954"/>
@@ -6950,7 +6792,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="403.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-23" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-143"/>
@@ -6960,7 +6801,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="60.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-120"/>
@@ -6975,7 +6815,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="283.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-141"/>
@@ -6996,7 +6835,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="822.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-128"/>
@@ -7014,7 +6852,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="276.4"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-154"/>
@@ -7028,7 +6865,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="1868"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-148"/>
@@ -7037,7 +6873,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="101.5"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-13" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-110"/>
@@ -7046,7 +6881,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="42.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-12" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1149"/>
@@ -7072,7 +6906,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="273"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-11" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-13"/>
@@ -7091,7 +6924,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="335.2"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-10" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-493"/>
@@ -7111,7 +6943,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="2674.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-93"/>
@@ -7132,7 +6963,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="50.7"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-8" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-87"/>
@@ -7158,7 +6988,6 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="796"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-94"/>
@@ -7174,7 +7003,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="21.3"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1112"/>
@@ -7184,7 +7012,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="68.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-139"/>
@@ -7210,7 +7037,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1230.1"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-964"/>
@@ -7239,7 +7065,6 @@
         <tag k="highway" v="road"/>
         <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
         <tag k="length" v="1833.6"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
@@ -7278,7 +7103,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="20645.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-23"/>
@@ -7306,7 +7130,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="2682.8"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1151"/>
@@ -7329,6 +7152,5 @@
         <tag k="surface" v="paved"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="717"/>
-        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/network/highway-2927-bridge-2/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-bridge-2/Expected.osm
@@ -4,1277 +4,1022 @@
     <node visible="true" id="-812" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012521346404696" lon="-72.3611555565896225">
         <tag k="hoot:status" v="3"/>
         <tag k="bdw-id" v="{6e6f4cd8-5809-48d4-83fc-129aa455a20b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-811" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013861911808847" lon="-72.3616633883052458">
         <tag k="hoot:status" v="3"/>
         <tag k="bdw-id" v="{eef519b5-7a1e-4101-9627-7014a8403704}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-805" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997880287896709" lon="-72.3619894089128906">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b65b630-0b42-4715-9290-c164a5660436}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-799" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006278906475814" lon="-72.3616258434131652">
         <tag k="hoot:status" v="3"/>
         <tag k="bdw-id" v="{e5b2c0cd-d8ba-4cc7-b325-67c9d49414ce}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-367" timestamp="2012-07-12T16:14:15Z" version="1" changeset="12197232" user="punkadiddle" uid="152973" lat="7.6999007391641490" lon="-72.3619783335608560">
         <tag k="hoot:status" v="2"/>
         <tag k="bdw-id" v="{269ded8c-88fd-4792-bcbb-6b71cfeb3454}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-342" timestamp="2012-07-12T16:14:12Z" version="1" changeset="12197232" user="punkadiddle" uid="152973" lat="7.7002507785244116" lon="-72.3620289331979478">
         <tag k="hoot:status" v="2"/>
         <tag k="bdw-id" v="{a9a65f8c-0819-4829-ae40-9546ed6e98f5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-326" timestamp="2012-07-10T16:22:04Z" version="1" changeset="12175062" user="punkadiddle" uid="152973" lat="7.7012125526970445" lon="-72.3609961014727787">
         <tag k="hoot:status" v="2"/>
         <tag k="bdw-id" v="{e3af4f8e-5eec-4c79-aab4-56fe2420d431}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-296" timestamp="2012-07-10T14:56:00Z" version="1" changeset="12174490" user="punkadiddle" uid="152973" lat="7.7006208228703041" lon="-72.3620566530983780">
         <tag k="hoot:status" v="2"/>
         <tag k="bdw-id" v="{297b891c-b3f1-4647-a704-a2bdf767ad75}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-293" timestamp="2012-07-10T14:55:54Z" version="1" changeset="12174490" user="punkadiddle" uid="152973" lat="7.7006193181646276" lon="-72.3618603108395320">
         <tag k="hoot:status" v="2"/>
         <tag k="bdw-id" v="{f302ecab-f75b-43dc-a73f-4a34012e3ef7}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-268" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000125445999998" lon="-72.3589731062100014">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{982630d9-e726-433a-bcd7-a33ef723c34f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998995600399986" lon="-72.3589844938999960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee7f5868-82c8-4f17-b42c-7ce7c75afca2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-266" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998106361499987" lon="-72.3589917918399976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{af37fca5-b78d-4cda-a388-95b1ddc59266}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-265" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993994747499999" lon="-72.3590126697099976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{960765e7-e8e7-424b-bb72-93a6897bb679}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-264" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993151479199993" lon="-72.3590223339899978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b34ba694-1b12-433b-85a2-120cfe899e15}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992909182700000" lon="-72.3590288738100043">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{398ad070-2704-4c96-9344-0d30bd3aeea5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992585774999984" lon="-72.3590461502100055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1a6777ee-9fa9-4ac4-915b-98ee76819e3d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-261" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992385942999970" lon="-72.3590730195799807">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{09df298a-2d0b-401c-9907-eb8dc9e19397}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992321979699989" lon="-72.3590979001800036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{616e8c64-a870-4dba-94b4-e98da5cf92d1}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992300854399973" lon="-72.3591403953499821">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a30fc37c-8163-4d47-ac10-a8e469983153}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992334148500019" lon="-72.3592847030199948">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c57bf62d-ad47-4dc7-86f6-693e6617d0dc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026718036500013" lon="-72.3587359608799972">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f337b438-01a8-4916-98a0-8a020ef93866}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024847145999997" lon="-72.3587602470999940">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ecbb75b5-d097-4d8f-b9ac-aa4c466078cb}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013714084200000" lon="-72.3587790233400057">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8c4823d6-673d-4fc6-8cb2-2c7f7c7065b4}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-254" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013424454900008" lon="-72.3588624947000056">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{95d2cd0d-d83b-426c-9b37-ca2f145adcf2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-253" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008197799199980" lon="-72.3597623706800022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{41ee920a-d2ed-432d-b3c9-163eac3b363b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008092709699989" lon="-72.3595223599700006">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c9817e93-2182-4fc8-8a78-f81830bca66d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-251" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007744741800002" lon="-72.3589044947500071">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c753f0f7-9ac3-4325-a21d-790d48100f62}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-250" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012598976399991" lon="-72.3597289086799975">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6b071116-3bdb-4a14-b0c9-4bf96b96d606}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012764845499984" lon="-72.3593171985600065">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{981feaca-838d-4552-ac59-a3e1d3d37557}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-248" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012955818400020" lon="-72.3590066044900055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ea76cb0d-0e1b-4a77-87ab-3c3b89b6bc3f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013077781100003" lon="-72.3589521360100036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dc8d2fd1-3c53-4243-8404-cbc639cdf774}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999971438299974" lon="-72.3587579203200022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5b351244-e61f-4d90-8a3f-2976296fa5ad}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000668045399996" lon="-72.3598254307700017">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{395dc79e-32f0-49da-873f-d02e840a4e85}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000550239600019" lon="-72.3596615684899973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{41cda987-2dcd-4cec-979d-e87cd45307d6}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024430316399988" lon="-72.3587628416200062">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0d532bc7-5901-49fb-9af5-7ac26f155bfe}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022753596499989" lon="-72.3587660034399960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b87fd95b-9069-4b25-9acd-8bfd2e7b30f4}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019420064599977" lon="-72.3587949213199835">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8f039b12-3202-400f-8ad6-c1fb64585b9a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017087688199979" lon="-72.3588288453800033">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a3014fe8-999a-4e77-b0ed-3b1300b319bf}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011678514400019" lon="-72.3588790485100048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{85c81f2a-f885-4316-8bf4-ab29e166b691}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-238" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007611580700006" lon="-72.3586901564100060">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5b1dbf2f-e2b5-4f49-8a5b-2b5f78982efb}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024746729499984" lon="-72.3585429223900007">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{018aab14-7edd-44c8-9742-cc31146db1e6}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-236" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025112673000011" lon="-72.3596282107299942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{89d1fec9-de0d-4d6f-97ef-e76e45e3dd77}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025058843299998" lon="-72.3593829638100061">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee9280ea-54c9-41bc-a529-72f3cb065e4c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-234" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002443052199983" lon="-72.3589490580299923">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{24e16643-fab4-4920-b770-536a667b00ad}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-233" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006631927900013" lon="-72.3622576000999942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{abb89eaa-f7e1-48ef-a20d-daccb382e6dc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006467123899993" lon="-72.3621917521900002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e822a229-32f9-49bf-8259-92e7209883c7}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-231" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006359377100004" lon="-72.3621451826700053">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{32de3d30-84d3-4478-bb8b-2c0f560a6a7d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-230" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026271959599999" lon="-72.3630450196699968">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{118a81bb-a69f-4d92-bbfd-bb1495693a02}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024136314199989" lon="-72.3631098588599997">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{06556a1e-4599-48a4-9954-80c574157f42}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018343149700002" lon="-72.3632777502100026">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{78838ae7-12eb-4638-87ae-9d20c4a63f20}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023457846799985" lon="-72.3620573045100031">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6185f7cc-d893-4348-9535-873732391681}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021065329700003" lon="-72.3621256362999929">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3731555f-5c69-4a2f-a2a2-19c139166164}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015651482700020" lon="-72.3622890368200018">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{81f5baf5-2787-49b8-90d4-2e796f47325d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-224" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012623905600011" lon="-72.3606986641199939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c989a443-e7b0-4ec3-a5d4-a1d8d467b90d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012264768899996" lon="-72.3606929453199967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{03691619-b190-44e5-af12-0b718693aec9}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011946802500004" lon="-72.3606873789299954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{74d94055-e32a-448f-ae0c-f623710810d3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005899704199976" lon="-72.3597828621900021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d6ff1f49-845e-4e4c-85dd-c807cb229f24}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004508032499999" lon="-72.3645342810900019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cb9f5bc1-0820-48e2-b355-32c68cd4a795}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003871811100009" lon="-72.3643266931999989">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{08681d5f-a5b7-4611-8ea3-c77d6be244b9}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002798132799999" lon="-72.3639517346500014">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7e1534df-0a76-4e7d-8e5c-796c313781c8}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002040256299988" lon="-72.3637306485599936">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6207ef23-ff4b-4311-84d3-74d3590cb32c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008287735000005" lon="-72.3605437910899951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb318626-0651-4678-a706-d458a0f7b740}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-215" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008253843899990" lon="-72.3605705059400037">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5acf5d01-cea8-4d8c-b07e-c72cd816b073}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007972569599996" lon="-72.3607473959300052">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4de83773-cb12-4014-a352-9a3186263975}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029913144300020" lon="-72.3643388391599842">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2dd1952f-5b09-4c08-b7a7-5950135e532a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029451957799990" lon="-72.3642402141099979">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{572b05ea-e0fe-4344-bd1a-79aba66e0e23}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-211" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029194344199992" lon="-72.3641647013199929">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{15646cdf-f8f5-454a-93c9-f60c215d85a6}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029000823099993" lon="-72.3640872884299995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cd4862c7-97ce-4b2f-a312-0a4c70ac5bd2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028743568799989" lon="-72.3639080177500063">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6014bb75-2061-4041-9614-32caeff0fc5e}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028559585300016" lon="-72.3638136811500061">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{294a16bf-825f-4ab1-9c0f-1092f547b442}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-207" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029272476499990" lon="-72.3629551069300021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d3544fd0-7f36-4db6-9b3c-8d55a20ede05}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028236705099973" lon="-72.3629831259799943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8b69cf3d-0c67-4afe-b55e-3484e5a211bc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-205" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027090382500001" lon="-72.3651492070899991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6cb57a87-35bb-4b55-b541-8d3f38dcd8c5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-204" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026454572700009" lon="-72.3650829173700032">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9ba2c828-3cb0-4e23-978e-175a5f9c0a1a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015378418000013" lon="-72.3622036787599967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0622996b-12af-4779-8f5b-e824949ed7be}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014912199299994" lon="-72.3620477259700010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ab76e169-e37a-41a4-9338-a8af40ccc6a2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6990490502900002" lon="-72.3592864234800004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fe3e54f6-c119-410b-9817-24a70ed71ab2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023333015699986" lon="-72.3620129969399954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8702c164-0903-496a-9f7e-740ab9d4a563}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021926759499992" lon="-72.3616215999099950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4c39a9b8-0abd-466f-9c60-14f8c579e90d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021745098799972" lon="-72.3615513291699841">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{83013c28-fe21-4143-8c06-afe4273fdddd}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017758671699976" lon="-72.3630599810399957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5bd7ddcc-49c6-469a-93b5-c427377cdbff}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016327996199978" lon="-72.3625044378700011">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{250c22dd-780b-44a5-aec3-5840c98bc7af}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012088752899990" lon="-72.3643351878800019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3e643060-ed6a-432f-a653-e20e3752bc77}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011570231600031" lon="-72.3641177542399987">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cfcd1c0a-050e-451a-a572-2ee9d49b3056}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009986579199978" lon="-72.3635211022599805">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3ba124af-3a0a-4357-9ec0-5daabdd54dbc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014475595599965" lon="-72.3618958642800010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e47c790e-aaa7-4699-85b1-9b13c9e0afeb}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012185099100012" lon="-72.3610281801099973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b58dd51-6a6c-4991-85d8-8310d90aee65}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012058795200025" lon="-72.3609601674999965">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2bfac72f-c5eb-4eda-bccb-39ae86bd1547}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011854733399998" lon="-72.3607682998599984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7a8e8f48-a3ad-43f4-bf37-a7bfffa4fd47}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011867500899989" lon="-72.3607269335499979">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2517d848-fc83-4184-bcb5-145f8998d9fa}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024978803100019" lon="-72.3653636431100011">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{19a73972-2edb-44b8-93d7-dd70ec0ba05a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029593477100011" lon="-72.3653755295199943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{24bd8d78-8ac7-40b4-bf34-f2f1e0e9d174}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028953822399995" lon="-72.3653253606699991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bfe364dd-a50a-4f35-9324-8004397ffda9}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028264479300015" lon="-72.3652641111099939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fad979c8-3563-4e4d-b0f2-0922deb597f3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027073002500011" lon="-72.3609297702300012">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c00c4d6e-18cf-4014-b189-c7a024821a61}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024966756600008" lon="-72.3608927498199961">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ac868205-8c68-42e5-8503-34adf8ed90ef}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016897398499991" lon="-72.3648851958499932">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{aaa495db-bb2c-4d14-b6f1-852d77945dd2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016640244399994" lon="-72.3648701313099991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d5d0a69d-76e9-4e17-8b74-0e4b84b56812}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016019476799995" lon="-72.3648422017000001">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7b21e8df-b452-4ed2-a820-a45834862a9c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015621251499988" lon="-72.3648169241400012">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{52359d05-ecca-42e8-9d49-0f9dc18d7e03}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015320594699999" lon="-72.3648214196999930">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{048ace9f-5506-4de2-bdd3-9523b46c6c6a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015020998500017" lon="-72.3648431532299838">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b54181d4-a211-41c1-984f-3812a57be74d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013769878999989" lon="-72.3649754676700070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2cb73e9b-5dc9-4d46-aeae-75de34976546}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013116965700004" lon="-72.3650257533199976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{39f5b7b6-9133-4b66-8695-b27845493733}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011985683099997" lon="-72.3651106152599937">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a3f0b378-1bf3-4e44-8e81-3b81b47a55b6}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006126074400001" lon="-72.3621489709500025">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4aa38a15-1d1a-496d-a6ac-c11d125801f3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005910945099982" lon="-72.3621499434400022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7db3022e-6731-4b4e-8f6d-da72dced98aa}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005495876499994" lon="-72.3621442957399950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6a4cec9f-62ae-4a45-bd74-fc3b5336cc88}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003910035800018" lon="-72.3620746576300036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb1529f2-de86-427b-b4fb-cda4954c891d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002851133800005" lon="-72.3620377767099825">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ab8bb983-17c8-4cc2-8d8a-50cdb7f5b830}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001765405099993" lon="-72.3620098119699833">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a43e29c7-5c4b-49ec-a12e-3fb954ce9b1e}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000151722999997" lon="-72.3619831066999950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{607c8fb3-2d66-428a-8421-ca69d4fd6b36}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998794510700019" lon="-72.3619774456099947">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0813dba4-e3d7-4fdb-a9a6-eb05878ba17c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998032185799987" lon="-72.3619853627400005">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a8c1b1d5-6513-4514-ab87-8cf7b65c72b7}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997383847400007" lon="-72.3620026328199941">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{64c29c0a-72de-4ae5-982e-675d405758a0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995928115399996" lon="-72.3620593355500006">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b6af514b-2a6e-47fb-ab24-aa8dae8659f3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013270798199986" lon="-72.3648078769700049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5c313c81-5777-4a62-9640-7d07b261562b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013010982400001" lon="-72.3646917833000032">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{49a05c15-a62c-4777-9905-b53a030e1b2c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012490775000018" lon="-72.3645015987799951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{18fe3d45-f033-4b11-beb4-2979965f70dc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018812826899969" lon="-72.3645933403099946">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2ac6ec6d-b9b4-42f3-b016-843d4db288c8}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018605171900001" lon="-72.3645600612099855">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cbf15011-67eb-4a89-855a-e2ab76c6cf69}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018431562299989" lon="-72.3645263168699984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9232806a-aae7-4c76-b722-c73c118779cd}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018131116899982" lon="-72.3644459178999995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a4804903-408d-443e-b664-1640d62563ff}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017914866500004" lon="-72.3643983965900048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b9d5b900-227f-45d6-b75f-91d3f7d503b0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016739074900000" lon="-72.3641703957000004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{44a846b4-3b66-4ef8-8469-38289351ef3b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999122416799990" lon="-72.3598398665299953">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{97da5ee2-a050-49e1-9ee1-1c25fb1d5df0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997171014199992" lon="-72.3598605828299952">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{547715c1-5fd7-4c84-83e9-07a34d33e514}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996722981099985" lon="-72.3598742513199937">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fce33577-9e74-4dcb-bc0d-ee698213e37a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996323785100005" lon="-72.3598990515200029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a8fbb3ef-0ecc-4426-b7a3-ef431231e0b5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008073074299999" lon="-72.3635727247900036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7bc2131a-998c-4eb2-8327-308a3fc6230b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004169135099989" lon="-72.3636700057400049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c1643b44-18b1-4a64-aad9-6987e1964038}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025105688900011" lon="-72.3604663040100036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ef317431-bd4b-4aae-9cbb-efec060dbbba}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025134469500003" lon="-72.3602217308899895">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4449e8a9-e837-44f4-93de-a2d440f3c7c5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009705876999988" lon="-72.3634189647799957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb8d560b-afba-41f3-a550-e4782b5e6a0c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009115960299992" lon="-72.3632323317799973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f02672bc-5098-44cc-8aae-7d17fab617bf}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008676288800002" lon="-72.3630775018600048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{763e8292-46a2-4045-b10a-601f81a4f3e3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028380173500004" lon="-72.3637438608899970">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c1b24ce7-377f-46f7-8fbe-d64e60a15d3c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027048353199978" lon="-72.3632830014399957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9f9d7e20-ae6a-4b64-8731-6efbe69b7694}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026376565999994" lon="-72.3638784585599950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8aff790a-de78-4972-a6c7-8256771bcd55}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021681667799973" lon="-72.3640271775699944">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0749bc5-4981-4e42-a91f-cd65c6101338}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020382077799994" lon="-72.3640629748000066">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a02de9d0-d7c1-4d80-82a5-f52744f735dc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019855596399998" lon="-72.3638471517800070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c01ea5a7-6169-48b2-a547-8e3cf0c6d9d0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017943246200025" lon="-72.3646545002600021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e75e3182-39f4-4a2e-9000-b3da70366cc8}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017613183100000" lon="-72.3646789551700067">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9d2e75b8-7b3e-4212-a6d3-13ffce9bd5b5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016925778499994" lon="-72.3647298860600046">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{43170a0b-5530-4103-a1db-21ce1da0f13b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015033074300012" lon="-72.3647676287800010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{47cef29e-8cb0-4bcb-bd96-f32e89861003}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019125718900012" lon="-72.3653594478400066">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{53fe45e8-12b6-4cd8-a776-1b0f38d075aa}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019170361199976" lon="-72.3652935094499981">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{953fa01d-77bb-40e9-b414-c9276745c00a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019098487599980" lon="-72.3652112486099952">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{65abc668-4648-4d8f-8f0e-0ff31c7651b3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018988007800004" lon="-72.3651629165800045">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00eae29a-18ee-4083-9d9b-6ce3beb4ebcb}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018695400000006" lon="-72.3650857263500029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1ebc0ac8-8992-4d6b-8c91-b6bc962193b5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018368800699992" lon="-72.3650283159600036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0a8b03e8-8cf1-4cb4-a6c6-743c9423e16f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017855075299995" lon="-72.3649637669900017">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{73f1a3d4-f061-477d-aa78-0167bc45d078}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017530332899975" lon="-72.3649325465199951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7f41aff8-101a-456d-85b7-4d65109fab2c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012823693799994" lon="-72.3648179282999990">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{aa207c4c-6123-4b19-9124-f867b4665a24}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012374695599979" lon="-72.3648322397200019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f567cdc7-60ea-4580-85d9-914239eddac4}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006060287499993" lon="-72.3650699608899970">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee9ae638-b3fc-41a5-886d-82cc4f355eb9}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008923923800001" lon="-72.3607497208700039">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00282eb6-07d9-4490-a60e-d8541a07ec51}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008460567700006" lon="-72.3607534871499922">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{27b64afd-85ec-4d9e-889c-96f38249e170}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017029639099981" lon="-72.3648606462199950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e813d633-c35d-4d36-af1b-170d39b085e7}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017121249399993" lon="-72.3648359878300056">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e7e8ea7e-62f1-461a-9f9e-cdb3307f77dd}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017322410099993" lon="-72.3647497908099950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{52724a1d-a920-4605-b298-1cd4bca5d8e5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005652468600010" lon="-72.3649338501799946">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ce494fa3-d0a3-4cd6-9cca-b5bef17f4acc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005029935499989" lon="-72.3647064545199896">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{efbcf4d1-45de-4f80-a7f3-200b90b4f26b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023699280499995" lon="-72.3596330036399991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f8906d8b-524d-4fc9-a16b-2f3c32d399d8}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014893720299993" lon="-72.3597033407099985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f32070c6-9028-4e04-b9b2-6e6a295d1ee3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012677290700005" lon="-72.3606008227500013">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e4fbe1ff-f723-431b-96fb-40f240a591ea}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012565179399992" lon="-72.3599581959600044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{10a8a646-89e4-4325-a1c0-0bba91edd235}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006222338299990" lon="-72.3620713771800013">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{29b4e035-bf6f-4c0a-8ea4-3d453ca11958}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006166110400009" lon="-72.3620127005400064">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3236cbd6-48d9-454d-a8c4-1371a982eaf6}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006200294399987" lon="-72.3618202711599992">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f5a74281-96eb-4f5e-b481-651edb664c2b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006146626000005" lon="-72.3617239950699940">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{65842328-7e41-408d-a5ae-934a30e075e0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006174317799978" lon="-72.3616800897999894">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0dccbbc-e9eb-46d7-b79b-120abe29eded}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021432854499992" lon="-72.3644346259099933">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ff09ca3d-4dc3-47a8-8646-aa0fa7e82936}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021206720000004" lon="-72.3643814086800035">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4d5d8d79-a11f-4de2-b6dc-15547a6d7cbd}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021015211100012" lon="-72.3643231872499939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5a9206d5-800f-4011-965d-f301a8d427eb}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026129862400001" lon="-72.3604632380500021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{824ffa86-73f5-400e-849e-67fa91014a0f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020204485399999" lon="-72.3645026282299995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6d7b17e4-660a-4bad-bd27-3f9ac8c26f45}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008388564899990" lon="-72.3604372371499949">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{83b1e61c-ba23-4c55-968d-955604dab858}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008414641999989" lon="-72.3603488479899966">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f58efa1d-1534-4d88-a24a-65f0e8a8b94c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014684370100017" lon="-72.3607199184299930">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d24f3529-f6f0-414e-8d8e-60da4d196983}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011480890199993" lon="-72.3597396552600003">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1f08e79d-65f6-4645-9193-d71b5f53fc5d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011314008299978" lon="-72.3606690550100069">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0fdb3dcf-8b32-41f0-90be-c389007acb55}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7010350738799991" lon="-72.3606303437099996">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c3670158-c9c6-4ff0-8a58-c1b76a1ec4e5}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008914643399997" lon="-72.3605619019399882">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d8cb4c59-7766-4836-be2c-e8c19fba607f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027208787900010" lon="-72.3596191073200004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3eeb7ede-2b3d-4c29-9e44-9d07960fa336}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009478563300000" lon="-72.3643993500499931">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0c5f531f-dc9d-4838-be76-22f347450aa0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007024150600003" lon="-72.3644763970700069">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3f4b8bd2-df1c-4138-b4fd-3260d8fe0ec3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005803708500009" lon="-72.3645073528099942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{eb14e619-d0c3-4d9a-979f-ccbb797c6951}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008241934799990" lon="-72.3605447727200044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9967ecd7-f1a3-4fc8-914e-e2f78db509fc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007832027999976" lon="-72.3605486476500062">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{138c095d-54fd-445b-90c5-923650b541e3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007356230099999" lon="-72.3605422724999983">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{22806f5a-e73a-4ba9-af2e-160f454900fe}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004424406699998" lon="-72.3603875287600005">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00d30ebe-52c8-45c5-bc86-5b1dc30bbe06}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999463079099986" lon="-72.3601460936800009">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{caee4c3f-bf77-40c2-b541-e49caf11c2fe}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998361407499969" lon="-72.3600846000900049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{af319fcf-ad29-45dc-8031-c484298dc8ab}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997747674000001" lon="-72.3600422314799943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{59ba072e-e835-424e-9638-3a46a515d8f3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996897282199992" lon="-72.3599654490699891">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e030d272-c409-4fc0-9339-9554f98ca67d}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000669276699982" lon="-72.3637773729799960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{698ee339-549a-4414-833d-70c41bf96aa3}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997781354999999" lon="-72.3638605285700010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{119ff15b-1a2e-4924-a6b3-d30e2cf7f7a0}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997060737399972" lon="-72.3638749536899866">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{249b4a4c-a063-4402-a9c1-dc9b0daf2923}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996463546499987" lon="-72.3638948664100070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{022159b5-d615-40cd-8e0b-7e15a2f3fffd}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025429482899987" lon="-72.3619990111400000">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{628254ce-ddf5-4a6d-8e2b-604d49b8740c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025063127400015" lon="-72.3607880166299964">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0f9afdde-b63b-4bc1-9563-1baa4b85e28c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005030098099985" lon="-72.3651013186299963">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b42fe56c-6b69-4eb8-9dc8-4cc15abf7100}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003987303299999" lon="-72.3651280253599936">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{de968008-487e-45f7-b75d-cc6a7e3c3b02}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996794169599996" lon="-72.3652826818200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{12b490fd-a953-4a29-858b-871368ccd8ba}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994617584999991" lon="-72.3653356666000036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b6be1c87-29d1-4959-9da4-9d17d7e664b8}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005950625799988" lon="-72.3622759602600070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dbc43ee4-a923-4289-afe8-1459523ab536}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004419767799988" lon="-72.3623265571600029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2e997e60-15a4-40d4-b464-f033b5e1e192}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002421877699998" lon="-72.3623841271899977">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0489272e-8d70-46b9-b3a7-bc232913d425}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001300551699998" lon="-72.3624071531999959">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c64c8768-ce14-47a8-9c38-8ace6941987b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263536499997" lon="-72.3629389733599879">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c626b399-6782-461d-917a-0cf0996b1fdb}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002326456700017" lon="-72.3629951913199960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{90fcd827-fbd0-48ae-a4d6-09673f960de9}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263687200001" lon="-72.3630515204099964">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7931c590-92d0-45e3-9827-de3955aed059}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001738660599983" lon="-72.3633648031100023">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0767e414-fe2f-4e87-86b1-83c5065f4304}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001659247899985" lon="-72.3634536496399789">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{39843252-90f8-4328-a1f2-80fab8e6b8b6}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001675363100013" lon="-72.3635159822700018">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{105fc6d8-94f1-4ef4-ba69-3046dff39d16}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001798178699969" lon="-72.3636234875299920">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ec320852-50a3-4e2c-aeda-0fd3e6195a7c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025861574699990" lon="-72.3629225343800044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cc54749b-a8ec-4890-85c3-09a892963506}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024048346499994" lon="-72.3623002673199949">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1b331fd7-7f67-4919-90e4-05086bf62cbf}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013730528799984" lon="-72.3620810506499907">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a7735e22-4c30-4d65-a692-ff1ed1f9376f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008919916799989" lon="-72.3622094409199974">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{85994d76-029a-4614-9df7-7b500fa1d7f1}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025805898900002" lon="-72.3650112703899993">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{12c8cfe5-2c80-4416-a6c6-7dd032a41850}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025182392699998" lon="-72.3649374931300002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f6efc0ea-6a32-4bce-b27b-56022d012add}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022252799000022" lon="-72.3645673879100002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{133a2d8b-e32e-4e50-ad73-c4854fcc925b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021796015300001" lon="-72.3645015413899984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8746ed36-9f0b-4eb7-9558-3fae339f6750}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026958136299992" lon="-72.3650447362499989">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ddd4701d-ab0c-42dc-8c75-900e0dc3af5e}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992193064799999" lon="-72.3588999086399838">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bbac7ebe-6c98-42a8-ae6e-b09b73364b98}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991501087799987" lon="-72.3586803331299961">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3e41468b-4ec7-41ce-a48d-39b762301e90}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013292813500005" lon="-72.3648242249600031">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{98c4d4ed-44cc-405e-972f-de5696f366be}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013324558299985" lon="-72.3648735912399985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9d22553e-4320-44c6-a1b3-e20179af825f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013304654399999" lon="-72.3649230197300000">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dd91b33a-be42-4891-bc91-2be90c51b853}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992473837099986" lon="-72.3588367156799990">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d51893a6-3df0-4d94-ae99-a0291cf1f8b2}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991559975199992" lon="-72.3588277695599942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a05ed439-4959-4ec7-a534-1e3cb1be92fc}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995335028499996" lon="-72.3597741646800046">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{26a7a9c4-a267-4a2a-8720-d176d5fa1034}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993052853000004" lon="-72.3595089049200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9893a976-8d41-4fa8-8b7f-7784f22cb53f}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992779188700000" lon="-72.3594700869700063">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{de4ac387-e204-40b6-a872-bac62a736235}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992564190600010" lon="-72.3594277203900020">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0f095b9-7fbc-4361-b994-d85f4e67855b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992412347999988" lon="-72.3593826898599985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{66fa7879-ad20-47e4-9140-c3c7de8a9f52}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988183784600013" lon="-72.3644868463200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{347874d6-7887-4085-9a1a-24efd90a2479}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988550299999998" lon="-72.3644932968399814">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{62350f3f-463b-42fb-8b9e-e32eb8a3b174}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988897343599980" lon="-72.3645093670400001">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{517b3307-09b5-4b3a-b497-e5bf7adf0d64}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994340143300004" lon="-72.3648455978899960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f354a4b8-acc1-4762-bfe4-1cdc0422cb72}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994883816500002" lon="-72.3648748282899987">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b778ee8d-262a-40b4-aa1d-4e2b3ff58d14}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995300524399983" lon="-72.3648891177899998">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{083899ed-ba61-47ce-8baf-6616ec0677ec}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995468363599979" lon="-72.3648901012099941">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4132d23d-4212-4639-a6b3-e5b6935de61c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995612977999981" lon="-72.3648866791999978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{06bf1610-0e90-49fc-9114-36b379c4660a}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995737206600010" lon="-72.3648786283799978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{575d3611-dc51-40ab-b2d8-c2561e00890b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996182300299996" lon="-72.3648208084500055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fd69d246-ec48-48f9-9317-26fae1eae0fe}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996632180000013" lon="-72.3647774958599967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9058c10d-26e0-4c35-ad74-e9aaed0ea42b}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996960073499991" lon="-72.3647552536900065">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{15f50f45-3907-4fb8-907a-bc3bc30b02ee}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997367568100019" lon="-72.3647365293199982">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3bafbefa-9894-45a8-a7cb-69912c23d12c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999384750299988" lon="-72.3646676866299856">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c4a1cf21-416f-414f-b333-94cc84807c1c}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000524529499996" lon="-72.3646327131999954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3d83ceeb-0418-4a95-b4ab-5fc7705850f7}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003252868600010" lon="-72.3645614283999947">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b1399b5-2753-4066-bc56-b8e3aefe90e7}"/>
-        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3644779235235234">
         <tag k="hoot:status" v="1"/>
@@ -1354,7 +1099,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1970" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-811"/>
@@ -1365,7 +1109,6 @@
         <tag k="layer" v="1"/>
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{40ea34f9-03b9-46b5-b9ad-7e71a1b00175}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1969" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-202"/>
@@ -1375,7 +1118,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1968" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-805"/>
@@ -1386,7 +1128,6 @@
         <tag k="bridge" v="yes"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{607c2a36-d410-462c-bcfe-cf528efb36d2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1967" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-231"/>
@@ -1406,7 +1147,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{05125c57-c79d-4118-98f5-342027ffbd88}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1966" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-799"/>
@@ -1417,7 +1157,6 @@
         <tag k="layer" v="1"/>
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{206c3cb6-55ad-4745-95a6-7b713f797b58}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1965" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-231"/>
@@ -1433,7 +1172,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-260"/>
@@ -1444,7 +1182,6 @@
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-268"/>
@@ -1461,7 +1198,6 @@
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-253"/>
@@ -1471,7 +1207,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-250"/>
@@ -1483,7 +1218,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-245"/>
@@ -1493,7 +1227,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-256"/>
@@ -1507,7 +1240,6 @@
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-254"/>
@@ -1518,7 +1250,6 @@
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-236"/>
@@ -1528,7 +1259,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-251"/>
@@ -1539,7 +1269,6 @@
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-233"/>
@@ -1548,7 +1277,6 @@
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{537c0976-006b-4203-a95e-03026a59dfa7}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-230"/>
@@ -1558,7 +1286,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-227"/>
@@ -1567,7 +1294,6 @@
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{9cbc6adc-20c7-4565-a103-a9cc523d8c95}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-224"/>
@@ -1581,7 +1307,6 @@
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-253"/>
@@ -1592,7 +1317,6 @@
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-220"/>
@@ -1603,7 +1327,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
@@ -1613,7 +1336,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:16Z"/>
         <tag k="bdw-id" v="{ce5ed05b-ab6e-4533-becd-513a7bbb445a}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-205"/>
@@ -1622,7 +1344,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-225"/>
@@ -1632,7 +1353,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-227"/>
@@ -1643,7 +1363,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-228"/>
@@ -1654,7 +1373,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-195"/>
@@ -1664,7 +1382,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-161"/>
@@ -1675,7 +1392,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-158"/>
@@ -1687,7 +1403,6 @@
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{6aa81513-dca3-45e8-9132-c60073bb31b1}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-245"/>
@@ -1700,7 +1415,6 @@
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-193"/>
@@ -1711,7 +1425,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-146"/>
@@ -1721,7 +1434,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-193"/>
@@ -1733,7 +1445,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-228"/>
@@ -1742,7 +1453,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-208"/>
@@ -1753,7 +1463,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-208"/>
@@ -1764,7 +1473,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-137"/>
@@ -1774,7 +1482,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-158"/>
@@ -1787,7 +1494,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-161"/>
@@ -1798,7 +1504,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-181"/>
@@ -1809,7 +1514,6 @@
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{06fdfdf2-6ac0-45a9-8895-42ee0c3a20d1}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-121"/>
@@ -1820,7 +1524,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-236"/>
@@ -1832,7 +1535,6 @@
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-224"/>
@@ -1843,7 +1545,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-104"/>
@@ -1854,7 +1555,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-104"/>
@@ -1864,7 +1564,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
@@ -1875,7 +1574,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-182"/>
@@ -1886,7 +1584,6 @@
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-250"/>
@@ -1897,7 +1594,6 @@
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-222"/>
@@ -1910,7 +1606,6 @@
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-195"/>
@@ -1922,7 +1617,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{b63b8bca-9850-40b8-a253-3bbd2aca3dd2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
@@ -1940,7 +1634,6 @@
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-217"/>
@@ -1952,7 +1645,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-76"/>
@@ -1960,7 +1652,6 @@
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-182"/>
@@ -1970,7 +1661,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-233"/>
@@ -1990,7 +1680,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-230"/>
@@ -2001,7 +1690,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-202"/>
@@ -2012,7 +1700,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-204"/>
@@ -2025,7 +1712,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-260"/>
@@ -2037,7 +1723,6 @@
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-161"/>
@@ -2050,7 +1735,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
         <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-149"/>
@@ -2065,7 +1749,6 @@
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-178"/>
@@ -2073,7 +1756,6 @@
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{01bf0fd7-c3f0-45ef-9565-1c25f24b0446}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-22"/>
@@ -2098,7 +1780,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:24:57Z;2012-07-12T16:14:19Z;2012-07-12T16:24:56Z"/>
         <tag k="bdw-id" v="{d6bb5ef0-cba5-4f65-bb54-309479757568}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21"/>
@@ -2110,7 +1791,6 @@
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19"/>
@@ -2119,7 +1799,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{6e1509b9-a960-4bd6-845e-6ac143dc8d18}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-18"/>
@@ -2129,7 +1808,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{efc93331-7a05-42f4-a7fc-78ab5793d04d}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-121"/>
@@ -2142,7 +1820,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16"/>
@@ -2153,7 +1830,6 @@
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15"/>
@@ -2164,7 +1840,6 @@
         <tag k="name" v="Avenida 11"/>
         <tag k="source:datetime" v="2012-07-10T17:03:23Z"/>
         <tag k="bdw-id" v="{d3f5dac4-74c6-42fe-b0bf-bad11de41657}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-14"/>
@@ -2181,7 +1856,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{6cdcf24d-4846-4e30-9360-c782f3239ee5}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-13"/>
@@ -2190,7 +1864,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-181"/>
@@ -2208,7 +1881,6 @@
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
         <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
@@ -2219,7 +1891,6 @@
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
@@ -2231,7 +1902,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-205"/>
@@ -2241,7 +1911,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{e1882670-308b-4243-9802-b0f59e00fcd8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-258"/>
@@ -2251,7 +1920,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:30:24Z"/>
         <tag k="bdw-id" v="{841e511f-12b8-465b-8dcf-3f2e88245c4f}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7"/>
@@ -2262,7 +1930,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-6"/>
@@ -2276,7 +1943,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-256"/>
@@ -2287,7 +1953,6 @@
         <tag k="name" v="Calle 16"/>
         <tag k="source:datetime" v="2012-07-10T17:03:25Z"/>
         <tag k="bdw-id" v="{7b9e474f-b2b4-4427-bae9-a57622382722}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-251"/>
@@ -2297,7 +1962,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-268"/>
@@ -2307,7 +1971,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
@@ -2317,7 +1980,6 @@
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1"/>
@@ -2328,6 +1990,5 @@
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/network/highway-2927-multiple-types-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-multiple-types-1/Expected.osm
@@ -626,7 +626,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-50"/>
@@ -656,7 +655,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
@@ -666,7 +664,6 @@
         <nd ref="-114"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. La Estrella"/>
         <tag k="source:datetime" v="2013-09-16T04:23:02.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -705,7 +702,6 @@
         <nd ref="-111"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. del Parque"/>
         <tag k="source:datetime" v="2015-08-19T15:26:01.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -744,7 +740,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-71"/>
@@ -766,7 +761,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-15"/>
@@ -787,7 +781,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-39"/>
@@ -795,7 +788,6 @@
         <nd ref="-112"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Gamboa"/>
         <tag k="source:datetime" v="2015-11-10T15:06:00.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -832,14 +824,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-71"/>
         <nd ref="-113"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Caracas"/>
         <tag k="source:datetime" v="2015-08-19T15:26:01.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -875,7 +865,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-61"/>
@@ -892,7 +881,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-59"/>
@@ -909,7 +897,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-59"/>
@@ -926,7 +913,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-67"/>
@@ -964,7 +950,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-50"/>
@@ -974,7 +959,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Vollmer"/>
         <tag k="source:datetime" v="2014-05-22T00:04:28.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -1004,7 +988,6 @@
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Vollmer"/>
         <tag k="source:datetime" v="2014-05-13T02:51:39.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -1042,7 +1025,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-37"/>
@@ -1064,7 +1046,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-15" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-34"/>
@@ -1084,7 +1065,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-15"/>
@@ -1112,7 +1092,6 @@
         <tag k="lit" v="yes"/>
         <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Distribuidor: San Bernardino"/>
         <tag k="foot:conditional" v="yes @ (su 06:00-13:00)"/>
         <tag k="source:datetime" v="2014-09-30T01:43:33.000Z;2019-01-17T19:50:06Z;2014-09-30T01:43:32.000Z"/>
@@ -1158,7 +1137,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-13"/>
@@ -1166,7 +1144,6 @@
         <nd ref="-39"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Gamboa"/>
         <tag k="source:datetime" v="2015-11-10T15:06:00.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -1213,7 +1190,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
@@ -1231,7 +1207,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-9"/>
@@ -1251,7 +1226,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-109"/>
@@ -1287,7 +1261,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-110"/>
@@ -1309,7 +1282,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-6"/>
@@ -1318,7 +1290,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Vollmer"/>
         <tag k="source:datetime" v="2014-05-22T01:04:26.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -1402,7 +1373,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-34"/>
@@ -1422,7 +1392,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-110"/>
@@ -1443,7 +1412,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
@@ -1481,6 +1449,5 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/network/highway-2927-name-preservation-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-name-preservation-1/Expected.osm
@@ -271,7 +271,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Este 2"/>
         <tag k="source:datetime" v="2014-04-17T22:53:50.000Z;2019-01-17T19:50:06Z;2014-06-22T20:55:22.000Z"/>
         <tag k="bicycle" v="yes"/>
@@ -307,7 +306,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-33"/>
@@ -324,7 +322,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Bulevar Panteón"/>
         <tag k="source:datetime" v="2015-07-01T16:10:48.000Z;2015-07-01T16:10:50.000Z;2014-09-04T18:33:58.000Z;2014-09-04T18:34:00.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -363,7 +360,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-19"/>
@@ -381,7 +377,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-8"/>
@@ -411,7 +406,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15"/>
@@ -427,7 +421,6 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Oeste 2"/>
         <tag k="source:datetime" v="2013-12-19T16:36:19.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -453,7 +446,6 @@
         <nd ref="-13"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Sur 2"/>
         <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -494,7 +486,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
@@ -507,24 +498,23 @@
         <nd ref="-81"/>
         <nd ref="-80"/>
         <nd ref="-35"/>
-        <tag k="surface" v="concrete"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2015-08-11T16:12:27.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="2"/>
-        <tag k="uuid" v="{c708f207-166d-4d9c-936f-158a78dacb43}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="no"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
         <tag k="highway" v="pedestrian"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{c708f207-166d-4d9c-936f-158a78dacb43}"/>
+        <tag k="lit" v="yes"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2015-08-11T16:12:27.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
@@ -541,7 +531,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35"/>
@@ -561,7 +550,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37"/>
@@ -580,7 +568,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-34"/>
@@ -597,14 +584,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-40"/>
         <nd ref="-3"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Sur"/>
         <tag k="source:datetime" v="2013-11-14T15:44:07.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -648,7 +633,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1"/>
@@ -676,6 +660,5 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/network/highway-2927-unmarked-ref-divided-road-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-unmarked-ref-divided-road-1/Expected.osm
@@ -211,7 +211,6 @@
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Sur 4"/>
         <tag k="source:datetime" v="2015-08-24T16:13:18.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -241,7 +240,6 @@
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Lecuna"/>
         <tag k="source:datetime" v="2015-05-11T03:32:46.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -276,7 +274,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-45"/>
@@ -293,7 +290,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-37"/>
@@ -304,7 +300,6 @@
         <tag k="surface" v="asphalt"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Baralt"/>
         <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -342,7 +337,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-38"/>
@@ -359,7 +353,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-35"/>
@@ -370,7 +363,6 @@
         <tag k="surface" v="asphalt"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Baralt"/>
         <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -398,7 +390,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Lecuna"/>
         <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -438,7 +429,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-28"/>
@@ -460,7 +450,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-22"/>
@@ -480,7 +469,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21"/>
@@ -497,7 +485,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-12"/>
@@ -508,7 +495,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. San Martín"/>
         <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -535,7 +521,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Lecuna"/>
         <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -564,7 +549,6 @@
         <tag k="surface" v="asphalt"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Baralt"/>
         <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -595,7 +579,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Oeste 8"/>
         <tag k="source:datetime" v="2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z;2014-05-19T20:08:16.000Z"/>
         <tag k="way_area" v="-999999"/>
@@ -622,24 +605,23 @@
         <nd ref="-16"/>
         <nd ref="-52"/>
         <nd ref="-7"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
         <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980}"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
@@ -657,7 +639,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-57"/>
@@ -682,7 +663,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
@@ -705,7 +685,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-9"/>
@@ -725,7 +704,6 @@
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
         <tag k="name" v="Av. Baralt"/>
         <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>

--- a/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/building-3037-dropped-multipoly-relations-1/Expected.osm
@@ -3,519 +3,390 @@
     <bounds minlat="10.24470824009" minlon="-67.59244220783999" maxlat="10.24774693597" maxlon="-67.59026216936"/>
     <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455528500799975" lon="-67.5919206810900022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-129"/>
     </node>
     <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454282894799977" lon="-67.5912685530000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-128"/>
     </node>
     <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454490062699985" lon="-67.5912645195400046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
     </node>
     <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453964175100012" lon="-67.5909891965900016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
     </node>
     <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452861327500013" lon="-67.5910106688100001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-125"/>
     </node>
     <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453365262600009" lon="-67.5912744966200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
     </node>
     <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453086517699994" lon="-67.5912799231300028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-123"/>
     </node>
     <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453559615100005" lon="-67.5915276081099989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
     </node>
     <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453145045600014" lon="-67.5915356795299829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
     </node>
     <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452844321300010" lon="-67.5913782379199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-120"/>
     </node>
     <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2451705680700016" lon="-67.5914004070999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452809193800007" lon="-67.5919781423800003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-118"/>
     </node>
     <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453176216100008" lon="-67.5919709963600042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117"/>
     </node>
     <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453231524400010" lon="-67.5919999554299977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-116"/>
     </node>
     <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453901852099989" lon="-67.5919869044700050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-115"/>
     </node>
     <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453839690899979" lon="-67.5919543607100053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114"/>
     </node>
     <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454023251600024" lon="-67.5919507867999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-113"/>
     </node>
     <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453825373700003" lon="-67.5918471893999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
     </node>
     <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454384248399997" lon="-67.5918363084999925">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-111"/>
     </node>
     <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454580651399993" lon="-67.5919391351799987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-110"/>
     </node>
     <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2451024947799993" lon="-67.5918882335599989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-109"/>
     </node>
     <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450982796600023" lon="-67.5918428087999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-108"/>
     </node>
     <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450101613900024" lon="-67.5918511437200067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-107"/>
     </node>
     <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450143774100013" lon="-67.5918965693699931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-106"/>
     </node>
     <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457179799999984" lon="-67.5918839275999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105"/>
     </node>
     <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455272814599994" lon="-67.5909240299200036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-104"/>
     </node>
     <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454290602000011" lon="-67.5909439202300035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-103"/>
     </node>
     <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456197587400002" lon="-67.5919038179099942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-102"/>
     </node>
     <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456772542000003" lon="-67.5908318952800045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
     </node>
     <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457106010600025" lon="-67.5908259075900020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-100"/>
     </node>
     <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457023785600008" lon="-67.5907792282799846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-99"/>
     </node>
     <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456690317000021" lon="-67.5907852159599969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-98"/>
     </node>
     <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456648147799996" lon="-67.5907612778100031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-97"/>
     </node>
     <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2454878578800006" lon="-67.5907930508600003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-96"/>
     </node>
     <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455059063699991" lon="-67.5908955160199838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
     </node>
     <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456828641700000" lon="-67.5908637429700008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
     </node>
     <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458831827599983" lon="-67.5918641263299946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
     </node>
     <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2456876998300022" lon="-67.5908899456099874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
     </node>
     <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2455775841400030" lon="-67.5909124682400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-91"/>
     </node>
     <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457730670699991" lon="-67.5918866498499966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-90"/>
     </node>
     <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2461908111599982" lon="-67.5917447620099949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-89"/>
     </node>
     <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2460060184599975" lon="-67.5907854327000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-88"/>
     </node>
     <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2459004956099999" lon="-67.5908061521799937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
     <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2460852883099971" lon="-67.5917654805899986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
     <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463518410599992" lon="-67.5917154432100062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
     <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2461634978500005" lon="-67.5907543413400020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
     <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2460479232700017" lon="-67.5907774269399795">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
     <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2462362664899977" lon="-67.5917385288099979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
     <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465183073699979" lon="-67.5917147084699934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
     <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464801887100005" lon="-67.5915003181900005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463735210200007" lon="-67.5915196509100014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464116396900007" lon="-67.5917340402900066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466811386200014" lon="-67.5916925329800051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464927333499993" lon="-67.5907171264900057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463910964699991" lon="-67.5907371382100024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465795017399994" lon="-67.5917125447000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467138919299963" lon="-67.5910773220600021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466343756799976" lon="-67.5907093491599937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465580349300005" lon="-67.5907261646800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466375520799993" lon="-67.5910941375800007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2471659199699996" lon="-67.5915866899699864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470590193600017" lon="-67.5910293099500024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469525531199999" lon="-67.5910501238600006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470594546299996" lon="-67.5916075038799988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469422819600009" lon="-67.5915351444299972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470418432100008" lon="-67.5915156803999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470270376699997" lon="-67.5914384843999869">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469274764199980" lon="-67.5914579493200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2469574004599995" lon="-67.5916139709099895">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
     <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2470569617100011" lon="-67.5915945068799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
     <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467914584600006" lon="-67.5910779066200007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467820632399995" lon="-67.5910347850300042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
     <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467163623699999" lon="-67.5910493765299947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467257575899993" lon="-67.5910924981200054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458232240600005" lon="-67.5908547533399968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458117666999993" lon="-67.5908091055599982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
     <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457548090400010" lon="-67.5908236781699969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
     <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2457662664000004" lon="-67.5908693259600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
     <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467481821799993" lon="-67.5908972939700021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
     <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467397195600025" lon="-67.5908419865699983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466790548900004" lon="-67.5908514474400022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466875175100025" lon="-67.5909067557399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465167272700004" lon="-67.5902785217400037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465190331300029" lon="-67.5902904818200057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
     <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2452717121199974" lon="-67.5905355695600036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
     <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2447082400900005" lon="-67.5918273647399985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
     <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2447957603199988" lon="-67.5923359772200030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
     <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449746129899975" lon="-67.5924422078399942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
     <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450295201999992" lon="-67.5924347875400002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
     <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450275308999998" lon="-67.5924197778499831">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
     <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464631267699993" lon="-67.5921367648000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
     <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464607120900002" lon="-67.5921242831099960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
     <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476332364800005" lon="-67.5918931294600043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477469359699978" lon="-67.5917258528699847">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477389679799984" lon="-67.5916769450300023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477275564800028" lon="-67.5916788408100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477069089500006" lon="-67.5915521083399966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477212675199993" lon="-67.5915497242399965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2477059655599980" lon="-67.5914557999499834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476835202800007" lon="-67.5914595276399979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476468998799959" lon="-67.5912347519799965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2476181737399994" lon="-67.5911991990799805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466139484699994" lon="-67.5902621693600025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450212230499975" lon="-67.5916578335399976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449718628599999" lon="-67.5916367336500059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2453800012900000" lon="-67.5906785383799900">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458482863700020" lon="-67.5905748834200040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2458527793799981" lon="-67.5905955768199931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2459350196900001" lon="-67.5905773727500048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2459333694300021" lon="-67.5905697716799949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2465866972199997" lon="-67.5904251571000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466356365299998" lon="-67.5904784904899998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466065947199994" lon="-67.5905056545099825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2466811017499992" lon="-67.5905868524999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2467087586000005" lon="-67.5905609843999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2474966015899991" lon="-67.5913090575700011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2475753228400013" lon="-67.5916866181400025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2475404129599976" lon="-67.5917431809999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463518509599982" lon="-67.5919804815100065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463533600200023" lon="-67.5919881869100010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2450073618000008" lon="-67.5922569169199932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449458931399988" lon="-67.5922234432599964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2448848975200004" lon="-67.5918525250699957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449035971200004" lon="-67.5917971250400029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2449538062699990" lon="-67.5918185882599971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464099381700002" lon="-67.5912184508700022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2464036087399997" lon="-67.5911761647499958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463481691300018" lon="-67.5911846246700065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.2463544994599989" lon="-67.5912269107899988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-129"/>
@@ -539,9 +410,8 @@
         <nd ref="-111"/>
         <nd ref="-110"/>
         <nd ref="-129"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-109"/>
@@ -549,9 +419,8 @@
         <nd ref="-107"/>
         <nd ref="-106"/>
         <nd ref="-109"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105"/>
@@ -559,9 +428,8 @@
         <nd ref="-103"/>
         <nd ref="-102"/>
         <nd ref="-105"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-101"/>
@@ -573,9 +441,8 @@
         <nd ref="-95"/>
         <nd ref="-94"/>
         <nd ref="-101"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-93"/>
@@ -583,9 +450,8 @@
         <nd ref="-91"/>
         <nd ref="-90"/>
         <nd ref="-93"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-89"/>
@@ -593,9 +459,8 @@
         <nd ref="-87"/>
         <nd ref="-86"/>
         <nd ref="-89"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85"/>
@@ -603,9 +468,8 @@
         <nd ref="-83"/>
         <nd ref="-82"/>
         <nd ref="-85"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-81"/>
@@ -613,9 +477,8 @@
         <nd ref="-79"/>
         <nd ref="-78"/>
         <nd ref="-81"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77"/>
@@ -623,9 +486,8 @@
         <nd ref="-75"/>
         <nd ref="-74"/>
         <nd ref="-77"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-73"/>
@@ -633,9 +495,8 @@
         <nd ref="-71"/>
         <nd ref="-70"/>
         <nd ref="-73"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-69"/>
@@ -643,9 +504,8 @@
         <nd ref="-67"/>
         <nd ref="-66"/>
         <nd ref="-69"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-65"/>
@@ -653,9 +513,8 @@
         <nd ref="-63"/>
         <nd ref="-62"/>
         <nd ref="-65"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-64"/>
@@ -663,9 +522,8 @@
         <nd ref="-61"/>
         <nd ref="-60"/>
         <nd ref="-64"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-59"/>
@@ -673,9 +531,8 @@
         <nd ref="-57"/>
         <nd ref="-56"/>
         <nd ref="-59"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-55"/>
@@ -683,9 +540,8 @@
         <nd ref="-53"/>
         <nd ref="-52"/>
         <nd ref="-55"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-51"/>
@@ -693,9 +549,8 @@
         <nd ref="-49"/>
         <nd ref="-48"/>
         <nd ref="-51"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="building" v="yes"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-47"/>
@@ -721,7 +576,6 @@
         <nd ref="-27"/>
         <nd ref="-47"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26"/>
@@ -748,7 +602,6 @@
         <nd ref="-5"/>
         <nd ref="-26"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4"/>
@@ -756,16 +609,14 @@
         <nd ref="-2"/>
         <nd ref="-1"/>
         <nd ref="-4"/>
-        <tag k="building" v="yes"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="building" v="yes"/>
     </way>
     <relation visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-3" role="outer"/>
         <member type="way" ref="-2" role="inner"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="building" v="yes"/>
         <tag k="type" v="multipolygon"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </relation>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2888/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2888/Expected.osm
@@ -3,4750 +3,3571 @@
     <bounds minlat="4.16848169976" minlon="73.50070843439001" maxlat="4.180162998169999" maxlon="73.51883655624"/>
     <node visible="true" id="-1177" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753916048199997" lon="73.5032219321300033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1177"/>
     </node>
     <node visible="true" id="-1176" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752696352899994" lon="73.5032306611199999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1176"/>
     </node>
     <node visible="true" id="-1175" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1750865666600001" lon="73.5032077120499991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1175"/>
     </node>
     <node visible="true" id="-1174" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1749829870999990" lon="73.5031675270499960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1174"/>
     </node>
     <node visible="true" id="-1173" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1748567038699997" lon="73.5031480425599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1173"/>
     </node>
     <node visible="true" id="-1172" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746585963099996" lon="73.5031390736800034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1172"/>
     </node>
     <node visible="true" id="-1171" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742641412599992" lon="73.5031018590500054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1171"/>
     </node>
     <node visible="true" id="-1170" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740569765800002" lon="73.5030885280399815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1170"/>
     </node>
     <node visible="true" id="-1169" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738058654000003" lon="73.5030585367199905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1169"/>
     </node>
     <node visible="true" id="-1168" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736876214100000" lon="73.5030409893099943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1168"/>
     </node>
     <node visible="true" id="-1167" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734360984799990" lon="73.5030220318899836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1167"/>
     </node>
     <node visible="true" id="-1166" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731790272899998" lon="73.5030064099100002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1166"/>
     </node>
     <node visible="true" id="-1165" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728316888999988" lon="73.5029713648300032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1165"/>
     </node>
     <node visible="true" id="-1164" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773385208400002" lon="73.5040510674299981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1164"/>
     </node>
     <node visible="true" id="-1163" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762871748499988" lon="73.5033436820999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1163"/>
     </node>
     <node visible="true" id="-1162" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762258805699988" lon="73.5033168342900041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1162"/>
     </node>
     <node visible="true" id="-1161" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761588286199993" lon="73.5033068837999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1161"/>
     </node>
     <node visible="true" id="-1160" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759867959799992" lon="73.5032945341300064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1160"/>
     </node>
     <node visible="true" id="-1159" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765882925599991" lon="73.5027318259400033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1159"/>
     </node>
     <node visible="true" id="-1158" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764756880900000" lon="73.5037391049099824">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1158"/>
     </node>
     <node visible="true" id="-1157" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764529332200011" lon="73.5039583888000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1157"/>
     </node>
     <node visible="true" id="-1156" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763880062299998" lon="73.5045840730699922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1156"/>
     </node>
     <node visible="true" id="-1155" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717664147399995" lon="73.5071508151699931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1155"/>
     </node>
     <node visible="true" id="-1154" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717452397099990" lon="73.5072157794099894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1154"/>
     </node>
     <node visible="true" id="-1153" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716894650000009" lon="73.5077741894800027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1153"/>
     </node>
     <node visible="true" id="-1152" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716272410499995" lon="73.5083696377800067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1152"/>
     </node>
     <node visible="true" id="-1151" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714939681300001" lon="73.5095921525900025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1151"/>
     </node>
     <node visible="true" id="-1150" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714817432200011" lon="73.5097033735499821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1150"/>
     </node>
     <node visible="true" id="-1149" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714416373099992" lon="73.5102078106300070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1149"/>
     </node>
     <node visible="true" id="-1148" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714067971200004" lon="73.5106316448000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1148"/>
     </node>
     <node visible="true" id="-1147" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1713256250199997" lon="73.5114075918699967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1147"/>
     </node>
     <node visible="true" id="-1146" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1712846229699991" lon="73.5117995391299814">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1146"/>
     </node>
     <node visible="true" id="-1145" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724207310499999" lon="73.5010364525799957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1145"/>
     </node>
     <node visible="true" id="-1144" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718574301699993" lon="73.5011924809600004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1144"/>
     </node>
     <node visible="true" id="-1143" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722568991400006" lon="73.5025702497899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1143"/>
     </node>
     <node visible="true" id="-1142" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1721608912699990" lon="73.5034967381100017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1142"/>
     </node>
     <node visible="true" id="-1141" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720970827099988" lon="73.5041197193200020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1141"/>
     </node>
     <node visible="true" id="-1140" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720264404199998" lon="73.5048098593299954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1140"/>
     </node>
     <node visible="true" id="-1139" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719020193300000" lon="73.5059360763099932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1139"/>
     </node>
     <node visible="true" id="-1138" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718349021899996" lon="73.5065650288500052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1138"/>
     </node>
     <node visible="true" id="-1137" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717822131300002" lon="73.5071023462599982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1137"/>
     </node>
     <node visible="true" id="-1136" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779915309000000" lon="73.5053510839399991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1136"/>
     </node>
     <node visible="true" id="-1135" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716438088499999" lon="73.5145111182600033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1135"/>
     </node>
     <node visible="true" id="-1134" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709165202699996" lon="73.5144421328499931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1134"/>
     </node>
     <node visible="true" id="-1133" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781189846099993" lon="73.5053547841300059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1133"/>
     </node>
     <node visible="true" id="-1132" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711817638499999" lon="73.5125978861800036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1132"/>
     </node>
     <node visible="true" id="-1131" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781358076800004" lon="73.5053514324799977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1131"/>
     </node>
     <node visible="true" id="-1130" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717360760299993" lon="73.5126639698199966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1130"/>
     </node>
     <node visible="true" id="-1129" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717695720599988" lon="73.5126753144499787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1129"/>
     </node>
     <node visible="true" id="-1128" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781497232799989" lon="73.5053414379899976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1128"/>
     </node>
     <node visible="true" id="-1127" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717893866900004" lon="73.5126930471199955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1127"/>
     </node>
     <node visible="true" id="-1126" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717253302000001" lon="73.5132182532500025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1126"/>
     </node>
     <node visible="true" id="-1125" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717184805100000" lon="73.5133890904899943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1125"/>
     </node>
     <node visible="true" id="-1124" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781593042099994" lon="73.5053224311299971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1124"/>
     </node>
     <node visible="true" id="-1123" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732609161200003" lon="73.5148024622099996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1123"/>
     </node>
     <node visible="true" id="-1122" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775511541499997" lon="73.5052877189999805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1122"/>
     </node>
     <node visible="true" id="-1121" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734874340500010" lon="73.5149147344900058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1121"/>
     </node>
     <node visible="true" id="-1120" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738001642199993" lon="73.5150433329600048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1120"/>
     </node>
     <node visible="true" id="-1119" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739468694599999" lon="73.5151069304599929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1119"/>
     </node>
     <node visible="true" id="-1118" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739630178300002" lon="73.5151184523799941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1118"/>
     </node>
     <node visible="true" id="-1117" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740165382799992" lon="73.5151566393899998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1117"/>
     </node>
     <node visible="true" id="-1116" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775613026199991" lon="73.5053120586899951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1116"/>
     </node>
     <node visible="true" id="-1115" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1721027991200001" lon="73.5155964708699941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1115"/>
     </node>
     <node visible="true" id="-1114" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720772296399993" lon="73.5157779028299956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1114"/>
     </node>
     <node visible="true" id="-1113" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775731914499987" lon="73.5053216381100043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1113"/>
     </node>
     <node visible="true" id="-1112" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720097437600003" lon="73.5164089491500050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1112"/>
     </node>
     <node visible="true" id="-1111" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775877132800012" lon="73.5053264112499818">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1111"/>
     </node>
     <node visible="true" id="-1110" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770794688699997" lon="73.5027287726099985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1110"/>
     </node>
     <node visible="true" id="-1109" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770160032500012" lon="73.5151420284600050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1109"/>
     </node>
     <node visible="true" id="-1108" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770283720999997" lon="73.5027324018900003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1108"/>
     </node>
     <node visible="true" id="-1107" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768527483300000" lon="73.5027171506599899">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1107"/>
     </node>
     <node visible="true" id="-1106" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768541566799993" lon="73.5027602780800038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1106"/>
     </node>
     <node visible="true" id="-1105" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769930106899995" lon="73.5151339691399954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1105"/>
     </node>
     <node visible="true" id="-1104" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771460372700000" lon="73.5031193701200039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1104"/>
     </node>
     <node visible="true" id="-1103" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768082838799998" lon="73.5150972359400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1103"/>
     </node>
     <node visible="true" id="-1102" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771154808500004" lon="73.5034218057400039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1102"/>
     </node>
     <node visible="true" id="-1101" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1766385198499991" lon="73.5150689868900002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1101"/>
     </node>
     <node visible="true" id="-1100" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764754653400002" lon="73.5150475218400032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1100"/>
     </node>
     <node visible="true" id="-1099" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770593852799989" lon="73.5040280398399943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1099"/>
     </node>
     <node visible="true" id="-1098" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761027364599999" lon="73.5149716826599899">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1098"/>
     </node>
     <node visible="true" id="-1097" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769998525000007" lon="73.5046257806999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1097"/>
     </node>
     <node visible="true" id="-1096" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769879244599997" lon="73.5047396702299949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1096"/>
     </node>
     <node visible="true" id="-1095" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717024211499991" lon="73.5135081370100067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1095"/>
     </node>
     <node visible="true" id="-1094" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716663593200005" lon="73.5138884127599823">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1094"/>
     </node>
     <node visible="true" id="-1093" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781738701799993" lon="73.5050963663599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1093"/>
     </node>
     <node visible="true" id="-1092" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716522685099990" lon="73.5140370012299940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1092"/>
     </node>
     <node visible="true" id="-1091" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716195198900001" lon="73.5141733433100057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1091"/>
     </node>
     <node visible="true" id="-1090" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1715983751100003" lon="73.5145669439800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1090"/>
     </node>
     <node visible="true" id="-1089" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1778469861500005" lon="73.5040708614299945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1089"/>
     </node>
     <node visible="true" id="-1088" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1715144983399997" lon="73.5154280272799951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1088"/>
     </node>
     <node visible="true" id="-1087" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770680292100000" lon="73.5151916397200011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1087"/>
     </node>
     <node visible="true" id="-1086" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777537444599995" lon="73.5040809210999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1086"/>
     </node>
     <node visible="true" id="-1085" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770543767000001" lon="73.5151715280999838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1085"/>
     </node>
     <node visible="true" id="-1084" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772945429000012" lon="73.5027580842399999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1084"/>
     </node>
     <node visible="true" id="-1083" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770367703700000" lon="73.5151547389399980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1083"/>
     </node>
     <node visible="true" id="-1082" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771841109799999" lon="73.5027430338899990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1082"/>
     </node>
     <node visible="true" id="-1081" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776119103799987" lon="73.5136202934200043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1081"/>
     </node>
     <node visible="true" id="-1080" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746658316499987" lon="73.5147476754300016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1080"/>
     </node>
     <node visible="true" id="-1079" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746358093699989" lon="73.5150551906399983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1079"/>
     </node>
     <node visible="true" id="-1078" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746099986899994" lon="73.5153896177099995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1078"/>
     </node>
     <node visible="true" id="-1077" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746012937199994" lon="73.5155024068500040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1077"/>
     </node>
     <node visible="true" id="-1076" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745374932499999" lon="73.5161193349899804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1076"/>
     </node>
     <node visible="true" id="-1075" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744683038500012" lon="73.5167883666599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1075"/>
     </node>
     <node visible="true" id="-1074" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744097694699995" lon="73.5172581829900054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1074"/>
     </node>
     <node visible="true" id="-1073" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776286565799987" lon="73.5136470902100001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1073"/>
     </node>
     <node visible="true" id="-1072" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743925208599997" lon="73.5173991457299962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1072"/>
     </node>
     <node visible="true" id="-1071" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743798098799987" lon="73.5175030249200034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1071"/>
     </node>
     <node visible="true" id="-1070" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1788672186199998" lon="73.5130030046299936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1070"/>
     </node>
     <node visible="true" id="-1069" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1787990900500001" lon="73.5129785505600069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1069"/>
     </node>
     <node visible="true" id="-1068" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1785849925199994" lon="73.5129126744299981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1068"/>
     </node>
     <node visible="true" id="-1067" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776528972599989" lon="73.5136606606399994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1067"/>
     </node>
     <node visible="true" id="-1066" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1789186899299997" lon="73.5096091432699836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1066"/>
     </node>
     <node visible="true" id="-1065" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705737521599993" lon="73.5138074863999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1065"/>
     </node>
     <node visible="true" id="-1064" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1790678859699995" lon="73.5103774400599974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1064"/>
     </node>
     <node visible="true" id="-1063" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1790874884300004" lon="73.5104440270399948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1063"/>
     </node>
     <node visible="true" id="-1062" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705626791999997" lon="73.5138239280600061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1062"/>
     </node>
     <node visible="true" id="-1061" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1790788407599999" lon="73.5104254581300012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1061"/>
     </node>
     <node visible="true" id="-1060" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779502583999992" lon="73.5111131408399814">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1060"/>
     </node>
     <node visible="true" id="-1059" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705594169799998" lon="73.5138384666500002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1059"/>
     </node>
     <node visible="true" id="-1058" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779052682200000" lon="73.5115416829300017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1058"/>
     </node>
     <node visible="true" id="-1057" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705820557700006" lon="73.5138987691999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1057"/>
     </node>
     <node visible="true" id="-1056" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777968125299987" lon="73.5123192270699946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1056"/>
     </node>
     <node visible="true" id="-1055" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705758481699995" lon="73.5140424458599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1055"/>
     </node>
     <node visible="true" id="-1054" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705458664899995" lon="73.5144071193099933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1054"/>
     </node>
     <node visible="true" id="-1053" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704863572599997" lon="73.5150040660300022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1053"/>
     </node>
     <node visible="true" id="-1052" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777380223500007" lon="73.5128045475800036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1052"/>
     </node>
     <node visible="true" id="-1051" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776976811799988" lon="73.5128944927100036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1051"/>
     </node>
     <node visible="true" id="-1050" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1782398196299999" lon="73.5050634112899957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1050"/>
     </node>
     <node visible="true" id="-1049" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1782966223800004" lon="73.5052150762300016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1049"/>
     </node>
     <node visible="true" id="-1048" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781277099099992" lon="73.5137833402799998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1048"/>
     </node>
     <node visible="true" id="-1047" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1784500670599991" lon="73.5056665628199966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1047"/>
     </node>
     <node visible="true" id="-1046" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1785679363300003" lon="73.5059692475799977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1046"/>
     </node>
     <node visible="true" id="-1045" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776088806500002" lon="73.5155619199500023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1045"/>
     </node>
     <node visible="true" id="-1044" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774520678600000" lon="73.5161243797700052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1044"/>
     </node>
     <node visible="true" id="-1043" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704132562299989" lon="73.5149963033399985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1043"/>
     </node>
     <node visible="true" id="-1042" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776929615300000" lon="73.5038562756100049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1042"/>
     </node>
     <node visible="true" id="-1041" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776675814599997" lon="73.5041022681599969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1041"/>
     </node>
     <node visible="true" id="-1040" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708946768799988" lon="73.5150478636799960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1040"/>
     </node>
     <node visible="true" id="-1039" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776339245199994" lon="73.5045124380300052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1039"/>
     </node>
     <node visible="true" id="-1038" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776023469199988" lon="73.5047053071800036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1038"/>
     </node>
     <node visible="true" id="-1037" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728105225499998" lon="73.5145937155299976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1037"/>
     </node>
     <node visible="true" id="-1036" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775797514099997" lon="73.5049191168699849">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1036"/>
     </node>
     <node visible="true" id="-1035" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729463419000004" lon="73.5146566645500030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1035"/>
     </node>
     <node visible="true" id="-1034" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774054612500002" lon="73.5028202761399996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1034"/>
     </node>
     <node visible="true" id="-1033" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1784134663399985" lon="73.5128973298400012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1033"/>
     </node>
     <node visible="true" id="-1032" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775133528299992" lon="73.5031289288099998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1032"/>
     </node>
     <node visible="true" id="-1031" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775705272500003" lon="73.5032921883699970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1031"/>
     </node>
     <node visible="true" id="-1030" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777078583299980" lon="73.5036284660999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1030"/>
     </node>
     <node visible="true" id="-1029" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777410434899993" lon="73.5037323520799930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1029"/>
     </node>
     <node visible="true" id="-1028" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777749636799992" lon="73.5038385391199967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1028"/>
     </node>
     <node visible="true" id="-1027" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1783846212500002" lon="73.5129070349200049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1027"/>
     </node>
     <node visible="true" id="-1026" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1778488907000000" lon="73.5039882892099996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1026"/>
     </node>
     <node visible="true" id="-1025" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1783675011900012" lon="73.5129222173799945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1025"/>
     </node>
     <node visible="true" id="-1024" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1778704457999991" lon="73.5040703792000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1024"/>
     </node>
     <node visible="true" id="-1023" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1783565315800004" lon="73.5129422645200066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1023"/>
     </node>
     <node visible="true" id="-1022" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781100918299989" lon="73.5047290266499971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1022"/>
     </node>
     <node visible="true" id="-1021" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1782835669000002" lon="73.5131996973699984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1021"/>
     </node>
     <node visible="true" id="-1020" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725993641999990" lon="73.5164614820599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1020"/>
     </node>
     <node visible="true" id="-1019" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726074474299999" lon="73.5164352961800063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1019"/>
     </node>
     <node visible="true" id="-1018" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779961316999987" lon="73.5044181084199977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018"/>
     </node>
     <node visible="true" id="-1017" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758246850599994" lon="73.5058126921800010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1017"/>
     </node>
     <node visible="true" id="-1016" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726299656999988" lon="73.5164069623699987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1016"/>
     </node>
     <node visible="true" id="-1015" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759209766199996" lon="73.5058848245899981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1015"/>
     </node>
     <node visible="true" id="-1014" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725460841199995" lon="73.5167645303800015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1014"/>
     </node>
     <node visible="true" id="-1013" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725705457299984" lon="73.5167500939100051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1013"/>
     </node>
     <node visible="true" id="-1012" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725851826999989" lon="73.5167345924100033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1012"/>
     </node>
     <node visible="true" id="-1011" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725956820099999" lon="73.5167160595299833">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1011"/>
     </node>
     <node visible="true" id="-1010" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726014367999991" lon="73.5166955664499966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1010"/>
     </node>
     <node visible="true" id="-1009" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723545098499990" lon="73.5132060464400041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1009"/>
     </node>
     <node visible="true" id="-1008" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764033874599988" lon="73.5062451095199947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1008"/>
     </node>
     <node visible="true" id="-1007" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723459876299991" lon="73.5133534067099959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1007"/>
     </node>
     <node visible="true" id="-1006" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765329471299992" lon="73.5063092427500067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1006"/>
     </node>
     <node visible="true" id="-1005" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767847151200002" lon="73.5064699951000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1005"/>
     </node>
     <node visible="true" id="-1004" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722723336399996" lon="73.5140303752800008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1004"/>
     </node>
     <node visible="true" id="-1003" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769799104399992" lon="73.5066339851800024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1003"/>
     </node>
     <node visible="true" id="-1002" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722337935400002" lon="73.5142932920799979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1002"/>
     </node>
     <node visible="true" id="-1001" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772539139899987" lon="73.5069167911699992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1001"/>
     </node>
     <node visible="true" id="-1000" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775704976899988" lon="73.5072762179199799">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1000"/>
     </node>
     <node visible="true" id="-999" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722032970500003" lon="73.5145624990900046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-999"/>
     </node>
     <node visible="true" id="-998" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720938427899990" lon="73.5155286969099961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-998"/>
     </node>
     <node visible="true" id="-997" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1782244539599995" lon="73.5081828726399920">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-997"/>
     </node>
     <node visible="true" id="-996" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1783672965200003" lon="73.5083682129599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-996"/>
     </node>
     <node visible="true" id="-995" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710522348199994" lon="73.5138495458400030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-995"/>
     </node>
     <node visible="true" id="-994" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1784988627899997" lon="73.5086785638900011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-994"/>
     </node>
     <node visible="true" id="-993" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706053377799988" lon="73.5137942962199986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-993"/>
     </node>
     <node visible="true" id="-992" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1787985307700000" lon="73.5092336904699977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-992"/>
     </node>
     <node visible="true" id="-991" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1788536627799990" lon="73.5093810434599959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-991"/>
     </node>
     <node visible="true" id="-990" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705860205000000" lon="73.5137989644699985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-990"/>
     </node>
     <node visible="true" id="-989" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1788825551299995" lon="73.5094717617199933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-989"/>
     </node>
     <node visible="true" id="-988" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761373714800003" lon="73.5062160965299825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-988"/>
     </node>
     <node visible="true" id="-987" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761698147599997" lon="73.5062662644400007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-987"/>
     </node>
     <node visible="true" id="-986" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762474365999989" lon="73.5063862931799861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-986"/>
     </node>
     <node visible="true" id="-985" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765114090499997" lon="73.5067944812000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-985"/>
     </node>
     <node visible="true" id="-984" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771903613199983" lon="73.5078173303599982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-984"/>
     </node>
     <node visible="true" id="-983" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775801369599987" lon="73.5084654724600028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-983"/>
     </node>
     <node visible="true" id="-982" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726401392000003" lon="73.5163785531200062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-982"/>
     </node>
     <node visible="true" id="-981" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1778026274199993" lon="73.5088578975999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-981"/>
     </node>
     <node visible="true" id="-980" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779011156500001" lon="73.5090531571299977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-980"/>
     </node>
     <node visible="true" id="-979" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779286235999997" lon="73.5092728083800040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-979"/>
     </node>
     <node visible="true" id="-978" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779848055099995" lon="73.5097214230899993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-978"/>
     </node>
     <node visible="true" id="-977" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726637623900000" lon="73.5160364585499906">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-977"/>
     </node>
     <node visible="true" id="-976" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1780123195699996" lon="73.5100685517199963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-976"/>
     </node>
     <node visible="true" id="-975" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725081932099997" lon="73.5117808041700016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-975"/>
     </node>
     <node visible="true" id="-974" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762529435599989" lon="73.5061767197500018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-974"/>
     </node>
     <node visible="true" id="-973" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1702598073399999" lon="73.5161787723899920">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-973"/>
     </node>
     <node visible="true" id="-972" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1702805958000004" lon="73.5162052663099956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-972"/>
     </node>
     <node visible="true" id="-971" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1703068834699994" lon="73.5162263642999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-971"/>
     </node>
     <node visible="true" id="-970" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1703372958899996" lon="73.5162409632399800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-970"/>
     </node>
     <node visible="true" id="-969" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1703590835400002" lon="73.5162466930199940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-969"/>
     </node>
     <node visible="true" id="-968" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707774777699997" lon="73.5162746024499967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-968"/>
     </node>
     <node visible="true" id="-967" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693344053799999" lon="73.5106435629100048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-967"/>
     </node>
     <node visible="true" id="-966" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694063153200007" lon="73.5111351701399940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-966"/>
     </node>
     <node visible="true" id="-965" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1695200483699999" lon="73.5118466182999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-965"/>
     </node>
     <node visible="true" id="-964" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1696370304499988" lon="73.5124646322699959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-964"/>
     </node>
     <node visible="true" id="-963" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1696752110300004" lon="73.5126923217100057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-963"/>
     </node>
     <node visible="true" id="-962" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1697455087499993" lon="73.5131192598399821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-962"/>
     </node>
     <node visible="true" id="-961" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1698941751899987" lon="73.5140287566299975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-961"/>
     </node>
     <node visible="true" id="-960" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1699547657700000" lon="73.5145133540600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-960"/>
     </node>
     <node visible="true" id="-959" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1700380630799998" lon="73.5149642338700033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-959"/>
     </node>
     <node visible="true" id="-958" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1701466981899999" lon="73.5155348613100017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-958"/>
     </node>
     <node visible="true" id="-957" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1702542972299996" lon="73.5161689746000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-957"/>
     </node>
     <node visible="true" id="-956" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708341456399998" lon="73.5165733208799850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-956"/>
     </node>
     <node visible="true" id="-955" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710996870899990" lon="73.5165945568700039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-955"/>
     </node>
     <node visible="true" id="-954" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1713818743000006" lon="73.5166263621700011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-954"/>
     </node>
     <node visible="true" id="-953" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716841360899997" lon="73.5166540840299945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-953"/>
     </node>
     <node visible="true" id="-952" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719847464599997" lon="73.5166894402500048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-952"/>
     </node>
     <node visible="true" id="-951" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723282565400002" lon="73.5167244114300047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-951"/>
     </node>
     <node visible="true" id="-950" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724838285999990" lon="73.5167526126700039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-950"/>
     </node>
     <node visible="true" id="-949" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725526170900009" lon="73.5167616680599991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-949"/>
     </node>
     <node visible="true" id="-948" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724767947299997" lon="73.5176326251299912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-948"/>
     </node>
     <node visible="true" id="-947" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711315532300013" lon="73.5162891907399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-947"/>
     </node>
     <node visible="true" id="-946" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714038865000003" lon="73.5163064862600066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-946"/>
     </node>
     <node visible="true" id="-945" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707610193599995" lon="73.5164678826399864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-945"/>
     </node>
     <node visible="true" id="-944" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707618002100002" lon="73.5165031505100046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-944"/>
     </node>
     <node visible="true" id="-943" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707759297500004" lon="73.5165354983899988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-943"/>
     </node>
     <node visible="true" id="-942" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708013042399994" lon="73.5165601099999861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-942"/>
     </node>
     <node visible="true" id="-941" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757062564699989" lon="73.5049644059599956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-941"/>
     </node>
     <node visible="true" id="-940" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756730684299992" lon="73.5052659173399832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-940"/>
     </node>
     <node visible="true" id="-939" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756368165900000" lon="73.5056559470200028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-939"/>
     </node>
     <node visible="true" id="-938" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756151782800002" lon="73.5057297393399978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-938"/>
     </node>
     <node visible="true" id="-937" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755534667699985" lon="73.5064890616600053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-937"/>
     </node>
     <node visible="true" id="-936" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754872540499992" lon="73.5071724720399970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-936"/>
     </node>
     <node visible="true" id="-935" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754787740399992" lon="73.5072209617199945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-935"/>
     </node>
     <node visible="true" id="-934" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754454214400001" lon="73.5074116753900029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-934"/>
     </node>
     <node visible="true" id="-933" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754204664799985" lon="73.5075543703599976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-933"/>
     </node>
     <node visible="true" id="-932" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753813004599989" lon="73.5080322519399800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-932"/>
     </node>
     <node visible="true" id="-931" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753480989499998" lon="73.5084373552400052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-931"/>
     </node>
     <node visible="true" id="-930" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759909109800004" lon="73.5020110948599950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930"/>
     </node>
     <node visible="true" id="-929" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760105548100004" lon="73.5020365254799941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-929"/>
     </node>
     <node visible="true" id="-928" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760163918500002" lon="73.5020680802999919">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-928"/>
     </node>
     <node visible="true" id="-927" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759375726899997" lon="73.5027488982599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-927"/>
     </node>
     <node visible="true" id="-926" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759169340200000" lon="73.5030413747700067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-926"/>
     </node>
     <node visible="true" id="-925" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758803900299997" lon="73.5032972540900005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-925"/>
     </node>
     <node visible="true" id="-924" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758181726599988" lon="73.5039124091599945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-924"/>
     </node>
     <node visible="true" id="-923" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747471461800005" lon="73.5140573415299912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-923"/>
     </node>
     <node visible="true" id="-922" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746858444799999" lon="73.5145426852699870">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-922"/>
     </node>
     <node visible="true" id="-921" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694057560899989" lon="73.5069109290299991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-921"/>
     </node>
     <node visible="true" id="-920" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693837596099987" lon="73.5071236698699977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-920"/>
     </node>
     <node visible="true" id="-919" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693854377999999" lon="73.5075187125799943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-919"/>
     </node>
     <node visible="true" id="-918" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693864638999996" lon="73.5077602754400061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-918"/>
     </node>
     <node visible="true" id="-917" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693912495999994" lon="73.5079209065099803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-917"/>
     </node>
     <node visible="true" id="-916" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693817168899994" lon="73.5081217082099982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-916"/>
     </node>
     <node visible="true" id="-915" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693706965399988" lon="73.5087399892800022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-915"/>
     </node>
     <node visible="true" id="-914" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693585936800002" lon="73.5093666678599789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-914"/>
     </node>
     <node visible="true" id="-913" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693291011999998" lon="73.5105819988300055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-913"/>
     </node>
     <node visible="true" id="-912" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752672136499980" lon="73.5091305273400053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-912"/>
     </node>
     <node visible="true" id="-911" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752516249199987" lon="73.5092422959999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-911"/>
     </node>
     <node visible="true" id="-910" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752340601999993" lon="73.5094219486699956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-910"/>
     </node>
     <node visible="true" id="-909" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751954099399997" lon="73.5098172636299978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-909"/>
     </node>
     <node visible="true" id="-908" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751419113699999" lon="73.5103816227699980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-908"/>
     </node>
     <node visible="true" id="-907" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1750807870399980" lon="73.5110278382600058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-907"/>
     </node>
     <node visible="true" id="-906" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1750511603499989" lon="73.5112609122100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-906"/>
     </node>
     <node visible="true" id="-905" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1749666996799997" lon="73.5119253634899934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-905"/>
     </node>
     <node visible="true" id="-904" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1749187740400000" lon="73.5124069661799950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-904"/>
     </node>
     <node visible="true" id="-903" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1748541433099993" lon="73.5130564325500018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-903"/>
     </node>
     <node visible="true" id="-902" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770331990400003" lon="73.5152099505699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-902"/>
     </node>
     <node visible="true" id="-901" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769998594799995" lon="73.5152659983200039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-901"/>
     </node>
     <node visible="true" id="-900" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768357523199988" lon="73.5156476949699851">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-900"/>
     </node>
     <node visible="true" id="-899" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767747593799998" lon="73.5157455096099994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-899"/>
     </node>
     <node visible="true" id="-898" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729475367899997" lon="73.5008905326199908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-898"/>
     </node>
     <node visible="true" id="-897" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731418233499991" lon="73.5008429851600056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-897"/>
     </node>
     <node visible="true" id="-896" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731797979599996" lon="73.5008336481599969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-896"/>
     </node>
     <node visible="true" id="-895" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1785613009399993" lon="73.5140549331100033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-895"/>
     </node>
     <node visible="true" id="-894" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1780950877700000" lon="73.5139004487599976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-894"/>
     </node>
     <node visible="true" id="-893" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776995066499998" lon="73.5152953280999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-893"/>
     </node>
     <node visible="true" id="-892" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774323217299996" lon="73.5152364665799922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-892"/>
     </node>
     <node visible="true" id="-891" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770715894299997" lon="73.5151989289099959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-891"/>
     </node>
     <node visible="true" id="-890" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770516947100003" lon="73.5152020226999809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-890"/>
     </node>
     <node visible="true" id="-889" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744528716399998" lon="73.5015302878900059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-889"/>
     </node>
     <node visible="true" id="-888" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747123683699989" lon="73.5017011587300004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-888"/>
     </node>
     <node visible="true" id="-887" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1748522299699999" lon="73.5017626648800046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-887"/>
     </node>
     <node visible="true" id="-886" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1750504449000001" lon="73.5018359952599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886"/>
     </node>
     <node visible="true" id="-885" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751513585699991" lon="73.5018674489499944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-885"/>
     </node>
     <node visible="true" id="-884" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753561836899991" lon="73.5019197417600054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-884"/>
     </node>
     <node visible="true" id="-883" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754598455999981" lon="73.5019405171599800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-883"/>
     </node>
     <node visible="true" id="-882" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759537451799993" lon="73.5019962129599804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-882"/>
     </node>
     <node visible="true" id="-881" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759771662000009" lon="73.5020025150700036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-881"/>
     </node>
     <node visible="true" id="-880" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732286316099989" lon="73.5008323360199824">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-880"/>
     </node>
     <node visible="true" id="-879" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732575923499997" lon="73.5008371149900057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-879"/>
     </node>
     <node visible="true" id="-878" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733444045500008" lon="73.5008621232099983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-878"/>
     </node>
     <node visible="true" id="-877" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737955670899991" lon="73.5010385952700034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-877"/>
     </node>
     <node visible="true" id="-876" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739005134899987" lon="73.5011360753599945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-876"/>
     </node>
     <node visible="true" id="-875" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739512930200009" lon="73.5011841751699961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-875"/>
     </node>
     <node visible="true" id="-874" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724250347599989" lon="73.5114887180299945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-874"/>
     </node>
     <node visible="true" id="-873" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722242790099990" lon="73.5114806128599980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-873"/>
     </node>
     <node visible="true" id="-872" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720280113999992" lon="73.5114913935999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-872"/>
     </node>
     <node visible="true" id="-871" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754670733100001" lon="73.5049543640299845">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-871"/>
     </node>
     <node visible="true" id="-870" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755319754399993" lon="73.5049486484099930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-870"/>
     </node>
     <node visible="true" id="-869" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736826544899985" lon="73.5042970272199909">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-869"/>
     </node>
     <node visible="true" id="-868" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726499317799997" lon="73.5041838454299921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-868"/>
     </node>
     <node visible="true" id="-867" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725787437699990" lon="73.5041557589500059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-867"/>
     </node>
     <node visible="true" id="-866" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725651918799995" lon="73.5041467976599989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-866"/>
     </node>
     <node visible="true" id="-865" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723809245999997" lon="73.5041239301199880">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-865"/>
     </node>
     <node visible="true" id="-864" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723087721199983" lon="73.5041412916099972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-864"/>
     </node>
     <node visible="true" id="-863" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1721114999999998" lon="73.5041259483100049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863"/>
     </node>
     <node visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1700621803500004" lon="73.5012311449499975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-862"/>
     </node>
     <node visible="true" id="-861" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745960280599999" lon="73.5038124213999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-861"/>
     </node>
     <node visible="true" id="-860" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745393868499994" lon="73.5043379955999825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-860"/>
     </node>
     <node visible="true" id="-859" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745315753899987" lon="73.5043573234400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-859"/>
     </node>
     <node visible="true" id="-858" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745157568400000" lon="73.5043709570399955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-858"/>
     </node>
     <node visible="true" id="-857" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744954303400013" lon="73.5043758805799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-857"/>
     </node>
     <node visible="true" id="-856" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751559870799992" lon="73.5046265375499956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-856"/>
     </node>
     <node visible="true" id="-855" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751709240799988" lon="73.5046395283600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-855"/>
     </node>
     <node visible="true" id="-854" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753791054900002" lon="73.5049670275599993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-854"/>
     </node>
     <node visible="true" id="-853" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754062234699987" lon="73.5049709266399987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-853"/>
     </node>
     <node visible="true" id="-852" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751824341799990" lon="73.5040681240899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-852"/>
     </node>
     <node visible="true" id="-851" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751365601600003" lon="73.5045506013599947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-851"/>
     </node>
     <node visible="true" id="-850" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751407722799989" lon="73.5045899656000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-850"/>
     </node>
     <node visible="true" id="-849" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755707611799995" lon="73.5071652487000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-849"/>
     </node>
     <node visible="true" id="-848" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734757560400002" lon="73.5027204999599917">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-848"/>
     </node>
     <node visible="true" id="-847" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734523597099988" lon="73.5028749883699959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-847"/>
     </node>
     <node visible="true" id="-846" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733706279299998" lon="73.5035819465699944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-846"/>
     </node>
     <node visible="true" id="-845" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733349609500001" lon="73.5039388636800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-845"/>
     </node>
     <node visible="true" id="-844" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733197384800000" lon="73.5041250749000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-844"/>
     </node>
     <node visible="true" id="-843" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733027061700003" lon="73.5042699156900028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-843"/>
     </node>
     <node visible="true" id="-842" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732822207200009" lon="73.5045620372199977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-842"/>
     </node>
     <node visible="true" id="-841" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732479478999993" lon="73.5047904933900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-841"/>
     </node>
     <node visible="true" id="-840" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732481184799992" lon="73.5048799366200001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-840"/>
     </node>
     <node visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768718497399995" lon="73.5040040087999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-839"/>
     </node>
     <node visible="true" id="-838" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768021169499994" lon="73.5040135202900018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-838"/>
     </node>
     <node visible="true" id="-837" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767910971199989" lon="73.5040090163499968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-837"/>
     </node>
     <node visible="true" id="-836" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767054183699983" lon="73.5040018418699930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-836"/>
     </node>
     <node visible="true" id="-835" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1766070513599995" lon="73.5039817180699941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-835"/>
     </node>
     <node visible="true" id="-834" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765693163399993" lon="73.5039692696000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-834"/>
     </node>
     <node visible="true" id="-833" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759775581099996" lon="73.5064933205800060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-833"/>
     </node>
     <node visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757688438300002" lon="73.5068573711299962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-832"/>
     </node>
     <node visible="true" id="-831" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756511547599997" lon="73.5070875524800016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-831"/>
     </node>
     <node visible="true" id="-830" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739376987999997" lon="73.5042130786600012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-830"/>
     </node>
     <node visible="true" id="-829" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739389056600000" lon="73.5042742450099951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-829"/>
     </node>
     <node visible="true" id="-828" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739446027399998" lon="73.5043230300999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-828"/>
     </node>
     <node visible="true" id="-827" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739465253299990" lon="73.5043349506400006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-827"/>
     </node>
     <node visible="true" id="-826" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739603798299996" lon="73.5043942046099943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-826"/>
     </node>
     <node visible="true" id="-825" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740942262899994" lon="73.5048691193100012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-825"/>
     </node>
     <node visible="true" id="-824" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733243262399995" lon="73.5048852132700006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-824"/>
     </node>
     <node visible="true" id="-823" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733923286299994" lon="73.5048688221600059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-823"/>
     </node>
     <node visible="true" id="-822" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745481475900004" lon="73.5102497136700066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-822"/>
     </node>
     <node visible="true" id="-821" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745331448799989" lon="73.5105564048400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-821"/>
     </node>
     <node visible="true" id="-820" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745064207899993" lon="73.5108766546400005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-820"/>
     </node>
     <node visible="true" id="-819" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744112844099988" lon="73.5102199591599970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-819"/>
     </node>
     <node visible="true" id="-818" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741808307399992" lon="73.5101735758100006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-818"/>
     </node>
     <node visible="true" id="-817" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740541863199994" lon="73.5031222449700010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-817"/>
     </node>
     <node visible="true" id="-816" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739590900600003" lon="73.5039000822199995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-816"/>
     </node>
     <node visible="true" id="-815" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753290562699998" lon="73.5026207994300051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-815"/>
     </node>
     <node visible="true" id="-814" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759880477099989" lon="73.5127054297799987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-814"/>
     </node>
     <node visible="true" id="-813" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758666315799999" lon="73.5126490676800017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-813"/>
     </node>
     <node visible="true" id="-812" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758309557300004" lon="73.5126288787299984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-812"/>
     </node>
     <node visible="true" id="-811" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755785807999999" lon="73.5125508998599884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-811"/>
     </node>
     <node visible="true" id="-810" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754586214399989" lon="73.5125233143299965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-810"/>
     </node>
     <node visible="true" id="-809" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751477706299989" lon="73.5124630853599825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-809"/>
     </node>
     <node visible="true" id="-808" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735221771199988" lon="73.5106589181300052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-808"/>
     </node>
     <node visible="true" id="-807" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693412757999990" lon="73.5044655645800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-807"/>
     </node>
     <node visible="true" id="-806" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693913263900004" lon="73.5044668717300027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-806"/>
     </node>
     <node visible="true" id="-805" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752069154699996" lon="73.5038428464099951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-805"/>
     </node>
     <node visible="true" id="-804" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751768764300010" lon="73.5038137169100025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-804"/>
     </node>
     <node visible="true" id="-803" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1750901108700011" lon="73.5038050196500024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-803"/>
     </node>
     <node visible="true" id="-802" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744558247099990" lon="73.5037563084499936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-802"/>
     </node>
     <node visible="true" id="-801" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743438612999988" lon="73.5037247908799856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-801"/>
     </node>
     <node visible="true" id="-800" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733555512200011" lon="73.5090655384900060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-800"/>
     </node>
     <node visible="true" id="-799" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733025390499989" lon="73.5090891232700017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-799"/>
     </node>
     <node visible="true" id="-798" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694174053099990" lon="73.5051855146599991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-798"/>
     </node>
     <node visible="true" id="-797" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694015548800003" lon="73.5062728391200011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-797"/>
     </node>
     <node visible="true" id="-796" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1699982879300004" lon="73.5069690528300015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-796"/>
     </node>
     <node visible="true" id="-795" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732204405899997" lon="73.5106275248499941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-795"/>
     </node>
     <node visible="true" id="-794" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1748963799599981" lon="73.5093801026900024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-794"/>
     </node>
     <node visible="true" id="-793" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1748377457699997" lon="73.5093451605600023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-793"/>
     </node>
     <node visible="true" id="-792" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747862715999995" lon="73.5093437042099964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-792"/>
     </node>
     <node visible="true" id="-791" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747115059299995" lon="73.5093533947299846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-791"/>
     </node>
     <node visible="true" id="-790" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745328306499987" lon="73.5092866890399819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-790"/>
     </node>
     <node visible="true" id="-789" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744949022599993" lon="73.5092828448299969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-789"/>
     </node>
     <node visible="true" id="-788" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744358225699978" lon="73.5093056432699967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-788"/>
     </node>
     <node visible="true" id="-787" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739886753600004" lon="73.5091632790900036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-787"/>
     </node>
     <node visible="true" id="-786" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738962821400003" lon="73.5091424953299963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-786"/>
     </node>
     <node visible="true" id="-785" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738727057899991" lon="73.5091611057700050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-785"/>
     </node>
     <node visible="true" id="-784" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734963359600004" lon="73.5091127014100039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-784"/>
     </node>
     <node visible="true" id="-783" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1695030686100001" lon="73.5031178582899969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-783"/>
     </node>
     <node visible="true" id="-782" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745242623699994" lon="73.5107088686000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-782"/>
     </node>
     <node visible="true" id="-781" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740739180599995" lon="73.5106758710499975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-781"/>
     </node>
     <node visible="true" id="-780" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761093207999993" lon="73.5019383406399953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-780"/>
     </node>
     <node visible="true" id="-779" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762953260999991" lon="73.5019723742099984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-779"/>
     </node>
     <node visible="true" id="-778" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769350977900004" lon="73.5022236072099986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-778"/>
     </node>
     <node visible="true" id="-777" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772435680299997" lon="73.5023655999799956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-777"/>
     </node>
     <node visible="true" id="-776" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1698290696200004" lon="73.5130950533499998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-776"/>
     </node>
     <node visible="true" id="-775" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1698124005599988" lon="73.5131033711799944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-775"/>
     </node>
     <node visible="true" id="-774" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694110824799999" lon="73.5026524745699987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-774"/>
     </node>
     <node visible="true" id="-773" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693970252699994" lon="73.5031121093399946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-773"/>
     </node>
     <node visible="true" id="-772" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1695349087200002" lon="73.5015131770699952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-772"/>
     </node>
     <node visible="true" id="-771" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1695098460800013" lon="73.5027564059799943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-771"/>
     </node>
     <node visible="true" id="-770" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764341492099986" lon="73.5027116444600068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-770"/>
     </node>
     <node visible="true" id="-769" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764268439799999" lon="73.5027012279000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-769"/>
     </node>
     <node visible="true" id="-768" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764254133899996" lon="73.5026917565599973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-768"/>
     </node>
     <node visible="true" id="-767" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764643960699992" lon="73.5022349966399986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-767"/>
     </node>
     <node visible="true" id="-766" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772805635500001" lon="73.5024120212099916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-766"/>
     </node>
     <node visible="true" id="-765" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773070602200013" lon="73.5024650889599940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-765"/>
     </node>
     <node visible="true" id="-764" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746551503199996" lon="73.5031719835999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-764"/>
     </node>
     <node visible="true" id="-763" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745996751499996" lon="73.5037729147500016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-763"/>
     </node>
     <node visible="true" id="-762" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764521478299992" lon="73.5027172560500048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-762"/>
     </node>
     <node visible="true" id="-761" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735409987700001" lon="73.5055234810100018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-761"/>
     </node>
     <node visible="true" id="-760" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735684802299993" lon="73.5055860084300008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-760"/>
     </node>
     <node visible="true" id="-759" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740363067599988" lon="73.5064541705399961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-759"/>
     </node>
     <node visible="true" id="-758" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740506233999994" lon="73.5065217696700017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-758"/>
     </node>
     <node visible="true" id="-757" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728075565799996" lon="73.5066908266000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-757"/>
     </node>
     <node visible="true" id="-756" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730493169599994" lon="73.5068261826600065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-756"/>
     </node>
     <node visible="true" id="-755" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732258277799996" lon="73.5069033060500061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-755"/>
     </node>
     <node visible="true" id="-754" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710393248499988" lon="73.5081100059399972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-754"/>
     </node>
     <node visible="true" id="-753" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737207446100006" lon="73.5063853358099948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-753"/>
     </node>
     <node visible="true" id="-752" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738157718799984" lon="73.5064316055800049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-752"/>
     </node>
     <node visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738203701999996" lon="73.5064602269600016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-751"/>
     </node>
     <node visible="true" id="-750" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753339386799997" lon="73.5057070902699934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-750"/>
     </node>
     <node visible="true" id="-749" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733995453399979" lon="73.5049490948999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-749"/>
     </node>
     <node visible="true" id="-748" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735535797699992" lon="73.5054189339300024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-748"/>
     </node>
     <node visible="true" id="-747" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735601343199988" lon="73.5054608654200052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-747"/>
     </node>
     <node visible="true" id="-746" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1701929948599998" lon="73.5101153783799930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-746"/>
     </node>
     <node visible="true" id="-745" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1700021967399987" lon="73.5118898468100070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-745"/>
     </node>
     <node visible="true" id="-744" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1699461315999997" lon="73.5124482628799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-744"/>
     </node>
     <node visible="true" id="-743" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1699124000899994" lon="73.5127205900199954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-743"/>
     </node>
     <node visible="true" id="-742" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1698694066599993" lon="73.5130453593099986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-742"/>
     </node>
     <node visible="true" id="-741" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1698503943800000" lon="73.5130771136199854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-741"/>
     </node>
     <node visible="true" id="-740" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710246356300003" lon="73.5082607439999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-740"/>
     </node>
     <node visible="true" id="-739" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710379274899987" lon="73.5082900732599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-739"/>
     </node>
     <node visible="true" id="-738" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710640247299988" lon="73.5083090433000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-738"/>
     </node>
     <node visible="true" id="-737" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740239817899987" lon="73.5068266025199932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-737"/>
     </node>
     <node visible="true" id="-736" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740209687000007" lon="73.5068522094500025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-736"/>
     </node>
     <node visible="true" id="-735" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740174754200003" lon="73.5068646403200034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-735"/>
     </node>
     <node visible="true" id="-734" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739708514699982" lon="73.5069335275299949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-734"/>
     </node>
     <node visible="true" id="-733" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739637659399991" lon="73.5070042538600035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-733"/>
     </node>
     <node visible="true" id="-732" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739270086699989" lon="73.5071007135900061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-732"/>
     </node>
     <node visible="true" id="-731" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739990569599987" lon="73.5067506338100003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-731"/>
     </node>
     <node visible="true" id="-730" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740216123299989" lon="73.5068009285800059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-730"/>
     </node>
     <node visible="true" id="-729" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736179240500002" lon="73.5070096408200016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-729"/>
     </node>
     <node visible="true" id="-728" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736325703599988" lon="73.5069526496299943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-728"/>
     </node>
     <node visible="true" id="-727" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736766710599991" lon="73.5068729474899811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-727"/>
     </node>
     <node visible="true" id="-726" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737334675299991" lon="73.5067136025299988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-726"/>
     </node>
     <node visible="true" id="-725" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737714028099999" lon="73.5066290247000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-725"/>
     </node>
     <node visible="true" id="-724" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737996528999988" lon="73.5065240079299969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724"/>
     </node>
     <node visible="true" id="-723" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738261650599995" lon="73.5064627477700014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-723"/>
     </node>
     <node visible="true" id="-722" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724720446400010" lon="73.5059947334599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-722"/>
     </node>
     <node visible="true" id="-721" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726025364799986" lon="73.5060057032700058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-721"/>
     </node>
     <node visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732779689699999" lon="73.5062269310399898">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-720"/>
     </node>
     <node visible="true" id="-719" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735143344800001" lon="73.5063285415699994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-719"/>
     </node>
     <node visible="true" id="-718" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735511972900010" lon="73.5063228943299976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-718"/>
     </node>
     <node visible="true" id="-717" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739110778499988" lon="73.5071203964299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-717"/>
     </node>
     <node visible="true" id="-716" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738818540900002" lon="73.5071323189999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-716"/>
     </node>
     <node visible="true" id="-715" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738566373400001" lon="73.5071294233499941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-715"/>
     </node>
     <node visible="true" id="-714" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736325810599988" lon="73.5070324074099943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-714"/>
     </node>
     <node visible="true" id="-713" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736243228099994" lon="73.5070216178799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-713"/>
     </node>
     <node visible="true" id="-712" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755594029699994" lon="73.5173207390299979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-712"/>
     </node>
     <node visible="true" id="-711" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740044192700001" lon="73.5086573093499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-711"/>
     </node>
     <node visible="true" id="-710" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755150222499999" lon="73.5173254761700008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-710"/>
     </node>
     <node visible="true" id="-709" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739854635099993" lon="73.5086564012299988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-709"/>
     </node>
     <node visible="true" id="-708" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739542038499993" lon="73.5086640113799916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-708"/>
     </node>
     <node visible="true" id="-707" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754531545699995" lon="73.5173488614800021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-707"/>
     </node>
     <node visible="true" id="-706" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739314339600009" lon="73.5086508398400014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-706"/>
     </node>
     <node visible="true" id="-705" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756821515900002" lon="73.5161308536700062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-705"/>
     </node>
     <node visible="true" id="-704" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738982429799982" lon="73.5086395757600002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-704"/>
     </node>
     <node visible="true" id="-703" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738925226700001" lon="73.5086216525699996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-703"/>
     </node>
     <node visible="true" id="-702" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738830295299998" lon="73.5086131754400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-702"/>
     </node>
     <node visible="true" id="-701" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754859872200001" lon="73.5171590287900045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-701"/>
     </node>
     <node visible="true" id="-700" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754595927600002" lon="73.5172739335399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-700"/>
     </node>
     <node visible="true" id="-699" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738318340799987" lon="73.5086028892300050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-699"/>
     </node>
     <node visible="true" id="-698" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738049490000000" lon="73.5086149029900042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-698"/>
     </node>
     <node visible="true" id="-697" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754054372299994" lon="73.5173675391099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-697"/>
     </node>
     <node visible="true" id="-696" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1750970833899990" lon="73.5173151077799929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-696"/>
     </node>
     <node visible="true" id="-695" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1789315125499993" lon="73.5069451710299973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-695"/>
     </node>
     <node visible="true" id="-694" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1791365841700001" lon="73.5075134185800039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-694"/>
     </node>
     <node visible="true" id="-693" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1792961958499992" lon="73.5079556988399929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-693"/>
     </node>
     <node visible="true" id="-692" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745345631699990" lon="73.5088564144000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-692"/>
     </node>
     <node visible="true" id="-691" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757368506099990" lon="73.5179816465599885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-691"/>
     </node>
     <node visible="true" id="-690" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745173303999987" lon="73.5087648891399965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-690"/>
     </node>
     <node visible="true" id="-689" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744821847599995" lon="73.5087224802099968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-689"/>
     </node>
     <node visible="true" id="-688" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757839884600001" lon="73.5178921462999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-688"/>
     </node>
     <node visible="true" id="-687" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744347711199987" lon="73.5087074673899963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-687"/>
     </node>
     <node visible="true" id="-686" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744016196499993" lon="73.5087169689099937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-686"/>
     </node>
     <node visible="true" id="-685" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758097964899994" lon="73.5178278734600070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-685"/>
     </node>
     <node visible="true" id="-684" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743723110599991" lon="73.5087538361199790">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-684"/>
     </node>
     <node visible="true" id="-683" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758680875800005" lon="73.5177022136299883">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-683"/>
     </node>
     <node visible="true" id="-682" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743505445299993" lon="73.5087699233999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-682"/>
     </node>
     <node visible="true" id="-681" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743268700399989" lon="73.5087794070300049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-681"/>
     </node>
     <node visible="true" id="-680" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742567368000003" lon="73.5087776516099893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-680"/>
     </node>
     <node visible="true" id="-679" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759529019799997" lon="73.5175387953799913">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679"/>
     </node>
     <node visible="true" id="-678" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741627907799987" lon="73.5087127002099976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678"/>
     </node>
     <node visible="true" id="-677" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741172869199987" lon="73.5087052349300052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-677"/>
     </node>
     <node visible="true" id="-676" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740613134700011" lon="73.5086741920699893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-676"/>
     </node>
     <node visible="true" id="-675" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1797270312199997" lon="73.5095020437699986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-675"/>
     </node>
     <node visible="true" id="-674" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1796552765200010" lon="73.5098641498200038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-674"/>
     </node>
     <node visible="true" id="-673" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1796426909799989" lon="73.5102297518400007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-673"/>
     </node>
     <node visible="true" id="-672" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1799646838799989" lon="73.5091710253000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-672"/>
     </node>
     <node visible="true" id="-671" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740424890699996" lon="73.5065568504799813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-671"/>
     </node>
     <node visible="true" id="-670" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739952510200000" lon="73.5067136500900062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-670"/>
     </node>
     <node visible="true" id="-669" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1794858840199991" lon="73.5084534941899790">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-669"/>
     </node>
     <node visible="true" id="-668" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760789305700010" lon="73.5172163500299831">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-668"/>
     </node>
     <node visible="true" id="-667" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1796413602899989" lon="73.5088615085900017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-667"/>
     </node>
     <node visible="true" id="-666" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760999735000004" lon="73.5171607802499949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-666"/>
     </node>
     <node visible="true" id="-665" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1797190572000007" lon="73.5090837016699936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-665"/>
     </node>
     <node visible="true" id="-664" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761641867799995" lon="73.5170591733400016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-664"/>
     </node>
     <node visible="true" id="-663" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1797536898699983" lon="73.5092254404399910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-663"/>
     </node>
     <node visible="true" id="-662" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1797542421099996" lon="73.5092878055499881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-662"/>
     </node>
     <node visible="true" id="-661" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1797337957499989" lon="73.5093876871499958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-661"/>
     </node>
     <node visible="true" id="-660" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759675250499981" lon="73.5108313470699954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-660"/>
     </node>
     <node visible="true" id="-659" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758835083200010" lon="73.5143818896199974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-659"/>
     </node>
     <node visible="true" id="-658" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759119297799998" lon="73.5110544162699995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-658"/>
     </node>
     <node visible="true" id="-657" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761414743699987" lon="73.5144446768599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-657"/>
     </node>
     <node visible="true" id="-656" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758462403400012" lon="73.5112168186099950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-656"/>
     </node>
     <node visible="true" id="-655" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757916056899997" lon="73.5114502061200028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-655"/>
     </node>
     <node visible="true" id="-654" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763345729300001" lon="73.5144840983400059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-654"/>
     </node>
     <node visible="true" id="-653" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757073252800003" lon="73.5116977410600043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-653"/>
     </node>
     <node visible="true" id="-652" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763965772300011" lon="73.5145060687100056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-652"/>
     </node>
     <node visible="true" id="-651" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759138578000004" lon="73.5115222036800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-651"/>
     </node>
     <node visible="true" id="-650" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762514790099994" lon="73.5117133907699838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-650"/>
     </node>
     <node visible="true" id="-649" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765795793899994" lon="73.5145873708199957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-649"/>
     </node>
     <node visible="true" id="-648" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727244720399996" lon="73.5132741423399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-648"/>
     </node>
     <node visible="true" id="-647" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727305957699992" lon="73.5131791186999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-647"/>
     </node>
     <node visible="true" id="-646" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760796634400004" lon="73.5136433317599938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-646"/>
     </node>
     <node visible="true" id="-645" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754574739599999" lon="73.5104085883800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-645"/>
     </node>
     <node visible="true" id="-644" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754886662399988" lon="73.5104257709499933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-644"/>
     </node>
     <node visible="true" id="-643" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760812390499993" lon="73.5136974171699933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-643"/>
     </node>
     <node visible="true" id="-642" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760198223099980" lon="73.5139114664400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-642"/>
     </node>
     <node visible="true" id="-641" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755492934999996" lon="73.5104463462800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-641"/>
     </node>
     <node visible="true" id="-640" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759945889300001" lon="73.5139798929200055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-640"/>
     </node>
     <node visible="true" id="-639" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756416311500004" lon="73.5104887623799925">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-639"/>
     </node>
     <node visible="true" id="-638" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758788368399991" lon="73.5105418509500055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-638"/>
     </node>
     <node visible="true" id="-637" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759774369299993" lon="73.5140061487799983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-637"/>
     </node>
     <node visible="true" id="-636" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760435686000008" lon="73.5105328476600022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-636"/>
     </node>
     <node visible="true" id="-635" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758274679399987" lon="73.5143228178300063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-635"/>
     </node>
     <node visible="true" id="-634" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762125499499998" lon="73.5105651272999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-634"/>
     </node>
     <node visible="true" id="-633" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758318380899988" lon="73.5143542945500030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-633"/>
     </node>
     <node visible="true" id="-632" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764083480500007" lon="73.5106300673400028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-632"/>
     </node>
     <node visible="true" id="-631" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764128258400000" lon="73.5106395770499859">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-631"/>
     </node>
     <node visible="true" id="-630" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764134979199987" lon="73.5106579775300020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-630"/>
     </node>
     <node visible="true" id="-629" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758360568299988" lon="73.5143577201899916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-629"/>
     </node>
     <node visible="true" id="-628" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763306966800000" lon="73.5111660345699960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-628"/>
     </node>
     <node visible="true" id="-627" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758586810099994" lon="73.5143719502599851">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-627"/>
     </node>
     <node visible="true" id="-626" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729107916499997" lon="73.5159763868300047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-626"/>
     </node>
     <node visible="true" id="-625" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732394385099996" lon="73.5160075350399893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-625"/>
     </node>
     <node visible="true" id="-624" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728414401399991" lon="73.5124020562300018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-624"/>
     </node>
     <node visible="true" id="-623" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741178180800000" lon="73.5160795088499839">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-623"/>
     </node>
     <node visible="true" id="-622" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769212247599992" lon="73.5176478312599926">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-622"/>
     </node>
     <node visible="true" id="-621" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716482474699994" lon="73.5138926743800027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-621"/>
     </node>
     <node visible="true" id="-620" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767166184200004" lon="73.5175867605699978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-620"/>
     </node>
     <node visible="true" id="-619" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764018426099989" lon="73.5174894362299938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-619"/>
     </node>
     <node visible="true" id="-618" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1713244766799980" lon="73.5138408370499974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-618"/>
     </node>
     <node visible="true" id="-617" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761314265499996" lon="73.5174556735299944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-617"/>
     </node>
     <node visible="true" id="-616" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711600757599996" lon="73.5138312235200004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-616"/>
     </node>
     <node visible="true" id="-615" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759993765500001" lon="73.5174296580400011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-615"/>
     </node>
     <node visible="true" id="-614" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710815016699998" lon="73.5138522626400004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-614"/>
     </node>
     <node visible="true" id="-613" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756991220900002" lon="73.5180760883200008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-613"/>
     </node>
     <node visible="true" id="-612" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746099307400000" lon="73.5089169615600042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-612"/>
     </node>
     <node visible="true" id="-611" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759671874200004" lon="73.5149441845599938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-611"/>
     </node>
     <node visible="true" id="-610" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756876726799996" lon="73.5149036763399977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-610"/>
     </node>
     <node visible="true" id="-609" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727648426899995" lon="73.5128659958599968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-609"/>
     </node>
     <node visible="true" id="-608" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754926733000000" lon="73.5148667070899933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-608"/>
     </node>
     <node visible="true" id="-607" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727689354099997" lon="73.5127878589899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-607"/>
     </node>
     <node visible="true" id="-606" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727771958199993" lon="73.5127456705599798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-606"/>
     </node>
     <node visible="true" id="-605" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745113874999991" lon="73.5147100697000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-605"/>
     </node>
     <node visible="true" id="-604" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741642494200004" lon="73.5146350680999916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-604"/>
     </node>
     <node visible="true" id="-603" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741418037100004" lon="73.5146333908799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-603"/>
     </node>
     <node visible="true" id="-602" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741314814999990" lon="73.5146523238199876">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-602"/>
     </node>
     <node visible="true" id="-601" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728080486899994" lon="73.5124291387199946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-601"/>
     </node>
     <node visible="true" id="-600" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741077590700000" lon="73.5148879279799985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-600"/>
     </node>
     <node visible="true" id="-599" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740837947499996" lon="73.5149207039900006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-599"/>
     </node>
     <node visible="true" id="-598" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740629621299998" lon="73.5149344363200044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-598"/>
     </node>
     <node visible="true" id="-597" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740233702799996" lon="73.5149946901800035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-597"/>
     </node>
     <node visible="true" id="-596" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728205794399997" lon="73.5124105034499991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-596"/>
     </node>
     <node visible="true" id="-595" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768341877899990" lon="73.5120158993899935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-595"/>
     </node>
     <node visible="true" id="-594" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768119441099998" lon="73.5122938100699912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-594"/>
     </node>
     <node visible="true" id="-593" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767502745899998" lon="73.5125634389499822">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-593"/>
     </node>
     <node visible="true" id="-592" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1766580932099995" lon="73.5128652510099982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-592"/>
     </node>
     <node visible="true" id="-591" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727459736399988" lon="73.5146226837599954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-591"/>
     </node>
     <node visible="true" id="-590" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727774280699998" lon="73.5146177848500031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-590"/>
     </node>
     <node visible="true" id="-589" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772293554599988" lon="73.5122339295699874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-589"/>
     </node>
     <node visible="true" id="-588" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764896479099995" lon="73.5140111387899822">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-588"/>
     </node>
     <node visible="true" id="-587" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764291693000004" lon="73.5140563730799954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-587"/>
     </node>
     <node visible="true" id="-586" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772034726599996" lon="73.5122353810800035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-586"/>
     </node>
     <node visible="true" id="-585" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1749142539799990" lon="73.5112433890799934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-585"/>
     </node>
     <node visible="true" id="-584" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747654416800000" lon="73.5118659177300060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-584"/>
     </node>
     <node visible="true" id="-583" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746993699599999" lon="73.5118686746399987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-583"/>
     </node>
     <node visible="true" id="-582" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741559067399994" lon="73.5117091460300003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-582"/>
     </node>
     <node visible="true" id="-581" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737793388399993" lon="73.5116057913400027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-581"/>
     </node>
     <node visible="true" id="-580" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736070559999989" lon="73.5115737991000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-580"/>
     </node>
     <node visible="true" id="-579" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733519633399991" lon="73.5115095481900056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-579"/>
     </node>
     <node visible="true" id="-578" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731988105999989" lon="73.5114770866999834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-578"/>
     </node>
     <node visible="true" id="-577" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770039112699990" lon="73.5107268735300039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-577"/>
     </node>
     <node visible="true" id="-576" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769192192199993" lon="73.5113382493599943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-576"/>
     </node>
     <node visible="true" id="-575" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768621403399990" lon="73.5115792608799978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-575"/>
     </node>
     <node visible="true" id="-574" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761083683699995" lon="73.5122116864800006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-574"/>
     </node>
     <node visible="true" id="-573" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769577179299997" lon="73.5131360015499951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-573"/>
     </node>
     <node visible="true" id="-572" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768473811600000" lon="73.5133331138599999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-572"/>
     </node>
     <node visible="true" id="-571" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760553566300000" lon="73.5122014248599953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-571"/>
     </node>
     <node visible="true" id="-570" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760262233499992" lon="73.5122021392299985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-570"/>
     </node>
     <node visible="true" id="-569" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760116711100004" lon="73.5122100805599956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-569"/>
     </node>
     <node visible="true" id="-568" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1766598757300004" lon="73.5137036473699794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-568"/>
     </node>
     <node visible="true" id="-567" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760050771799992" lon="73.5122246018100043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-567"/>
     </node>
     <node visible="true" id="-566" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769997404299994" lon="73.5129650812999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-566"/>
     </node>
     <node visible="true" id="-565" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760036191100003" lon="73.5124156924899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-565"/>
     </node>
     <node visible="true" id="-564" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767735845699985" lon="73.5128904715199951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-564"/>
     </node>
     <node visible="true" id="-563" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760114007200002" lon="73.5125907730899968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-563"/>
     </node>
     <node visible="true" id="-562" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765958503700000" lon="73.5128516586800060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-562"/>
     </node>
     <node visible="true" id="-561" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761961662799996" lon="73.5127449595800044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-561"/>
     </node>
     <node visible="true" id="-560" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760228274199989" lon="73.5127171572300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-560"/>
     </node>
     <node visible="true" id="-559" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760309211099980" lon="73.5129139133599949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-559"/>
     </node>
     <node visible="true" id="-558" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760302532799995" lon="73.5131041525900031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-558"/>
     </node>
     <node visible="true" id="-557" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760376586600003" lon="73.5134367450599910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-557"/>
     </node>
     <node visible="true" id="-556" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752052730100004" lon="73.5103941955899955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-556"/>
     </node>
     <node visible="true" id="-555" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760470499899993" lon="73.5135485283399959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-555"/>
     </node>
     <node visible="true" id="-554" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753085581700002" lon="73.5103864554099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-554"/>
     </node>
     <node visible="true" id="-553" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763755181100004" lon="73.5141403011199941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-553"/>
     </node>
     <node visible="true" id="-552" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763452366199987" lon="73.5141788360899966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-552"/>
     </node>
     <node visible="true" id="-551" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762545563200000" lon="73.5143810162099953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-551"/>
     </node>
     <node visible="true" id="-550" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771724014000000" lon="73.5122501770100030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-550"/>
     </node>
     <node visible="true" id="-549" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767303486199987" lon="73.5141204790199936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-549"/>
     </node>
     <node visible="true" id="-548" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769584301800000" lon="73.5142237521099986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-548"/>
     </node>
     <node visible="true" id="-547" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771550157999995" lon="73.5122693296100067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-547"/>
     </node>
     <node visible="true" id="-546" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772031656599999" lon="73.5143035141300061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-546"/>
     </node>
     <node visible="true" id="-545" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771448963999989" lon="73.5122931009699982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-545"/>
     </node>
     <node visible="true" id="-544" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767947686899998" lon="73.5123872335300064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-544"/>
     </node>
     <node visible="true" id="-543" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767000327000012" lon="73.5123616549399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-543"/>
     </node>
     <node visible="true" id="-542" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765092451299983" lon="73.5122999478499963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-542"/>
     </node>
     <node visible="true" id="-541" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770662547299988" lon="73.5128239003300052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-541"/>
     </node>
     <node visible="true" id="-540" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770275799399998" lon="73.5129756715599996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-540"/>
     </node>
     <node visible="true" id="-539" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763301961699995" lon="73.5122485574299844">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-539"/>
     </node>
     <node visible="true" id="-538" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770144484299996" lon="73.5130272034100045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-538"/>
     </node>
     <node visible="true" id="-537" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761666288799990" lon="73.5122177025599939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-537"/>
     </node>
     <node visible="true" id="-536" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743501480599994" lon="73.5097075032199996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-536"/>
     </node>
     <node visible="true" id="-535" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752538942099999" lon="73.5156731642800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-535"/>
     </node>
     <node visible="true" id="-534" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754305151800013" lon="73.5157976750799946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-534"/>
     </node>
     <node visible="true" id="-533" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742554703200003" lon="73.5096763777899866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-533"/>
     </node>
     <node visible="true" id="-532" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754711126299995" lon="73.5158327341700044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-532"/>
     </node>
     <node visible="true" id="-531" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742018037299990" lon="73.5096177614799871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-531"/>
     </node>
     <node visible="true" id="-530" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1754769798400000" lon="73.5158592615599957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-530"/>
     </node>
     <node visible="true" id="-529" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741807134699993" lon="73.5096190810599950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-529"/>
     </node>
     <node visible="true" id="-528" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755615222299998" lon="73.5159134877900016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-528"/>
     </node>
     <node visible="true" id="-527" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741571603900001" lon="73.5096257267200031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-527"/>
     </node>
     <node visible="true" id="-526" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741172612499993" lon="73.5096758951199973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-526"/>
     </node>
     <node visible="true" id="-525" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756998096100002" lon="73.5160341226399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-525"/>
     </node>
     <node visible="true" id="-524" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741107612999997" lon="73.5096793636000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-524"/>
     </node>
     <node visible="true" id="-523" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740223101799998" lon="73.5096530436699993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-523"/>
     </node>
     <node visible="true" id="-522" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739655669999998" lon="73.5096416459099942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-522"/>
     </node>
     <node visible="true" id="-521" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757194932299999" lon="73.5160397750899932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-521"/>
     </node>
     <node visible="true" id="-520" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739326336900007" lon="73.5096396474699958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-520"/>
     </node>
     <node visible="true" id="-519" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738970522699983" lon="73.5096318920899989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-519"/>
     </node>
     <node visible="true" id="-518" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738759384700002" lon="73.5096384642999823">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-518"/>
     </node>
     <node visible="true" id="-517" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757458654199988" lon="73.5160333969899966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-517"/>
     </node>
     <node visible="true" id="-516" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736075388299998" lon="73.5095704493700026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-516"/>
     </node>
     <node visible="true" id="-515" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735767423199999" lon="73.5095666769099978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-515"/>
     </node>
     <node visible="true" id="-514" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779615081399992" lon="73.5104999918099935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-514"/>
     </node>
     <node visible="true" id="-513" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752215445499994" lon="73.5156336043499863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-513"/>
     </node>
     <node visible="true" id="-512" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781820168399992" lon="73.5093021503400053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-512"/>
     </node>
     <node visible="true" id="-511" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752258718700004" lon="73.5156512693599922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-511"/>
     </node>
     <node visible="true" id="-510" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751467437300018" lon="73.5079146468199980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-510"/>
     </node>
     <node visible="true" id="-509" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746166892799987" lon="73.5076591572999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-509"/>
     </node>
     <node visible="true" id="-508" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1749763262799995" lon="73.5097906537699970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-508"/>
     </node>
     <node visible="true" id="-507" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747862842299988" lon="73.5097596032699983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-507"/>
     </node>
     <node visible="true" id="-506" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752374009399995" lon="73.5156653680899979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-506"/>
     </node>
     <node visible="true" id="-505" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747263417699996" lon="73.5097645681299809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-505"/>
     </node>
     <node visible="true" id="-504" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1746045821199997" lon="73.5097591032500048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-504"/>
     </node>
     <node visible="true" id="-503" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745030244699990" lon="73.5097230545299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-503"/>
     </node>
     <node visible="true" id="-502" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744291672899987" lon="73.5097016234699936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-502"/>
     </node>
     <node visible="true" id="-501" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760969819699998" lon="73.5150769919700053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-501"/>
     </node>
     <node visible="true" id="-500" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732804349099988" lon="73.5110632029600026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-500"/>
     </node>
     <node visible="true" id="-499" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733786550399978" lon="73.5110515474799939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-499"/>
     </node>
     <node visible="true" id="-498" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734843496399989" lon="73.5110647431600057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-498"/>
     </node>
     <node visible="true" id="-497" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731161267999992" lon="73.5140585349199966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-497"/>
     </node>
     <node visible="true" id="-496" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738905518999996" lon="73.5111440438499955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-496"/>
     </node>
     <node visible="true" id="-495" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740361793899998" lon="73.5111633546699892">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-495"/>
     </node>
     <node visible="true" id="-494" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731262671799989" lon="73.5140454853300014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-494"/>
     </node>
     <node visible="true" id="-493" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731341902499990" lon="73.5140165390399858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-493"/>
     </node>
     <node visible="true" id="-492" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741442947899996" lon="73.5111547519099986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-492"/>
     </node>
     <node visible="true" id="-491" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741937494099997" lon="73.5111611169400021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-491"/>
     </node>
     <node visible="true" id="-490" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742221179799994" lon="73.5111610634899932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-490"/>
     </node>
     <node visible="true" id="-489" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742926663399995" lon="73.5111778833799860">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-489"/>
     </node>
     <node visible="true" id="-488" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743400950299998" lon="73.5112036551699930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-488"/>
     </node>
     <node visible="true" id="-487" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745111593299988" lon="73.5112262313000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-487"/>
     </node>
     <node visible="true" id="-486" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747563258799998" lon="73.5112582489600044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-486"/>
     </node>
     <node visible="true" id="-485" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735576189500003" lon="73.5095791819600066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-485"/>
     </node>
     <node visible="true" id="-484" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735539577399994" lon="73.5095901909100036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-484"/>
     </node>
     <node visible="true" id="-483" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757641551300004" lon="73.5160134278600026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-483"/>
     </node>
     <node visible="true" id="-482" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735528426700013" lon="73.5096606351199995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-482"/>
     </node>
     <node visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735032893299993" lon="73.5099284265200055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-481"/>
     </node>
     <node visible="true" id="-480" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757681159300004" lon="73.5159866876900026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480"/>
     </node>
     <node visible="true" id="-479" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734898599300001" lon="73.5100564592299861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-479"/>
     </node>
     <node visible="true" id="-478" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758062749900002" lon="73.5158837240999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-478"/>
     </node>
     <node visible="true" id="-477" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734954234899995" lon="73.5100968941700046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-477"/>
     </node>
     <node visible="true" id="-476" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758488550799990" lon="73.5157952989700050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-476"/>
     </node>
     <node visible="true" id="-475" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758795908899993" lon="73.5156600625499976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-475"/>
     </node>
     <node visible="true" id="-474" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734520106600010" lon="73.5104268589900016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-474"/>
     </node>
     <node visible="true" id="-473" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1759753591999997" lon="73.5154416807699960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-473"/>
     </node>
     <node visible="true" id="-472" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734332840599997" lon="73.5105114673799847">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-472"/>
     </node>
     <node visible="true" id="-471" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734355813599988" lon="73.5106201096999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-471"/>
     </node>
     <node visible="true" id="-470" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734322675700000" lon="73.5106590883300015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-470"/>
     </node>
     <node visible="true" id="-469" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760919340799996" lon="73.5151019854800012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-469"/>
     </node>
     <node visible="true" id="-468" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745046330099997" lon="73.5099738896299897">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-468"/>
     </node>
     <node visible="true" id="-467" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1744059110700000" lon="73.5102190843099947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-467"/>
     </node>
     <node visible="true" id="-466" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762842903700008" lon="73.5076486880400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-466"/>
     </node>
     <node visible="true" id="-465" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763808368699999" lon="73.5076654323799943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-465"/>
     </node>
     <node visible="true" id="-464" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709378055100013" lon="73.5150820096900048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-464"/>
     </node>
     <node visible="true" id="-463" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764693419099999" lon="73.5076894758399959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-463"/>
     </node>
     <node visible="true" id="-462" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765944421399999" lon="73.5077130915199888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-462"/>
     </node>
     <node visible="true" id="-461" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708934558999990" lon="73.5153593734899999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-461"/>
     </node>
     <node visible="true" id="-460" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767066496699998" lon="73.5077228314400060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-460"/>
     </node>
     <node visible="true" id="-459" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709579681499998" lon="73.5153383176299826">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-459"/>
     </node>
     <node visible="true" id="-458" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767174185299991" lon="73.5077312786499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-458"/>
     </node>
     <node visible="true" id="-457" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710732818500009" lon="73.5153659944199944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-457"/>
     </node>
     <node visible="true" id="-456" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714628690899991" lon="73.5153817731799819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-456"/>
     </node>
     <node visible="true" id="-455" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718135908300011" lon="73.5154514928699854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-455"/>
     </node>
     <node visible="true" id="-454" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719640814499988" lon="73.5154592034100034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-454"/>
     </node>
     <node visible="true" id="-453" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720210909799995" lon="73.5154884747900041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-453"/>
     </node>
     <node visible="true" id="-452" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769263606199987" lon="73.5081483024700049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-452"/>
     </node>
     <node visible="true" id="-451" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770107892999988" lon="73.5083033965500050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-451"/>
     </node>
     <node visible="true" id="-450" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720426156099997" lon="73.5154910976900027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-450"/>
     </node>
     <node visible="true" id="-449" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770309897800013" lon="73.5083149144799961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-449"/>
     </node>
     <node visible="true" id="-448" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756887771799995" lon="73.5181083790799903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-448"/>
     </node>
     <node visible="true" id="-447" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1751790875600001" lon="73.5180681604900030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-447"/>
     </node>
     <node visible="true" id="-446" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776519279799995" lon="73.5058740719800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-446"/>
     </node>
     <node visible="true" id="-445" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731716261800003" lon="73.5178158854999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-445"/>
     </node>
     <node visible="true" id="-444" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776729155099988" lon="73.5058894912699969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-444"/>
     </node>
     <node visible="true" id="-443" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709092177299993" lon="73.5150492293799971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-443"/>
     </node>
     <node visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776766751099990" lon="73.5058931067999879">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-442"/>
     </node>
     <node visible="true" id="-441" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777618498399995" lon="73.5063021025400047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-441"/>
     </node>
     <node visible="true" id="-440" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709197835799996" lon="73.5150522817500018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-440"/>
     </node>
     <node visible="true" id="-439" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1778238714099993" lon="73.5065130999399940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-439"/>
     </node>
     <node visible="true" id="-438" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779854789000002" lon="73.5071495921099967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-438"/>
     </node>
     <node visible="true" id="-437" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709311122899999" lon="73.5150614737000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-437"/>
     </node>
     <node visible="true" id="-436" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755645044899996" lon="73.5074267690999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-436"/>
     </node>
     <node visible="true" id="-435" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761903954299999" lon="73.5076250843000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-435"/>
     </node>
     <node visible="true" id="-434" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1758814379899993" lon="73.5089446311099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-434"/>
     </node>
     <node visible="true" id="-433" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762390608099995" lon="73.5144593479799937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-433"/>
     </node>
     <node visible="true" id="-432" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1757550394999994" lon="73.5093233327200011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-432"/>
     </node>
     <node visible="true" id="-431" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762047510000002" lon="73.5145541432100060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-431"/>
     </node>
     <node visible="true" id="-430" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761728189499987" lon="73.5146341529799940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-430"/>
     </node>
     <node visible="true" id="-429" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1755168101700004" lon="73.5091934221200063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-429"/>
     </node>
     <node visible="true" id="-428" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1756315428699997" lon="73.5092815857500028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-428"/>
     </node>
     <node visible="true" id="-427" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752796851799996" lon="73.5148322202699944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-427"/>
     </node>
     <node visible="true" id="-426" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752618516300002" lon="73.5149702466899981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-426"/>
     </node>
     <node visible="true" id="-425" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772697840899999" lon="73.5098452945999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-425"/>
     </node>
     <node visible="true" id="-424" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752311082399993" lon="73.5154644561399948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-424"/>
     </node>
     <node visible="true" id="-423" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1752208795200003" lon="73.5154912521900030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-423"/>
     </node>
     <node visible="true" id="-422" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1787681371499987" lon="73.5103217020100033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-422"/>
     </node>
     <node visible="true" id="-421" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760139921699988" lon="73.5149536795800032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-421"/>
     </node>
     <node visible="true" id="-420" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720627665499981" lon="73.5154990769799923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-420"/>
     </node>
     <node visible="true" id="-419" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770393200700004" lon="73.5083892026400036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-419"/>
     </node>
     <node visible="true" id="-418" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770574869299999" lon="73.5084253098400069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-418"/>
     </node>
     <node visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720802235300001" lon="73.5155118898900071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-417"/>
     </node>
     <node visible="true" id="-416" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773026434100000" lon="73.5088581179599885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-416"/>
     </node>
     <node visible="true" id="-415" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773744092899987" lon="73.5090038526099931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-415"/>
     </node>
     <node visible="true" id="-414" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774450715199993" lon="73.5092071267099811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-414"/>
     </node>
     <node visible="true" id="-413" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774877146099998" lon="73.5093854489199998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-413"/>
     </node>
     <node visible="true" id="-412" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708209337400000" lon="73.5158886047200042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-412"/>
     </node>
     <node visible="true" id="-411" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774877561699988" lon="73.5094029930299939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-411"/>
     </node>
     <node visible="true" id="-410" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775351992499985" lon="73.5096013812499933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-410"/>
     </node>
     <node visible="true" id="-409" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775982487800007" lon="73.5099142242400063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-409"/>
     </node>
     <node visible="true" id="-408" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729600811199994" lon="73.5134119933899939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-408"/>
     </node>
     <node visible="true" id="-407" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728819904699987" lon="73.5140069843599946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-407"/>
     </node>
     <node visible="true" id="-406" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775904510999995" lon="73.5099364453800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-406"/>
     </node>
     <node visible="true" id="-405" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728797715699999" lon="73.5140386357099942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-405"/>
     </node>
     <node visible="true" id="-404" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728656534799988" lon="73.5142400218200009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-404"/>
     </node>
     <node visible="true" id="-403" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728631971399990" lon="73.5143363997199941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-403"/>
     </node>
     <node visible="true" id="-402" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762753539499995" lon="73.5076776917399997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-402"/>
     </node>
     <node visible="true" id="-401" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728237168399982" lon="73.5144783803699937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-401"/>
     </node>
     <node visible="true" id="-400" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1761847506600001" lon="73.5078981753199940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-400"/>
     </node>
     <node visible="true" id="-399" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760599954800002" lon="73.5083561394999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-399"/>
     </node>
     <node visible="true" id="-398" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719704248399996" lon="73.5084040149999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-398"/>
     </node>
     <node visible="true" id="-397" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720266674699999" lon="73.5084262342199963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-397"/>
     </node>
     <node visible="true" id="-396" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771409485700000" lon="73.5177118474200029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-396"/>
     </node>
     <node visible="true" id="-395" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727389551299989" lon="73.5082173580599942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-395"/>
     </node>
     <node visible="true" id="-394" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770507847799987" lon="73.5177723298999837">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-394"/>
     </node>
     <node visible="true" id="-393" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727468733999995" lon="73.5082217440699992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-393"/>
     </node>
     <node visible="true" id="-392" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727831950800010" lon="73.5082418629999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-392"/>
     </node>
     <node visible="true" id="-391" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769566045600000" lon="73.5178264007600006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-391"/>
     </node>
     <node visible="true" id="-390" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729613003599990" lon="73.5082954619799978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-390"/>
     </node>
     <node visible="true" id="-389" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730178565399996" lon="73.5083109622199942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-389"/>
     </node>
     <node visible="true" id="-388" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730492896699998" lon="73.5083156808399991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-388"/>
     </node>
     <node visible="true" id="-387" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768367683400003" lon="73.5178833745899993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-387"/>
     </node>
     <node visible="true" id="-386" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767280187800004" lon="73.5179422686099997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-386"/>
     </node>
     <node visible="true" id="-385" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731162663599992" lon="73.5083556990000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-385"/>
     </node>
     <node visible="true" id="-384" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1766154093199992" lon="73.5179934636099972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-384"/>
     </node>
     <node visible="true" id="-383" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732958393099997" lon="73.5084182362400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-383"/>
     </node>
     <node visible="true" id="-382" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733221799299987" lon="73.5084145281399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-382"/>
     </node>
     <node visible="true" id="-381" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776497046200003" lon="73.5171426222800051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-381"/>
     </node>
     <node visible="true" id="-380" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718493657500009" lon="73.5120985079000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-380"/>
     </node>
     <node visible="true" id="-379" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776183065300012" lon="73.5171978976800062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-379"/>
     </node>
     <node visible="true" id="-378" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726146099499992" lon="73.5078546077400006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-378"/>
     </node>
     <node visible="true" id="-377" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725857734399989" lon="73.5081638781000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-377"/>
     </node>
     <node visible="true" id="-376" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775510399500000" lon="73.5172984864800014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-376"/>
     </node>
     <node visible="true" id="-375" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725598798299997" lon="73.5084415847299937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-375"/>
     </node>
     <node visible="true" id="-374" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725429690499993" lon="73.5086229506199942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-374"/>
     </node>
     <node visible="true" id="-373" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774450889299999" lon="73.5174342865600039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-373"/>
     </node>
     <node visible="true" id="-372" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725235268599992" lon="73.5089327506500041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-372"/>
     </node>
     <node visible="true" id="-371" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725154567999994" lon="73.5090613416199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-371"/>
     </node>
     <node visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773254661200001" lon="73.5175583122099852">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-370"/>
     </node>
     <node visible="true" id="-369" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772266566800003" lon="73.5176452479999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-369"/>
     </node>
     <node visible="true" id="-368" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1780819359399999" lon="73.5059229127000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-368"/>
     </node>
     <node visible="true" id="-367" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724784618499999" lon="73.5176430599699984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-367"/>
     </node>
     <node visible="true" id="-366" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760552898699990" lon="73.5054173216900040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-366"/>
     </node>
     <node visible="true" id="-365" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724937007899996" lon="73.5176823033099964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-365"/>
     </node>
     <node visible="true" id="-364" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764667078799995" lon="73.5055208200700037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-364"/>
     </node>
     <node visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768251491499999" lon="73.5056256750900019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-363"/>
     </node>
     <node visible="true" id="-362" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770013691499992" lon="73.5056880835499982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-362"/>
     </node>
     <node visible="true" id="-361" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772139409500006" lon="73.5057706759399991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-361"/>
     </node>
     <node visible="true" id="-360" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725132871399992" lon="73.5177071923800014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-360"/>
     </node>
     <node visible="true" id="-359" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725479069799993" lon="73.5177313063600053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359"/>
     </node>
     <node visible="true" id="-358" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776230433699997" lon="73.5058621471799967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-358"/>
     </node>
     <node visible="true" id="-357" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765480533999995" lon="73.5180197085200007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-357"/>
     </node>
     <node visible="true" id="-356" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733750543100010" lon="73.5084254280200042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-356"/>
     </node>
     <node visible="true" id="-355" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1765004267799997" lon="73.5180329342699963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-355"/>
     </node>
     <node visible="true" id="-354" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736119118699992" lon="73.5085302635300053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-354"/>
     </node>
     <node visible="true" id="-353" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736657160200004" lon="73.5085616810300024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-353"/>
     </node>
     <node visible="true" id="-352" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737424493299997" lon="73.5085914395800017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-352"/>
     </node>
     <node visible="true" id="-351" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764039288300001" lon="73.5180543810800060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-351"/>
     </node>
     <node visible="true" id="-350" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763061638499988" lon="73.5180690713000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-350"/>
     </node>
     <node visible="true" id="-349" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727449293199994" lon="73.5082686591400005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-349"/>
     </node>
     <node visible="true" id="-348" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727573810000003" lon="73.5084100411600048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-348"/>
     </node>
     <node visible="true" id="-347" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1760958683799991" lon="73.5181405017799960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-347"/>
     </node>
     <node visible="true" id="-346" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727746031399997" lon="73.5087045593400035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-346"/>
     </node>
     <node visible="true" id="-345" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728060085099994" lon="73.5089847484200050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-345"/>
     </node>
     <node visible="true" id="-344" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731431761200000" lon="73.5178091952499955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-344"/>
     </node>
     <node visible="true" id="-343" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729428807000009" lon="73.5177620942599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-343"/>
     </node>
     <node visible="true" id="-342" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725780997299999" lon="73.5177410902399942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-342"/>
     </node>
     <node visible="true" id="-341" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781347848900001" lon="73.5055557442099996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-341"/>
     </node>
     <node visible="true" id="-340" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781104796299999" lon="73.5057339556600056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-340"/>
     </node>
     <node visible="true" id="-339" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1780848983399990" lon="73.5058246038600061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-339"/>
     </node>
     <node visible="true" id="-338" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1801410248499984" lon="73.5096362623799990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-338"/>
     </node>
     <node visible="true" id="-337" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724543697099996" lon="73.5065350367499946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-337"/>
     </node>
     <node visible="true" id="-336" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1801252345299993" lon="73.5097143717800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-336"/>
     </node>
     <node visible="true" id="-335" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724373154499990" lon="73.5066319574900007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-335"/>
     </node>
     <node visible="true" id="-334" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724104286300001" lon="73.5068629673999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-334"/>
     </node>
     <node visible="true" id="-333" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723744669800000" lon="73.5072272851199955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-333"/>
     </node>
     <node visible="true" id="-332" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1800913951199998" lon="73.5098290048800038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-332"/>
     </node>
     <node visible="true" id="-331" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723389145299992" lon="73.5074895312999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-331"/>
     </node>
     <node visible="true" id="-330" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723176751599995" lon="73.5078026239099955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-330"/>
     </node>
     <node visible="true" id="-329" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1800622265099996" lon="73.5099031966500007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-329"/>
     </node>
     <node visible="true" id="-328" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722451081200003" lon="73.5084087365000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-328"/>
     </node>
     <node visible="true" id="-327" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722344942599996" lon="73.5084496071600029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-327"/>
     </node>
     <node visible="true" id="-326" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1800279327499990" lon="73.5099751811499971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-326"/>
     </node>
     <node visible="true" id="-325" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1799663888799987" lon="73.5100795619199943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325"/>
     </node>
     <node visible="true" id="-324" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1701313754799996" lon="73.5106744262599960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-324"/>
     </node>
     <node visible="true" id="-323" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1797379151299987" lon="73.5103251785200058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-323"/>
     </node>
     <node visible="true" id="-322" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707338102499998" lon="73.5107204895499962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-322"/>
     </node>
     <node visible="true" id="-321" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747089264399992" lon="73.5026584084699834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-321"/>
     </node>
     <node visible="true" id="-320" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747362932799996" lon="73.5024772913800035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-320"/>
     </node>
     <node visible="true" id="-319" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1801470681499993" lon="73.5091195284900039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-319"/>
     </node>
     <node visible="true" id="-318" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747862785399992" lon="73.5019601557900017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-318"/>
     </node>
     <node visible="true" id="-317" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1801594804899986" lon="73.5091818957500038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-317"/>
     </node>
     <node visible="true" id="-316" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738442311999995" lon="73.5012488660299965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-316"/>
     </node>
     <node visible="true" id="-315" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737858482399988" lon="73.5018598875600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-315"/>
     </node>
     <node visible="true" id="-314" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1801629981699993" lon="73.5092294693999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-314"/>
     </node>
     <node visible="true" id="-313" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739917514200000" lon="73.5036912311500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-313"/>
     </node>
     <node visible="true" id="-312" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736392219499994" lon="73.5036566950399930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-312"/>
     </node>
     <node visible="true" id="-311" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733762890999992" lon="73.5036377586900045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-311"/>
     </node>
     <node visible="true" id="-310" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1801513061299991" lon="73.5095572461899991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-310"/>
     </node>
     <node visible="true" id="-309" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1721826314499992" lon="73.5035146860600008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-309"/>
     </node>
     <node visible="true" id="-308" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1787714608400002" lon="73.5133694394900061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-308"/>
     </node>
     <node visible="true" id="-307" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1785869254299994" lon="73.5139873594199997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-307"/>
     </node>
     <node visible="true" id="-306" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706758777800008" lon="73.5119678020199956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306"/>
     </node>
     <node visible="true" id="-305" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1782868504500001" lon="73.5149842067300057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-305"/>
     </node>
     <node visible="true" id="-304" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781657703599997" lon="73.5154395229200048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-304"/>
     </node>
     <node visible="true" id="-303" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779690062999988" lon="73.5160868598700006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-303"/>
     </node>
     <node visible="true" id="-302" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720005525899992" lon="73.5107860800300017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-302"/>
     </node>
     <node visible="true" id="-301" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1777106409000000" lon="73.5169960923699932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-301"/>
     </node>
     <node visible="true" id="-300" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719978297999987" lon="73.5108236544700020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-300"/>
     </node>
     <node visible="true" id="-299" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719713912099987" lon="73.5108793625099963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-299"/>
     </node>
     <node visible="true" id="-298" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719496880299998" lon="73.5112217015699940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-298"/>
     </node>
     <node visible="true" id="-297" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719198268000008" lon="73.5114801507699980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-297"/>
     </node>
     <node visible="true" id="-296" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1776771548599996" lon="73.5170853000900024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-296"/>
     </node>
     <node visible="true" id="-295" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1796167240099997" lon="73.5105065130299948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-295"/>
     </node>
     <node visible="true" id="-294" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707698579699990" lon="73.5104312539500029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-294"/>
     </node>
     <node visible="true" id="-293" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707155544900001" lon="73.5108669676800019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-293"/>
     </node>
     <node visible="true" id="-292" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706734519499982" lon="73.5113518377099950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-292"/>
     </node>
     <node visible="true" id="-291" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1795741042699994" lon="73.5106025301799946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-291"/>
     </node>
     <node visible="true" id="-290" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706238365899990" lon="73.5119232238200055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-290"/>
     </node>
     <node visible="true" id="-289" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706368979799997" lon="73.5119476954999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-289"/>
     </node>
     <node visible="true" id="-288" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1792019457799983" lon="73.5118781964399801">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-288"/>
     </node>
     <node visible="true" id="-287" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1788895527200003" lon="73.5129175389599965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-287"/>
     </node>
     <node visible="true" id="-286" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706544890000004" lon="73.5119614004899944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-286"/>
     </node>
     <node visible="true" id="-285" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738264074499991" lon="73.5172337124100039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-285"/>
     </node>
     <node visible="true" id="-284" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738465841700005" lon="73.5172295332900063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-284"/>
     </node>
     <node visible="true" id="-283" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738569010499997" lon="73.5172292202200026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-283"/>
     </node>
     <node visible="true" id="-282" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740259098899992" lon="73.5172716960299937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-282"/>
     </node>
     <node visible="true" id="-281" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1740893663799987" lon="73.5172805657699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-281"/>
     </node>
     <node visible="true" id="-280" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729723845100004" lon="73.5016941760700036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-280"/>
     </node>
     <node visible="true" id="-279" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741512579500011" lon="73.5173196301199852">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-279"/>
     </node>
     <node visible="true" id="-278" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729199331600002" lon="73.5022684891099942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-278"/>
     </node>
     <node visible="true" id="-277" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742891897000005" lon="73.5173759031499969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-277"/>
     </node>
     <node visible="true" id="-276" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728490139199996" lon="73.5026202450199833">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-276"/>
     </node>
     <node visible="true" id="-275" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728470541499991" lon="73.5028199606800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-275"/>
     </node>
     <node visible="true" id="-274" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1743414339799996" lon="73.5179695775299962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-274"/>
     </node>
     <node visible="true" id="-273" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727019277399995" lon="73.5042429226299845">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-273"/>
     </node>
     <node visible="true" id="-272" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726625977599996" lon="73.5042955733800056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-272"/>
     </node>
     <node visible="true" id="-271" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762023720399988" lon="73.5181140342100008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-271"/>
     </node>
     <node visible="true" id="-270" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762307414500004" lon="73.5181273798999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-270"/>
     </node>
     <node visible="true" id="-269" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726517768499995" lon="73.5043711305600027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-269"/>
     </node>
     <node visible="true" id="-268" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1703187957200001" lon="73.5088441874899985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-268"/>
     </node>
     <node visible="true" id="-267" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704881563199985" lon="73.5088684795399985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-267"/>
     </node>
     <node visible="true" id="-266" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707298432999993" lon="73.5088961864699968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-266"/>
     </node>
     <node visible="true" id="-265" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732187332299988" lon="73.5171435669299882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-265"/>
     </node>
     <node visible="true" id="-264" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733000837700001" lon="73.5171241142199960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-264"/>
     </node>
     <node visible="true" id="-263" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733401581399985" lon="73.5171381924100018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-263"/>
     </node>
     <node visible="true" id="-262" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1734900647700002" lon="73.5171649312399893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-262"/>
     </node>
     <node visible="true" id="-261" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707458424799988" lon="73.5089122103500046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-261"/>
     </node>
     <node visible="true" id="-260" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1736864479299989" lon="73.5178887925400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-260"/>
     </node>
     <node visible="true" id="-259" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737496764200008" lon="73.5174293744800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-259"/>
     </node>
     <node visible="true" id="-258" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737788408999998" lon="73.5172712909599966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-258"/>
     </node>
     <node visible="true" id="-257" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737915969900001" lon="73.5172551699400003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-257"/>
     </node>
     <node visible="true" id="-256" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738077428100002" lon="73.5172424144199965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-256"/>
     </node>
     <node visible="true" id="-255" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707505409700003" lon="73.5089380309200067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-255"/>
     </node>
     <node visible="true" id="-254" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737665449399994" lon="73.5044619159200039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-254"/>
     </node>
     <node visible="true" id="-253" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737850140999990" lon="73.5044895765900037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-253"/>
     </node>
     <node visible="true" id="-252" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1778380407699993" lon="73.5028430104499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-252"/>
     </node>
     <node visible="true" id="-251" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1781563010299996" lon="73.5037197669999927">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-251"/>
     </node>
     <node visible="true" id="-250" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738064792799987" lon="73.5045406126800032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-250"/>
     </node>
     <node visible="true" id="-249" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738581123499987" lon="73.5047242492800024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-249"/>
     </node>
     <node visible="true" id="-248" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738602816000006" lon="73.5047412707500030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-248"/>
     </node>
     <node visible="true" id="-247" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1783560718000006" lon="73.5042775339200034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-247"/>
     </node>
     <node visible="true" id="-246" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738554559799992" lon="73.5047703354899937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-246"/>
     </node>
     <node visible="true" id="-245" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1784050493400002" lon="73.5044444852999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-245"/>
     </node>
     <node visible="true" id="-244" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739205979299987" lon="73.5049963037899943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-244"/>
     </node>
     <node visible="true" id="-243" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1784587220299994" lon="73.5045985287599990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-243"/>
     </node>
     <node visible="true" id="-242" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1739740829200001" lon="73.5051551080100012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-242"/>
     </node>
     <node visible="true" id="-241" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1785855249799990" lon="73.5049624602900025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-241"/>
     </node>
     <node visible="true" id="-240" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741940037800003" lon="73.5059388148600021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-240"/>
     </node>
     <node visible="true" id="-239" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1790413872199990" lon="73.5062023852999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-239"/>
     </node>
     <node visible="true" id="-238" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742099214500001" lon="73.5043493675400015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-238"/>
     </node>
     <node visible="true" id="-237" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1794862508299992" lon="73.5073803670899935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-237"/>
     </node>
     <node visible="true" id="-236" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1742084263399990" lon="73.5044115736599935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-236"/>
     </node>
     <node visible="true" id="-235" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1798425449199987" lon="73.5083186301399962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-235"/>
     </node>
     <node visible="true" id="-234" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1745261416899995" lon="73.5055449672500032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-234"/>
     </node>
     <node visible="true" id="-233" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726637302400000" lon="73.5044102414200040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-233"/>
     </node>
     <node visible="true" id="-232" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726805203299993" lon="73.5044470290099952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-232"/>
     </node>
     <node visible="true" id="-231" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762608292899994" lon="73.5181482254500054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-231"/>
     </node>
     <node visible="true" id="-230" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726167841599988" lon="73.5048877189800010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-230"/>
     </node>
     <node visible="true" id="-229" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726129568800001" lon="73.5050482817500068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-229"/>
     </node>
     <node visible="true" id="-228" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725770079100002" lon="73.5053899838199953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-228"/>
     </node>
     <node visible="true" id="-227" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762790270099996" lon="73.5181687957099967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-227"/>
     </node>
     <node visible="true" id="-226" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725366119499991" lon="73.5057646018200046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-226"/>
     </node>
     <node visible="true" id="-225" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725198977899991" lon="73.5057793828100046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-225"/>
     </node>
     <node visible="true" id="-224" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1762926071299997" lon="73.5181926430900035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-224"/>
     </node>
     <node visible="true" id="-223" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725118838100004" lon="73.5057983490199831">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-223"/>
     </node>
     <node visible="true" id="-222" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725018868599992" lon="73.5059288387100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-222"/>
     </node>
     <node visible="true" id="-221" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725165272399991" lon="73.5059480819499953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-221"/>
     </node>
     <node visible="true" id="-220" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1763009934699999" lon="73.5182187557699933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-220"/>
     </node>
     <node visible="true" id="-219" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725115172100002" lon="73.5059938501599959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-219"/>
     </node>
     <node visible="true" id="-218" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1764035207799992" lon="73.5188365562400037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-218"/>
     </node>
     <node visible="true" id="-217" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737200819099991" lon="73.5043007425399821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-217"/>
     </node>
     <node visible="true" id="-216" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726839512499989" lon="73.5073012432799970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-216"/>
     </node>
     <node visible="true" id="-215" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771445899000001" lon="73.5168865978999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-215"/>
     </node>
     <node visible="true" id="-214" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726868467799996" lon="73.5073393893000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-214"/>
     </node>
     <node visible="true" id="-213" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771187829500001" lon="73.5168936948600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-213"/>
     </node>
     <node visible="true" id="-212" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726947389199989" lon="73.5073614857499962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-212"/>
     </node>
     <node visible="true" id="-211" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770819030399995" lon="73.5168934837600005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-211"/>
     </node>
     <node visible="true" id="-210" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727109430900002" lon="73.5073785025199982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-210"/>
     </node>
     <node visible="true" id="-209" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774344195399999" lon="73.5161156130899940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-209"/>
     </node>
     <node visible="true" id="-208" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771391920100012" lon="73.5159582795700004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-208"/>
     </node>
     <node visible="true" id="-207" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769325682099989" lon="73.5158668723900064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-207"/>
     </node>
     <node visible="true" id="-206" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731411412999986" lon="73.5075559865099990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-206"/>
     </node>
     <node visible="true" id="-205" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714033900900001" lon="73.5040416316199980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-205"/>
     </node>
     <node visible="true" id="-204" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773737194799985" lon="73.5161684884899955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-204"/>
     </node>
     <node visible="true" id="-203" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773636441799988" lon="73.5161898986399933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-203"/>
     </node>
     <node visible="true" id="-202" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729135897600003" lon="73.5052073232999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-202"/>
     </node>
     <node visible="true" id="-201" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728908766599995" lon="73.5054221313500022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-201"/>
     </node>
     <node visible="true" id="-200" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1772216568599987" lon="73.5166870113099975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-200"/>
     </node>
     <node visible="true" id="-199" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728299946600007" lon="73.5060132275600040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-199"/>
     </node>
     <node visible="true" id="-198" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728078086700000" lon="73.5062345941699817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-198"/>
     </node>
     <node visible="true" id="-197" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727550463599989" lon="73.5066704254600012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-197"/>
     </node>
     <node visible="true" id="-196" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771877488699989" lon="73.5168431804300013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-196"/>
     </node>
     <node visible="true" id="-195" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727145861499988" lon="73.5070654865800037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-195"/>
     </node>
     <node visible="true" id="-194" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1771669548599988" lon="73.5168719402699935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-194"/>
     </node>
     <node visible="true" id="-193" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726888117099978" lon="73.5072033229499908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-193"/>
     </node>
     <node visible="true" id="-192" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708258170399999" lon="73.5076676720499904">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-192"/>
     </node>
     <node visible="true" id="-191" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731049330399994" lon="73.5178002021000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-191"/>
     </node>
     <node visible="true" id="-190" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731381272499988" lon="73.5175567396299954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-190"/>
     </node>
     <node visible="true" id="-189" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710837274500001" lon="73.5076971598300020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-189"/>
     </node>
     <node visible="true" id="-188" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711382607399994" lon="73.5077110263100053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-188"/>
     </node>
     <node visible="true" id="-187" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731328430400003" lon="73.5174949893199994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-187"/>
     </node>
     <node visible="true" id="-186" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731686480399990" lon="73.5171794561500036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-186"/>
     </node>
     <node visible="true" id="-185" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705091691399980" lon="73.5070193877100024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-185"/>
     </node>
     <node visible="true" id="-184" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1697730107399993" lon="73.5081701471700057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-184"/>
     </node>
     <node visible="true" id="-183" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731800489799999" lon="73.5171561030000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-183"/>
     </node>
     <node visible="true" id="-182" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1697218446299988" lon="73.5087214305499970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-182"/>
     </node>
     <node visible="true" id="-181" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1697183887599989" lon="73.5087772937500006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-181"/>
     </node>
     <node visible="true" id="-180" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731978023799989" lon="73.5171449717600041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-180"/>
     </node>
     <node visible="true" id="-179" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1702535656499995" lon="73.5088289014299932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-179"/>
     </node>
     <node visible="true" id="-178" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732175231199982" lon="73.5075609713099993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-178"/>
     </node>
     <node visible="true" id="-177" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1732898380299996" lon="73.5075860266399985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-177"/>
     </node>
     <node visible="true" id="-176" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770725817700001" lon="73.5169136988999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-176"/>
     </node>
     <node visible="true" id="-175" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733952219299990" lon="73.5076549696899946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175"/>
     </node>
     <node visible="true" id="-174" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1770387011000008" lon="73.5169871762399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-174"/>
     </node>
     <node visible="true" id="-173" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737087278900002" lon="73.5077775419500057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-173"/>
     </node>
     <node visible="true" id="-172" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1769246798499990" lon="73.5172738721499996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-172"/>
     </node>
     <node visible="true" id="-171" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737490586300003" lon="73.5077561044600003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171"/>
     </node>
     <node visible="true" id="-170" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737648180999996" lon="73.5077364576399930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170"/>
     </node>
     <node visible="true" id="-169" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737688361299989" lon="73.5077056833099789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-169"/>
     </node>
     <node visible="true" id="-168" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738326616099988" lon="73.5075320376099910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-168"/>
     </node>
     <node visible="true" id="-167" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1738748472099996" lon="73.5073867566899963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-167"/>
     </node>
     <node visible="true" id="-166" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768848154599985" lon="73.5173512246499854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-166"/>
     </node>
     <node visible="true" id="-165" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1768509285899995" lon="73.5174278946399937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165"/>
     </node>
     <node visible="true" id="-164" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1698289706600002" lon="73.5075672083799958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-164"/>
     </node>
     <node visible="true" id="-163" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1767827223099987" lon="73.5176102035800056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-163"/>
     </node>
     <node visible="true" id="-162" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1702646706800000" lon="73.5076148477100020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-162"/>
     </node>
     <node visible="true" id="-161" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704483536199994" lon="73.5076321389800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-161"/>
     </node>
     <node visible="true" id="-160" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726785778699993" lon="73.5159663537600068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-160"/>
     </node>
     <node visible="true" id="-159" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685723660100011" lon="73.5049509082899846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-159"/>
     </node>
     <node visible="true" id="-158" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685898038099980" lon="73.5049585817500031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-158"/>
     </node>
     <node visible="true" id="-157" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726898828599994" lon="73.5159144916100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-157"/>
     </node>
     <node visible="true" id="-156" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1686085750400004" lon="73.5049618965900038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-156"/>
     </node>
     <node visible="true" id="-155" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726866653399997" lon="73.5158982725100003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-155"/>
     </node>
     <node visible="true" id="-154" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1689759669699988" lon="73.5049648277300065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-154"/>
     </node>
     <node visible="true" id="-153" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726731355199984" lon="73.5158775984999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153"/>
     </node>
     <node visible="true" id="-152" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693313635399996" lon="73.5049676187600056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-152"/>
     </node>
     <node visible="true" id="-151" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694234293999992" lon="73.5049683417799855">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-151"/>
     </node>
     <node visible="true" id="-150" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726518083399995" lon="73.5158650365499966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-150"/>
     </node>
     <node visible="true" id="-149" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714592817699989" lon="73.5157115166999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-149"/>
     </node>
     <node visible="true" id="-148" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685263193700006" lon="73.5015228367300040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-148"/>
     </node>
     <node visible="true" id="-147" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714836140299987" lon="73.5154881209199971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-147"/>
     </node>
     <node visible="true" id="-146" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685022554899991" lon="73.5016811207199936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-146"/>
     </node>
     <node visible="true" id="-145" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1684852142299995" lon="73.5018930031099984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-145"/>
     </node>
     <node visible="true" id="-144" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714951823299993" lon="73.5154586880599794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144"/>
     </node>
     <node visible="true" id="-143" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1684821379599990" lon="73.5028230565900031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-143"/>
     </node>
     <node visible="true" id="-142" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1684816997600000" lon="73.5029555102699987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-142"/>
     </node>
     <node visible="true" id="-141" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1684867643799999" lon="73.5031521176599938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-141"/>
     </node>
     <node visible="true" id="-140" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685131197299992" lon="73.5041752572700062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-140"/>
     </node>
     <node visible="true" id="-139" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685237194099996" lon="73.5044459048900052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-139"/>
     </node>
     <node visible="true" id="-138" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685422456999994" lon="73.5049189533300051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-138"/>
     </node>
     <node visible="true" id="-137" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726688582599998" lon="73.5160168208300036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-137"/>
     </node>
     <node visible="true" id="-136" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685529070699987" lon="73.5049346938799886">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136"/>
     </node>
     <node visible="true" id="-135" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728368862799989" lon="73.5149150500399884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-135"/>
     </node>
     <node visible="true" id="-134" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1693938201099998" lon="73.5031752177900017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-134"/>
     </node>
     <node visible="true" id="-133" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1779161284099988" lon="73.5162725155900034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-133"/>
     </node>
     <node visible="true" id="-132" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694679542300008" lon="73.5031883086300013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-132"/>
     </node>
     <node visible="true" id="-131" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1775758102899996" lon="73.5161741877400061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-131"/>
     </node>
     <node visible="true" id="-130" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774428705900002" lon="73.5161246644500039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-130"/>
     </node>
     <node visible="true" id="-129" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706653743099995" lon="73.5033217224099928">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-129"/>
     </node>
     <node visible="true" id="-128" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1715351769800000" lon="73.5034246629100068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-128"/>
     </node>
     <node visible="true" id="-127" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1774214940899999" lon="73.5161284934799824">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
     </node>
     <node visible="true" id="-126" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714598006200001" lon="73.5040544168300016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
     </node>
     <node visible="true" id="-125" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1773944150400002" lon="73.5161447089299998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-125"/>
     </node>
     <node visible="true" id="-124" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1689856052499996" lon="73.5044562756200008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
     </node>
     <node visible="true" id="-123" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1689986367299996" lon="73.5037686567700064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-123"/>
     </node>
     <node visible="true" id="-122" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726271003799988" lon="73.5158631880999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
     </node>
     <node visible="true" id="-121" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1690162291100012" lon="73.5031589917399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
     </node>
     <node visible="true" id="-120" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725588788300003" lon="73.5158494045899999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-120"/>
     </node>
     <node visible="true" id="-119" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1690253265199999" lon="73.5028437141399849">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-118" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725057770699987" lon="73.5158386758899951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-118"/>
     </node>
     <node visible="true" id="-117" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724275440299996" lon="73.5157968191700064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117"/>
     </node>
     <node visible="true" id="-116" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1690615493799994" lon="73.5011619599199832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-116"/>
     </node>
     <node visible="true" id="-115" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1724121580299984" lon="73.5157828614599964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-115"/>
     </node>
     <node visible="true" id="-114" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1722265395399987" lon="73.5157897661899966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114"/>
     </node>
     <node visible="true" id="-113" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694374576499991" lon="73.5015421646999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-113"/>
     </node>
     <node visible="true" id="-112" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725846025299997" lon="73.5156382854299864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
     </node>
     <node visible="true" id="-111" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726164563100010" lon="73.5156313799899976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-111"/>
     </node>
     <node visible="true" id="-110" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694047757300003" lon="73.5028586901899956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-110"/>
     </node>
     <node visible="true" id="-109" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727052555399995" lon="73.5153393410000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-109"/>
     </node>
     <node visible="true" id="-108" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727262584500000" lon="73.5152117241400020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-108"/>
     </node>
     <node visible="true" id="-107" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727803624200002" lon="73.5150759548200057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-107"/>
     </node>
     <node visible="true" id="-106" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1689550538999995" lon="73.5028501748799812">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-106"/>
     </node>
     <node visible="true" id="-105" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720531762400004" lon="73.5102645926199898">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105"/>
     </node>
     <node visible="true" id="-104" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719715302699987" lon="73.5102579173199899">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-104"/>
     </node>
     <node visible="true" id="-103" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1719167988799990" lon="73.5102384281800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-103"/>
     </node>
     <node visible="true" id="-102" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718541971399992" lon="73.5102270038400007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-102"/>
     </node>
     <node visible="true" id="-101" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717808025199989" lon="73.5102279116299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
     </node>
     <node visible="true" id="-100" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716788118399988" lon="73.5102234869000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-100"/>
     </node>
     <node visible="true" id="-99" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708622784399996" lon="73.5037464659799866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-99"/>
     </node>
     <node visible="true" id="-98" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708367043400010" lon="73.5039860939699992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-98"/>
     </node>
     <node visible="true" id="-97" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1707742589899999" lon="73.5045901437599980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-97"/>
     </node>
     <node visible="true" id="-96" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694380037099990" lon="73.5044429173399863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-96"/>
     </node>
     <node visible="true" id="-95" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1696957111499993" lon="73.5044747003699968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
     </node>
     <node visible="true" id="-94" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728889120499995" lon="73.5100092860500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
     </node>
     <node visible="true" id="-93" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725337623199987" lon="73.5115473041099960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
     </node>
     <node visible="true" id="-92" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725388781399984" lon="73.5115005857600039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
     </node>
     <node visible="true" id="-91" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1725577481700000" lon="73.5113282619699788">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-91"/>
     </node>
     <node visible="true" id="-90" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726385264799992" lon="73.5104861373999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-90"/>
     </node>
     <node visible="true" id="-89" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726606167399991" lon="73.5103142591499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-89"/>
     </node>
     <node visible="true" id="-88" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726872779299988" lon="73.5101068153999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-88"/>
     </node>
     <node visible="true" id="-87" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726977430399996" lon="73.5099985479299818">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
     <node visible="true" id="-86" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1689953816000003" lon="73.5007798695800005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
     <node visible="true" id="-85" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1689482849599990" lon="73.5007992547399880">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
     <node visible="true" id="-84" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1688595341199992" lon="73.5008489955299922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
     <node visible="true" id="-83" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1687799297700003" lon="73.5009122540199940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
     <node visible="true" id="-82" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1687442107699999" lon="73.5009484543499951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
     <node visible="true" id="-81" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1686820927399983" lon="73.5010288280600008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
     <node visible="true" id="-80" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716762070000000" lon="73.5163714912399939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1686337042499995" lon="73.5011180746299999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714016164799999" lon="73.5163394737000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1686150639599999" lon="73.5011653122499951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714092925599990" lon="73.5162279264099965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685741583300002" lon="73.5013058574299976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714294595099997" lon="73.5161118625200061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1685512600599992" lon="73.5013986783599904">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1714537617099996" lon="73.5158725131900042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1700456937599997" lon="73.5045176003000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1713872690699985" lon="73.5046603987599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1715849269199996" lon="73.5046840962299939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1726428187400000" lon="73.5047957338500026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1695511307300004" lon="73.5007084343900061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694555318699988" lon="73.5007147876600015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1694015216199993" lon="73.5007183770500063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1691438798000000" lon="73.5007450828900062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1690650154900002" lon="73.5007593675999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704859719099989" lon="73.5131246253699970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="-61" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704901738099993" lon="73.5131445834799990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
     <node visible="true" id="-60" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1704966462099993" lon="73.5131565948600070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
     <node visible="true" id="-59" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705110227399995" lon="73.5131711143300066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-58" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705229913499995" lon="73.5131777273099942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
     <node visible="true" id="-57" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705429695999987" lon="73.5131821897799966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-56" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705032563499991" lon="73.5125567848899948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705219357100001" lon="73.5125687462000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-54" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1705302137000002" lon="73.5125845018200010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
     <node visible="true" id="-53" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730354200599988" lon="73.5124188897499948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
     <node visible="true" id="-52" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730195512999986" lon="73.5121771854999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
     <node visible="true" id="-51" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729882569600001" lon="73.5115806781600014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
     <node visible="true" id="-50" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729787869199990" lon="73.5114443483600013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729509913199987" lon="73.5110195574300036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729447913800000" lon="73.5108721636299975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729370653399993" lon="73.5108148226299818">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-46" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729153549199989" lon="73.5104996240799977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
     <node visible="true" id="-45" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729162711100001" lon="73.5104218984800042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
     <node visible="true" id="-44" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711536604999999" lon="73.5132339621900002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
     <node visible="true" id="-43" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711722058299996" lon="73.5132226190799827">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
     <node visible="true" id="-42" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1713997185400000" lon="73.5132403825799940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
     <node visible="true" id="-41" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718436438099991" lon="73.5132597603599862">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
     <node visible="true" id="-40" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1720953336399997" lon="73.5132820721200062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
     <node visible="true" id="-39" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1723175403899990" lon="73.5133526221899842">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
     <node visible="true" id="-38" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727114443800000" lon="73.5133841911300010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
     <node visible="true" id="-37" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728439613099990" lon="73.5133965443600061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
     <node visible="true" id="-36" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730983516100002" lon="73.5134271443399996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731085069300002" lon="73.5135941558900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730615409900000" lon="73.5023504079100007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-33" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1729764563600007" lon="73.5023380911000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728946824599999" lon="73.5023329921399977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1728708370099996" lon="73.5023360854899863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1727745519999999" lon="73.5023494707999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718896783799995" lon="73.5022515319299998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718596386100000" lon="73.5022551930500043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1712555326600000" lon="73.5120253259800052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1711593002599994" lon="73.5127722377600037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710925669999996" lon="73.5135465633999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1710004255599991" lon="73.5142387447399983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1747260901899992" lon="73.5025448167200040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741249097199997" lon="73.5024803128599871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1741074550299988" lon="73.5024785548999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1737092243399996" lon="73.5024385534799904">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1735083060199987" lon="73.5024194041699985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1733188959399987" lon="73.5024013516899970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1731809806599998" lon="73.5023721458399990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1730777995899997" lon="73.5023598876499875">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716926415000000" lon="73.5031589710600031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1716842178200002" lon="73.5031661819199940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1709432137199993" lon="73.5030905524800033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708333708800005" lon="73.5030832408099997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1701157827399999" lon="73.5030003195000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1695064701000000" lon="73.5029364531900029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1702976411400003" lon="73.5094651186000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1706850264099993" lon="73.5095066408800051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1708787474299998" lon="73.5095274050599983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1703292862000003" lon="73.5125349892099962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718399741400001" lon="73.5022666626099976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718295938200001" lon="73.5022777696599974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1718178125999987" lon="73.5023055341599871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717375179199987" lon="73.5030839719999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717205287399990" lon="73.5031247058399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-979" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-840"/>
         <nd ref="-824"/>
         <nd ref="-823"/>
         <nd ref="-749"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Gulhazaaru Goalhi"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="300.2"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Gulhazaaru Goalhi"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-979"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="300.2"/>
     </way>
     <way visible="true" id="-947" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1050"/>
         <nd ref="-1022"/>
         <nd ref="-1018"/>
         <nd ref="-1024"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1119"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-947"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1119"/>
     </way>
     <way visible="true" id="-917" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-976"/>
@@ -4759,20 +3580,19 @@
         <nd ref="-985"/>
         <nd ref="-986"/>
         <nd ref="-987"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1701.6"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Fareedhee Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Fareedhee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:21.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-917"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1701.6"/>
     </way>
     <way visible="true" id="-878" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-930"/>
@@ -4815,19 +3635,18 @@
         <nd ref="-1072"/>
         <nd ref="-1071"/>
         <nd ref="-274"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Majeedhee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="30352.6"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Majeedhee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-09T14:42:24.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-878"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="30352.6"/>
     </way>
     <way visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-891"/>
@@ -4836,18 +3655,17 @@
         <nd ref="-901"/>
         <nd ref="-900"/>
         <nd ref="-899"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Roashanee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="141.5"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Roashanee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:31:39.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-862"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="141.5"/>
     </way>
     <way visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-663"/>
@@ -4855,20 +3673,19 @@
         <nd ref="-667"/>
         <nd ref="-669"/>
         <nd ref="-235"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="554.9"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-839"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="554.9"/>
     </way>
     <way visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-323"/>
@@ -4880,20 +3697,19 @@
         <nd ref="-663"/>
         <nd ref="-672"/>
         <nd ref="-319"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="557.8"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kandi Dhon Maniku Goalhi"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Kandi Dhon Maniku Goalhi"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-832"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="557.8"/>
     </way>
     <way visible="true" id="-766" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-560"/>
@@ -4908,19 +3724,18 @@
         <nd ref="-637"/>
         <nd ref="-635"/>
         <nd ref="-633"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kalhuhuraa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="334.9"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Kalhuhuraa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-766"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="334.9"/>
     </way>
     <way visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-521"/>
@@ -4934,18 +3749,17 @@
         <nd ref="-469"/>
         <nd ref="-501"/>
         <nd ref="-1098"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Violet Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="217.2"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Violet Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-751"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="217.2"/>
     </way>
     <way visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-466"/>
@@ -4967,37 +3781,35 @@
         <nd ref="-410"/>
         <nd ref="-409"/>
         <nd ref="-406"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kenery Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="413.6"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Kenery Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:46:42.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-720"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="413.6"/>
     </way>
     <way visible="true" id="-622" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-371"/>
         <nd ref="-372"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="134.4"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Jamaaludheen Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Jamaaludheen Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-622"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="134.4"/>
     </way>
     <way visible="true" id="-500" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-219"/>
@@ -5011,19 +3823,18 @@
         <nd ref="-751"/>
         <nd ref="-723"/>
         <nd ref="-671"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Maaveyo Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="761.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Maaveyo Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:31:29.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-500"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="761.4"/>
     </way>
     <way visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-167"/>
@@ -5043,38 +3854,36 @@
         <nd ref="-193"/>
         <nd ref="-195"/>
         <nd ref="-197"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="412.4"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Iskandharu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Iskandharu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-10-08T14:35:12.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-481"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="412.4"/>
     </way>
     <way visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
         <nd ref="-764"/>
         <nd ref="-763"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sabudheli Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="124.3"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Sabudheli Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-442"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="124.3"/>
     </way>
     <way visible="true" id="-432" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-767"/>
@@ -5083,36 +3892,34 @@
         <nd ref="-770"/>
         <nd ref="-762"/>
         <nd ref="-1159"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="100.5"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-432"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="100.5"/>
     </way>
     <way visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
         <nd ref="-1144"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="125.9"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-417"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="125.9"/>
     </way>
     <way visible="true" id="-408" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-368"/>
@@ -5124,20 +3931,19 @@
         <nd ref="-1124"/>
         <nd ref="-1093"/>
         <nd ref="-1050"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="559.2"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Chanbeylee Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Chanbeylee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:34:21.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-408"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="559.2"/>
     </way>
     <way visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
@@ -5145,19 +3951,18 @@
         <nd ref="-23"/>
         <nd ref="-320"/>
         <nd ref="-318"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sabudheli Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="156"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Sabudheli Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-370"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="156"/>
     </way>
     <way visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-31"/>
@@ -5175,55 +3980,52 @@
         <nd ref="-12"/>
         <nd ref="-11"/>
         <nd ref="-10"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1341.4"/>
         <tag k="sidewalk" v="both"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="foot" v="yes"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="name" v="Boduthakurufaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-02-17T19:01:33.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-363"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1341.4"/>
     </way>
     <way visible="true" id="-185" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1097"/>
         <nd ref="-1038"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Handhuvaree Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="67.6"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Handhuvaree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:21.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-185"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="67.6"/>
     </way>
     <way visible="true" id="-184" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1099"/>
         <nd ref="-1164"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="31.2"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-184"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="31.2"/>
     </way>
     <way visible="true" id="-183" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1102"/>
@@ -5232,38 +4034,36 @@
         <nd ref="-1161"/>
         <nd ref="-1160"/>
         <nd ref="-925"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Shaheed Ali Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="138.7"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Shaheed Ali Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-183"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="138.7"/>
     </way>
     <way visible="true" id="-182" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1159"/>
         <nd ref="-1158"/>
         <nd ref="-1157"/>
         <nd ref="-1156"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Muniyaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="413.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Muniyaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-182"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="413.8"/>
     </way>
     <way visible="true" id="-181" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-925"/>
@@ -5280,46 +4080,43 @@
         <nd ref="-1167"/>
         <nd ref="-1166"/>
         <nd ref="-1165"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Shaheed Ali Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1710.5"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Shaheed Ali Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-181"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1710.5"/>
     </way>
     <way visible="true" id="-180" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-898"/>
         <nd ref="-1145"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="125.9"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-180"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="125.9"/>
     </way>
     <way visible="true" id="-179" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-999"/>
         <nd ref="-1135"/>
         <nd ref="-1134"/>
-        <tag k="length" v="143.9"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-179"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="143.9"/>
     </way>
     <way visible="true" id="-178" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1037"/>
@@ -5331,11 +4128,10 @@
         <nd ref="-1118"/>
         <nd ref="-1117"/>
         <nd ref="-1078"/>
-        <tag k="length" v="657.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-178"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="657.6"/>
     </way>
     <way visible="true" id="-177" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-998"/>
@@ -5343,22 +4139,21 @@
         <nd ref="-1114"/>
         <nd ref="-1112"/>
         <nd ref="-952"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="458.4"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Lonuziyaaraiy Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Lonuziyaaraiy Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-03-09T18:17:04.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-177"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="458.4"/>
     </way>
     <way visible="true" id="-176" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1084"/>
@@ -5367,20 +4162,19 @@
         <nd ref="-1108"/>
         <nd ref="-1107"/>
         <nd ref="-1106"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="154.8"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-176"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="154.8"/>
     </way>
     <way visible="true" id="-174" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1082"/>
@@ -5389,19 +4183,18 @@
         <nd ref="-1099"/>
         <nd ref="-1097"/>
         <nd ref="-1096"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Fulooniyaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="890.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Fulooniyaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-174"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="890.8"/>
     </way>
     <way visible="true" id="-173" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1029"/>
@@ -5417,19 +4210,18 @@
         <nd ref="-1136"/>
         <nd ref="-1133"/>
         <nd ref="-1131"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Gandhakoalhi Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="838.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Gandhakoalhi Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:34:22.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-173"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="838.8"/>
     </way>
     <way visible="true" id="-172" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1088"/>
@@ -5444,40 +4236,38 @@
         <nd ref="-1129"/>
         <nd ref="-1130"/>
         <nd ref="-1132"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="643.5"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Buruzu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buruzu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-172"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="643.5"/>
     </way>
     <way visible="true" id="-171" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1024"/>
         <nd ref="-1089"/>
         <nd ref="-1086"/>
         <nd ref="-1041"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="22.9"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-171"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="22.9"/>
     </way>
     <way visible="true" id="-169" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-988"/>
@@ -5496,38 +4286,36 @@
         <nd ref="-989"/>
         <nd ref="-1066"/>
         <nd ref="-1064"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Orchid Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1785.3"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Orchid Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-169"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1785.3"/>
     </way>
     <way visible="true" id="-168" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-291"/>
         <nd ref="-1063"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="64.7"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Chandhanee Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Chandhanee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-10-08T02:06:40.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paving_stones"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-168"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="64.7"/>
     </way>
     <way visible="true" id="-167" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-995"/>
@@ -5540,11 +4328,10 @@
         <nd ref="-1055"/>
         <nd ref="-1054"/>
         <nd ref="-1053"/>
-        <tag k="length" v="188.2"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-167"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="188.2"/>
     </way>
     <way visible="true" id="-166" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1024"/>
@@ -5555,29 +4342,27 @@
         <nd ref="-1031"/>
         <nd ref="-1032"/>
         <nd ref="-1034"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1119"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-166"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1119"/>
     </way>
     <way visible="true" id="-165" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1022"/>
         <nd ref="-243"/>
-        <tag k="length" v="41.4"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="41.4"/>
     </way>
     <way visible="true" id="-164" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1070"/>
@@ -5592,30 +4377,28 @@
         <nd ref="-893"/>
         <nd ref="-1045"/>
         <nd ref="-1044"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Ameeru Ahmed Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1284"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Ameeru Ahmed Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-31T17:36:18.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-164"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1284"/>
     </way>
     <way visible="true" id="-163" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-959"/>
         <nd ref="-1043"/>
         <nd ref="-1053"/>
         <nd ref="-1040"/>
-        <tag k="length" v="191.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-163"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="191.6"/>
     </way>
     <way visible="true" id="-162" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1048"/>
@@ -5627,36 +4410,34 @@
         <nd ref="-1056"/>
         <nd ref="-1058"/>
         <nd ref="-1060"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="685.2"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Medhuziyaarai Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Medhuziyaarai Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-162"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="685.2"/>
     </way>
     <way visible="true" id="-161" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1018"/>
         <nd ref="-247"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Bandharumathee Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="43.0"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Bandharumathee Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-161"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="43.0"/>
     </way>
     <way visible="true" id="-160" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-975"/>
@@ -5666,22 +4447,21 @@
         <nd ref="-1002"/>
         <nd ref="-999"/>
         <nd ref="-998"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="597"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Lonuziyaaraiy Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Lonuziyaaraiy Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-03-09T18:17:04.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-160"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="597"/>
     </way>
     <way visible="true" id="-159" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-987"/>
@@ -5689,20 +4469,19 @@
         <nd ref="-1015"/>
         <nd ref="-1017"/>
         <nd ref="-938"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1134.4"/>
-        <tag k="source:imagery" v="Unknown;DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Fareedhee Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Fareedhee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="Unknown;DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:46:42.000Z;2015-10-22T17:25:21.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-159"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1134.4"/>
     </way>
     <way visible="true" id="-158" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1114"/>
@@ -5730,20 +4509,19 @@
         <nd ref="-949"/>
         <nd ref="-1014"/>
         <nd ref="-950"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="source" v="DigitalGlobe"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="353.7"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Hithigas Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Hithigas Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2011-08-06T19:57:25.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-158"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="353.7"/>
     </way>
     <way visible="true" id="-157" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-968"/>
@@ -5758,37 +4536,35 @@
         <nd ref="-952"/>
         <nd ref="-951"/>
         <nd ref="-950"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Ameenee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="1918.7"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Ameenee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:57:44.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-157"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1918.7"/>
     </way>
     <way visible="true" id="-156" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-949"/>
         <nd ref="-948"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="source" v="DigitalGlobe"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="87.3"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Hithigas Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Hithigas Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2011-08-06T19:57:25.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-156"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="87.3"/>
     </way>
     <way visible="true" id="-155" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-96"/>
@@ -5823,22 +4599,21 @@
         <nd ref="-968"/>
         <nd ref="-947"/>
         <nd ref="-946"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="12922.2"/>
         <tag k="sidewalk" v="both"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="foot" v="yes"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="name" v="Boduthakurufaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-02-17T19:01:33.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-155"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="12922.2"/>
     </way>
     <way visible="true" id="-154" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-898"/>
@@ -5860,19 +4635,18 @@
         <nd ref="-882"/>
         <nd ref="-881"/>
         <nd ref="-930"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="251.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-154"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="251.8"/>
     </way>
     <way visible="true" id="-153" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-893"/>
@@ -5887,53 +4661,50 @@
         <nd ref="-1101"/>
         <nd ref="-1100"/>
         <nd ref="-1098"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sosun Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="225"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Sosun Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-153"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="225"/>
     </way>
     <way visible="true" id="-152" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-895"/>
         <nd ref="-894"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Naadhee Goalhi"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="54.7"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Naadhee Goalhi"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-152"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="54.7"/>
     </way>
     <way visible="true" id="-150" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-201"/>
         <nd ref="-228"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Riyaasee Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="35.1"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Riyaasee Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-150"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="35.1"/>
     </way>
     <way visible="true" id="-149" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-297"/>
@@ -5941,23 +4712,22 @@
         <nd ref="-873"/>
         <nd ref="-874"/>
         <nd ref="-92"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="69.1"/>
-        <tag k="horse" v="no"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="maxspeed" v="25"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Raadhafathi Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="source:datetime" v="2015-02-02T09:34:55.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
+        <tag k="horse" v="no"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Raadhafathi Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-02-02T09:34:55.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-149"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="69.1"/>
     </way>
     <way visible="true" id="-148" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1176"/>
@@ -5971,19 +4741,18 @@
         <nd ref="-871"/>
         <nd ref="-870"/>
         <nd ref="-941"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Alivilaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="238.2"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Alivilaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-148"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="238.2"/>
     </way>
     <way visible="true" id="-147" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-763"/>
@@ -5994,19 +4763,18 @@
         <nd ref="-857"/>
         <nd ref="-238"/>
         <nd ref="-828"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Handhuvaree Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="263.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Handhuvaree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:21.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-147"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="263.4"/>
     </way>
     <way visible="true" id="-146" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-217"/>
@@ -6018,28 +4786,26 @@
         <nd ref="-864"/>
         <nd ref="-863"/>
         <nd ref="-1141"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Handhuvaree Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="182.9"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Handhuvaree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:21.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-146"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="182.9"/>
     </way>
     <way visible="true" id="-145" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-862"/>
         <nd ref="-772"/>
-        <tag k="length" v="66.5"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-145"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="66.5"/>
     </way>
     <way visible="true" id="-144" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-987"/>
@@ -6048,19 +4814,18 @@
         <nd ref="-831"/>
         <nd ref="-849"/>
         <nd ref="-935"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Fandiyaaru magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="132.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Fandiyaaru magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2012-10-12T05:34:21.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-144"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="132.8"/>
     </way>
     <way visible="true" id="-143" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1099"/>
@@ -6071,18 +4836,17 @@
         <nd ref="-835"/>
         <nd ref="-834"/>
         <nd ref="-1157"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="68.4"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-143"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="68.4"/>
     </way>
     <way visible="true" id="-142" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-21"/>
@@ -6093,38 +4857,36 @@
         <nd ref="-830"/>
         <nd ref="-829"/>
         <nd ref="-828"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buluekiyaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="617.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Buluekiyaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-142"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="617.4"/>
     </way>
     <way visible="true" id="-141" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-828"/>
         <nd ref="-827"/>
         <nd ref="-826"/>
         <nd ref="-825"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Dhakandhaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="62.9"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Dhakandhaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-141"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="62.9"/>
     </way>
     <way visible="true" id="-140" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-19"/>
@@ -6139,19 +4901,18 @@
         <nd ref="-842"/>
         <nd ref="-841"/>
         <nd ref="-840"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Muranga Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="900.6"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Muranga Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-140"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="900.6"/>
     </way>
     <way visible="true" id="-139" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-822"/>
@@ -6159,64 +4920,60 @@
         <nd ref="-782"/>
         <nd ref="-820"/>
         <nd ref="-487"/>
-        <tag k="length" v="217.2"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-139"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="217.2"/>
     </way>
     <way visible="true" id="-138" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-822"/>
         <nd ref="-819"/>
         <nd ref="-467"/>
         <nd ref="-818"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Rah Dhebai Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="83.6"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Rah Dhebai Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:54.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-138"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="83.6"/>
     </way>
     <way visible="true" id="-137" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-763"/>
         <nd ref="-802"/>
         <nd ref="-801"/>
         <nd ref="-313"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="68.4"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-137"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="68.4"/>
     </way>
     <way visible="true" id="-136" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1176"/>
         <nd ref="-815"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Iramaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="68.0"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Iramaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-136"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="68.0"/>
     </way>
     <way visible="true" id="-135" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-560"/>
@@ -6227,46 +4984,43 @@
         <nd ref="-810"/>
         <nd ref="-809"/>
         <nd ref="-904"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Husnuheenaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="128.1"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Husnuheenaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-135"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="128.1"/>
     </way>
     <way visible="true" id="-134" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1106"/>
         <nd ref="-1159"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="100.5"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-134"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="100.5"/>
     </way>
     <way visible="true" id="-132" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-807"/>
         <nd ref="-152"/>
-        <tag k="length" v="55.8"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-132"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="55.8"/>
     </way>
     <way visible="true" id="-131" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-924"/>
@@ -6274,18 +5028,17 @@
         <nd ref="-804"/>
         <nd ref="-803"/>
         <nd ref="-763"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="137.6"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-131"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="137.6"/>
     </way>
     <way visible="true" id="-130" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-372"/>
@@ -6304,20 +5057,19 @@
         <nd ref="-793"/>
         <nd ref="-794"/>
         <nd ref="-910"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="623.8"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Nikagas Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Nikagas Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-130"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="623.8"/>
     </way>
     <way visible="true" id="-129" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-67"/>
@@ -6327,70 +5079,65 @@
         <nd ref="-783"/>
         <nd ref="-132"/>
         <nd ref="-96"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="length" v="1242.3"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="sidewalk" v="both"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2015-02-17T19:01:33.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source" v="DigitalGlobe"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-129"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="name" v="Boduthakurufaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-02-17T19:01:33.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1242.3"/>
     </way>
     <way visible="true" id="-128" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-921"/>
         <nd ref="-796"/>
         <nd ref="-185"/>
         <nd ref="-1155"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="528.2"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Maafaithakurufaanu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Maafaithakurufaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-02-17T19:01:34.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-128"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="528.2"/>
     </way>
     <way visible="true" id="-127" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-251"/>
         <nd ref="-1028"/>
-        <tag k="length" v="44.5"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="44.5"/>
     </way>
     <way visible="true" id="-126" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-808"/>
         <nd ref="-470"/>
         <nd ref="-795"/>
-        <tag k="length" v="67.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="67.6"/>
     </way>
     <way visible="true" id="-124" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-782"/>
         <nd ref="-781"/>
-        <tag k="length" v="50.3"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="50.3"/>
     </way>
     <way visible="true" id="-123" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-268"/>
@@ -6404,37 +5151,34 @@
         <nd ref="-776"/>
         <nd ref="-775"/>
         <nd ref="-962"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Falhumathee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1944.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Falhumathee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-123"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1944.4"/>
     </way>
     <way visible="true" id="-122" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-743"/>
         <nd ref="-963"/>
-        <tag k="length" v="26.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="26.6"/>
     </way>
     <way visible="true" id="-121" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-745"/>
         <nd ref="-965"/>
-        <tag k="length" v="53.9"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="53.9"/>
     </way>
     <way visible="true" id="-120" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-66"/>
@@ -6443,22 +5187,21 @@
         <nd ref="-110"/>
         <nd ref="-773"/>
         <nd ref="-132"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="833.4"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="sidewalk" v="both"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu Magu"/>
         <tag k="foot" v="yes"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="source:datetime" v="2015-02-17T19:01:33.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source" v="DigitalGlobe"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-120"/>
+        <tag k="highway" v="primary"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-02-17T19:01:33.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="833.4"/>
     </way>
     <way visible="true" id="-119" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1034"/>
@@ -6469,20 +5212,19 @@
         <nd ref="-779"/>
         <nd ref="-780"/>
         <nd ref="-930"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="source" v="DigitalGlobe"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="373.0"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-119"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="373.0"/>
     </way>
     <way visible="true" id="-117" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-749"/>
@@ -6493,99 +5235,93 @@
         <nd ref="-759"/>
         <nd ref="-758"/>
         <nd ref="-671"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Muiveyo Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="195.7"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Muiveyo Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-117"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="195.7"/>
     </way>
     <way visible="true" id="-116" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-197"/>
         <nd ref="-757"/>
         <nd ref="-756"/>
         <nd ref="-755"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Badifasgandu Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="58.5"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Badifasgandu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:31:28.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-116"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="58.5"/>
     </way>
     <way visible="true" id="-115" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1139"/>
         <nd ref="-722"/>
         <nd ref="-219"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Koarukendi Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="253.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Koarukendi Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-115"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="253.8"/>
     </way>
     <way visible="true" id="-114" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-335"/>
         <nd ref="-1138"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Badifasganu Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="67.5"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Badifasganu Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:31:29.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-114"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="67.5"/>
     </way>
     <way visible="true" id="-113" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-750"/>
         <nd ref="-938"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="31.4"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Ruvaa Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Ruvaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:31:29.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-113"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="31.4"/>
     </way>
     <way visible="true" id="-112" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1008"/>
         <nd ref="-986"/>
-        <tag k="length" v="23.4"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="23.4"/>
     </way>
     <way visible="true" id="-111" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-189"/>
@@ -6594,19 +5330,18 @@
         <nd ref="-739"/>
         <nd ref="-738"/>
         <nd ref="-1152"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Thabureyzee Higun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="133.1"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Thabureyzee Higun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:59:00.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-111"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="133.1"/>
     </way>
     <way visible="true" id="-110" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-671"/>
@@ -6631,56 +5366,53 @@
         <nd ref="-725"/>
         <nd ref="-724"/>
         <nd ref="-723"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Badifasgandu Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="168.8"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Badifasgandu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:31:28.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-110"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="168.8"/>
     </way>
     <way visible="true" id="-109" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1155"/>
         <nd ref="-333"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="68.2"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Maafaithakurufaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Maafaithakurufaanu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-02-17T19:01:34.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-109"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="68.2"/>
     </way>
     <way visible="true" id="-108" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-615"/>
         <nd ref="-712"/>
         <nd ref="-710"/>
         <nd ref="-707"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Filigas Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="62.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Filigas Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-108"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="62.8"/>
     </way>
     <way visible="true" id="-107" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-521"/>
@@ -6688,37 +5420,35 @@
         <nd ref="-701"/>
         <nd ref="-700"/>
         <nd ref="-707"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Violet Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="148.6"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Violet Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-107"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="148.6"/>
     </way>
     <way visible="true" id="-105" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-707"/>
         <nd ref="-697"/>
         <nd ref="-696"/>
         <nd ref="-1074"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Filigas Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="117.3"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Filigas Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-105"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="117.3"/>
     </way>
     <way visible="true" id="-104" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-448"/>
@@ -6729,18 +5459,17 @@
         <nd ref="-683"/>
         <nd ref="-679"/>
         <nd ref="-615"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Roashanee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="83.0"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Roashanee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:31:39.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-104"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="83.0"/>
     </way>
     <way visible="true" id="-103" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-669"/>
@@ -6751,47 +5480,44 @@
         <nd ref="-1047"/>
         <nd ref="-1049"/>
         <nd ref="-1050"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1258.5"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-103"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1258.5"/>
     </way>
     <way visible="true" id="-101" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-237"/>
         <nd ref="-694"/>
-        <tag k="length" v="41.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="41.6"/>
     </way>
     <way visible="true" id="-100" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-615"/>
         <nd ref="-668"/>
         <nd ref="-666"/>
         <nd ref="-664"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Roashanee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="45.2"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Roashanee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:31:39.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-100"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="45.2"/>
     </way>
     <way visible="true" id="-99" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-636"/>
@@ -6800,38 +5526,36 @@
         <nd ref="-656"/>
         <nd ref="-655"/>
         <nd ref="-653"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Neeloafaru Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="269.6"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Neeloafaru Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-99"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="269.6"/>
     </way>
     <way visible="true" id="-98" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-655"/>
         <nd ref="-651"/>
         <nd ref="-650"/>
         <nd ref="-595"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Daisy Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="132.0"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Daisy Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-98"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="132.0"/>
     </way>
     <way visible="true" id="-97" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-633"/>
@@ -6843,19 +5567,18 @@
         <nd ref="-654"/>
         <nd ref="-652"/>
         <nd ref="-649"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Abadhah Fehi Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="175.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Abadhah Fehi Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:55:00.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-97"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="175.4"/>
     </way>
     <way visible="true" id="-96" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-560"/>
@@ -6871,22 +5594,21 @@
         <nd ref="-542"/>
         <nd ref="-543"/>
         <nd ref="-544"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="334.9"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Alikilegefaanu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Alikilegefaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-96"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="334.9"/>
     </way>
     <way visible="true" id="-95" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-908"/>
@@ -6903,18 +5625,17 @@
         <nd ref="-631"/>
         <nd ref="-630"/>
         <nd ref="-628"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Rah Dhebai Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="411.6"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Rah Dhebai Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:54.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-95"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="411.6"/>
     </way>
     <way visible="true" id="-94" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-160"/>
@@ -6922,11 +5643,10 @@
         <nd ref="-625"/>
         <nd ref="-623"/>
         <nd ref="-1076"/>
-        <tag k="length" v="207.7"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="207.7"/>
     </way>
     <way visible="true" id="-93" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-38"/>
@@ -6939,11 +5659,10 @@
         <nd ref="-596"/>
         <nd ref="-624"/>
         <nd ref="-53"/>
-        <tag k="length" v="133.3"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="133.3"/>
     </way>
     <way visible="true" id="-92" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1094"/>
@@ -6952,11 +5671,10 @@
         <nd ref="-616"/>
         <nd ref="-614"/>
         <nd ref="-995"/>
-        <tag k="length" v="69.2"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="69.2"/>
     </way>
     <way visible="true" id="-91" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-396"/>
@@ -6966,19 +5684,18 @@
         <nd ref="-619"/>
         <nd ref="-617"/>
         <nd ref="-615"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Filigas Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="262.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Filigas Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-91"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="262.4"/>
     </way>
     <way visible="true" id="-90" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1098"/>
@@ -6988,19 +5705,18 @@
         <nd ref="-608"/>
         <nd ref="-427"/>
         <nd ref="-1080"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sosun Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="485.7"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Sosun Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-90"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="485.7"/>
     </way>
     <way visible="true" id="-89" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1080"/>
@@ -7013,19 +5729,18 @@
         <nd ref="-598"/>
         <nd ref="-597"/>
         <nd ref="-1118"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sosun Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="238"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Sosun Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:24.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-89"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="238"/>
     </way>
     <way visible="true" id="-88" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-577"/>
@@ -7036,31 +5751,29 @@
         <nd ref="-544"/>
         <nd ref="-593"/>
         <nd ref="-592"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="723.9"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Lily Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="unclassified"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Lily Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-10-07T20:39:52.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-88"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="723.9"/>
     </way>
     <way visible="true" id="-87" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-999"/>
         <nd ref="-591"/>
         <nd ref="-590"/>
         <nd ref="-1037"/>
-        <tag k="length" v="68.9"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="68.9"/>
     </way>
     <way visible="true" id="-86" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-49"/>
@@ -7078,11 +5791,10 @@
         <nd ref="-486"/>
         <nd ref="-585"/>
         <nd ref="-906"/>
-        <tag k="length" v="473.8"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="473.8"/>
     </way>
     <way visible="true" id="-85" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-50"/>
@@ -7094,22 +5806,21 @@
         <nd ref="-583"/>
         <nd ref="-584"/>
         <nd ref="-905"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="228.2"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Alikilegefaanu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Alikilegefaanu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-85"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="228.2"/>
     </way>
     <way visible="true" id="-84" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1056"/>
@@ -7133,18 +5844,17 @@
         <nd ref="-431"/>
         <nd ref="-430"/>
         <nd ref="-421"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Hithaffinivaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="685"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Hithaffinivaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:41:15.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-84"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="685"/>
     </way>
     <way visible="true" id="-83" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-540"/>
@@ -7154,103 +5864,97 @@
         <nd ref="-562"/>
         <nd ref="-561"/>
         <nd ref="-560"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Husnuheenaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="231.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Husnuheenaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:51:53.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-83"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="231.4"/>
     </way>
     <way visible="true" id="-81" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-588"/>
         <nd ref="-549"/>
         <nd ref="-548"/>
         <nd ref="-546"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Karankaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="85.9"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Karankaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:55:00.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-81"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="85.9"/>
     </way>
     <way visible="true" id="-80" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-514"/>
         <nd ref="-976"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="48.2"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Medhuziyaarai Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Medhuziyaarai Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-80"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="48.2"/>
     </way>
     <way visible="true" id="-79" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-979"/>
         <nd ref="-512"/>
         <nd ref="-991"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="103.7"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Faamdheyri Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Faamdheyri Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:37:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-79"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="103.7"/>
     </way>
     <way visible="true" id="-78" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-932"/>
         <nd ref="-510"/>
         <nd ref="-509"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kaaminee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="94.7"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Kaaminee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:53:28.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-78"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="94.7"/>
     </way>
     <way visible="true" id="-77" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-504"/>
         <nd ref="-468"/>
         <nd ref="-467"/>
-        <tag k="length" v="55.7"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="55.7"/>
     </way>
     <way visible="true" id="-76" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-423"/>
@@ -7264,29 +5968,27 @@
         <nd ref="-528"/>
         <nd ref="-525"/>
         <nd ref="-521"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Thandiraiymaa Goalhi"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="217.2"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Thandiraiymaa Goalhi"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-76"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="217.2"/>
     </way>
     <way visible="true" id="-75" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-405"/>
         <nd ref="-497"/>
         <nd ref="-494"/>
         <nd ref="-493"/>
-        <tag k="length" v="31.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="31.6"/>
     </way>
     <way visible="true" id="-74" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-909"/>
@@ -7320,11 +6022,10 @@
         <nd ref="-472"/>
         <nd ref="-471"/>
         <nd ref="-470"/>
-        <tag k="length" v="627"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="627"/>
     </way>
     <way visible="true" id="-73" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-237"/>
@@ -7381,19 +6082,18 @@
         <nd ref="-191"/>
         <nd ref="-343"/>
         <nd ref="-342"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="18177.6"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-09T14:42:23.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-73"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="18177.6"/>
     </way>
     <way visible="true" id="-72" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-438"/>
@@ -7409,20 +6109,19 @@
         <nd ref="-364"/>
         <nd ref="-366"/>
         <nd ref="-940"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="378.1"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe;Bing"/>
-        <tag k="name" v="Shaariu Varudhee"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Shaariu Varudhee"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:34:21.000Z;2014-11-28T17:34:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-72"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="378.1"/>
     </way>
     <way visible="true" id="-71" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-408"/>
@@ -7432,30 +6131,28 @@
         <nd ref="-403"/>
         <nd ref="-401"/>
         <nd ref="-1037"/>
-        <tag k="length" v="265"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="265"/>
     </way>
     <way visible="true" id="-68" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-427"/>
         <nd ref="-426"/>
         <nd ref="-424"/>
         <nd ref="-423"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Abadhah Ufaa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="73.6"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Abadhah Ufaa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-68"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="73.6"/>
     </way>
     <way visible="true" id="-67" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1064"/>
@@ -7505,21 +6202,20 @@
         <nd ref="-393"/>
         <nd ref="-395"/>
         <nd ref="-377"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="2281.7"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Chandhanee Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Chandhanee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-10-08T02:06:40.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paving_stones"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-67"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="2281.7"/>
     </way>
     <way visible="true" id="-65" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1040"/>
@@ -7539,29 +6235,27 @@
         <nd ref="-420"/>
         <nd ref="-417"/>
         <nd ref="-998"/>
-        <tag k="length" v="530.7"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="530.7"/>
     </way>
     <way visible="true" id="-64" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-968"/>
         <nd ref="-412"/>
         <nd ref="-461"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Ameenee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="1474.7"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Ameenee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:57:44.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-64"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1474.7"/>
     </way>
     <way visible="true" id="-63" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-934"/>
@@ -7573,37 +6267,35 @@
         <nd ref="-399"/>
         <nd ref="-434"/>
         <nd ref="-432"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Champa Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="608.8"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Champa Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:46:43.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-63"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="608.8"/>
     </way>
     <way visible="true" id="-62" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1152"/>
         <nd ref="-398"/>
         <nd ref="-397"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Nikagas Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="45.1"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Nikagas Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-62"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="45.1"/>
     </way>
     <way visible="true" id="-61" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1129"/>
@@ -7614,22 +6306,21 @@
         <nd ref="-300"/>
         <nd ref="-302"/>
         <nd ref="-105"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="404.4"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Buruzu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buruzu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-61"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="404.4"/>
     </way>
     <way visible="true" id="-60" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-378"/>
@@ -7637,37 +6328,35 @@
         <nd ref="-375"/>
         <nd ref="-374"/>
         <nd ref="-372"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="403.2"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Iskandharu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Iskandharu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-10-08T14:35:12.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-60"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="403.2"/>
     </way>
     <way visible="true" id="-59" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-328"/>
         <nd ref="-375"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Nikagas Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="35.2"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Nikagas Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-59"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="35.2"/>
     </way>
     <way visible="true" id="-57" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-948"/>
@@ -7676,19 +6365,18 @@
         <nd ref="-360"/>
         <nd ref="-359"/>
         <nd ref="-342"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="17.6"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-09T14:42:23.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="primary"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-57"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="17.6"/>
     </way>
     <way visible="true" id="-55" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-252"/>
@@ -7699,19 +6387,18 @@
         <nd ref="-241"/>
         <nd ref="-239"/>
         <nd ref="-237"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="7586"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-09T14:42:23.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-55"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="7586"/>
     </way>
     <way visible="true" id="-54" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-345"/>
@@ -7719,20 +6406,19 @@
         <nd ref="-348"/>
         <nd ref="-349"/>
         <nd ref="-393"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="85.0"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Joashee Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Joashee Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:53:28.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-54"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="85.0"/>
     </way>
     <way visible="true" id="-52" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-105"/>
@@ -7745,33 +6431,31 @@
         <nd ref="-335"/>
         <nd ref="-337"/>
         <nd ref="-219"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1908"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Buruzu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buruzu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-52"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1908"/>
     </way>
     <way visible="true" id="-50" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-876"/>
         <nd ref="-316"/>
         <nd ref="-315"/>
         <nd ref="-20"/>
-        <tag k="length" v="147.0"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="147.0"/>
     </way>
     <way visible="true" id="-49" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-313"/>
@@ -7779,18 +6463,17 @@
         <nd ref="-311"/>
         <nd ref="-309"/>
         <nd ref="-1142"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="411"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-49"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="411"/>
     </way>
     <way visible="true" id="-48" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-7"/>
@@ -7803,29 +6486,26 @@
         <nd ref="-286"/>
         <nd ref="-306"/>
         <nd ref="-27"/>
-        <tag k="length" v="1021.2"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="1021.2"/>
     </way>
     <way visible="true" id="-47" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1147"/>
         <nd ref="-292"/>
-        <tag k="length" v="72.9"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="72.9"/>
     </way>
     <way visible="true" id="-46" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-324"/>
         <nd ref="-322"/>
-        <tag k="length" v="67.3"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="67.3"/>
     </way>
     <way visible="true" id="-45" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-915"/>
@@ -7837,49 +6517,46 @@
         <nd ref="-261"/>
         <nd ref="-255"/>
         <nd ref="-8"/>
-        <tag k="length" v="663.9"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="663.9"/>
     </way>
     <way visible="true" id="-44" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-184"/>
         <nd ref="-916"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Hudhufalhu Goalhi"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="43.9"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Hudhufalhu Goalhi"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-44"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="43.9"/>
     </way>
     <way visible="true" id="-43" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-31"/>
         <nd ref="-278"/>
         <nd ref="-280"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="73.3"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Buruzu Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buruzu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-43"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="73.3"/>
     </way>
     <way visible="true" id="-42" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-260"/>
@@ -7895,11 +6572,10 @@
         <nd ref="-279"/>
         <nd ref="-277"/>
         <nd ref="-1072"/>
-        <tag k="length" v="142.7"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="142.7"/>
     </way>
     <way visible="true" id="-40" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-191"/>
@@ -7912,11 +6588,10 @@
         <nd ref="-264"/>
         <nd ref="-263"/>
         <nd ref="-262"/>
-        <tag k="length" v="108.0"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="108.0"/>
     </way>
     <way visible="true" id="-39" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-217"/>
@@ -7929,37 +6604,35 @@
         <nd ref="-244"/>
         <nd ref="-242"/>
         <nd ref="-240"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Naseemee Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="189.9"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Naseemee Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-39"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="189.9"/>
     </way>
     <way visible="true" id="-38" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-238"/>
         <nd ref="-236"/>
         <nd ref="-234"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Miriyas Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="137.6"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Miriyas Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-38"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="137.6"/>
     </way>
     <way visible="true" id="-37" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-219"/>
@@ -7981,22 +6654,21 @@
         <nd ref="-275"/>
         <nd ref="-276"/>
         <nd ref="-31"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1647.6"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Buruzu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buruzu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-37"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1647.6"/>
     </way>
     <way visible="true" id="-36" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-271"/>
@@ -8006,11 +6678,10 @@
         <nd ref="-224"/>
         <nd ref="-220"/>
         <nd ref="-218"/>
-        <tag k="length" v="86.2"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="86.2"/>
     </way>
     <way visible="true" id="-35" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-211"/>
@@ -8025,20 +6696,19 @@
         <nd ref="-127"/>
         <nd ref="-130"/>
         <nd ref="-1044"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="102.2"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Meheli Goalhi"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Meheli Goalhi"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-35"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="102.2"/>
     </way>
     <way visible="true" id="-34" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-899"/>
@@ -8048,53 +6718,50 @@
         <nd ref="-1044"/>
         <nd ref="-131"/>
         <nd ref="-133"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="141"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kasthoori Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Kasthoori Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-34"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="141"/>
     </way>
     <way visible="true" id="-33" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-98"/>
         <nd ref="-205"/>
         <nd ref="-126"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Handhuvaree Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="69.8"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Handhuvaree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:46:42.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-33"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="69.8"/>
     </way>
     <way visible="true" id="-32" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-126"/>
         <nd ref="-1141"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Handhuvaree Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="71.3"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Handhuvaree Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:46:42.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-32"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="71.3"/>
     </way>
     <way visible="true" id="-31" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-919"/>
@@ -8105,47 +6772,44 @@
         <nd ref="-189"/>
         <nd ref="-188"/>
         <nd ref="-1153"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Vaidheri Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1032.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Vaidheri Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-02-17T19:01:34.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-31"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1032.4"/>
     </way>
     <way visible="true" id="-30" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-185"/>
         <nd ref="-161"/>
-        <tag k="length" v="68.4"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="68.4"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-164"/>
         <nd ref="-184"/>
         <nd ref="-182"/>
         <nd ref="-181"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Hudhufalhu Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="269.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Hudhufalhu Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2015-02-17T19:01:34.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="269.8"/>
     </way>
     <way visible="true" id="-28" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-202"/>
@@ -8153,20 +6817,19 @@
         <nd ref="-199"/>
         <nd ref="-198"/>
         <nd ref="-197"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="1237.2"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Iskandharu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Iskandharu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-10-08T14:35:12.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-28"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1237.2"/>
     </way>
     <way visible="true" id="-27" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-163"/>
@@ -8176,20 +6839,19 @@
         <nd ref="-174"/>
         <nd ref="-176"/>
         <nd ref="-211"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="102.2"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Meheli Goalhi"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Meheli Goalhi"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:58:16.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-27"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="102.2"/>
     </way>
     <way visible="true" id="-26" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-67"/>
@@ -8220,22 +6882,20 @@
         <nd ref="-159"/>
         <nd ref="-158"/>
         <nd ref="-156"/>
-        <tag k="length" v="3865.4"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="3865.4"/>
     </way>
     <way visible="true" id="-25" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-156"/>
         <nd ref="-154"/>
         <nd ref="-152"/>
         <nd ref="-151"/>
-        <tag k="length" v="272.1"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="272.1"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-954"/>
@@ -8248,32 +6908,30 @@
         <nd ref="-147"/>
         <nd ref="-144"/>
         <nd ref="-1088"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="403.5"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="fiЯas 16042011"/>
-        <tag k="name" v="Buruzu Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Buruzu Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:20.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-24"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="403.5"/>
     </way>
     <way visible="true" id="-23" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-143"/>
         <nd ref="-106"/>
         <nd ref="-119"/>
-        <tag k="length" v="60.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="60.6"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-120"/>
@@ -8284,11 +6942,10 @@
         <nd ref="-107"/>
         <nd ref="-135"/>
         <nd ref="-1035"/>
-        <tag k="length" v="283.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="283.6"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-141"/>
@@ -8298,36 +6955,34 @@
         <nd ref="-129"/>
         <nd ref="-128"/>
         <nd ref="-1142"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Izzuddeen Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="822.2"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Izzuddeen Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:06:43.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="822.2"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-128"/>
         <nd ref="-126"/>
         <nd ref="-70"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Ujaalaa Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="276.4"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Ujaalaa Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="276.4"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-154"/>
@@ -8337,29 +6992,26 @@
         <nd ref="-119"/>
         <nd ref="-116"/>
         <nd ref="-63"/>
-        <tag k="length" v="1868"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="1868"/>
     </way>
     <way visible="true" id="-14" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-148"/>
         <nd ref="-113"/>
-        <tag k="length" v="101.5"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="101.5"/>
     </way>
     <way visible="true" id="-13" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-110"/>
         <nd ref="-119"/>
-        <tag k="length" v="42.3"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="42.3"/>
     </way>
     <way visible="true" id="-12" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1149"/>
@@ -8370,41 +7022,39 @@
         <nd ref="-104"/>
         <nd ref="-105"/>
         <nd ref="-89"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="273"/>
-        <tag k="horse" v="no"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="maxspeed" v="25"/>
-        <tag k="source:imagery" v="Unknown"/>
-        <tag k="name" v="Siththi Maavaa Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="source:datetime" v="2015-02-02T09:25:36.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
+        <tag k="horse" v="no"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Siththi Maavaa Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="Unknown"/>
+        <tag k="source:datetime" v="2015-02-02T09:25:36.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-12"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="273"/>
     </way>
     <way visible="true" id="-11" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-13"/>
         <nd ref="-99"/>
         <nd ref="-98"/>
         <nd ref="-97"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Aazaadhee Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="335.2"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Aazaadhee Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="335.2"/>
     </way>
     <way visible="true" id="-10" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-493"/>
@@ -8420,32 +7070,30 @@
         <nd ref="-46"/>
         <nd ref="-45"/>
         <nd ref="-94"/>
-        <tag k="length" v="2674.8"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="2674.8"/>
     </way>
     <way visible="true" id="-9" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-93"/>
         <nd ref="-51"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="oneway" v="yes"/>
-        <tag k="length" v="50.7"/>
-        <tag k="horse" v="no"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="maxspeed" v="25"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Raadhafathi Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="source:datetime" v="2015-02-02T09:34:55.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
+        <tag k="horse" v="no"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Raadhafathi Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-02-02T09:34:55.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="50.7"/>
     </way>
     <way visible="true" id="-8" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-87"/>
@@ -8456,41 +7104,38 @@
         <nd ref="-92"/>
         <nd ref="-93"/>
         <nd ref="-975"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="796"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Lonuziyaaraiy Magu"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Lonuziyaaraiy Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-03-09T18:17:04.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="796"/>
     </way>
     <way visible="true" id="-7" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-94"/>
         <nd ref="-87"/>
-        <tag k="length" v="21.3"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="21.3"/>
     </way>
     <way visible="true" id="-6" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1112"/>
         <nd ref="-80"/>
         <nd ref="-78"/>
-        <tag k="length" v="68.1"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="68.1"/>
     </way>
     <way visible="true" id="-5" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-139"/>
@@ -8504,19 +7149,18 @@
         <nd ref="-70"/>
         <nd ref="-69"/>
         <nd ref="-68"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Hilaalee Hingun"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="length" v="1230.1"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="Bing"/>
-        <tag k="name" v="Hilaalee Hingun"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-11-28T17:29:47.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1230.1"/>
     </way>
     <way visible="true" id="-4" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-964"/>
@@ -8541,11 +7185,10 @@
         <nd ref="-37"/>
         <nd ref="-408"/>
         <nd ref="-36"/>
-        <tag k="length" v="1833.6"/>
-        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2019-01-24T18:58:28Z"/>
+        <tag k="length" v="1833.6"/>
     </way>
     <way visible="true" id="-3" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
@@ -8572,19 +7215,18 @@
         <nd ref="-25"/>
         <nd ref="-995"/>
         <nd ref="-24"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Ameenee Magu"/>
         <tag k="source:imagery:sensor" v="WV03_VNIR"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="20645.8"/>
         <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Ameenee Magu"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
         <tag k="source:datetime" v="2014-10-08T02:57:44.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-3"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="20645.8"/>
     </way>
     <way visible="true" id="-2" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-23"/>
@@ -8599,20 +7241,19 @@
         <nd ref="-33"/>
         <nd ref="-32"/>
         <nd ref="-31"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="2682.8"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="DigitalGlobe"/>
-        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="2682.8"/>
     </way>
     <way visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1151"/>
@@ -8620,21 +7261,20 @@
         <nd ref="-8"/>
         <nd ref="-9"/>
         <nd ref="-914"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="length" v="717"/>
-        <tag k="maxspeed" v="25"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source" v="local knowledge"/>
-        <tag k="name" v="Rah Dhebai Hingun"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="25"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Rah Dhebai Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
         <tag k="source:datetime" v="2014-11-28T17:43:41.000Z;2019-01-24T18:58:28Z"/>
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="717"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2927-bridge-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-bridge-1/Expected.osm
@@ -3,3966 +3,3003 @@
     <bounds minlat="10.5015" minlon="-66.92259999999999" maxlat="10.5099" maxlon="-66.9147"/>
     <node visible="true" id="-5236" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082301450004501" lon="-66.9167206087748383">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5236"/>
     </node>
     <node visible="true" id="-5234" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5084235274567863" lon="-66.9177535677229969">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5234"/>
     </node>
     <node visible="true" id="-5229" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5081656432906207" lon="-66.9167200335213863">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5229"/>
     </node>
     <node visible="true" id="-5227" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5083481288326226" lon="-66.9177703591333710">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5227"/>
     </node>
     <node visible="true" id="-5221" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5071969938525136" lon="-66.9219602198050580">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5221"/>
     </node>
     <node visible="true" id="-5220" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060175046317461" lon="-66.9218696482961519">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5220"/>
     </node>
     <node visible="true" id="-5217" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062662208783522" lon="-66.9201004705132050">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5217"/>
     </node>
     <node visible="true" id="-5216" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5081641872141720" lon="-66.9207106564285397">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5216"/>
     </node>
     <node visible="true" id="-945" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5067652497099981" lon="-66.9161491526400027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-945"/>
     </node>
     <node visible="true" id="-944" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5066794441900004" lon="-66.9157311405100046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-944"/>
     </node>
     <node visible="true" id="-943" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-943"/>
     </node>
     <node visible="true" id="-942" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-942"/>
     </node>
     <node visible="true" id="-941" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195200010" lon="-66.9148632606599989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-941"/>
     </node>
     <node visible="true" id="-940" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-940"/>
     </node>
     <node visible="true" id="-939" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087822501599994" lon="-66.9205606987899984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-939"/>
     </node>
     <node visible="true" id="-938" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087881806399981" lon="-66.9206763885199933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-938"/>
     </node>
     <node visible="true" id="-937" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087818048099990" lon="-66.9207182430999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-937"/>
     </node>
     <node visible="true" id="-936" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087784733100023" lon="-66.9207334703800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-936"/>
     </node>
     <node visible="true" id="-935" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087736797900000" lon="-66.9207482940399956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-935"/>
     </node>
     <node visible="true" id="-934" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087674704699996" lon="-66.9207625711199938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-934"/>
     </node>
     <node visible="true" id="-933" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087599052400016" lon="-66.9207761639300003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-933"/>
     </node>
     <node visible="true" id="-932" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087510570599996" lon="-66.9207889413799961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-932"/>
     </node>
     <node visible="true" id="-931" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087410112599997" lon="-66.9208007802599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-931"/>
     </node>
     <node visible="true" id="-930" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087298647100003" lon="-66.9208115663799958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930"/>
     </node>
     <node visible="true" id="-929" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087177249299977" lon="-66.9208211957299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-929"/>
     </node>
     <node visible="true" id="-928" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087047089700008" lon="-66.9208295754399813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-928"/>
     </node>
     <node visible="true" id="-927" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086909423700003" lon="-66.9208366246899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-927"/>
     </node>
     <node visible="true" id="-926" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086765578999977" lon="-66.9208422755099974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-926"/>
     </node>
     <node visible="true" id="-925" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086616942699980" lon="-66.9208464733900001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-925"/>
     </node>
     <node visible="true" id="-924" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086464948299980" lon="-66.9208491778600063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-924"/>
     </node>
     <node visible="true" id="-923" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086311061700002" lon="-66.9208503628299951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-923"/>
     </node>
     <node visible="true" id="-922" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086156766800016" lon="-66.9208500168700056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-922"/>
     </node>
     <node visible="true" id="-921" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085660942099999" lon="-66.9208384023600047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-921"/>
     </node>
     <node visible="true" id="-920" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085304670599999" lon="-66.9208140015799984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-920"/>
     </node>
     <node visible="true" id="-919" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084577154699979" lon="-66.9207622234900015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-919"/>
     </node>
     <node visible="true" id="-918" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083707883800006" lon="-66.9206896343300031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-918"/>
     </node>
     <node visible="true" id="-917" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082939662099992" lon="-66.9206280372199984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-917"/>
     </node>
     <node visible="true" id="-916" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040445870400010" lon="-66.9224095164999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-916"/>
     </node>
     <node visible="true" id="-915" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039924044300008" lon="-66.9224174342899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-915"/>
     </node>
     <node visible="true" id="-914" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039246767600005" lon="-66.9224388707999793">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-914"/>
     </node>
     <node visible="true" id="-913" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038634434600002" lon="-66.9224639132600032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-913"/>
     </node>
     <node visible="true" id="-912" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038539809200007" lon="-66.9224690241100006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-912"/>
     </node>
     <node visible="true" id="-911" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038447006600002" lon="-66.9224744655400059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-911"/>
     </node>
     <node visible="true" id="-910" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038356139899989" lon="-66.9224802309200015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-910"/>
     </node>
     <node visible="true" id="-909" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038267319799985" lon="-66.9224863132299959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-909"/>
     </node>
     <node visible="true" id="-908" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038180654499982" lon="-66.9224927050399998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-908"/>
     </node>
     <node visible="true" id="-907" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038096249699997" lon="-66.9224993985900056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-907"/>
     </node>
     <node visible="true" id="-906" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038014208099995" lon="-66.9225063857099940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-906"/>
     </node>
     <node visible="true" id="-905" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037934629700018" lon="-66.9225136578799891">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-905"/>
     </node>
     <node visible="true" id="-904" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037857611399996" lon="-66.9225212062499963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-904"/>
     </node>
     <node visible="true" id="-903" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037783247199989" lon="-66.9225290216299982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-903"/>
     </node>
     <node visible="true" id="-902" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037711627500006" lon="-66.9225370944899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-902"/>
     </node>
     <node visible="true" id="-901" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037642839700016" lon="-66.9225454149899832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-901"/>
     </node>
     <node visible="true" id="-900" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037530185399994" lon="-66.9225604472100031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-900"/>
     </node>
     <node visible="true" id="-899" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034778550399999" lon="-66.9225942178100013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-899"/>
     </node>
     <node visible="true" id="-898" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035613673300006" lon="-66.9225243217500037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-898"/>
     </node>
     <node visible="true" id="-897" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036717385100005" lon="-66.9224195771400048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-897"/>
     </node>
     <node visible="true" id="-896" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037426883100000" lon="-66.9223616254000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-896"/>
     </node>
     <node visible="true" id="-895" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037495744299996" lon="-66.9223520091900070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-895"/>
     </node>
     <node visible="true" id="-894" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037569178000005" lon="-66.9223427448499990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-894"/>
     </node>
     <node visible="true" id="-893" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037647008500006" lon="-66.9223338545399997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-893"/>
     </node>
     <node visible="true" id="-892" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037729049399999" lon="-66.9223253595500012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-892"/>
     </node>
     <node visible="true" id="-891" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037815104199996" lon="-66.9223172802199855">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-891"/>
     </node>
     <node visible="true" id="-890" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037904967100015" lon="-66.9223096358900023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-890"/>
     </node>
     <node visible="true" id="-889" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037998422799976" lon="-66.9223024448599944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-889"/>
     </node>
     <node visible="true" id="-888" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038095247599994" lon="-66.9222957243499934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-888"/>
     </node>
     <node visible="true" id="-887" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038195209800005" lon="-66.9222894904399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-887"/>
     </node>
     <node visible="true" id="-886" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038298070000025" lon="-66.9222837580600043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886"/>
     </node>
     <node visible="true" id="-885" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038403581999980" lon="-66.9222785409299945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-885"/>
     </node>
     <node visible="true" id="-884" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038511493100017" lon="-66.9222738515399982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-884"/>
     </node>
     <node visible="true" id="-883" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038621545099993" lon="-66.9222697011200012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-883"/>
     </node>
     <node visible="true" id="-882" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038733474499999" lon="-66.9222660995999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-882"/>
     </node>
     <node visible="true" id="-881" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038847013299996" lon="-66.9222630556100029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-881"/>
     </node>
     <node visible="true" id="-880" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039477880999996" lon="-66.9222452994700063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-880"/>
     </node>
     <node visible="true" id="-879" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040154011000002" lon="-66.9222293377499966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-879"/>
     </node>
     <node visible="true" id="-878" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040839707099991" lon="-66.9222215807299960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-878"/>
     </node>
     <node visible="true" id="-877" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041033650500015" lon="-66.9222148420499963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-877"/>
     </node>
     <node visible="true" id="-876" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041225148299979" lon="-66.9222074235500060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-876"/>
     </node>
     <node visible="true" id="-875" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041413967199961" lon="-66.9221993342499957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-875"/>
     </node>
     <node visible="true" id="-874" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041599877199978" lon="-66.9221905840200009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-874"/>
     </node>
     <node visible="true" id="-873" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041782651800002" lon="-66.9221811835199958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-873"/>
     </node>
     <node visible="true" id="-872" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041962068300005" lon="-66.9221711441900027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-872"/>
     </node>
     <node visible="true" id="-871" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042137907999997" lon="-66.9221604782800057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-871"/>
     </node>
     <node visible="true" id="-870" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042309956800004" lon="-66.9221491987700006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-870"/>
     </node>
     <node visible="true" id="-869" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042478005100008" lon="-66.9221373193999796">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-869"/>
     </node>
     <node visible="true" id="-868" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042641848099976" lon="-66.9221248546599981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-868"/>
     </node>
     <node visible="true" id="-867" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042801286100005" lon="-66.9221118197300058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-867"/>
     </node>
     <node visible="true" id="-866" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042908581999992" lon="-66.9221025055600052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-866"/>
     </node>
     <node visible="true" id="-865" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043700411499987" lon="-66.9220609207900026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-865"/>
     </node>
     <node visible="true" id="-864" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044260032499999" lon="-66.9220255604799945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-864"/>
     </node>
     <node visible="true" id="-863" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044353490899987" lon="-66.9220069666800015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863"/>
     </node>
     <node visible="true" id="-862" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044358143699998" lon="-66.9219929827600026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-862"/>
     </node>
     <node visible="true" id="-861" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044277255500020" lon="-66.9219737966800068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-861"/>
     </node>
     <node visible="true" id="-860" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044174232300005" lon="-66.9219644478399971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-860"/>
     </node>
     <node visible="true" id="-859" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044045778199990" lon="-66.9219592232600036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-859"/>
     </node>
     <node visible="true" id="-858" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043907386700024" lon="-66.9219587531199949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-858"/>
     </node>
     <node visible="true" id="-857" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043811273400003" lon="-66.9219614011000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-857"/>
     </node>
     <node visible="true" id="-856" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042767598900006" lon="-66.9220177517400003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-856"/>
     </node>
     <node visible="true" id="-855" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042093141199988" lon="-66.9220592580499982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-855"/>
     </node>
     <node visible="true" id="-854" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041752622299978" lon="-66.9220987164499803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-854"/>
     </node>
     <node visible="true" id="-853" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041652686300022" lon="-66.9221060618800010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-853"/>
     </node>
     <node visible="true" id="-852" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041549584699982" lon="-66.9221129461400039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-852"/>
     </node>
     <node visible="true" id="-851" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041443525900000" lon="-66.9221193553200067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-851"/>
     </node>
     <node visible="true" id="-850" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041334724100022" lon="-66.9221252764799885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-850"/>
     </node>
     <node visible="true" id="-849" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041223399099977" lon="-66.9221306976500045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-849"/>
     </node>
     <node visible="true" id="-848" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041109775899990" lon="-66.9221356078799943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-848"/>
     </node>
     <node visible="true" id="-847" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040994083899992" lon="-66.9221399972499995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-847"/>
     </node>
     <node visible="true" id="-846" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040876556799976" lon="-66.9221438568999787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-846"/>
     </node>
     <node visible="true" id="-845" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040757432100005" lon="-66.9221471790299915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-845"/>
     </node>
     <node visible="true" id="-844" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040636950300001" lon="-66.9221499569299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-844"/>
     </node>
     <node visible="true" id="-843" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040515354999986" lon="-66.9221521849899972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-843"/>
     </node>
     <node visible="true" id="-842" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040392891700023" lon="-66.9221538586999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-842"/>
     </node>
     <node visible="true" id="-841" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040269807800009" lon="-66.9221549746900024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-841"/>
     </node>
     <node visible="true" id="-840" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040146352000008" lon="-66.9221555306999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-840"/>
     </node>
     <node visible="true" id="-839" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040022773599979" lon="-66.9221555256000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-839"/>
     </node>
     <node visible="true" id="-838" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039776066999977" lon="-66.9221556904900012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-838"/>
     </node>
     <node visible="true" id="-837" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039399799999984" lon="-66.9221559419599998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-837"/>
     </node>
     <node visible="true" id="-836" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038614669899992" lon="-66.9221619407600059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-836"/>
     </node>
     <node visible="true" id="-835" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038504334499976" lon="-66.9221632969399849">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-835"/>
     </node>
     <node visible="true" id="-834" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038394563500024" lon="-66.9221650596900020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-834"/>
     </node>
     <node visible="true" id="-833" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038285503300006" lon="-66.9221672266399850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-833"/>
     </node>
     <node visible="true" id="-832" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038177299700024" lon="-66.9221697948899958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-832"/>
     </node>
     <node visible="true" id="-831" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038070097399991" lon="-66.9221727610299979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-831"/>
     </node>
     <node visible="true" id="-830" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037964039500018" lon="-66.9221761210799997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-830"/>
     </node>
     <node visible="true" id="-829" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037859267799991" lon="-66.9221798705499964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-829"/>
     </node>
     <node visible="true" id="-828" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037755922200002" lon="-66.9221840044399983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-828"/>
     </node>
     <node visible="true" id="-827" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037654140800001" lon="-66.9221885172199933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-827"/>
     </node>
     <node visible="true" id="-826" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037554059700025" lon="-66.9221934028600032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-826"/>
     </node>
     <node visible="true" id="-825" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037455812600022" lon="-66.9221986548299981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-825"/>
     </node>
     <node visible="true" id="-824" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037359530599979" lon="-66.9222042661200049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-824"/>
     </node>
     <node visible="true" id="-823" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037265342599984" lon="-66.9222102292199992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-823"/>
     </node>
     <node visible="true" id="-822" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037173374300004" lon="-66.9222165361800023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-822"/>
     </node>
     <node visible="true" id="-821" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037083748600004" lon="-66.9222231785499986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-821"/>
     </node>
     <node visible="true" id="-820" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036284024499977" lon="-66.9222821029500068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-820"/>
     </node>
     <node visible="true" id="-819" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034863535799996" lon="-66.9223751988100020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-819"/>
     </node>
     <node visible="true" id="-818" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034198822499985" lon="-66.9224276465100019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-818"/>
     </node>
     <node visible="true" id="-817" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034092908300014" lon="-66.9224348799099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-817"/>
     </node>
     <node visible="true" id="-816" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033984560300002" lon="-66.9224417353899952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-816"/>
     </node>
     <node visible="true" id="-815" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033873910600022" lon="-66.9224482046199967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-815"/>
     </node>
     <node visible="true" id="-814" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033761093999995" lon="-66.9224542797000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-814"/>
     </node>
     <node visible="true" id="-813" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033646247799979" lon="-66.9224599532399935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-813"/>
     </node>
     <node visible="true" id="-812" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033529511999983" lon="-66.9224652183300037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-812"/>
     </node>
     <node visible="true" id="-811" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033411028899994" lon="-66.9224700685499982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-811"/>
     </node>
     <node visible="true" id="-810" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033290942799997" lon="-66.9224744979800050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-810"/>
     </node>
     <node visible="true" id="-809" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033169399999995" lon="-66.9224785012399934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-809"/>
     </node>
     <node visible="true" id="-808" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033046548499982" lon="-66.9224820734499986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-808"/>
     </node>
     <node visible="true" id="-807" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032922538100006" lon="-66.9224852102500023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-807"/>
     </node>
     <node visible="true" id="-806" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032797519900019" lon="-66.9224879078300035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-806"/>
     </node>
     <node visible="true" id="-805" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032695045699995" lon="-66.9224897782600010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-805"/>
     </node>
     <node visible="true" id="-804" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030999160599965" lon="-66.9225137199599942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-804"/>
     </node>
     <node visible="true" id="-803" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028625950799999" lon="-66.9225353771399938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-803"/>
     </node>
     <node visible="true" id="-802" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027135201099977" lon="-66.9225486612599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-802"/>
     </node>
     <node visible="true" id="-801" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026747243000003" lon="-66.9225573881300022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-801"/>
     </node>
     <node visible="true" id="-800" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026624367999997" lon="-66.9225631163100019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-800"/>
     </node>
     <node visible="true" id="-799" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026503546299992" lon="-66.9225692743199971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-799"/>
     </node>
     <node visible="true" id="-798" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026384925099965" lon="-66.9225758546500060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-798"/>
     </node>
     <node visible="true" id="-797" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026268648900007" lon="-66.9225828492700003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-797"/>
     </node>
     <node visible="true" id="-796" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026154859399981" lon="-66.9225902496799989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-796"/>
     </node>
     <node visible="true" id="-795" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026043695099975" lon="-66.9225980468499984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-795"/>
     </node>
     <node visible="true" id="-794" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015288125800001" lon="-66.9159977800899952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-794"/>
     </node>
     <node visible="true" id="-793" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015120575399976" lon="-66.9213846762699944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-793"/>
     </node>
     <node visible="true" id="-792" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086139687800006" lon="-66.9216279922300004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-792"/>
     </node>
     <node visible="true" id="-791" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083126373100004" lon="-66.9217581592599942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-791"/>
     </node>
     <node visible="true" id="-790" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080393113399992" lon="-66.9218612427000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-790"/>
     </node>
     <node visible="true" id="-789" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078613864699975" lon="-66.9219478668400001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-789"/>
     </node>
     <node visible="true" id="-788" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077941566699984" lon="-66.9219625554400039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-788"/>
     </node>
     <node visible="true" id="-787" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076501270299989" lon="-66.9219651006099951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-787"/>
     </node>
     <node visible="true" id="-786" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072132582499975" lon="-66.9219601110600024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-786"/>
     </node>
     <node visible="true" id="-785" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5068735117000003" lon="-66.9219623826299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-785"/>
     </node>
     <node visible="true" id="-784" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062499974199994" lon="-66.9219036006099941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-784"/>
     </node>
     <node visible="true" id="-783" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060194185500002" lon="-66.9218706015399931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-783"/>
     </node>
     <node visible="true" id="-782" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060079334399994" lon="-66.9218648812800012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-782"/>
     </node>
     <node visible="true" id="-781" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059970743199997" lon="-66.9218580253999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-781"/>
     </node>
     <node visible="true" id="-780" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059869508200006" lon="-66.9218501030999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-780"/>
     </node>
     <node visible="true" id="-779" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059776651000014" lon="-66.9218411943400042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-779"/>
     </node>
     <node visible="true" id="-778" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059693109100003" lon="-66.9218313890499985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-778"/>
     </node>
     <node visible="true" id="-777" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059619725700006" lon="-66.9218207862000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-777"/>
     </node>
     <node visible="true" id="-776" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059557241500006" lon="-66.9218094928200031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-776"/>
     </node>
     <node visible="true" id="-775" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059506287299982" lon="-66.9217976228899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-775"/>
     </node>
     <node visible="true" id="-774" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059467377299978" lon="-66.9217852962400030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-774"/>
     </node>
     <node visible="true" id="-773" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059440904199999" lon="-66.9217726372899904">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-773"/>
     </node>
     <node visible="true" id="-772" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059427135399996" lon="-66.9217597738099812">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-772"/>
     </node>
     <node visible="true" id="-771" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059426209800009" lon="-66.9217468356499978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-771"/>
     </node>
     <node visible="true" id="-770" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059438136800001" lon="-66.9217339534099978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-770"/>
     </node>
     <node visible="true" id="-769" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059462795899989" lon="-66.9217212571000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-769"/>
     </node>
     <node visible="true" id="-768" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059499938199981" lon="-66.9217088749000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-768"/>
     </node>
     <node visible="true" id="-767" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059609192599979" lon="-66.9215616287399939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-767"/>
     </node>
     <node visible="true" id="-766" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059812237399992" lon="-66.9214849028799961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-766"/>
     </node>
     <node visible="true" id="-765" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060045791699999" lon="-66.9214201707499967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-765"/>
     </node>
     <node visible="true" id="-764" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060426091799979" lon="-66.9213268069100025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-764"/>
     </node>
     <node visible="true" id="-763" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060688680199998" lon="-66.9212515429699977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-763"/>
     </node>
     <node visible="true" id="-762" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060967998700008" lon="-66.9212048013999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-762"/>
     </node>
     <node visible="true" id="-761" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061453311899999" lon="-66.9211263849500000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-761"/>
     </node>
     <node visible="true" id="-760" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061630956900007" lon="-66.9211146599100033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-760"/>
     </node>
     <node visible="true" id="-759" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061787993800007" lon="-66.9211002411900040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-759"/>
     </node>
     <node visible="true" id="-758" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061920462600007" lon="-66.9210834924000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-758"/>
     </node>
     <node visible="true" id="-757" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062025022900016" lon="-66.9210648358899931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-757"/>
     </node>
     <node visible="true" id="-756" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062099038099994" lon="-66.9210447421200030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-756"/>
     </node>
     <node visible="true" id="-755" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062140641499990" lon="-66.9210237177999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-755"/>
     </node>
     <node visible="true" id="-754" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062148784200016" lon="-66.9210022931000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-754"/>
     </node>
     <node visible="true" id="-753" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062123260800000" lon="-66.9209810082899992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-753"/>
     </node>
     <node visible="true" id="-752" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062064714800005" lon="-66.9209604001100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-752"/>
     </node>
     <node visible="true" id="-751" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061974622800012" lon="-66.9209409882400053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-751"/>
     </node>
     <node visible="true" id="-750" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061855256499985" lon="-66.9209232621799970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-750"/>
     </node>
     <node visible="true" id="-749" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061709625999988" lon="-66.9209076689400035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-749"/>
     </node>
     <node visible="true" id="-748" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061541403700005" lon="-66.9208946017299979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-748"/>
     </node>
     <node visible="true" id="-747" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061354831599996" lon="-66.9208843900700003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-747"/>
     </node>
     <node visible="true" id="-746" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061154614499994" lon="-66.9208772914600019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-746"/>
     </node>
     <node visible="true" id="-745" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5058921756200014" lon="-66.9208232196699981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-745"/>
     </node>
     <node visible="true" id="-744" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056540184999978" lon="-66.9207677456300019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-744"/>
     </node>
     <node visible="true" id="-743" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056384589299974" lon="-66.9207636844299998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-743"/>
     </node>
     <node visible="true" id="-742" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056239883000000" lon="-66.9207566216600043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-742"/>
     </node>
     <node visible="true" id="-741" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056111674899988" lon="-66.9207468310499962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-741"/>
     </node>
     <node visible="true" id="-740" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056004934200011" lon="-66.9207346920899937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-740"/>
     </node>
     <node visible="true" id="-739" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055893856699996" lon="-66.9207131301400011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-739"/>
     </node>
     <node visible="true" id="-738" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055856679000001" lon="-66.9206973322000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-738"/>
     </node>
     <node visible="true" id="-737" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055850852099990" lon="-66.9206811044199981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-737"/>
     </node>
     <node visible="true" id="-736" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054844906600007" lon="-66.9202988277200035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-736"/>
     </node>
     <node visible="true" id="-735" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054158428399962" lon="-66.9200289697500068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-735"/>
     </node>
     <node visible="true" id="-734" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5053958635899995" lon="-66.9199284853699794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-734"/>
     </node>
     <node visible="true" id="-733" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089287612799982" lon="-66.9217302900599975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-733"/>
     </node>
     <node visible="true" id="-732" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088875236000003" lon="-66.9216849471000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-732"/>
     </node>
     <node visible="true" id="-731" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088478770700000" lon="-66.9216381775199949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-731"/>
     </node>
     <node visible="true" id="-730" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088098699899977" lon="-66.9215900382999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-730"/>
     </node>
     <node visible="true" id="-729" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087771953400004" lon="-66.9215351826599942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-729"/>
     </node>
     <node visible="true" id="-728" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087302746899987" lon="-66.9214564102500020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-728"/>
     </node>
     <node visible="true" id="-727" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086553430300000" lon="-66.9213200567499911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-727"/>
     </node>
     <node visible="true" id="-726" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085851663100005" lon="-66.9211811438999860">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-726"/>
     </node>
     <node visible="true" id="-725" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085578297700000" lon="-66.9211235779699933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-725"/>
     </node>
     <node visible="true" id="-724" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085362564099984" lon="-66.9210856267999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724"/>
     </node>
     <node visible="true" id="-723" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085131987399976" lon="-66.9210485775199970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-723"/>
     </node>
     <node visible="true" id="-722" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084886936299977" lon="-66.9210124893599954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-722"/>
     </node>
     <node visible="true" id="-721" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084627802599986" lon="-66.9209774200299989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-721"/>
     </node>
     <node visible="true" id="-720" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084355000799974" lon="-66.9209434256100053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-720"/>
     </node>
     <node visible="true" id="-719" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084068967099977" lon="-66.9209105604600012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-719"/>
     </node>
     <node visible="true" id="-718" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083770158800007" lon="-66.9208788771200034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-718"/>
     </node>
     <node visible="true" id="-717" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083459053699961" lon="-66.9208484262699983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-717"/>
     </node>
     <node visible="true" id="-716" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083136149299978" lon="-66.9208192565999838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-716"/>
     </node>
     <node visible="true" id="-715" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082801961900003" lon="-66.9207914147399947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-715"/>
     </node>
     <node visible="true" id="-714" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082457025999982" lon="-66.9207649452099815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-714"/>
     </node>
     <node visible="true" id="-713" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082101893100006" lon="-66.9207398903500064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-713"/>
     </node>
     <node visible="true" id="-712" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081737131000015" lon="-66.9207162902099952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-712"/>
     </node>
     <node visible="true" id="-711" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081363322999977" lon="-66.9206941825299992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-711"/>
     </node>
     <node visible="true" id="-710" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080981066899977" lon="-66.9206736026599884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-710"/>
     </node>
     <node visible="true" id="-709" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080250690800003" lon="-66.9206415924600009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-709"/>
     </node>
     <node visible="true" id="-708" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079509703999996" lon="-66.9206121774400060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-708"/>
     </node>
     <node visible="true" id="-707" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078759009200002" lon="-66.9205853934300023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-707"/>
     </node>
     <node visible="true" id="-706" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077999521199974" lon="-66.9205612730799970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-706"/>
     </node>
     <node visible="true" id="-705" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077232165200023" lon="-66.9205398457600040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-705"/>
     </node>
     <node visible="true" id="-704" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076909209700009" lon="-66.9205316913599830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-704"/>
     </node>
     <node visible="true" id="-703" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073682502200008" lon="-66.9204381356600067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-703"/>
     </node>
     <node visible="true" id="-702" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5070149405299986" lon="-66.9203267056799973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-702"/>
     </node>
     <node visible="true" id="-701" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065140467500004" lon="-66.9201790411700017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-701"/>
     </node>
     <node visible="true" id="-700" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5058274583899998" lon="-66.9199613656799954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-700"/>
     </node>
     <node visible="true" id="-699" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054152416999997" lon="-66.9198466389700002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-699"/>
     </node>
     <node visible="true" id="-698" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5052043085500006" lon="-66.9197879328699798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-698"/>
     </node>
     <node visible="true" id="-697" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5049556215299997" lon="-66.9197417400799992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-697"/>
     </node>
     <node visible="true" id="-696" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044982816499992" lon="-66.9196554676200037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-696"/>
     </node>
     <node visible="true" id="-695" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042886042300001" lon="-66.9196196487399959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-695"/>
     </node>
     <node visible="true" id="-694" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042590063100008" lon="-66.9196183788599797">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-694"/>
     </node>
     <node visible="true" id="-693" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042293825600002" lon="-66.9196181535100010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-693"/>
     </node>
     <node visible="true" id="-692" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041997690699986" lon="-66.9196189729699995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-692"/>
     </node>
     <node visible="true" id="-691" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041702019199992" lon="-66.9196208362299956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-691"/>
     </node>
     <node visible="true" id="-690" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041407171399968" lon="-66.9196237410299943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-690"/>
     </node>
     <node visible="true" id="-689" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041113506400006" lon="-66.9196276838300008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-689"/>
     </node>
     <node visible="true" id="-688" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040821382099985" lon="-66.9196326598199818">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-688"/>
     </node>
     <node visible="true" id="-687" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040531154399996" lon="-66.9196386629400024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-687"/>
     </node>
     <node visible="true" id="-686" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040277550400010" lon="-66.9196447909200032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-686"/>
     </node>
     <node visible="true" id="-685" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036746892600004" lon="-66.9197311686099994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-685"/>
     </node>
     <node visible="true" id="-684" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033531057099996" lon="-66.9198035101299951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-684"/>
     </node>
     <node visible="true" id="-683" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032744731199976" lon="-66.9198497659500049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-683"/>
     </node>
     <node visible="true" id="-682" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030926815000001" lon="-66.9198935214599970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-682"/>
     </node>
     <node visible="true" id="-681" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030075322399981" lon="-66.9199089798500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-681"/>
     </node>
     <node visible="true" id="-680" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029916815999993" lon="-66.9199138512099978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-680"/>
     </node>
     <node visible="true" id="-679" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029762736299990" lon="-66.9199200040900024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679"/>
     </node>
     <node visible="true" id="-678" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029614096000010" lon="-66.9199273980400022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678"/>
     </node>
     <node visible="true" id="-677" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029471872400020" lon="-66.9199359844500066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-677"/>
     </node>
     <node visible="true" id="-676" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029337000299989" lon="-66.9199457068800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-676"/>
     </node>
     <node visible="true" id="-675" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029210366400001" lon="-66.9199565014200033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-675"/>
     </node>
     <node visible="true" id="-674" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029037667199994" lon="-66.9199745463699998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-674"/>
     </node>
     <node visible="true" id="-673" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311726000010" lon="-66.9202954139200017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-673"/>
     </node>
     <node visible="true" id="-672" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089963778199991" lon="-66.9216582198399976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-672"/>
     </node>
     <node visible="true" id="-671" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089658248599989" lon="-66.9216250456200044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-671"/>
     </node>
     <node visible="true" id="-670" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089356635200009" lon="-66.9215898807999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-670"/>
     </node>
     <node visible="true" id="-669" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088680430700023" lon="-66.9215043898200008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-669"/>
     </node>
     <node visible="true" id="-668" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087471214399990" lon="-66.9212721603000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-668"/>
     </node>
     <node visible="true" id="-667" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087292921599982" lon="-66.9212284178200036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-667"/>
     </node>
     <node visible="true" id="-666" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087099629799994" lon="-66.9211853307299975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-666"/>
     </node>
     <node visible="true" id="-665" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086891574300001" lon="-66.9211429515499958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-665"/>
     </node>
     <node visible="true" id="-664" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086669008700007" lon="-66.9211013319099948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-664"/>
     </node>
     <node visible="true" id="-663" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086432204199998" lon="-66.9210605224999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-663"/>
     </node>
     <node visible="true" id="-662" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086181449300007" lon="-66.9210205730500007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-662"/>
     </node>
     <node visible="true" id="-661" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085917049499979" lon="-66.9209815322300017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-661"/>
     </node>
     <node visible="true" id="-660" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085639326899987" lon="-66.9209434476100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-660"/>
     </node>
     <node visible="true" id="-659" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084696773799990" lon="-66.9208421845400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-659"/>
     </node>
     <node visible="true" id="-658" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083719820700008" lon="-66.9207443071399979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-658"/>
     </node>
     <node visible="true" id="-657" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083461538699989" lon="-66.9207221068899969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-657"/>
     </node>
     <node visible="true" id="-656" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083195746500007" lon="-66.9207008309999907">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-656"/>
     </node>
     <node visible="true" id="-655" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082922767899998" lon="-66.9206805054000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-655"/>
     </node>
     <node visible="true" id="-654" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082642935699990" lon="-66.9206611548400048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-654"/>
     </node>
     <node visible="true" id="-653" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082356590699977" lon="-66.9206428029000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-653"/>
     </node>
     <node visible="true" id="-652" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082064081699986" lon="-66.9206254719399993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-652"/>
     </node>
     <node visible="true" id="-651" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081765765199986" lon="-66.9206091830699989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-651"/>
     </node>
     <node visible="true" id="-650" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081462004699997" lon="-66.9205939561399958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-650"/>
     </node>
     <node visible="true" id="-649" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081153170100006" lon="-66.9205798096999871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-649"/>
     </node>
     <node visible="true" id="-648" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080839637799990" lon="-66.9205667609899990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-648"/>
     </node>
     <node visible="true" id="-647" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080521789799999" lon="-66.9205548258999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-647"/>
     </node>
     <node visible="true" id="-646" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080276005800002" lon="-66.9205464578599987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-646"/>
     </node>
     <node visible="true" id="-645" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078079281599983" lon="-66.9204702485599938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-645"/>
     </node>
     <node visible="true" id="-644" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075456556799995" lon="-66.9203827551699959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-644"/>
     </node>
     <node visible="true" id="-643" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073785157399993" lon="-66.9203359439400032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-643"/>
     </node>
     <node visible="true" id="-642" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5070572768999977" lon="-66.9202356233499955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-642"/>
     </node>
     <node visible="true" id="-641" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064754877999995" lon="-66.9200610203400004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-641"/>
     </node>
     <node visible="true" id="-640" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059526758900024" lon="-66.9199008977499972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-640"/>
     </node>
     <node visible="true" id="-639" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054544730200003" lon="-66.9197521800099793">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-639"/>
     </node>
     <node visible="true" id="-638" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5051235942399988" lon="-66.9196783685300005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-638"/>
     </node>
     <node visible="true" id="-637" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5047224410899993" lon="-66.9196132910799975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-637"/>
     </node>
     <node visible="true" id="-636" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043164138099989" lon="-66.9195532045099952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-636"/>
     </node>
     <node visible="true" id="-635" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042312353800007" lon="-66.9195339417800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-635"/>
     </node>
     <node visible="true" id="-634" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042219293599999" lon="-66.9195290267799976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-634"/>
     </node>
     <node visible="true" id="-633" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042129804400002" lon="-66.9195234758200002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-633"/>
     </node>
     <node visible="true" id="-632" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042044311300007" lon="-66.9195173152500047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-632"/>
     </node>
     <node visible="true" id="-631" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041963220200021" lon="-66.9195105743300047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-631"/>
     </node>
     <node visible="true" id="-630" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041886916300005" lon="-66.9195032850699931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-630"/>
     </node>
     <node visible="true" id="-629" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041815761899997" lon="-66.9194954821099799">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-629"/>
     </node>
     <node visible="true" id="-628" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041750095000026" lon="-66.9194872024799992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-628"/>
     </node>
     <node visible="true" id="-627" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041690227400029" lon="-66.9194784855200027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-627"/>
     </node>
     <node visible="true" id="-626" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041636443400002" lon="-66.9194693726099956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-626"/>
     </node>
     <node visible="true" id="-625" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041588998600002" lon="-66.9194599070399931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-625"/>
     </node>
     <node visible="true" id="-624" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041548118099985" lon="-66.9194501337699990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-624"/>
     </node>
     <node visible="true" id="-623" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041513996099987" lon="-66.9194400992000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-623"/>
     </node>
     <node visible="true" id="-622" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041486794699992" lon="-66.9194298510000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-622"/>
     </node>
     <node visible="true" id="-621" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041466643099994" lon="-66.9194194378199967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-621"/>
     </node>
     <node visible="true" id="-620" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041453636999993" lon="-66.9194089091299986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-620"/>
     </node>
     <node visible="true" id="-619" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040979867799980" lon="-66.9191679280099976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-619"/>
     </node>
     <node visible="true" id="-618" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039619644999984" lon="-66.9186283969700071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-618"/>
     </node>
     <node visible="true" id="-617" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038227678499982" lon="-66.9181037623399817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-617"/>
     </node>
     <node visible="true" id="-616" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037591646399999" lon="-66.9178827232099991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-616"/>
     </node>
     <node visible="true" id="-615" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036092753500032" lon="-66.9172242905600001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-615"/>
     </node>
     <node visible="true" id="-614" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034107391700005" lon="-66.9163810800500016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-614"/>
     </node>
     <node visible="true" id="-613" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084379255800009" lon="-66.9195653678700069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-613"/>
     </node>
     <node visible="true" id="-612" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078691862199989" lon="-66.9196609831000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-612"/>
     </node>
     <node visible="true" id="-611" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078541203400011" lon="-66.9196565428299976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-611"/>
     </node>
     <node visible="true" id="-610" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078401326099975" lon="-66.9196493525899996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-610"/>
     </node>
     <node visible="true" id="-609" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078222226300007" lon="-66.9196339823400024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-609"/>
     </node>
     <node visible="true" id="-608" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078092175899993" lon="-66.9196142067600022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-608"/>
     </node>
     <node visible="true" id="-607" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078037918000007" lon="-66.9195993266800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-607"/>
     </node>
     <node visible="true" id="-606" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078009899599998" lon="-66.9195757523300045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-606"/>
     </node>
     <node visible="true" id="-605" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077536309599981" lon="-66.9192812643999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-605"/>
     </node>
     <node visible="true" id="-604" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086789080600003" lon="-66.9195209107899842">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-604"/>
     </node>
     <node visible="true" id="-603" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085785455400007" lon="-66.9190457208599980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-603"/>
     </node>
     <node visible="true" id="-602" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084681434299974" lon="-66.9184233462000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-602"/>
     </node>
     <node visible="true" id="-601" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089473686999995" lon="-66.9214125773400070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-601"/>
     </node>
     <node visible="true" id="-600" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088439846499995" lon="-66.9207372628499968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-600"/>
     </node>
     <node visible="true" id="-599" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088207340199986" lon="-66.9205589132299963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-599"/>
     </node>
     <node visible="true" id="-598" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087870630100024" lon="-66.9204128634799957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-598"/>
     </node>
     <node visible="true" id="-597" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087327784999989" lon="-66.9199917563800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-597"/>
     </node>
     <node visible="true" id="-596" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086747186699991" lon="-66.9196186067100030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-596"/>
     </node>
     <node visible="true" id="-595" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086589365699989" lon="-66.9195245951899835">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-595"/>
     </node>
     <node visible="true" id="-594" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086676205600007" lon="-66.9190891815299977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-594"/>
     </node>
     <node visible="true" id="-593" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085482689799985" lon="-66.9184074126199988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-593"/>
     </node>
     <node visible="true" id="-592" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092733841099992" lon="-66.9217712948999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-592"/>
     </node>
     <node visible="true" id="-591" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092539297700007" lon="-66.9217522853000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-591"/>
     </node>
     <node visible="true" id="-590" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092351875700007" lon="-66.9217325587000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-590"/>
     </node>
     <node visible="true" id="-589" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092171833699997" lon="-66.9217121423099996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-589"/>
     </node>
     <node visible="true" id="-588" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091999420200004" lon="-66.9216910643000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-588"/>
     </node>
     <node visible="true" id="-587" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091834872999996" lon="-66.9216693537699996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-587"/>
     </node>
     <node visible="true" id="-586" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091678419299992" lon="-66.9216470406699955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-586"/>
     </node>
     <node visible="true" id="-585" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091530275000000" lon="-66.9216241557999894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-585"/>
     </node>
     <node visible="true" id="-584" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091390644399976" lon="-66.9216007307300060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-584"/>
     </node>
     <node visible="true" id="-583" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091259720300005" lon="-66.9215767977799914">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-583"/>
     </node>
     <node visible="true" id="-582" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091137683400007" lon="-66.9215523899899978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-582"/>
     </node>
     <node visible="true" id="-581" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091024701899993" lon="-66.9215275410300023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-581"/>
     </node>
     <node visible="true" id="-580" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090920931900005" lon="-66.9215022851999919">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-580"/>
     </node>
     <node visible="true" id="-579" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090826516500009" lon="-66.9214766573499986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-579"/>
     </node>
     <node visible="true" id="-578" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090741586000007" lon="-66.9214506928299926">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-578"/>
     </node>
     <node visible="true" id="-577" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090666257600009" lon="-66.9214244274899954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-577"/>
     </node>
     <node visible="true" id="-576" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090299118899999" lon="-66.9212563521799950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-576"/>
     </node>
     <node visible="true" id="-575" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089392300299984" lon="-66.9207415488900068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-575"/>
     </node>
     <node visible="true" id="-574" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088121598500024" lon="-66.9199332990800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-574"/>
     </node>
     <node visible="true" id="-573" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096955576499997" lon="-66.9193774115800011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-573"/>
     </node>
     <node visible="true" id="-572" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093143124200008" lon="-66.9194309689600004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-572"/>
     </node>
     <node visible="true" id="-571" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087400640999995" lon="-66.9195122541500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-571"/>
     </node>
     <node visible="true" id="-570" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083680347499993" lon="-66.9183853975000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-570"/>
     </node>
     <node visible="true" id="-569" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079139132900004" lon="-66.9184551810299979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-569"/>
     </node>
     <node visible="true" id="-568" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073803076899992" lon="-66.9185500339099946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-568"/>
     </node>
     <node visible="true" id="-567" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072755510100002" lon="-66.9185723283499954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-567"/>
     </node>
     <node visible="true" id="-566" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071494636500020" lon="-66.9185673662299934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-566"/>
     </node>
     <node visible="true" id="-565" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071010608699975" lon="-66.9185676903900060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-565"/>
     </node>
     <node visible="true" id="-564" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065128829599974" lon="-66.9187169667000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-564"/>
     </node>
     <node visible="true" id="-563" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084579523099979" lon="-66.9183691350099963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-563"/>
     </node>
     <node visible="true" id="-562" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083689952900006" lon="-66.9178959340000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-562"/>
     </node>
     <node visible="true" id="-561" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082540464100003" lon="-66.9172041726399982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-561"/>
     </node>
     <node visible="true" id="-560" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094156974900006" lon="-66.9181771718800036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-560"/>
     </node>
     <node visible="true" id="-559" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087512526700007" lon="-66.9183160886099984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-559"/>
     </node>
     <node visible="true" id="-558" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085381975299992" lon="-66.9183546218499998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-558"/>
     </node>
     <node visible="true" id="-557" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083567247499978" lon="-66.9174034179000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-557"/>
     </node>
     <node visible="true" id="-556" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077948642800010" lon="-66.9172593429800031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-556"/>
     </node>
     <node visible="true" id="-555" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071945532900024" lon="-66.9173640398300051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-555"/>
     </node>
     <node visible="true" id="-554" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082891319900007" lon="-66.9171569800300006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-554"/>
     </node>
     <node visible="true" id="-553" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082470243099984" lon="-66.9171657005500009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-553"/>
     </node>
     <node visible="true" id="-552" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081666657999975" lon="-66.9167254408300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-552"/>
     </node>
     <node visible="true" id="-551" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080421179299996" lon="-66.9160668015299933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-551"/>
     </node>
     <node visible="true" id="-550" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079896716799990" lon="-66.9158018761199997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-550"/>
     </node>
     <node visible="true" id="-549" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079668038400005" lon="-66.9156822002800027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-549"/>
     </node>
     <node visible="true" id="-548" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-548"/>
     </node>
     <node visible="true" id="-547" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-547"/>
     </node>
     <node visible="true" id="-546" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081273995000011" lon="-66.9170906772600063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-546"/>
     </node>
     <node visible="true" id="-545" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074340443699974" lon="-66.9172195429299990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-545"/>
     </node>
     <node visible="true" id="-544" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5068586905599979" lon="-66.9173317852699938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-544"/>
     </node>
     <node visible="true" id="-543" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061376644000006" lon="-66.9174681416800041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-543"/>
     </node>
     <node visible="true" id="-542" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082283234300000" lon="-66.9170632438499950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-542"/>
     </node>
     <node visible="true" id="-541" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082591445899975" lon="-66.9168886642300009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-541"/>
     </node>
     <node visible="true" id="-540" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081827136299992" lon="-66.9164457405200039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-540"/>
     </node>
     <node visible="true" id="-539" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092129559499980" lon="-66.9168556654999804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-539"/>
     </node>
     <node visible="true" id="-538" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083800427800025" lon="-66.9170220030599978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-538"/>
     </node>
     <node visible="true" id="-537" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093081230899994" lon="-66.9169406820499972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-537"/>
     </node>
     <node visible="true" id="-536" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090305066999985" lon="-66.9169993754299810">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-536"/>
     </node>
     <node visible="true" id="-535" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054198110300003" lon="-66.9164128790300055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-535"/>
     </node>
     <node visible="true" id="-534" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5051697971199989" lon="-66.9153252867399999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-534"/>
     </node>
     <node visible="true" id="-533" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5017691462699982" lon="-66.9147128052199918">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-533"/>
     </node>
     <node visible="true" id="-532" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000024" lon="-66.9179020508999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-532"/>
     </node>
     <node visible="true" id="-531" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699979" lon="-66.9171032446199803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-531"/>
     </node>
     <node visible="true" id="-530" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021944227699979" lon="-66.9165971720299950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-530"/>
     </node>
     <node visible="true" id="-529" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020857885299979" lon="-66.9160550627699990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-529"/>
     </node>
     <node visible="true" id="-528" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020058897099986" lon="-66.9156069727699929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-528"/>
     </node>
     <node visible="true" id="-527" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018764962799995" lon="-66.9150590220200030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-527"/>
     </node>
     <node visible="true" id="-526" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018507009000004" lon="-66.9149758286500003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-526"/>
     </node>
     <node visible="true" id="-525" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-525"/>
     </node>
     <node visible="true" id="-524" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800022" lon="-66.9191175683799884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-524"/>
     </node>
     <node visible="true" id="-523" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579599985" lon="-66.9184036784899945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-523"/>
     </node>
     <node visible="true" id="-522" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768700005" lon="-66.9184060968199930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-522"/>
     </node>
     <node visible="true" id="-521" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611199996" lon="-66.9182588634100028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-521"/>
     </node>
     <node visible="true" id="-520" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-520"/>
     </node>
     <node visible="true" id="-519" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654499996" lon="-66.9182879955099850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-519"/>
     </node>
     <node visible="true" id="-518" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032842497800019" lon="-66.9180571054100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-518"/>
     </node>
     <node visible="true" id="-517" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-517"/>
     </node>
     <node visible="true" id="-516" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-516"/>
     </node>
     <node visible="true" id="-515" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439091999998" lon="-66.9179112165300012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-515"/>
     </node>
     <node visible="true" id="-514" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799992" lon="-66.9172775671599993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-514"/>
     </node>
     <node visible="true" id="-513" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-513"/>
     </node>
     <node visible="true" id="-512" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328600000" lon="-66.9184260814800069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-512"/>
     </node>
     <node visible="true" id="-511" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905699970" lon="-66.9183505367499976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-511"/>
     </node>
     <node visible="true" id="-510" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083091997399993" lon="-66.9171527139500029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-510"/>
     </node>
     <node visible="true" id="-509" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082891070699986" lon="-66.9170467214800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-509"/>
     </node>
     <node visible="true" id="-508" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-508"/>
     </node>
     <node visible="true" id="-507" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099977" lon="-66.9194331024600046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-507"/>
     </node>
     <node visible="true" id="-506" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226900015" lon="-66.9196067043800014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-506"/>
     </node>
     <node visible="true" id="-505" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930900002" lon="-66.9197283843299999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-505"/>
     </node>
     <node visible="true" id="-504" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019060823800015" lon="-66.9208505552000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-504"/>
     </node>
     <node visible="true" id="-503" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800003" lon="-66.9199025736400017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-503"/>
     </node>
     <node visible="true" id="-502" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-502"/>
     </node>
     <node visible="true" id="-501" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021955604800024" lon="-66.9207009846099936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-501"/>
     </node>
     <node visible="true" id="-500" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-500"/>
     </node>
     <node visible="true" id="-499" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029978296399999" lon="-66.9197189401899948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-499"/>
     </node>
     <node visible="true" id="-498" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030613326499989" lon="-66.9196450069299971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-498"/>
     </node>
     <node visible="true" id="-497" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031033764699995" lon="-66.9195962114999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-497"/>
     </node>
     <node visible="true" id="-496" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031072953599978" lon="-66.9195789741499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-496"/>
     </node>
     <node visible="true" id="-495" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031121528699991" lon="-66.9195619825299985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-495"/>
     </node>
     <node visible="true" id="-494" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031179340899996" lon="-66.9195452887699958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-494"/>
     </node>
     <node visible="true" id="-493" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031246212799996" lon="-66.9195289440999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-493"/>
     </node>
     <node visible="true" id="-492" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031321939200009" lon="-66.9195129986800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-492"/>
     </node>
     <node visible="true" id="-491" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031406287699998" lon="-66.9194975014400057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-491"/>
     </node>
     <node visible="true" id="-490" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031498999499977" lon="-66.9194824999400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-490"/>
     </node>
     <node visible="true" id="-489" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031599789999994" lon="-66.9194680402100062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-489"/>
     </node>
     <node visible="true" id="-488" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031708349999988" lon="-66.9194541666199996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-488"/>
     </node>
     <node visible="true" id="-487" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031824346300002" lon="-66.9194409217499953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-487"/>
     </node>
     <node visible="true" id="-486" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031947422999981" lon="-66.9194283462399824">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-486"/>
     </node>
     <node visible="true" id="-485" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032077202499998" lon="-66.9194164786800059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-485"/>
     </node>
     <node visible="true" id="-484" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032213286299978" lon="-66.9194053554899995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-484"/>
     </node>
     <node visible="true" id="-483" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032355257100001" lon="-66.9193950108000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-483"/>
     </node>
     <node visible="true" id="-482" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032502678999986" lon="-66.9193854763500013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-482"/>
     </node>
     <node visible="true" id="-481" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032681428399997" lon="-66.9193782480000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-481"/>
     </node>
     <node visible="true" id="-480" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032853857600017" lon="-66.9193695928999830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480"/>
     </node>
     <node visible="true" id="-479" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033018853499982" lon="-66.9193595669299981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-479"/>
     </node>
     <node visible="true" id="-478" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033175350799972" lon="-66.9193482348099877">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-478"/>
     </node>
     <node visible="true" id="-477" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033322339199984" lon="-66.9193356696999899">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-477"/>
     </node>
     <node visible="true" id="-476" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033458869699992" lon="-66.9193219527300016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-476"/>
     </node>
     <node visible="true" id="-475" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033584060999985" lon="-66.9193071724500044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-475"/>
     </node>
     <node visible="true" id="-474" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033697104599995" lon="-66.9192914242800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-474"/>
     </node>
     <node visible="true" id="-473" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033797271000022" lon="-66.9192748098899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-473"/>
     </node>
     <node visible="true" id="-472" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033883913299988" lon="-66.9192574365499979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-472"/>
     </node>
     <node visible="true" id="-471" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033956472199996" lon="-66.9192394164099937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-471"/>
     </node>
     <node visible="true" id="-470" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034014479300009" lon="-66.9192208658100043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-470"/>
     </node>
     <node visible="true" id="-469" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034057560099985" lon="-66.9192019045199942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-469"/>
     </node>
     <node visible="true" id="-468" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034085436499982" lon="-66.9191826549500064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-468"/>
     </node>
     <node visible="true" id="-467" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034097928399994" lon="-66.9191632413700006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-467"/>
     </node>
     <node visible="true" id="-466" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034004880899996" lon="-66.9190363107399975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-466"/>
     </node>
     <node visible="true" id="-465" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032390066199994" lon="-66.9182831560700038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-465"/>
     </node>
     <node visible="true" id="-464" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031881615899980" lon="-66.9180781926399959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-464"/>
     </node>
     <node visible="true" id="-463" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015322329400007" lon="-66.9216200500300005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-463"/>
     </node>
     <node visible="true" id="-462" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016398406599993" lon="-66.9214481051500059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-462"/>
     </node>
     <node visible="true" id="-461" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094012735299991" lon="-66.9166840477899996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-461"/>
     </node>
     <node visible="true" id="-460" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093687881700042" lon="-66.9165144423500067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-460"/>
     </node>
     <node visible="true" id="-459" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093050151899980" lon="-66.9162439076399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-459"/>
     </node>
     <node visible="true" id="-458" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092802416300000" lon="-66.9161112343300033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-458"/>
     </node>
     <node visible="true" id="-457" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019902737699979" lon="-66.9209381544999928">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-457"/>
     </node>
     <node visible="true" id="-456" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-456"/>
     </node>
     <node visible="true" id="-455" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022250648999957" lon="-66.9208000921599933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-455"/>
     </node>
     <node visible="true" id="-454" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020767294499997" lon="-66.9210000434199941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-454"/>
     </node>
     <node visible="true" id="-453" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020070219699999" lon="-66.9210940066599989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-453"/>
     </node>
     <node visible="true" id="-452" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018371189799993" lon="-66.9213461233500055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-452"/>
     </node>
     <node visible="true" id="-451" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016243236399998" lon="-66.9216378751199983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-451"/>
     </node>
     <node visible="true" id="-450" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022550139300002" lon="-66.9212592136399991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-450"/>
     </node>
     <node visible="true" id="-449" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025094695099988" lon="-66.9214422182599975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-449"/>
     </node>
     <node visible="true" id="-448" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026710715200000" lon="-66.9215527962399932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-448"/>
     </node>
     <node visible="true" id="-447" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026873578200011" lon="-66.9215595944299935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-447"/>
     </node>
     <node visible="true" id="-446" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027044573800001" lon="-66.9215638947999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-446"/>
     </node>
     <node visible="true" id="-445" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027219972699992" lon="-66.9215656035700022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-445"/>
     </node>
     <node visible="true" id="-444" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027395949499986" lon="-66.9215646834500006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-444"/>
     </node>
     <node visible="true" id="-443" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027568666200004" lon="-66.9215611545299964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-443"/>
     </node>
     <node visible="true" id="-442" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027889404999986" lon="-66.9215466333299958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-442"/>
     </node>
     <node visible="true" id="-441" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031088263600001" lon="-66.9214289246800007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-441"/>
     </node>
     <node visible="true" id="-440" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035092954900016" lon="-66.9212972625499987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-440"/>
     </node>
     <node visible="true" id="-439" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037328937999987" lon="-66.9212212412599996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-439"/>
     </node>
     <node visible="true" id="-438" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037412539300004" lon="-66.9212154433400030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-438"/>
     </node>
     <node visible="true" id="-437" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037543837099996" lon="-66.9211999287299903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-437"/>
     </node>
     <node visible="true" id="-436" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037587543100006" lon="-66.9211906835400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-436"/>
     </node>
     <node visible="true" id="-435" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037614695400023" lon="-66.9211808118599976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-435"/>
     </node>
     <node visible="true" id="-434" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037624468599979" lon="-66.9211706137199798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-434"/>
     </node>
     <node visible="true" id="-433" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037616565800001" lon="-66.9211603990400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-433"/>
     </node>
     <node visible="true" id="-432" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019222646799957" lon="-66.9210167259899862">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-432"/>
     </node>
     <node visible="true" id="-431" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020144928000025" lon="-66.9210839362499996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-431"/>
     </node>
     <node visible="true" id="-430" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033851321600036" lon="-66.9213380837500011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-430"/>
     </node>
     <node visible="true" id="-429" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033517576899982" lon="-66.9212092518300068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-429"/>
     </node>
     <node visible="true" id="-428" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033330426800013" lon="-66.9211144764099970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-428"/>
     </node>
     <node visible="true" id="-427" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033265781800011" lon="-66.9210483504499933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-427"/>
     </node>
     <node visible="true" id="-426" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-426"/>
     </node>
     <node visible="true" id="-425" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028420722499991" lon="-66.9208148481099983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-425"/>
     </node>
     <node visible="true" id="-424" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028790556900020" lon="-66.9208342641399980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-424"/>
     </node>
     <node visible="true" id="-423" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029166871999990" lon="-66.9208523641499937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-423"/>
     </node>
     <node visible="true" id="-422" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029549209299997" lon="-66.9208691260800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-422"/>
     </node>
     <node visible="true" id="-421" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029937103000002" lon="-66.9208845295100048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-421"/>
     </node>
     <node visible="true" id="-420" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030330080499983" lon="-66.9208985556699929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-420"/>
     </node>
     <node visible="true" id="-419" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030727663099999" lon="-66.9209111874900060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-419"/>
     </node>
     <node visible="true" id="-418" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031129366199991" lon="-66.9209224095500019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-418"/>
     </node>
     <node visible="true" id="-417" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031534700499982" lon="-66.9209322082000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-417"/>
     </node>
     <node visible="true" id="-416" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031943172299975" lon="-66.9209405714899930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-416"/>
     </node>
     <node visible="true" id="-415" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032354283699991" lon="-66.9209474892400067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-415"/>
     </node>
     <node visible="true" id="-414" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032767533900007" lon="-66.9209529530100014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-414"/>
     </node>
     <node visible="true" id="-413" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033182419600006" lon="-66.9209569561499933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-413"/>
     </node>
     <node visible="true" id="-412" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033294982300021" lon="-66.9209576602799956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-412"/>
     </node>
     <node visible="true" id="-411" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033561824500001" lon="-66.9209593295099978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-411"/>
     </node>
     <node visible="true" id="-410" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035540927500008" lon="-66.9209661335400057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-410"/>
     </node>
     <node visible="true" id="-409" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037461854600025" lon="-66.9209917840099990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-409"/>
     </node>
     <node visible="true" id="-408" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037859432000023" lon="-66.9209970929299942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-408"/>
     </node>
     <node visible="true" id="-407" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041341233999983" lon="-66.9211052980199952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-407"/>
     </node>
     <node visible="true" id="-406" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041460421099995" lon="-66.9211106936400029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-406"/>
     </node>
     <node visible="true" id="-405" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041573054799997" lon="-66.9211173738100058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-405"/>
     </node>
     <node visible="true" id="-404" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041677784100020" lon="-66.9211252584099867">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-404"/>
     </node>
     <node visible="true" id="-403" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041773353199979" lon="-66.9211342529000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-403"/>
     </node>
     <node visible="true" id="-402" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041858615800017" lon="-66.9211442494000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-402"/>
     </node>
     <node visible="true" id="-401" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041932549499961" lon="-66.9211551280200041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-401"/>
     </node>
     <node visible="true" id="-400" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041994267599996" lon="-66.9211667583199983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-400"/>
     </node>
     <node visible="true" id="-399" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042043029999999" lon="-66.9211790007900049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-399"/>
     </node>
     <node visible="true" id="-398" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042078251799982" lon="-66.9211917086399950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-398"/>
     </node>
     <node visible="true" id="-397" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042099510600000" lon="-66.9212047294600012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-397"/>
     </node>
     <node visible="true" id="-396" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042106551599996" lon="-66.9212179070800062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-396"/>
     </node>
     <node visible="true" id="-395" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042099290199982" lon="-66.9212310834899995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-395"/>
     </node>
     <node visible="true" id="-394" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042077813599981" lon="-66.9212441006500001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-394"/>
     </node>
     <node visible="true" id="-393" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042042379199980" lon="-66.9212568024699976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-393"/>
     </node>
     <node visible="true" id="-392" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041993412100005" lon="-66.9212690365999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-392"/>
     </node>
     <node visible="true" id="-391" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041014424600014" lon="-66.9214269575000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-391"/>
     </node>
     <node visible="true" id="-390" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040751560899999" lon="-66.9214661450500046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-390"/>
     </node>
     <node visible="true" id="-389" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040348473500007" lon="-66.9215749160899946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-389"/>
     </node>
     <node visible="true" id="-388" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040310464799997" lon="-66.9215908210099997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-388"/>
     </node>
     <node visible="true" id="-387" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040261854000008" lon="-66.9216064283800023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-387"/>
     </node>
     <node visible="true" id="-386" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040202865499985" lon="-66.9216216661299939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-386"/>
     </node>
     <node visible="true" id="-385" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040133771799997" lon="-66.9216364638899961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-385"/>
     </node>
     <node visible="true" id="-384" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040054891899981" lon="-66.9216507533400033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-384"/>
     </node>
     <node visible="true" id="-383" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039966590099976" lon="-66.9216644684800031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-383"/>
     </node>
     <node visible="true" id="-382" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039869274000015" lon="-66.9216775459899935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-382"/>
     </node>
     <node visible="true" id="-381" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039763393199994" lon="-66.9216899254900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-381"/>
     </node>
     <node visible="true" id="-380" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039649436399980" lon="-66.9217015497999910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-380"/>
     </node>
     <node visible="true" id="-379" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039527929900007" lon="-66.9217123652500021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-379"/>
     </node>
     <node visible="true" id="-378" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039399434800025" lon="-66.9217223219000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-378"/>
     </node>
     <node visible="true" id="-377" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039264544299975" lon="-66.9217313737800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-377"/>
     </node>
     <node visible="true" id="-376" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039123881499989" lon="-66.9217394790800029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-376"/>
     </node>
     <node visible="true" id="-375" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038978095799997" lon="-66.9217466003699997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-375"/>
     </node>
     <node visible="true" id="-374" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038827860400001" lon="-66.9217527047800047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-374"/>
     </node>
     <node visible="true" id="-373" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036867019599995" lon="-66.9218405728600061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-373"/>
     </node>
     <node visible="true" id="-372" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034632047399974" lon="-66.9219798269299986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-372"/>
     </node>
     <node visible="true" id="-371" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033276024599971" lon="-66.9220916728200024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-371"/>
     </node>
     <node visible="true" id="-370" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032437496500002" lon="-66.9221836669100014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-370"/>
     </node>
     <node visible="true" id="-369" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031693808300002" lon="-66.9222499961500006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-369"/>
     </node>
     <node visible="true" id="-368" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031612861799992" lon="-66.9222600471800035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-368"/>
     </node>
     <node visible="true" id="-367" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031527531099993" lon="-66.9222697208600010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-367"/>
     </node>
     <node visible="true" id="-366" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031437988499974" lon="-66.9222789976900003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-366"/>
     </node>
     <node visible="true" id="-365" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031344414499994" lon="-66.9222878589699945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-365"/>
     </node>
     <node visible="true" id="-364" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031246997800025" lon="-66.9222962868199858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-364"/>
     </node>
     <node visible="true" id="-363" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031145934799977" lon="-66.9223042642499877">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-363"/>
     </node>
     <node visible="true" id="-362" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031041429299989" lon="-66.9223117751700016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-362"/>
     </node>
     <node visible="true" id="-361" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030933692099993" lon="-66.9223188044500006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-361"/>
     </node>
     <node visible="true" id="-360" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030822940399968" lon="-66.9223253378899869">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-360"/>
     </node>
     <node visible="true" id="-359" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030709397500015" lon="-66.9223313623299987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359"/>
     </node>
     <node visible="true" id="-358" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030593292500001" lon="-66.9223368656300011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-358"/>
     </node>
     <node visible="true" id="-357" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030474859399998" lon="-66.9223418366700002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-357"/>
     </node>
     <node visible="true" id="-356" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030354337100018" lon="-66.9223462654399981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-356"/>
     </node>
     <node visible="true" id="-355" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030231968699983" lon="-66.9223501430000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-355"/>
     </node>
     <node visible="true" id="-354" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030108000800020" lon="-66.9223534615500029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-354"/>
     </node>
     <node visible="true" id="-353" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029506452800003" lon="-66.9223794649199988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-353"/>
     </node>
     <node visible="true" id="-352" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029224121900011" lon="-66.9223895889199838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-352"/>
     </node>
     <node visible="true" id="-351" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028938466400010" lon="-66.9223987111300005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-351"/>
     </node>
     <node visible="true" id="-350" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028649834099994" lon="-66.9224068204299982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-350"/>
     </node>
     <node visible="true" id="-349" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028358576900001" lon="-66.9224139069499984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-349"/>
     </node>
     <node visible="true" id="-348" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028065049499979" lon="-66.9224199620500002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-348"/>
     </node>
     <node visible="true" id="-347" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027880542100007" lon="-66.9224232203499980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-347"/>
     </node>
     <node visible="true" id="-346" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027254067399962" lon="-66.9224370491999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-346"/>
     </node>
     <node visible="true" id="-345" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026422018000005" lon="-66.9224437007199953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-345"/>
     </node>
     <node visible="true" id="-344" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026274663800017" lon="-66.9224488972599971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-344"/>
     </node>
     <node visible="true" id="-343" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026129194100033" lon="-66.9224546102699946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-343"/>
     </node>
     <node visible="true" id="-342" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025985786200007" lon="-66.9224608327899944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-342"/>
     </node>
     <node visible="true" id="-341" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025844614900024" lon="-66.9224675572399832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-341"/>
     </node>
     <node visible="true" id="-340" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025705851999991" lon="-66.9224747754199996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-340"/>
     </node>
     <node visible="true" id="-339" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025569666800003" lon="-66.9224824785399903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-339"/>
     </node>
     <node visible="true" id="-338" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025436224999975" lon="-66.9224906572199956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-338"/>
     </node>
     <node visible="true" id="-337" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025305689299984" lon="-66.9224993014900065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-337"/>
     </node>
     <node visible="true" id="-336" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025178218600015" lon="-66.9225084008100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-336"/>
     </node>
     <node visible="true" id="-335" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025087488999986" lon="-66.9225153009700051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-335"/>
     </node>
     <node visible="true" id="-334" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024702782100015" lon="-66.9225362829299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-334"/>
     </node>
     <node visible="true" id="-333" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024439437900021" lon="-66.9225681558099978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-333"/>
     </node>
     <node visible="true" id="-332" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024223872799993" lon="-66.9225926820899986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-332"/>
     </node>
     <node visible="true" id="-331" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5097894898599993" lon="-66.9189306639899968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-331"/>
     </node>
     <node visible="true" id="-330" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5097055605299978" lon="-66.9184338315699989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-330"/>
     </node>
     <node visible="true" id="-329" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096711711800008" lon="-66.9182015923399973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-329"/>
     </node>
     <node visible="true" id="-328" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096708096599993" lon="-66.9181464964500066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-328"/>
     </node>
     <node visible="true" id="-327" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096727363800024" lon="-66.9181350198300038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-327"/>
     </node>
     <node visible="true" id="-326" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096794358299999" lon="-66.9180951141999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-326"/>
     </node>
     <node visible="true" id="-325" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096630176799977" lon="-66.9179835180599980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325"/>
     </node>
     <node visible="true" id="-324" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5095590491499991" lon="-66.9175064447099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-324"/>
     </node>
     <node visible="true" id="-323" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5095227850599979" lon="-66.9173300714100066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-323"/>
     </node>
     <node visible="true" id="-322" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094717696600011" lon="-66.9170685079999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-322"/>
     </node>
     <node visible="true" id="-321" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094540852999998" lon="-66.9169916399700071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-321"/>
     </node>
     <node visible="true" id="-320" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020243295300020" lon="-66.9224822075899937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-320"/>
     </node>
     <node visible="true" id="-319" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020621497000004" lon="-66.9224162470899984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-319"/>
     </node>
     <node visible="true" id="-318" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020848911200009" lon="-66.9223842075199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-318"/>
     </node>
     <node visible="true" id="-317" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020918695199992" lon="-66.9223783048300049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-317"/>
     </node>
     <node visible="true" id="-316" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020990587800007" lon="-66.9223726664299932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-316"/>
     </node>
     <node visible="true" id="-315" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021064491099967" lon="-66.9223673000099950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-315"/>
     </node>
     <node visible="true" id="-314" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021140304199996" lon="-66.9223622128800031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-314"/>
     </node>
     <node visible="true" id="-313" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021217924000005" lon="-66.9223574119699975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-313"/>
     </node>
     <node visible="true" id="-312" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021297244699987" lon="-66.9223529038300029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-312"/>
     </node>
     <node visible="true" id="-311" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021378158000012" lon="-66.9223486945899850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-311"/>
     </node>
     <node visible="true" id="-310" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021460553799990" lon="-66.9223447899999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-310"/>
     </node>
     <node visible="true" id="-309" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021544319700002" lon="-66.9223411953799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-309"/>
     </node>
     <node visible="true" id="-308" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021629341599994" lon="-66.9223379156299814">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-308"/>
     </node>
     <node visible="true" id="-307" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021715503700008" lon="-66.9223349552199949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-307"/>
     </node>
     <node visible="true" id="-306" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021802688399983" lon="-66.9223323181700067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306"/>
     </node>
     <node visible="true" id="-305" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021890777000024" lon="-66.9223300080900003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-305"/>
     </node>
     <node visible="true" id="-304" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021979649400006" lon="-66.9223280281299964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-304"/>
     </node>
     <node visible="true" id="-303" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5022069184499980" lon="-66.9223263809799960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-303"/>
     </node>
     <node visible="true" id="-302" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024514346900002" lon="-66.9222812640000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-302"/>
     </node>
     <node visible="true" id="-301" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5025507142699990" lon="-66.9222545107000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-301"/>
     </node>
     <node visible="true" id="-300" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5025774197900006" lon="-66.9222437030300057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-300"/>
     </node>
     <node visible="true" id="-299" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5026079945899991" lon="-66.9222396335400020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-299"/>
     </node>
     <node visible="true" id="-298" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5027331878599988" lon="-66.9222272014399948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-298"/>
     </node>
     <node visible="true" id="-297" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5029110445900002" lon="-66.9222250466300039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-297"/>
     </node>
     <node visible="true" id="-296" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030515884900026" lon="-66.9222202422599963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-296"/>
     </node>
     <node visible="true" id="-295" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031031692299983" lon="-66.9222112009200032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-295"/>
     </node>
     <node visible="true" id="-294" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031547436499988" lon="-66.9222011933100021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-294"/>
     </node>
     <node visible="true" id="-293" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031899114700025" lon="-66.9222316849699865">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-293"/>
     </node>
     <node visible="true" id="-292" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060914807999985" lon="-66.9224291806099956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-292"/>
     </node>
     <node visible="true" id="-291" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060633816999971" lon="-66.9223179485600070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-291"/>
     </node>
     <node visible="true" id="-290" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060590372099973" lon="-66.9222515998099965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-290"/>
     </node>
     <node visible="true" id="-289" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060511819099993" lon="-66.9221267988699964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-289"/>
     </node>
     <node visible="true" id="-288" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060503386299988" lon="-66.9219980000100065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-288"/>
     </node>
     <node visible="true" id="-287" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060598688499987" lon="-66.9217814183299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-287"/>
     </node>
     <node visible="true" id="-286" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062818944800007" lon="-66.9181573339999858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-286"/>
     </node>
     <node visible="true" id="-285" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061648468000008" lon="-66.9176740356499948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-285"/>
     </node>
     <node visible="true" id="-284" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059300716599999" lon="-66.9188410517999870">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-284"/>
     </node>
     <node visible="true" id="-283" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055750874899996" lon="-66.9189091096399977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-283"/>
     </node>
     <node visible="true" id="-282" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051952928599981" lon="-66.9189899105600006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-282"/>
     </node>
     <node visible="true" id="-281" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047918416500004" lon="-66.9190485100699988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-281"/>
     </node>
     <node visible="true" id="-280" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040953147699962" lon="-66.9191573294800008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-280"/>
     </node>
     <node visible="true" id="-279" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040457241999974" lon="-66.9191555192399932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-279"/>
     </node>
     <node visible="true" id="-278" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039586815799986" lon="-66.9191686789999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-278"/>
     </node>
     <node visible="true" id="-277" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038523144699987" lon="-66.9191875579400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-277"/>
     </node>
     <node visible="true" id="-276" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037625517700004" lon="-66.9192077231899987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-276"/>
     </node>
     <node visible="true" id="-275" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063523938099994" lon="-66.9162722837800032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-275"/>
     </node>
     <node visible="true" id="-274" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059284661799985" lon="-66.9163486464699986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-274"/>
     </node>
     <node visible="true" id="-273" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069191310600001" lon="-66.9168471839300025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-273"/>
     </node>
     <node visible="true" id="-272" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068529482000006" lon="-66.9165352802399980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-272"/>
     </node>
     <node visible="true" id="-271" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066023617799988" lon="-66.9174816718000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-271"/>
     </node>
     <node visible="true" id="-270" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069967027600004" lon="-66.9173048613500043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-270"/>
     </node>
     <node visible="true" id="-269" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072214588500010" lon="-66.9185794613800056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-269"/>
     </node>
     <node visible="true" id="-268" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071615708699984" lon="-66.9182477991100058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-268"/>
     </node>
     <node visible="true" id="-267" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070787627000009" lon="-66.9177817534199875">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-267"/>
     </node>
     <node visible="true" id="-266" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070130883199990" lon="-66.9174000858100015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-266"/>
     </node>
     <node visible="true" id="-265" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061359141099988" lon="-66.9175366525399795">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-265"/>
     </node>
     <node visible="true" id="-264" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061437431500000" lon="-66.9175738276800018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-264"/>
     </node>
     <node visible="true" id="-263" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060422756899978" lon="-66.9175942167299951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-263"/>
     </node>
     <node visible="true" id="-262" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055432188300006" lon="-66.9177014809399964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-262"/>
     </node>
     <node visible="true" id="-261" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051692639099983" lon="-66.9177721839400022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-261"/>
     </node>
     <node visible="true" id="-260" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059956875499978" lon="-66.9175044098199834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-260"/>
     </node>
     <node visible="true" id="-259" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055515677300004" lon="-66.9175962862999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-259"/>
     </node>
     <node visible="true" id="-258" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049533554100023" lon="-66.9177147688200051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-258"/>
     </node>
     <node visible="true" id="-257" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061021202100005" lon="-66.9174772214900031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-257"/>
     </node>
     <node visible="true" id="-256" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060778466800002" lon="-66.9174345332900060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-256"/>
     </node>
     <node visible="true" id="-255" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059951321099998" lon="-66.9170344960599834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-255"/>
     </node>
     <node visible="true" id="-254" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059042314299980" lon="-66.9166075381699841">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-254"/>
     </node>
     <node visible="true" id="-253" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058777022099985" lon="-66.9164296754899937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-253"/>
     </node>
     <node visible="true" id="-252" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046685254200014" lon="-66.9178680922500035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-252"/>
     </node>
     <node visible="true" id="-251" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038070532700001" lon="-66.9180491496999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-251"/>
     </node>
     <node visible="true" id="-250" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053432219099996" lon="-66.9198265946899937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-250"/>
     </node>
     <node visible="true" id="-249" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053649547400010" lon="-66.9197322105199817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-249"/>
     </node>
     <node visible="true" id="-248" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052494527399993" lon="-66.9191995371999866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-248"/>
     </node>
     <node visible="true" id="-247" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5050732855399982" lon="-66.9183869069299817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-247"/>
     </node>
     <node visible="true" id="-246" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049342697800014" lon="-66.9178171933099861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-246"/>
     </node>
     <node visible="true" id="-245" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045356450099998" lon="-66.9177906358799959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-245"/>
     </node>
     <node visible="true" id="-244" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037778407700024" lon="-66.9179476279900030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-244"/>
     </node>
     <node visible="true" id="-243" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049111476799997" lon="-66.9177224348500062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-243"/>
     </node>
     <node visible="true" id="-242" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048757827699983" lon="-66.9175775034800040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-242"/>
     </node>
     <node visible="true" id="-241" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047173406399974" lon="-66.9169096394799965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-241"/>
     </node>
     <node visible="true" id="-240" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058770043799985" lon="-66.9163602237699990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-240"/>
     </node>
     <node visible="true" id="-239" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058538840399986" lon="-66.9163143857499989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-239"/>
     </node>
     <node visible="true" id="-238" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058434388300004" lon="-66.9162936772499961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-238"/>
     </node>
     <node visible="true" id="-237" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5057298551400002" lon="-66.9158682208299922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-237"/>
     </node>
     <node visible="true" id="-236" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-236"/>
     </node>
     <node visible="true" id="-235" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-235"/>
     </node>
     <node visible="true" id="-234" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-234"/>
     </node>
     <node visible="true" id="-233" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299997" lon="-66.9151838086699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-233"/>
     </node>
     <node visible="true" id="-232" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-232"/>
     </node>
     <node visible="true" id="-231" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699999" lon="-66.9151444806499995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-231"/>
     </node>
     <node visible="true" id="-230" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-230"/>
     </node>
     <node visible="true" id="-229" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-229"/>
     </node>
     <node visible="true" id="-228" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042815343599987" lon="-66.9147518508599859">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-228"/>
     </node>
     <node visible="true" id="-227" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032642808799981" lon="-66.9157474172099995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-227"/>
     </node>
     <node visible="true" id="-226" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030713079300000" lon="-66.9149294392900060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-226"/>
     </node>
     <node visible="true" id="-225" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042510361299986" lon="-66.9153836661400021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-225"/>
     </node>
     <node visible="true" id="-224" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035492336900003" lon="-66.9155513811799949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-224"/>
     </node>
     <node visible="true" id="-223" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032438332300000" lon="-66.9156426956199937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-223"/>
     </node>
     <node visible="true" id="-222" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546599987" lon="-66.9153896753699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-222"/>
     </node>
     <node visible="true" id="-221" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457500006" lon="-66.9149623942000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-221"/>
     </node>
     <node visible="true" id="-220" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080860520500021" lon="-66.9158961567700032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-220"/>
     </node>
     <node visible="true" id="-219" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080252273599992" lon="-66.9156127823600002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-219"/>
     </node>
     <node visible="true" id="-218" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164700004" lon="-66.9153835618100032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-218"/>
     </node>
     <node visible="true" id="-217" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844299999" lon="-66.9148101529700057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-217"/>
     </node>
     <node visible="true" id="-216" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800037" lon="-66.9178452289699948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-216"/>
     </node>
     <node visible="true" id="-215" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-215"/>
     </node>
     <node visible="true" id="-214" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039194989899993" lon="-66.9196712758399883">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-214"/>
     </node>
     <node visible="true" id="-213" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039704792399995" lon="-66.9195592527499912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-213"/>
     </node>
     <node visible="true" id="-212" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039802668399993" lon="-66.9195420380700057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-212"/>
     </node>
     <node visible="true" id="-211" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039880360800026" lon="-66.9195238027599970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-211"/>
     </node>
     <node visible="true" id="-210" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039936844599993" lon="-66.9195047874499949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-210"/>
     </node>
     <node visible="true" id="-209" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039971374299981" lon="-66.9194852430599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-209"/>
     </node>
     <node visible="true" id="-208" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039983494300007" lon="-66.9194654274899960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-208"/>
     </node>
     <node visible="true" id="-207" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039973044699995" lon="-66.9194456021999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-207"/>
     </node>
     <node visible="true" id="-206" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039940163500010" lon="-66.9194260288099940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-206"/>
     </node>
     <node visible="true" id="-205" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039885284400007" lon="-66.9194069655899995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-205"/>
     </node>
     <node visible="true" id="-204" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039809131699986" lon="-66.9193886640899933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-204"/>
     </node>
     <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039712710100002" lon="-66.9193713657999893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-203"/>
     </node>
     <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039597292100009" lon="-66.9193552990000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-202"/>
     </node>
     <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039464400600000" lon="-66.9193406756700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-201"/>
     </node>
     <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039315789199978" lon="-66.9193276887999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-200"/>
     </node>
     <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039153418899982" lon="-66.9193165097299953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-199"/>
     </node>
     <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038979432200001" lon="-66.9193072859900013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-198"/>
     </node>
     <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038711250799981" lon="-66.9192933751199917">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-197"/>
     </node>
     <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038453873499993" lon="-66.9192935174699954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-196"/>
     </node>
     <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038196887600002" lon="-66.9192920768799979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-195"/>
     </node>
     <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037941245499997" lon="-66.9192890587199969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-194"/>
     </node>
     <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037687894899996" lon="-66.9192844741500039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-193"/>
     </node>
     <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037437775000004" lon="-66.9192783401800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-192"/>
     </node>
     <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037334723099995" lon="-66.9192751305700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-191"/>
     </node>
     <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037191812899984" lon="-66.9192706795400056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-190"/>
     </node>
     <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036950920299983" lon="-66.9192615206400063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-189"/>
     </node>
     <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036715990199987" lon="-66.9192508974099951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-188"/>
     </node>
     <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036487893300023" lon="-66.9192388492499930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-187"/>
     </node>
     <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036267475399985" lon="-66.9192254208099939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-186"/>
     </node>
     <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036055553199983" lon="-66.9192106618699967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-185"/>
     </node>
     <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035852912600003" lon="-66.9191946271400013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-184"/>
     </node>
     <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035660304499974" lon="-66.9191773760500013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-183"/>
     </node>
     <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035478442900008" lon="-66.9191589725499938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-182"/>
     </node>
     <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035308001999983" lon="-66.9191394848599970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-181"/>
     </node>
     <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035233190399993" lon="-66.9191289288099966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-180"/>
     </node>
     <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035162070299997" lon="-66.9191181153699972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-179"/>
     </node>
     <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035094728299985" lon="-66.9191070577099936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-178"/>
     </node>
     <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035031246399981" lon="-66.9190957693100046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-177"/>
     </node>
     <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034971702000011" lon="-66.9190842639199985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-176"/>
     </node>
     <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034916167599999" lon="-66.9190725555699970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175"/>
     </node>
     <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034864711000004" lon="-66.9190606585000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-174"/>
     </node>
     <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034817394699989" lon="-66.9190485872299945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-173"/>
     </node>
     <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034774276499991" lon="-66.9190363564499933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-172"/>
     </node>
     <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034735408800017" lon="-66.9190239810599934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171"/>
     </node>
     <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034700839000017" lon="-66.9190114761599943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170"/>
     </node>
     <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034670609299976" lon="-66.9189988569600018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-169"/>
     </node>
     <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034644756399977" lon="-66.9189861388399976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-168"/>
     </node>
     <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034623311899988" lon="-66.9189733373100069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-167"/>
     </node>
     <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034268959599988" lon="-66.9188101090799989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-166"/>
     </node>
     <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5033042606499976" lon="-66.9182751022899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165"/>
     </node>
     <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032568712999979" lon="-66.9180631138100068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-164"/>
     </node>
     <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030270432499986" lon="-66.9147251119999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-163"/>
     </node>
     <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045740190299970" lon="-66.9165666487800053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-162"/>
     </node>
     <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045299362899964" lon="-66.9163211548700048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-161"/>
     </node>
     <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044405943299974" lon="-66.9158470813899982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-160"/>
     </node>
     <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043741888499991" lon="-66.9155341129499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-159"/>
     </node>
     <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043582842800021" lon="-66.9154639941399836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-158"/>
     </node>
     <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046516504500040" lon="-66.9166619300499974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-157"/>
     </node>
     <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046769630700005" lon="-66.9165677409999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-156"/>
     </node>
     <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046011597699991" lon="-66.9161736758899934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-155"/>
     </node>
     <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045687244099994" lon="-66.9159888408800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-154"/>
     </node>
     <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044906445499997" lon="-66.9155966217399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153"/>
     </node>
     <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044716726299967" lon="-66.9154840413900018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-152"/>
     </node>
     <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044679569899984" lon="-66.9154575822200002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-151"/>
     </node>
     <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044649218899977" lon="-66.9154359692000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-150"/>
     </node>
     <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043894673900002" lon="-66.9153129303799972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-149"/>
     </node>
     <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096322146500007" lon="-66.9155947246599965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-148"/>
     </node>
     <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092728589799975" lon="-66.9156553398100016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-147"/>
     </node>
     <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091801185500007" lon="-66.9156787637299999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-146"/>
     </node>
     <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090236679100002" lon="-66.9157182792099974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-145"/>
     </node>
     <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086644395900031" lon="-66.9157982945799858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144"/>
     </node>
     <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082264324199990" lon="-66.9158849647899956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-143"/>
     </node>
     <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079317687000007" lon="-66.9159482085800050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-142"/>
     </node>
     <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074756193199992" lon="-66.9160421477200060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-141"/>
     </node>
     <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067934462499988" lon="-66.9161876369699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-140"/>
     </node>
     <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067748030699999" lon="-66.9161912149800031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-139"/>
     </node>
     <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068154619499996" lon="-66.9221456928499947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-138"/>
     </node>
     <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067771756999999" lon="-66.9216615938599801">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-137"/>
     </node>
     <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067966759099995" lon="-66.9214219473199989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136"/>
     </node>
     <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068400008000005" lon="-66.9210668188599982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-135"/>
     </node>
     <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068421848000000" lon="-66.9210163419700024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-134"/>
     </node>
     <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068426240999990" lon="-66.9209658187999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-133"/>
     </node>
     <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068413181599993" lon="-66.9209153109299990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-132"/>
     </node>
     <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068382685700001" lon="-66.9208648798799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-131"/>
     </node>
     <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068334790499982" lon="-66.9208145870999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-130"/>
     </node>
     <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068269554300002" lon="-66.9207644938600055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-129"/>
     </node>
     <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068187056600024" lon="-66.9207146611899901">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-128"/>
     </node>
     <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068087397899994" lon="-66.9206651498100058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
     </node>
     <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067970699599993" lon="-66.9206160200500051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
     </node>
     <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067876554299993" lon="-66.9205810401399930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-125"/>
     </node>
     <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066714401599999" lon="-66.9199945602299948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
     </node>
     <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065514100199984" lon="-66.9193619775499968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-123"/>
     </node>
     <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064335067399970" lon="-66.9187861553899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
     </node>
     <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064215152299987" lon="-66.9187364196500027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
     </node>
     <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039070353500037" lon="-66.9225971136300046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-120"/>
     </node>
     <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039205406799976" lon="-66.9225821776499998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039358283100039" lon="-66.9225691129399962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-118"/>
     </node>
     <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039526463099993" lon="-66.9225581347800045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117"/>
     </node>
     <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040592021299997" lon="-66.9224868957000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-116"/>
     </node>
     <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5041008246299992" lon="-66.9224478276699983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-115"/>
     </node>
     <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5041377634199975" lon="-66.9224040891199934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114"/>
     </node>
     <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042506062499985" lon="-66.9223506049900010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-113"/>
     </node>
     <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043546856499983" lon="-66.9222814760800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
     </node>
     <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044485666299998" lon="-66.9222287797799993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-111"/>
     </node>
     <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045394544799997" lon="-66.9221686650400045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-110"/>
     </node>
     <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046303423099996" lon="-66.9221085502600062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-109"/>
     </node>
     <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046843760400002" lon="-66.9220412433700034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-108"/>
     </node>
     <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047545067299986" lon="-66.9219589520299820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-107"/>
     </node>
     <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047894308399989" lon="-66.9218962358799985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-106"/>
     </node>
     <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047986594700014" lon="-66.9218899126099984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105"/>
     </node>
     <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048083889299981" lon="-66.9218844090199951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-104"/>
     </node>
     <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048185480799976" lon="-66.9218797653599893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-103"/>
     </node>
     <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048290626600025" lon="-66.9218760155700068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-102"/>
     </node>
     <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048398558099976" lon="-66.9218731870599868">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
     </node>
     <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048508486200021" lon="-66.9218713005100057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-100"/>
     </node>
     <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048619607399996" lon="-66.9218703697000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-99"/>
     </node>
     <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048731109300011" lon="-66.9218704014499934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-98"/>
     </node>
     <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048842176800008" lon="-66.9218713955300046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-97"/>
     </node>
     <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048951997900026" lon="-66.9218733446499954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-96"/>
     </node>
     <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049059769899991" lon="-66.9218762345900018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
     </node>
     <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049164704900004" lon="-66.9218800442099990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
     </node>
     <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049266035799977" lon="-66.9218847456500043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
     </node>
     <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049363021800026" lon="-66.9218903045599944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
     </node>
     <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049454953899986" lon="-66.9218966802999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-91"/>
     </node>
     <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5050997160699993" lon="-66.9220652454000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-90"/>
     </node>
     <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051591695399988" lon="-66.9221511337299972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-89"/>
     </node>
     <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052266462600006" lon="-66.9223381310799965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-88"/>
     </node>
     <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052863431100025" lon="-66.9224612100299936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
     <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053102880499996" lon="-66.9225205574399951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
     <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053327120799995" lon="-66.9225724765999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
     <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094299418899961" lon="-66.9169115387200009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
     <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098929898699982" lon="-66.9167171441300042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
     <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094049278800004" lon="-66.9168165613399992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
     <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098801357199996" lon="-66.9194266970799987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
     <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096758779499986" lon="-66.9181163069000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098666174000002" lon="-66.9193527216999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094893116399977" lon="-66.9219630065600057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094511167099984" lon="-66.9219496928599966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093171784799981" lon="-66.9219030056799795">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092779757799981" lon="-66.9218809953700031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092395571399990" lon="-66.9218576159800023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092019693799976" lon="-66.9218328959999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091652582799995" lon="-66.9218068655400060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091294685799976" lon="-66.9217795563299944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090946438700001" lon="-66.9217510016299855">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090608265799990" lon="-66.9217212362400033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090221939399981" lon="-66.9216843590299959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096589336199990" lon="-66.9221201602099995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094775881599976" lon="-66.9220713881800009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094413869800007" lon="-66.9220612686000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094055573700000" lon="-66.9220498785399940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093701429599999" lon="-66.9220372318900019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093351869100005" lon="-66.9220233440500039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092668196299996" lon="-66.9219919139700039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
     <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092334916999999" lon="-66.9219744100399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
     <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092007886100003" lon="-66.9219557414500059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091687502100015" lon="-66.9219359309600037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
     <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091374155399979" lon="-66.9219150027000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091068227700024" lon="-66.9218929821799975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090770091700030" lon="-66.9218698962099978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090615095499977" lon="-66.9218572159000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
     <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090158072899982" lon="-66.9218164769699797">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
     <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089715398900019" lon="-66.9217741511599939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
     <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089541299099984" lon="-66.9217563006399985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
     <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098610153999985" lon="-66.9223342548799991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097554013100005" lon="-66.9223270593700050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097071699200004" lon="-66.9223140055800059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096594187499992" lon="-66.9222992588500034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096122059799999" lon="-66.9222828371599832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
     <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095655891500002" lon="-66.9222647605100036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
     <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095196250300003" lon="-66.9222450509300018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
     <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094743696300004" lon="-66.9222237324199938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
     <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094298780999988" lon="-66.9222008309699987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
     <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093862046299975" lon="-66.9221763744699984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
     <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093397812800013" lon="-66.9221480991700020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
     <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092912423399998" lon="-66.9220996965700010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
     <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093086107700007" lon="-66.9220116876699791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
     <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5030216030534156" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5042702357392166" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5055726487324517" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5061263174137789" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5019773254829722" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5024207826546370" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9218128281131044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9216660902135345">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9198273048406094">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9191121238655313">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9184432685039354">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9172728837260422">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9185233694162633">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5017660737884562" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9150505735035637">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5077664451104162" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9213871847514383">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9160029618147263">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5037296643490183" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5034735566289115" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5026017825486893" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5064658613273991" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9223373273507605">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9221834345442232">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9220751717364521">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9193479034154564">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9180924320168202">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9195506086608987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9167158545658367">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9167990839550271">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5039050309753375" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5053410803396421" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5068735544789007" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9155511759909132">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5031510625137052" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5078486207237187" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5089812841696180" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-8019" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-220"/>
         <nd ref="-540"/>
         <nd ref="-5236"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:34.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{781d71a3-4c17-4f7d-baf4-87a70049cb08}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8019"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:34.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{781d71a3-4c17-4f7d-baf4-87a70049cb08}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8018" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5236"/>
         <nd ref="-541"/>
         <nd ref="-509"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Puente: Llaguno"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="layer" v="1"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:34.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{781d71a3-4c17-4f7d-baf4-87a70049cb08}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8018"/>
+        <tag k="name" v="Puente: Llaguno"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:34.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{781d71a3-4c17-4f7d-baf4-87a70049cb08}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8015" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5234"/>
         <nd ref="-558"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:40.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{89d3f564-9ee7-483b-8618-a571d9a2c921}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8015"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:40.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{89d3f564-9ee7-483b-8618-a571d9a2c921}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8014" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-510"/>
         <nd ref="-557"/>
         <nd ref="-5234"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Puente: Llaguno"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="layer" v="1"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:40.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{89d3f564-9ee7-483b-8618-a571d9a2c921}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8014"/>
+        <tag k="name" v="Puente: Llaguno"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:40.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{89d3f564-9ee7-483b-8618-a571d9a2c921}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8008" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-509"/>
         <nd ref="-510"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Puente: Llaguno"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="layer" v="1"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{739e9fb0-22ec-4f89-977d-7dd397f89fd0}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8008"/>
+        <tag k="name" v="Puente: Llaguno"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{739e9fb0-22ec-4f89-977d-7dd397f89fd0}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8005" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5229"/>
@@ -3972,152 +3009,142 @@
         <nd ref="-548"/>
         <nd ref="-547"/>
         <nd ref="-22"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2014-09-04T18:34:00.000Z;2014-12-26T14:05:25.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{7b7843fb-5c2c-4397-b0ae-87d592f04b7f}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8005"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2014-09-04T18:34:00.000Z;2014-12-26T14:05:25.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{7b7843fb-5c2c-4397-b0ae-87d592f04b7f}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8004" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-542"/>
         <nd ref="-552"/>
         <nd ref="-5229"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Puente: Llaguno"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="layer" v="1"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:05.000Z;2014-12-26T14:05:25.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{7b7843fb-5c2c-4397-b0ae-87d592f04b7f}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8004"/>
+        <tag k="name" v="Puente: Llaguno"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:05.000Z;2014-12-26T14:05:25.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{7b7843fb-5c2c-4397-b0ae-87d592f04b7f}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8001" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-563"/>
         <nd ref="-562"/>
         <nd ref="-5227"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="layer" v="-1"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:32.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{6d8e0da5-9629-4040-a4d3-a8f3e0c1e784}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="layer" v="-1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8001"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:32.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{6d8e0da5-9629-4040-a4d3-a8f3e0c1e784}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8000" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5227"/>
         <nd ref="-561"/>
         <nd ref="-553"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Puente: Llaguno"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="layer" v="1"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:05.000Z;2015-06-12T14:47:32.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{6d8e0da5-9629-4040-a4d3-a8f3e0c1e784}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8000"/>
+        <tag k="name" v="Puente: Llaguno"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:05.000Z;2015-06-12T14:47:32.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{6d8e0da5-9629-4040-a4d3-a8f3e0c1e784}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-7994" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-553"/>
         <nd ref="-542"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Puente: Llaguno"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="layer" v="1"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:05.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{58dcbcff-fbf6-4501-b66a-ab5f0e880694}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7994"/>
+        <tag k="name" v="Puente: Llaguno"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:05.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{58dcbcff-fbf6-4501-b66a-ab5f0e880694}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-7990" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5221"/>
@@ -4129,23 +3156,21 @@
         <nd ref="-791"/>
         <nd ref="-792"/>
         <nd ref="-729"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
-        <tag k="name" v="Av. Oeste 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7990"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 4"/>
+        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
+        <tag k="source:datetime" v="2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-7989" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-699"/>
@@ -4199,23 +3224,21 @@
         <nd ref="-781"/>
         <nd ref="-782"/>
         <nd ref="-5220"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
-        <tag k="name" v="Av. Oeste 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7989"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 4"/>
+        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
+        <tag k="source:datetime" v="2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-7988" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5220"/>
@@ -4223,26 +3246,24 @@
         <nd ref="-784"/>
         <nd ref="-785"/>
         <nd ref="-5221"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="layer" v="1"/>
-        <tag k="bridge" v="yes"/>
         <tag k="alt_name" v="Av. Oeste 4"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
-        <tag k="name" v="Puente: Unión"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-25T15:14:46.000Z;2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="layer" v="1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7988"/>
+        <tag k="name" v="Puente: Unión"/>
+        <tag k="source:datetime" v="2014-04-25T15:14:46.000Z;2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="-7983" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5216"/>
@@ -4258,60 +3279,56 @@
         <nd ref="-702"/>
         <nd ref="-701"/>
         <nd ref="-5217"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Viaducto: Nueva República"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Sucre"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="layer" v="3"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:51:40.000Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
-        <tag k="motor_vehicle" v="permissive"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="3"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7983"/>
+        <tag k="name" v="Viaducto: Nueva República"/>
+        <tag k="source:datetime" v="2015-06-12T14:51:40.000Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-404" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-26"/>
         <nd ref="-513"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sur 4"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2015-08-24T16:13:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-404"/>
+        <tag k="name" v="Av. Sur 4"/>
+        <tag k="source:datetime" v="2015-08-24T16:13:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-394" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-37"/>
@@ -4348,47 +3365,43 @@
         <nd ref="-637"/>
         <nd ref="-638"/>
         <nd ref="-249"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z;2019-01-17T19:50:05.676Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{006de0c0-48c5-434f-8fdb-29c68cb4c649};{48532445-a733-416c-a55c-1fad8bf34ae1}"/>
-        <tag k="name" v="Av. Oeste 6"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2015-08-03T17:38:19.000Z"/>
-        <tag k="highway" v="secondary"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-394"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z;2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 6"/>
+        <tag k="uuid" v="{006de0c0-48c5-434f-8fdb-29c68cb4c649};{48532445-a733-416c-a55c-1fad8bf34ae1}"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2015-08-03T17:38:19.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-391" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-507"/>
         <nd ref="-524"/>
         <nd ref="-523"/>
         <nd ref="-520"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-391"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-372" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-214"/>
@@ -4407,31 +3420,29 @@
         <nd ref="-673"/>
         <nd ref="-426"/>
         <nd ref="-456"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z;2019-01-17T19:50:05.669Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2015-10-15T16:12:12.000Z;2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454};{35fb46ac-4c0c-4d19-a3d2-94876d592c26}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="destination" v="San Martín;Centro"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-372"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2015-10-15T16:12:12.000Z;2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454};{35fb46ac-4c0c-4d19-a3d2-94876d592c26}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z;2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+        <tag k="destination" v="San Martín;Centro"/>
     </way>
     <way visible="true" id="-365" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-5217"/>
@@ -4452,30 +3463,28 @@
         <nd ref="-687"/>
         <nd ref="-686"/>
         <nd ref="-214"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-25T15:37:21.000Z;2019-01-17T19:50:06Z;2014-05-19T20:36:26.000Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
-        <tag k="motor_vehicle" v="permissive"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-365"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2014-04-25T15:37:21.000Z;2019-01-17T19:50:06Z;2014-05-19T20:36:26.000Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-314" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-293"/>
@@ -4518,22 +3527,20 @@
         <nd ref="-333"/>
         <nd ref="-332"/>
         <nd ref="-32"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="El Calvario"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-09-15T22:49:24.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-314"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="El Calvario"/>
+        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c}"/>
+        <tag k="source:datetime" v="2015-09-15T22:49:24.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-311" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-191"/>
@@ -4542,24 +3549,22 @@
         <nd ref="-278"/>
         <nd ref="-279"/>
         <nd ref="-280"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary_link"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-311"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="secondary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-307" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-269"/>
@@ -4572,42 +3577,38 @@
         <nd ref="-282"/>
         <nd ref="-281"/>
         <nd ref="-280"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z;2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c};{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z;2015-04-23T16:51:25.000Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-307"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z;2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c};{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
+        <tag k="source:datetime" v="2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z;2015-04-23T16:51:25.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-216"/>
         <nd ref="-215"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{a439f440-165f-401c-9395-166374e5bdd7}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-04-18T01:17:19.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-104"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{a439f440-165f-401c-9395-166374e5bdd7}"/>
+        <tag k="source:datetime" v="2013-04-18T01:17:19.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-164"/>
@@ -4661,27 +3662,25 @@
         <nd ref="-212"/>
         <nd ref="-213"/>
         <nd ref="-214"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="foot" v="no"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2014-12-24T02:49:57.000Z"/>
-        <tag k="uuid" v="{aec76311-ef7c-458d-b5dc-495745461b2f}"/>
-        <tag k="destination" v="San Martín"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-103"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2014-12-24T02:49:57.000Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="uuid" v="{aec76311-ef7c-458d-b5dc-495745461b2f}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="destination" v="San Martín"/>
+        <tag k="highway" v="primary_link"/>
     </way>
     <way visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-149"/>
@@ -4691,30 +3690,28 @@
         <nd ref="-161"/>
         <nd ref="-162"/>
         <nd ref="-157"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="lanes" v="1"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2013-12-19T16:34:21.000Z;2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{fb707a34-dd57-41b3-b236-7d7c6de3cd29}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-102"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2013-12-19T16:34:21.000Z;2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="1"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{fb707a34-dd57-41b3-b236-7d7c6de3cd29}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-149"/>
@@ -4726,30 +3723,28 @@
         <nd ref="-155"/>
         <nd ref="-156"/>
         <nd ref="-157"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="lanes" v="1"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z;2015-07-07T18:03:14.000Z;2013-12-19T16:34:22.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-101"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z;2015-07-07T18:03:14.000Z;2013-12-19T16:34:22.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="1"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-653"/>
@@ -4777,46 +3772,42 @@
         <nd ref="-938"/>
         <nd ref="-939"/>
         <nd ref="-598"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="foot" v="no"/>
-        <tag k="source:datetime" v="2014-04-25T15:54:45.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{f1a85717-8752-48b3-9d48-c8c5d3c1e99c}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-100"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2014-04-25T15:54:45.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{f1a85717-8752-48b3-9d48-c8c5d3c1e99c}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary_link"/>
     </way>
     <way visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-51"/>
         <nd ref="-68"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{73768fac-23de-4ae6-b24f-a14cae4ab15b}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-98"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{73768fac-23de-4ae6-b24f-a14cae4ab15b}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-51"/>
@@ -4843,30 +3834,28 @@
         <nd ref="-713"/>
         <nd ref="-712"/>
         <nd ref="-5216"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:51:44.000Z;2019-01-17T19:50:06Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
-        <tag k="motor_vehicle" v="permissive"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-97"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2015-06-12T14:51:44.000Z;2019-01-17T19:50:06Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-595"/>
@@ -4879,77 +3868,71 @@
         <nd ref="-607"/>
         <nd ref="-606"/>
         <nd ref="-605"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="access" v="private"/>
-        <tag k="oneway" v="no"/>
-        <tag k="service" v="driveway"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{905a39fa-496f-4b2f-810f-663fd92c5565}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-06-24T05:28:45.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="service"/>
-        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-95"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="service" v="driveway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{905a39fa-496f-4b2f-810f-663fd92c5565}"/>
+        <tag k="source:datetime" v="2014-06-24T05:28:45.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="access" v="private"/>
     </way>
     <way visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-595"/>
         <nd ref="-604"/>
         <nd ref="-571"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{63dbcce4-3f71-4568-9c3c-36f0e8cb836d}"/>
-        <tag k="name" v="Av. Norte 10"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:00.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-94"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 10"/>
+        <tag k="uuid" v="{63dbcce4-3f71-4568-9c3c-36f0e8cb836d}"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:00.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-595"/>
         <nd ref="-603"/>
         <nd ref="-602"/>
         <nd ref="-563"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="layer" v="-1"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{4fde3a77-aa34-4531-b770-6c3818311f8a}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="layer" v="-1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-93"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{4fde3a77-aa34-4531-b770-6c3818311f8a}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-601"/>
@@ -4959,63 +3942,59 @@
         <nd ref="-597"/>
         <nd ref="-596"/>
         <nd ref="-595"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="layer" v="-1"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{ae210ee0-b440-4ebc-87d9-91e9d194b8ed}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="-1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-92"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{ae210ee0-b440-4ebc-87d9-91e9d194b8ed}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-558"/>
         <nd ref="-593"/>
         <nd ref="-594"/>
         <nd ref="-571"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-06-24T05:28:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8bdee643-f6c6-4bcf-a2ab-662da78e442c}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-91"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2014-06-24T05:28:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8bdee643-f6c6-4bcf-a2ab-662da78e442c}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-571"/>
@@ -5039,51 +4018,47 @@
         <nd ref="-591"/>
         <nd ref="-592"/>
         <nd ref="-77"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-12-10T04:55:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{c31794dc-aae1-41f8-9908-8475b8e999de}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-90"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2014-12-10T04:55:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{c31794dc-aae1-41f8-9908-8475b8e999de}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-571"/>
         <nd ref="-572"/>
         <nd ref="-573"/>
         <nd ref="-79"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{022fd160-a0bb-46ef-a78c-9eeadebe02b3}"/>
-        <tag k="name" v="Av. Norte 10"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-06-05T14:13:59.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-89"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 10"/>
+        <tag k="uuid" v="{022fd160-a0bb-46ef-a78c-9eeadebe02b3}"/>
+        <tag k="source:datetime" v="2015-06-05T14:13:59.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-563"/>
@@ -5092,124 +4067,114 @@
         <nd ref="-568"/>
         <nd ref="-567"/>
         <nd ref="-269"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c}"/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-88"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c}"/>
+        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-558"/>
         <nd ref="-563"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{ac26def1-7e6e-4947-9322-20587353e9f1}"/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-87"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{ac26def1-7e6e-4947-9322-20587353e9f1}"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-327"/>
         <nd ref="-560"/>
         <nd ref="-559"/>
         <nd ref="-558"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{9f87d03d-3b17-4360-a370-c5313fcc639f}"/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-85"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{9f87d03d-3b17-4360-a370-c5313fcc639f}"/>
+        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-553"/>
         <nd ref="-556"/>
         <nd ref="-555"/>
         <nd ref="-266"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{569d7378-99ce-4e3e-8863-37c85ab179f9}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-82"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{569d7378-99ce-4e3e-8863-37c85ab179f9}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-553"/>
         <nd ref="-554"/>
         <nd ref="-510"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc}"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-81"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-257"/>
@@ -5220,154 +4185,142 @@
         <nd ref="-546"/>
         <nd ref="-542"/>
         <nd ref="-509"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z;2014-12-26T14:05:26.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0};{91bd559b-809d-4cef-ae04-6103684ae9fb};{e2598c3b-e27d-4c8d-8283-1f589dfccac4}"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-80"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z;2014-12-26T14:05:26.000Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0};{91bd559b-809d-4cef-ae04-6103684ae9fb};{e2598c3b-e27d-4c8d-8283-1f589dfccac4}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-510"/>
         <nd ref="-536"/>
         <nd ref="-537"/>
         <nd ref="-84"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0}"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-76"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-84"/>
         <nd ref="-82"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380}"/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-75"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380}"/>
+        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-156"/>
         <nd ref="-535"/>
         <nd ref="-239"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{3b13e0ef-5bb0-405c-b1cd-f960330ad854}"/>
-        <tag k="name" v="Av. Sur 4"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="1"/>
-        <tag k="surface" v="paving_stones"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-74"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 4"/>
+        <tag k="uuid" v="{3b13e0ef-5bb0-405c-b1cd-f960330ad854}"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="paving_stones"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="1"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-235"/>
         <nd ref="-534"/>
         <nd ref="-151"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="motor_vehicle" v="no"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{fdc60078-3a67-4381-9d4c-642c5ac1287f}"/>
-        <tag k="name" v="Av. Sur 2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="pedestrian"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-73"/>
+        <tag k="name" v="Av. Sur 2"/>
+        <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="uuid" v="{fdc60078-3a67-4381-9d4c-642c5ac1287f}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="no"/>
+        <tag k="highway" v="pedestrian"/>
     </way>
     <way visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-526"/>
         <nd ref="-163"/>
         <nd ref="-3"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sur"/>
-        <tag k="lanes" v="2"/>
-        <tag k="layer" v="-3"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.666Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="foot" v="no"/>
-        <tag k="source:datetime" v="2013-12-26T19:49:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{d7de87ac-7197-42fe-b791-1a65a1a7974b};{5e7b547b-a9cf-4e4e-a649-360a6925911c};{391a3187-29a7-4217-8429-1e389cd586a5}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="tunnel" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="-3"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-72"/>
+        <tag k="name" v="Av. Sur"/>
+        <tag k="source:datetime" v="2013-12-26T19:49:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="uuid" v="{d7de87ac-7197-42fe-b791-1a65a1a7974b};{5e7b547b-a9cf-4e4e-a649-360a6925911c};{391a3187-29a7-4217-8429-1e389cd586a5}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.666Z"/>
+        <tag k="tunnel" v="yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-520"/>
@@ -5380,208 +4333,192 @@
         <nd ref="-528"/>
         <nd ref="-527"/>
         <nd ref="-526"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980};{bdf0d568-d4fa-4c77-ad37-c4b60ea708f2}"/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:45.000Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
-        <tag k="surface" v="asphalt"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-71"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980};{bdf0d568-d4fa-4c77-ad37-c4b60ea708f2}"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:45.000Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-499"/>
         <nd ref="-525"/>
         <nd ref="-507"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-69"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-251"/>
         <nd ref="-521"/>
         <nd ref="-520"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{0d03894e-5353-42d2-9f60-0316286dab1b}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-68"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{0d03894e-5353-42d2-9f60-0316286dab1b}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-511"/>
         <nd ref="-519"/>
         <nd ref="-516"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{c7000abf-95fe-4c00-9be5-00533f4d7ef0}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-67"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{c7000abf-95fe-4c00-9be5-00533f4d7ef0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-516"/>
         <nd ref="-517"/>
         <nd ref="-518"/>
         <nd ref="-244"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{40a71cf9-24ff-42b7-af9f-a80a93b7a29e}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-66"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{40a71cf9-24ff-42b7-af9f-a80a93b7a29e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-512"/>
         <nd ref="-511"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{7839e6b8-9f99-4b27-96f9-6342a40197de}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-65"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{7839e6b8-9f99-4b27-96f9-6342a40197de}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-507"/>
         <nd ref="-506"/>
         <nd ref="-505"/>
         <nd ref="-502"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{60cb34a4-b2a7-4427-baa6-7bfd0f871bc1}"/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-63"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{60cb34a4-b2a7-4427-baa6-7bfd0f871bc1}"/>
+        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-457"/>
         <nd ref="-504"/>
         <nd ref="-503"/>
         <nd ref="-502"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8bd0e392-a3b6-4f60-80ed-05254da2cb8e}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-62"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8bd0e392-a3b6-4f60-80ed-05254da2cb8e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-30"/>
@@ -5628,30 +4565,28 @@
         <nd ref="-466"/>
         <nd ref="-465"/>
         <nd ref="-464"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:11.000Z;2019-01-17T19:50:06Z;2014-04-21T23:52:41.000Z;2014-04-21T23:52:43.000Z;2014-12-24T02:39:20.000Z;2015-10-15T16:12:12.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{6f44fd8f-d8fd-4e57-b362-afb57ca0c781};{78aeebde-818c-45c7-9246-3000f001c09a}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-61"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:11.000Z;2019-01-17T19:50:06Z;2014-04-21T23:52:41.000Z;2014-04-21T23:52:43.000Z;2014-12-24T02:39:20.000Z;2015-10-15T16:12:12.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{6f44fd8f-d8fd-4e57-b362-afb57ca0c781};{78aeebde-818c-45c7-9246-3000f001c09a}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-82"/>
@@ -5660,73 +4595,67 @@
         <nd ref="-459"/>
         <nd ref="-458"/>
         <nd ref="-146"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.669Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380};{8683446c-cd51-4173-953f-792506c2b133}"/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-60"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.669Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380};{8683446c-cd51-4173-953f-792506c2b133}"/>
+        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-454"/>
         <nd ref="-457"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Metroguía;osm:line"/>
-        <tag k="uuid" v="{d3cf6f64-8525-4139-b1ff-b351e3a4d999}"/>
-        <tag k="name" v="Callejón Penichez"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-21T23:52:41.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-59"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Callejón Penichez"/>
+        <tag k="uuid" v="{d3cf6f64-8525-4139-b1ff-b351e3a4d999}"/>
+        <tag k="source:datetime" v="2014-04-21T23:52:41.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-426"/>
         <nd ref="-455"/>
         <nd ref="-454"/>
         <nd ref="-431"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-57"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-432"/>
@@ -5751,22 +4680,20 @@
         <nd ref="-434"/>
         <nd ref="-433"/>
         <nd ref="-409"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Metroguía;osm:line"/>
-        <tag k="uuid" v="{8fed249a-1156-48df-88e7-3572ee880756};{9b1a6ca0-962e-447b-b3f9-686be3adb939}"/>
-        <tag k="name" v="Callejón Penichez"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-11-08T12:50:13.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-56"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Callejón Penichez"/>
+        <tag k="uuid" v="{8fed249a-1156-48df-88e7-3572ee880756};{9b1a6ca0-962e-447b-b3f9-686be3adb939}"/>
+        <tag k="source:datetime" v="2014-11-08T12:50:13.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-430"/>
@@ -5774,20 +4701,18 @@
         <nd ref="-428"/>
         <nd ref="-427"/>
         <nd ref="-412"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{2c746cd5-7fed-451d-ab6b-99ecfd467865}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-54"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{2c746cd5-7fed-451d-ab6b-99ecfd467865}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-79"/>
@@ -5804,194 +4729,178 @@
         <nd ref="-322"/>
         <nd ref="-321"/>
         <nd ref="-84"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{49e61517-6b6d-4314-894b-9dbb2113bab8}"/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2013-11-12T18:40:59.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:44.000Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-53"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{49e61517-6b6d-4314-894b-9dbb2113bab8}"/>
+        <tag k="source:datetime" v="2013-11-12T18:40:59.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:44.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-121"/>
         <nd ref="-286"/>
         <nd ref="-285"/>
         <nd ref="-264"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.672Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{110c0fcd-4178-4061-8d4f-cfc665d2bcb4}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-16T18:24:48.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-52"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.672Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="uuid" v="{110c0fcd-4178-4061-8d4f-cfc665d2bcb4}"/>
+        <tag k="source:datetime" v="2014-04-16T18:24:48.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-240"/>
         <nd ref="-274"/>
         <nd ref="-275"/>
         <nd ref="-139"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{993c8b95-a1be-4116-8186-22c5a2bc3b96}"/>
-        <tag k="name" v="Av. Sur 4"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
-        <tag k="surface" v="asphalt"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-50"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 4"/>
+        <tag k="uuid" v="{993c8b95-a1be-4116-8186-22c5a2bc3b96}"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-139"/>
         <nd ref="-272"/>
         <nd ref="-273"/>
         <nd ref="-270"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe};{6d3a27e4-a1f4-4584-8d5f-04d9295f29ad}"/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
-        <tag k="surface" v="concrete"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-49"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe};{6d3a27e4-a1f4-4584-8d5f-04d9295f29ad}"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-266"/>
         <nd ref="-271"/>
         <nd ref="-264"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:58.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{52b96f30-702b-4d97-92b4-7338515c81c0}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-48"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:58.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{52b96f30-702b-4d97-92b4-7338515c81c0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-270"/>
         <nd ref="-266"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe}"/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
-        <tag k="surface" v="concrete"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-47"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe}"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-269"/>
         <nd ref="-268"/>
         <nd ref="-267"/>
         <nd ref="-266"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{63630fad-74ee-4cd8-9eff-b0503d3b902b}"/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
-        <tag k="surface" v="concrete"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-46"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{63630fad-74ee-4cd8-9eff-b0503d3b902b}"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-264"/>
         <nd ref="-265"/>
         <nd ref="-257"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
         <tag k="sidewalk" v="both"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="1"/>
-        <tag k="surface" v="concrete"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-45"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170}"/>
+        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="1"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-264"/>
@@ -5999,31 +4908,29 @@
         <nd ref="-262"/>
         <nd ref="-261"/>
         <nd ref="-246"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{81d897e2-47a5-4f7f-a15b-017cf45d4912}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-44"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{81d897e2-47a5-4f7f-a15b-017cf45d4912}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-243"/>
@@ -6031,28 +4938,26 @@
         <nd ref="-259"/>
         <nd ref="-260"/>
         <nd ref="-257"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{bc0b107e-cb23-4e0d-9643-3d54ced6a3b7}"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-43"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{bc0b107e-cb23-4e0d-9643-3d54ced6a3b7}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-257"/>
@@ -6061,83 +4966,77 @@
         <nd ref="-254"/>
         <nd ref="-253"/>
         <nd ref="-240"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z;2019-01-17T19:50:05.674Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
         <tag k="sidewalk" v="both"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170};{26d294f7-6565-4b94-80c4-2c7bcb34380a}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="1"/>
-        <tag k="surface" v="concrete"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-42"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z;2019-01-17T19:50:05.674Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170};{26d294f7-6565-4b94-80c4-2c7bcb34380a}"/>
+        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="1"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-246"/>
         <nd ref="-252"/>
         <nd ref="-251"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{a99d148f-6883-4595-9543-c7d2cdff4acd}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-41"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{a99d148f-6883-4595-9543-c7d2cdff4acd}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-243"/>
         <nd ref="-246"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Oeste 4"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-17T18:05:50.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{7c94360d-c347-492f-a2c4-6edce5cab2f7}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-40"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2015-08-17T18:05:50.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{7c94360d-c347-492f-a2c4-6edce5cab2f7}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-246"/>
@@ -6145,137 +5044,127 @@
         <nd ref="-248"/>
         <nd ref="-249"/>
         <nd ref="-250"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Oeste 4"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-06-10T02:45:38.000Z;2019-01-17T19:50:06Z;2015-08-17T18:05:50.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{cbee07c1-c63c-4fa0-908c-effbd7e8e7f2}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-39"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2014-06-10T02:45:38.000Z;2019-01-17T19:50:06Z;2015-08-17T18:05:50.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{cbee07c1-c63c-4fa0-908c-effbd7e8e7f2}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-244"/>
         <nd ref="-245"/>
         <nd ref="-243"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{d5b69c9e-fde6-4cf7-9af6-5c2a363f055e}"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-38"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{d5b69c9e-fde6-4cf7-9af6-5c2a363f055e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-157"/>
         <nd ref="-241"/>
         <nd ref="-242"/>
         <nd ref="-243"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{9ad6953d-3ec1-4845-a58a-948133832973}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-37"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{9ad6953d-3ec1-4845-a58a-948133832973}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-149"/>
         <nd ref="-225"/>
         <nd ref="-224"/>
         <nd ref="-223"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{1c605363-8a32-4bb4-b559-ea1c6b1133c6}"/>
-        <tag k="name" v="Av. Sur 2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-13T13:38:12.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-36"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 2"/>
+        <tag k="uuid" v="{1c605363-8a32-4bb4-b559-ea1c6b1133c6}"/>
+        <tag k="source:datetime" v="2013-11-13T13:38:12.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-36"/>
         <nd ref="-228"/>
         <nd ref="-149"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-07-07T18:03:14.000Z;2013-12-19T16:34:22.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-34"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2015-07-07T18:03:14.000Z;2013-12-19T16:34:22.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-240"/>
@@ -6291,30 +5180,28 @@
         <nd ref="-230"/>
         <nd ref="-229"/>
         <nd ref="-35"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="paving_stones"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="source:datetime" v="2013-12-19T16:36:19.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{82fc4cc9-b0a0-42e9-a811-c99032648c0d}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.675Z"/>
         <tag k="sidewalk" v="both"/>
         <tag k="horse" v="no"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.675Z"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="pedestrian"/>
-        <tag k="source:datetime" v="2013-12-19T16:36:19.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{82fc4cc9-b0a0-42e9-a811-c99032648c0d}"/>
-        <tag k="motor_vehicle" v="no"/>
-        <tag k="bicycle" v="yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="osm_id" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-33"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="no"/>
+        <tag k="highway" v="pedestrian"/>
     </way>
     <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-34"/>
@@ -6324,20 +5211,18 @@
         <nd ref="-289"/>
         <nd ref="-288"/>
         <nd ref="-287"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{d87ac22e-5556-4eef-a1c4-3c4e8dcbfabf}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-32"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{d87ac22e-5556-4eef-a1c4-3c4e8dcbfabf}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-33"/>
@@ -6369,22 +5254,20 @@
         <nd ref="-295"/>
         <nd ref="-294"/>
         <nd ref="-293"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{05262cb4-489f-42bc-a67c-e519b12512a3}"/>
-        <tag k="name" v="La Amargura"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-31"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="La Amargura"/>
+        <tag k="uuid" v="{05262cb4-489f-42bc-a67c-e519b12512a3}"/>
+        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-426"/>
@@ -6445,22 +5328,20 @@
         <nd ref="-371"/>
         <nd ref="-370"/>
         <nd ref="-293"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c}"/>
-        <tag k="name" v="La Amargura"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-30"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="La Amargura"/>
+        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c}"/>
+        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-431"/>
@@ -6468,108 +5349,100 @@
         <nd ref="-452"/>
         <nd ref="-451"/>
         <nd ref="-31"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2};{2d9e0733-5346-4fea-b94a-05ffadc0eca5}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2};{2d9e0733-5346-4fea-b94a-05ffadc0eca5}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-502"/>
         <nd ref="-508"/>
         <nd ref="-29"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{80712126-af56-4518-8afe-f507ca285392}"/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-27"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{80712126-af56-4518-8afe-f507ca285392}"/>
+        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-502"/>
         <nd ref="-28"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-26"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-27"/>
         <nd ref="-511"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{449793a7-7d3a-4607-b9a0-74834a4e876a}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-25"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{449793a7-7d3a-4607-b9a0-74834a4e876a}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-513"/>
@@ -6577,147 +5450,135 @@
         <nd ref="-216"/>
         <nd ref="-515"/>
         <nd ref="-511"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2013-04-18T01:17:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-24"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108}"/>
+        <tag k="source:datetime" v="2013-04-18T01:17:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-520"/>
         <nd ref="-522"/>
         <nd ref="-512"/>
         <nd ref="-25"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:59.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{e7c51f67-fb91-4865-a8bc-dd68ca0a5ffc}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-23"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:59.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{e7c51f67-fb91-4865-a8bc-dd68ca0a5ffc}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-526"/>
         <nd ref="-533"/>
         <nd ref="-24"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{70cd026b-7a36-4a7c-9917-1c2cd87e49ba}"/>
-        <tag k="name" v="Av. Este 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-03-18T22:04:39.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-22"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Este 8"/>
+        <tag k="uuid" v="{70cd026b-7a36-4a7c-9917-1c2cd87e49ba}"/>
+        <tag k="source:datetime" v="2014-03-18T22:04:39.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-23"/>
         <nd ref="-526"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sur"/>
-        <tag k="lanes" v="2"/>
-        <tag k="layer" v="-3"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="source:datetime" v="2013-12-26T19:49:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="uuid" v="{5e7b547b-a9cf-4e4e-a649-360a6925911c}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="tunnel" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="-3"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-21"/>
+        <tag k="name" v="Av. Sur"/>
+        <tag k="source:datetime" v="2013-12-26T19:49:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="uuid" v="{5e7b547b-a9cf-4e4e-a649-360a6925911c}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
+        <tag k="tunnel" v="yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-462"/>
         <nd ref="-793"/>
         <nd ref="-21"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{c5e19b40-456f-4bfc-abe8-ec19bdccbb1c}"/>
-        <tag k="name" v="Av. Sur 10"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-10-07T17:37:52.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-19"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 10"/>
+        <tag k="uuid" v="{c5e19b40-456f-4bfc-abe8-ec19bdccbb1c}"/>
+        <tag k="source:datetime" v="2014-10-07T17:37:52.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-20"/>
         <nd ref="-794"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
-        <tag k="motor_vehicle" v="no"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{798b51dd-2f20-46c7-8f75-9954e225a46a}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur 2"/>
+        <tag k="source:datetime" v="2015-05-11T03:32:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
         <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{798b51dd-2f20-46c7-8f75-9954e225a46a}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="attribution" v="osm"/>
         <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2015-05-11T03:32:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
-        <tag k="lanes" v="2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-18"/>
     </way>
     <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-114"/>
@@ -6739,20 +5600,18 @@
         <nd ref="-901"/>
         <nd ref="-900"/>
         <nd ref="-19"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:55:34Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{52f3c8c5-203c-4ec0-b9cd-70b2a0826c2f}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{52f3c8c5-203c-4ec0-b9cd-70b2a0826c2f}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:55:34Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-18"/>
@@ -6862,20 +5721,18 @@
         <nd ref="-796"/>
         <nd ref="-795"/>
         <nd ref="-17"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:55:34Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{52f3c8c5-203c-4ec0-b9cd-70b2a0826c2f}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-16"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{52f3c8c5-203c-4ec0-b9cd-70b2a0826c2f}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:55:34Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-139"/>
@@ -6886,26 +5743,24 @@
         <nd ref="-941"/>
         <nd ref="-940"/>
         <nd ref="-16"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
-        <tag k="lit" v="yes"/>
-        <tag k="motor_vehicle" v="permissive"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{c708f207-166d-4d9c-936f-158a78dacb43}"/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-08-11T16:12:27.000Z;2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="pedestrian"/>
-        <tag k="lanes" v="2"/>
         <tag k="surface" v="concrete"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-15"/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="source:datetime" v="2015-08-11T16:12:27.000Z;2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{c708f207-166d-4d9c-936f-158a78dacb43}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="highway" v="pedestrian"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15"/>
@@ -6922,28 +5777,26 @@
         <nd ref="-40"/>
         <nd ref="-39"/>
         <nd ref="-38"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="foot" v="no"/>
-        <tag k="source:datetime" v="2014-04-25T15:59:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{de291bb3-eeb7-46a5-9ccd-03eb6c52f288}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2014-04-25T15:59:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{de291bb3-eeb7-46a5-9ccd-03eb6c52f288}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary_link"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-14"/>
@@ -6965,29 +5818,27 @@
         <nd ref="-53"/>
         <nd ref="-52"/>
         <nd ref="-51"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:51:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{705baa53-182f-4ff6-b76a-8cc44c780077}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2015-06-12T14:51:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{705baa53-182f-4ff6-b76a-8cc44c780077}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-249"/>
@@ -7037,90 +5888,82 @@
         <nd ref="-77"/>
         <nd ref="-78"/>
         <nd ref="-13"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z;2019-01-17T19:50:05.662Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-06-24T05:28:39.000Z;2015-06-12T14:51:48.000Z;2019-01-17T19:50:06Z;2014-06-24T05:28:44.000Z;2014-06-10T02:45:38.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{03d98885-a3e7-4365-abe1-5c8dbdc6c314};{006de0c0-48c5-434f-8fdb-29c68cb4c649}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-12"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2014-06-24T05:28:39.000Z;2015-06-12T14:51:48.000Z;2019-01-17T19:50:06Z;2014-06-24T05:28:44.000Z;2014-06-10T02:45:38.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{03d98885-a3e7-4365-abe1-5c8dbdc6c314};{006de0c0-48c5-434f-8fdb-29c68cb4c649}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z;2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-79"/>
         <nd ref="-12"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{5d1dcd8b-5831-4997-92f3-3f70d8c2b54e}"/>
-        <tag k="name" v="Av. Norte 10"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-06-05T14:13:59.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 10"/>
+        <tag k="uuid" v="{5d1dcd8b-5831-4997-92f3-3f70d8c2b54e}"/>
+        <tag k="source:datetime" v="2015-06-05T14:13:59.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
         <nd ref="-80"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{1ce93b0a-4ad4-4d27-bc5a-25de9d1ebf08}"/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-06-05T14:13:58.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{1ce93b0a-4ad4-4d27-bc5a-25de9d1ebf08}"/>
+        <tag k="source:datetime" v="2015-06-05T14:13:58.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-79"/>
         <nd ref="-81"/>
         <nd ref="-10"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{0acdb253-1430-495e-a917-db5a720fb49a}"/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-12T18:41:07.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{0acdb253-1430-495e-a917-db5a720fb49a}"/>
+        <tag k="source:datetime" v="2013-11-12T18:41:07.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-509"/>
@@ -7129,57 +5972,53 @@
         <nd ref="-82"/>
         <nd ref="-83"/>
         <nd ref="-9"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z;2019-01-17T19:50:05.665Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{7512b600-71cc-4d15-b49c-caa2cd0024b4};{8ff50434-41c1-45b3-a518-4dcc5fabb0e1}"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{7512b600-71cc-4d15-b49c-caa2cd0024b4};{8ff50434-41c1-45b3-a518-4dcc5fabb0e1}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z;2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-8"/>
         <nd ref="-84"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{04a03a24-524c-4b23-9e0e-82a46440c656}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{04a03a24-524c-4b23-9e0e-82a46440c656}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7"/>
@@ -7220,20 +6059,18 @@
         <nd ref="-86"/>
         <nd ref="-85"/>
         <nd ref="-6"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.708Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{35d24223-a8cf-4cfa-af6e-3b1f52a93d89}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.708Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{35d24223-a8cf-4cfa-af6e-3b1f52a93d89}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
@@ -7255,23 +6092,21 @@
         <nd ref="-123"/>
         <nd ref="-122"/>
         <nd ref="-121"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.707Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{cd46a62e-2862-4f80-a150-a9e9b52f34af}"/>
-        <tag k="name" v="El Limón"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-05-11T19:26:58.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.707Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="El Limón"/>
+        <tag k="uuid" v="{cd46a62e-2862-4f80-a150-a9e9b52f34af}"/>
+        <tag k="source:datetime" v="2015-05-11T19:26:58.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-139"/>
@@ -7285,25 +6120,23 @@
         <nd ref="-147"/>
         <nd ref="-148"/>
         <nd ref="-4"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.707Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{d5f2e884-0d06-4ba5-befe-c902d727c179}"/>
-        <tag k="name" v="Av. Norte 4"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-10-29T12:28:43.000Z;2019-01-17T19:50:06Z;2015-08-11T15:27:56.000Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="4"/>
-        <tag k="surface" v="asphalt"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.707Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 4"/>
+        <tag k="uuid" v="{d5f2e884-0d06-4ba5-befe-c902d727c179}"/>
+        <tag k="source:datetime" v="2015-10-29T12:28:43.000Z;2019-01-17T19:50:06Z;2015-08-11T15:27:56.000Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="4"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
@@ -7311,52 +6144,48 @@
         <nd ref="-218"/>
         <nd ref="-219"/>
         <nd ref="-220"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.676Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:34.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{781d71a3-4c17-4f7d-baf4-87a70049cb08};{08a509fe-fd4e-40f0-ac90-d5753212beb5}"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:38.000Z;2015-06-12T14:47:34.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{781d71a3-4c17-4f7d-baf4-87a70049cb08};{08a509fe-fd4e-40f0-ac90-d5753212beb5}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.676Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-146"/>
         <nd ref="-222"/>
         <nd ref="-221"/>
         <nd ref="-1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{858a22af-8bb3-4e67-bf46-1f284bc6bcec}"/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{858a22af-8bb3-4e67-bf46-1f284bc6bcec}"/>
+        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2927-bridge-2/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-bridge-2/Expected.osm
@@ -3,1345 +3,1071 @@
     <bounds minlat="7.6988" minlon="-72.36539999999999" maxlat="7.703000000000001" maxlon="-72.3584"/>
     <node visible="true" id="-880" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012553812881999" lon="-72.3611678554792235">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-880"/>
     </node>
     <node visible="true" id="-879" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013901482034317" lon="-72.3616783782998283">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-879"/>
     </node>
     <node visible="true" id="-876" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007844373138692" lon="-72.3608138875766400">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-876"/>
     </node>
     <node visible="true" id="-875" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006221644488200" lon="-72.3616555431526365">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-875"/>
     </node>
     <node visible="true" id="-872" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996465494859683" lon="-72.3620384038982110">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-872"/>
     </node>
     <node visible="true" id="-871" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998374847308737" lon="-72.3619818040271099">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-871"/>
     </node>
     <node visible="true" id="-268" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000125445999998" lon="-72.3589731062100014">
-        <tag k="bdw-id" v="{982630d9-e726-433a-bcd7-a33ef723c34f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-268"/>
+        <tag k="bdw-id" v="{982630d9-e726-433a-bcd7-a33ef723c34f}"/>
     </node>
     <node visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998995600399986" lon="-72.3589844938999960">
-        <tag k="bdw-id" v="{ee7f5868-82c8-4f17-b42c-7ce7c75afca2}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-267"/>
+        <tag k="bdw-id" v="{ee7f5868-82c8-4f17-b42c-7ce7c75afca2}"/>
     </node>
     <node visible="true" id="-266" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998106361499987" lon="-72.3589917918399976">
-        <tag k="bdw-id" v="{af37fca5-b78d-4cda-a388-95b1ddc59266}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-266"/>
+        <tag k="bdw-id" v="{af37fca5-b78d-4cda-a388-95b1ddc59266}"/>
     </node>
     <node visible="true" id="-265" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993994747499999" lon="-72.3590126697099976">
-        <tag k="bdw-id" v="{960765e7-e8e7-424b-bb72-93a6897bb679}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-265"/>
+        <tag k="bdw-id" v="{960765e7-e8e7-424b-bb72-93a6897bb679}"/>
     </node>
     <node visible="true" id="-264" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993151479199993" lon="-72.3590223339899978">
-        <tag k="bdw-id" v="{b34ba694-1b12-433b-85a2-120cfe899e15}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-264"/>
+        <tag k="bdw-id" v="{b34ba694-1b12-433b-85a2-120cfe899e15}"/>
     </node>
     <node visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992909182700000" lon="-72.3590288738100043">
-        <tag k="bdw-id" v="{398ad070-2704-4c96-9344-0d30bd3aeea5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-263"/>
+        <tag k="bdw-id" v="{398ad070-2704-4c96-9344-0d30bd3aeea5}"/>
     </node>
     <node visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992585774999984" lon="-72.3590461502100055">
-        <tag k="bdw-id" v="{1a6777ee-9fa9-4ac4-915b-98ee76819e3d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-262"/>
+        <tag k="bdw-id" v="{1a6777ee-9fa9-4ac4-915b-98ee76819e3d}"/>
     </node>
     <node visible="true" id="-261" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992385942999970" lon="-72.3590730195799807">
-        <tag k="bdw-id" v="{09df298a-2d0b-401c-9907-eb8dc9e19397}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-261"/>
+        <tag k="bdw-id" v="{09df298a-2d0b-401c-9907-eb8dc9e19397}"/>
     </node>
     <node visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992321979699989" lon="-72.3590979001800036">
-        <tag k="bdw-id" v="{616e8c64-a870-4dba-94b4-e98da5cf92d1}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-260"/>
+        <tag k="bdw-id" v="{616e8c64-a870-4dba-94b4-e98da5cf92d1}"/>
     </node>
     <node visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992300854399973" lon="-72.3591403953499821">
-        <tag k="bdw-id" v="{a30fc37c-8163-4d47-ac10-a8e469983153}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-259"/>
+        <tag k="bdw-id" v="{a30fc37c-8163-4d47-ac10-a8e469983153}"/>
     </node>
     <node visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992334148500019" lon="-72.3592847030199948">
-        <tag k="bdw-id" v="{c57bf62d-ad47-4dc7-86f6-693e6617d0dc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-258"/>
+        <tag k="bdw-id" v="{c57bf62d-ad47-4dc7-86f6-693e6617d0dc}"/>
     </node>
     <node visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026718036500013" lon="-72.3587359608799972">
-        <tag k="bdw-id" v="{f337b438-01a8-4916-98a0-8a020ef93866}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-257"/>
+        <tag k="bdw-id" v="{f337b438-01a8-4916-98a0-8a020ef93866}"/>
     </node>
     <node visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024847145999997" lon="-72.3587602470999940">
-        <tag k="bdw-id" v="{ecbb75b5-d097-4d8f-b9ac-aa4c466078cb}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-256"/>
+        <tag k="bdw-id" v="{ecbb75b5-d097-4d8f-b9ac-aa4c466078cb}"/>
     </node>
     <node visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013714084200000" lon="-72.3587790233400057">
-        <tag k="bdw-id" v="{8c4823d6-673d-4fc6-8cb2-2c7f7c7065b4}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-255"/>
+        <tag k="bdw-id" v="{8c4823d6-673d-4fc6-8cb2-2c7f7c7065b4}"/>
     </node>
     <node visible="true" id="-254" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013424454900008" lon="-72.3588624947000056">
-        <tag k="bdw-id" v="{95d2cd0d-d83b-426c-9b37-ca2f145adcf2}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-254"/>
+        <tag k="bdw-id" v="{95d2cd0d-d83b-426c-9b37-ca2f145adcf2}"/>
     </node>
     <node visible="true" id="-253" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008197799199980" lon="-72.3597623706800022">
-        <tag k="bdw-id" v="{41ee920a-d2ed-432d-b3c9-163eac3b363b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-253"/>
+        <tag k="bdw-id" v="{41ee920a-d2ed-432d-b3c9-163eac3b363b}"/>
     </node>
     <node visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008092709699989" lon="-72.3595223599700006">
-        <tag k="bdw-id" v="{c9817e93-2182-4fc8-8a78-f81830bca66d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-252"/>
+        <tag k="bdw-id" v="{c9817e93-2182-4fc8-8a78-f81830bca66d}"/>
     </node>
     <node visible="true" id="-251" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007744741800002" lon="-72.3589044947500071">
-        <tag k="bdw-id" v="{c753f0f7-9ac3-4325-a21d-790d48100f62}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-251"/>
+        <tag k="bdw-id" v="{c753f0f7-9ac3-4325-a21d-790d48100f62}"/>
     </node>
     <node visible="true" id="-250" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012598976399991" lon="-72.3597289086799975">
-        <tag k="bdw-id" v="{6b071116-3bdb-4a14-b0c9-4bf96b96d606}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-250"/>
+        <tag k="bdw-id" v="{6b071116-3bdb-4a14-b0c9-4bf96b96d606}"/>
     </node>
     <node visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012764845499984" lon="-72.3593171985600065">
-        <tag k="bdw-id" v="{981feaca-838d-4552-ac59-a3e1d3d37557}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-249"/>
+        <tag k="bdw-id" v="{981feaca-838d-4552-ac59-a3e1d3d37557}"/>
     </node>
     <node visible="true" id="-248" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012955818400020" lon="-72.3590066044900055">
-        <tag k="bdw-id" v="{ea76cb0d-0e1b-4a77-87ab-3c3b89b6bc3f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-248"/>
+        <tag k="bdw-id" v="{ea76cb0d-0e1b-4a77-87ab-3c3b89b6bc3f}"/>
     </node>
     <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013077781100003" lon="-72.3589521360100036">
-        <tag k="bdw-id" v="{dc8d2fd1-3c53-4243-8404-cbc639cdf774}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-247"/>
+        <tag k="bdw-id" v="{dc8d2fd1-3c53-4243-8404-cbc639cdf774}"/>
     </node>
     <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999971438299974" lon="-72.3587579203200022">
-        <tag k="bdw-id" v="{5b351244-e61f-4d90-8a3f-2976296fa5ad}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-246"/>
+        <tag k="bdw-id" v="{5b351244-e61f-4d90-8a3f-2976296fa5ad}"/>
     </node>
     <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000668045399996" lon="-72.3598254307700017">
-        <tag k="bdw-id" v="{395dc79e-32f0-49da-873f-d02e840a4e85}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-245"/>
+        <tag k="bdw-id" v="{395dc79e-32f0-49da-873f-d02e840a4e85}"/>
     </node>
     <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000550239600019" lon="-72.3596615684899973">
-        <tag k="bdw-id" v="{41cda987-2dcd-4cec-979d-e87cd45307d6}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-244"/>
+        <tag k="bdw-id" v="{41cda987-2dcd-4cec-979d-e87cd45307d6}"/>
     </node>
     <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024430316399988" lon="-72.3587628416200062">
-        <tag k="bdw-id" v="{0d532bc7-5901-49fb-9af5-7ac26f155bfe}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-243"/>
+        <tag k="bdw-id" v="{0d532bc7-5901-49fb-9af5-7ac26f155bfe}"/>
     </node>
     <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022753596499989" lon="-72.3587660034399960">
-        <tag k="bdw-id" v="{b87fd95b-9069-4b25-9acd-8bfd2e7b30f4}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-242"/>
+        <tag k="bdw-id" v="{b87fd95b-9069-4b25-9acd-8bfd2e7b30f4}"/>
     </node>
     <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019420064599977" lon="-72.3587949213199835">
-        <tag k="bdw-id" v="{8f039b12-3202-400f-8ad6-c1fb64585b9a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-241"/>
+        <tag k="bdw-id" v="{8f039b12-3202-400f-8ad6-c1fb64585b9a}"/>
     </node>
     <node visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017087688199979" lon="-72.3588288453800033">
-        <tag k="bdw-id" v="{a3014fe8-999a-4e77-b0ed-3b1300b319bf}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-240"/>
+        <tag k="bdw-id" v="{a3014fe8-999a-4e77-b0ed-3b1300b319bf}"/>
     </node>
     <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011678514400019" lon="-72.3588790485100048">
-        <tag k="bdw-id" v="{85c81f2a-f885-4316-8bf4-ab29e166b691}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-239"/>
+        <tag k="bdw-id" v="{85c81f2a-f885-4316-8bf4-ab29e166b691}"/>
     </node>
     <node visible="true" id="-238" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007611580700006" lon="-72.3586901564100060">
-        <tag k="bdw-id" v="{5b1dbf2f-e2b5-4f49-8a5b-2b5f78982efb}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-238"/>
+        <tag k="bdw-id" v="{5b1dbf2f-e2b5-4f49-8a5b-2b5f78982efb}"/>
     </node>
     <node visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024746729499984" lon="-72.3585429223900007">
-        <tag k="bdw-id" v="{018aab14-7edd-44c8-9742-cc31146db1e6}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-237"/>
+        <tag k="bdw-id" v="{018aab14-7edd-44c8-9742-cc31146db1e6}"/>
     </node>
     <node visible="true" id="-236" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025112673000011" lon="-72.3596282107299942">
-        <tag k="bdw-id" v="{89d1fec9-de0d-4d6f-97ef-e76e45e3dd77}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-236"/>
+        <tag k="bdw-id" v="{89d1fec9-de0d-4d6f-97ef-e76e45e3dd77}"/>
     </node>
     <node visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025058843299998" lon="-72.3593829638100061">
-        <tag k="bdw-id" v="{ee9280ea-54c9-41bc-a529-72f3cb065e4c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-235"/>
+        <tag k="bdw-id" v="{ee9280ea-54c9-41bc-a529-72f3cb065e4c}"/>
     </node>
     <node visible="true" id="-234" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002443052199983" lon="-72.3589490580299923">
-        <tag k="bdw-id" v="{24e16643-fab4-4920-b770-536a667b00ad}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-234"/>
+        <tag k="bdw-id" v="{24e16643-fab4-4920-b770-536a667b00ad}"/>
     </node>
     <node visible="true" id="-233" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006631927900013" lon="-72.3622576000999942">
-        <tag k="bdw-id" v="{abb89eaa-f7e1-48ef-a20d-daccb382e6dc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-233"/>
+        <tag k="bdw-id" v="{abb89eaa-f7e1-48ef-a20d-daccb382e6dc}"/>
     </node>
     <node visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006467123899993" lon="-72.3621917521900002">
-        <tag k="bdw-id" v="{e822a229-32f9-49bf-8259-92e7209883c7}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-232"/>
+        <tag k="bdw-id" v="{e822a229-32f9-49bf-8259-92e7209883c7}"/>
     </node>
     <node visible="true" id="-231" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006359377100004" lon="-72.3621451826700053">
-        <tag k="bdw-id" v="{45a42602-0a92-4eaa-baff-690cf431b96e}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-231"/>
+        <tag k="bdw-id" v="{45a42602-0a92-4eaa-baff-690cf431b96e}"/>
     </node>
     <node visible="true" id="-230" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026271959599999" lon="-72.3630450196699968">
-        <tag k="bdw-id" v="{118a81bb-a69f-4d92-bbfd-bb1495693a02}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-230"/>
+        <tag k="bdw-id" v="{118a81bb-a69f-4d92-bbfd-bb1495693a02}"/>
     </node>
     <node visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024136314199989" lon="-72.3631098588599997">
-        <tag k="bdw-id" v="{06556a1e-4599-48a4-9954-80c574157f42}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-229"/>
+        <tag k="bdw-id" v="{06556a1e-4599-48a4-9954-80c574157f42}"/>
     </node>
     <node visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018343149700002" lon="-72.3632777502100026">
-        <tag k="bdw-id" v="{78838ae7-12eb-4638-87ae-9d20c4a63f20}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-228"/>
+        <tag k="bdw-id" v="{78838ae7-12eb-4638-87ae-9d20c4a63f20}"/>
     </node>
     <node visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023457846799985" lon="-72.3620573045100031">
-        <tag k="bdw-id" v="{6185f7cc-d893-4348-9535-873732391681}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-227"/>
+        <tag k="bdw-id" v="{6185f7cc-d893-4348-9535-873732391681}"/>
     </node>
     <node visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021065329700003" lon="-72.3621256362999929">
-        <tag k="bdw-id" v="{3731555f-5c69-4a2f-a2a2-19c139166164}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-226"/>
+        <tag k="bdw-id" v="{3731555f-5c69-4a2f-a2a2-19c139166164}"/>
     </node>
     <node visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015651482700020" lon="-72.3622890368200018">
-        <tag k="bdw-id" v="{81f5baf5-2787-49b8-90d4-2e796f47325d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-225"/>
+        <tag k="bdw-id" v="{81f5baf5-2787-49b8-90d4-2e796f47325d}"/>
     </node>
     <node visible="true" id="-224" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012623905600011" lon="-72.3606986641199939">
-        <tag k="bdw-id" v="{c989a443-e7b0-4ec3-a5d4-a1d8d467b90d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-224"/>
+        <tag k="bdw-id" v="{c989a443-e7b0-4ec3-a5d4-a1d8d467b90d}"/>
     </node>
     <node visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012264768899996" lon="-72.3606929453199967">
-        <tag k="bdw-id" v="{03691619-b190-44e5-af12-0b718693aec9}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-223"/>
+        <tag k="bdw-id" v="{03691619-b190-44e5-af12-0b718693aec9}"/>
     </node>
     <node visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011946802500004" lon="-72.3606873789299954">
-        <tag k="bdw-id" v="{367c6198-a706-4f2c-aadd-a40ae8bd028f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-222"/>
+        <tag k="bdw-id" v="{367c6198-a706-4f2c-aadd-a40ae8bd028f}"/>
     </node>
     <node visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005899704199976" lon="-72.3597828621900021">
-        <tag k="bdw-id" v="{d6ff1f49-845e-4e4c-85dd-c807cb229f24}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-221"/>
+        <tag k="bdw-id" v="{d6ff1f49-845e-4e4c-85dd-c807cb229f24}"/>
     </node>
     <node visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004508032499999" lon="-72.3645342810900019">
-        <tag k="bdw-id" v="{cb9f5bc1-0820-48e2-b355-32c68cd4a795}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-220"/>
+        <tag k="bdw-id" v="{cb9f5bc1-0820-48e2-b355-32c68cd4a795}"/>
     </node>
     <node visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003871811100009" lon="-72.3643266931999989">
-        <tag k="bdw-id" v="{08681d5f-a5b7-4611-8ea3-c77d6be244b9}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-219"/>
+        <tag k="bdw-id" v="{08681d5f-a5b7-4611-8ea3-c77d6be244b9}"/>
     </node>
     <node visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002798132799999" lon="-72.3639517346500014">
-        <tag k="bdw-id" v="{7e1534df-0a76-4e7d-8e5c-796c313781c8}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-218"/>
+        <tag k="bdw-id" v="{7e1534df-0a76-4e7d-8e5c-796c313781c8}"/>
     </node>
     <node visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002040256299988" lon="-72.3637306485599936">
-        <tag k="bdw-id" v="{6207ef23-ff4b-4311-84d3-74d3590cb32c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-217"/>
+        <tag k="bdw-id" v="{6207ef23-ff4b-4311-84d3-74d3590cb32c}"/>
     </node>
     <node visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008287735000005" lon="-72.3605437910899951">
-        <tag k="bdw-id" v="{bb318626-0651-4678-a706-d458a0f7b740}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-216"/>
+        <tag k="bdw-id" v="{bb318626-0651-4678-a706-d458a0f7b740}"/>
     </node>
     <node visible="true" id="-215" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008253843899990" lon="-72.3605705059400037">
-        <tag k="bdw-id" v="{5acf5d01-cea8-4d8c-b07e-c72cd816b073}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-215"/>
+        <tag k="bdw-id" v="{5acf5d01-cea8-4d8c-b07e-c72cd816b073}"/>
     </node>
     <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007972569599996" lon="-72.3607473959300052">
-        <tag k="bdw-id" v="{f14d1506-471f-4379-bef7-6d82fd126994}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-214"/>
+        <tag k="bdw-id" v="{f14d1506-471f-4379-bef7-6d82fd126994}"/>
     </node>
     <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029913144300020" lon="-72.3643388391599842">
-        <tag k="bdw-id" v="{2dd1952f-5b09-4c08-b7a7-5950135e532a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-213"/>
+        <tag k="bdw-id" v="{2dd1952f-5b09-4c08-b7a7-5950135e532a}"/>
     </node>
     <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029451957799990" lon="-72.3642402141099979">
-        <tag k="bdw-id" v="{572b05ea-e0fe-4344-bd1a-79aba66e0e23}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-212"/>
+        <tag k="bdw-id" v="{572b05ea-e0fe-4344-bd1a-79aba66e0e23}"/>
     </node>
     <node visible="true" id="-211" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029194344199992" lon="-72.3641647013199929">
-        <tag k="bdw-id" v="{15646cdf-f8f5-454a-93c9-f60c215d85a6}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-211"/>
+        <tag k="bdw-id" v="{15646cdf-f8f5-454a-93c9-f60c215d85a6}"/>
     </node>
     <node visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029000823099993" lon="-72.3640872884299995">
-        <tag k="bdw-id" v="{cd4862c7-97ce-4b2f-a312-0a4c70ac5bd2}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-210"/>
+        <tag k="bdw-id" v="{cd4862c7-97ce-4b2f-a312-0a4c70ac5bd2}"/>
     </node>
     <node visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028743568799989" lon="-72.3639080177500063">
-        <tag k="bdw-id" v="{6014bb75-2061-4041-9614-32caeff0fc5e}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-209"/>
+        <tag k="bdw-id" v="{6014bb75-2061-4041-9614-32caeff0fc5e}"/>
     </node>
     <node visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028559585300016" lon="-72.3638136811500061">
-        <tag k="bdw-id" v="{294a16bf-825f-4ab1-9c0f-1092f547b442}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-208"/>
+        <tag k="bdw-id" v="{294a16bf-825f-4ab1-9c0f-1092f547b442}"/>
     </node>
     <node visible="true" id="-207" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029272476499990" lon="-72.3629551069300021">
-        <tag k="bdw-id" v="{d3544fd0-7f36-4db6-9b3c-8d55a20ede05}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-207"/>
+        <tag k="bdw-id" v="{d3544fd0-7f36-4db6-9b3c-8d55a20ede05}"/>
     </node>
     <node visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028236705099973" lon="-72.3629831259799943">
-        <tag k="bdw-id" v="{8b69cf3d-0c67-4afe-b55e-3484e5a211bc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-206"/>
+        <tag k="bdw-id" v="{8b69cf3d-0c67-4afe-b55e-3484e5a211bc}"/>
     </node>
     <node visible="true" id="-205" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027090382500001" lon="-72.3651492070899991">
-        <tag k="bdw-id" v="{6cb57a87-35bb-4b55-b541-8d3f38dcd8c5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-205"/>
+        <tag k="bdw-id" v="{6cb57a87-35bb-4b55-b541-8d3f38dcd8c5}"/>
     </node>
     <node visible="true" id="-204" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026454572700009" lon="-72.3650829173700032">
-        <tag k="bdw-id" v="{9ba2c828-3cb0-4e23-978e-175a5f9c0a1a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-204"/>
+        <tag k="bdw-id" v="{9ba2c828-3cb0-4e23-978e-175a5f9c0a1a}"/>
     </node>
     <node visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015378418000013" lon="-72.3622036787599967">
-        <tag k="bdw-id" v="{0622996b-12af-4779-8f5b-e824949ed7be}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-203"/>
+        <tag k="bdw-id" v="{0622996b-12af-4779-8f5b-e824949ed7be}"/>
     </node>
     <node visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014912199299994" lon="-72.3620477259700010">
-        <tag k="bdw-id" v="{63b9dec9-ca0b-4526-bc31-f702d4954e13}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-202"/>
+        <tag k="bdw-id" v="{63b9dec9-ca0b-4526-bc31-f702d4954e13}"/>
     </node>
     <node visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6990490502900002" lon="-72.3592864234800004">
-        <tag k="bdw-id" v="{fe3e54f6-c119-410b-9817-24a70ed71ab2}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-201"/>
+        <tag k="bdw-id" v="{fe3e54f6-c119-410b-9817-24a70ed71ab2}"/>
     </node>
     <node visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023333015699986" lon="-72.3620129969399954">
-        <tag k="bdw-id" v="{8702c164-0903-496a-9f7e-740ab9d4a563}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-200"/>
+        <tag k="bdw-id" v="{8702c164-0903-496a-9f7e-740ab9d4a563}"/>
     </node>
     <node visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021926759499992" lon="-72.3616215999099950">
-        <tag k="bdw-id" v="{4c39a9b8-0abd-466f-9c60-14f8c579e90d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-199"/>
+        <tag k="bdw-id" v="{4c39a9b8-0abd-466f-9c60-14f8c579e90d}"/>
     </node>
     <node visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021745098799972" lon="-72.3615513291699841">
-        <tag k="bdw-id" v="{83013c28-fe21-4143-8c06-afe4273fdddd}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-198"/>
+        <tag k="bdw-id" v="{83013c28-fe21-4143-8c06-afe4273fdddd}"/>
     </node>
     <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017758671699976" lon="-72.3630599810399957">
-        <tag k="bdw-id" v="{5bd7ddcc-49c6-469a-93b5-c427377cdbff}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-197"/>
+        <tag k="bdw-id" v="{5bd7ddcc-49c6-469a-93b5-c427377cdbff}"/>
     </node>
     <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016327996199978" lon="-72.3625044378700011">
-        <tag k="bdw-id" v="{250c22dd-780b-44a5-aec3-5840c98bc7af}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-196"/>
+        <tag k="bdw-id" v="{250c22dd-780b-44a5-aec3-5840c98bc7af}"/>
     </node>
     <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012088752899990" lon="-72.3643351878800019">
-        <tag k="bdw-id" v="{3e643060-ed6a-432f-a653-e20e3752bc77}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-195"/>
+        <tag k="bdw-id" v="{3e643060-ed6a-432f-a653-e20e3752bc77}"/>
     </node>
     <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011570231600031" lon="-72.3641177542399987">
-        <tag k="bdw-id" v="{cfcd1c0a-050e-451a-a572-2ee9d49b3056}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-194"/>
+        <tag k="bdw-id" v="{cfcd1c0a-050e-451a-a572-2ee9d49b3056}"/>
     </node>
     <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009986579199978" lon="-72.3635211022599805">
-        <tag k="bdw-id" v="{3ba124af-3a0a-4357-9ec0-5daabdd54dbc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-193"/>
+        <tag k="bdw-id" v="{3ba124af-3a0a-4357-9ec0-5daabdd54dbc}"/>
     </node>
     <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014475595599965" lon="-72.3618958642800010">
-        <tag k="bdw-id" v="{e47c790e-aaa7-4699-85b1-9b13c9e0afeb}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-192"/>
+        <tag k="bdw-id" v="{e47c790e-aaa7-4699-85b1-9b13c9e0afeb}"/>
     </node>
     <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012185099100012" lon="-72.3610281801099973">
-        <tag k="bdw-id" v="{2b58dd51-6a6c-4991-85d8-8310d90aee65}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-191"/>
+        <tag k="bdw-id" v="{2b58dd51-6a6c-4991-85d8-8310d90aee65}"/>
     </node>
     <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012058795200025" lon="-72.3609601674999965">
-        <tag k="bdw-id" v="{2bfac72f-c5eb-4eda-bccb-39ae86bd1547}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-190"/>
+        <tag k="bdw-id" v="{2bfac72f-c5eb-4eda-bccb-39ae86bd1547}"/>
     </node>
     <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011854733399998" lon="-72.3607682998599984">
-        <tag k="bdw-id" v="{7a8e8f48-a3ad-43f4-bf37-a7bfffa4fd47}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-189"/>
+        <tag k="bdw-id" v="{7a8e8f48-a3ad-43f4-bf37-a7bfffa4fd47}"/>
     </node>
     <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011867500899989" lon="-72.3607269335499979">
-        <tag k="bdw-id" v="{2517d848-fc83-4184-bcb5-145f8998d9fa}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-188"/>
+        <tag k="bdw-id" v="{2517d848-fc83-4184-bcb5-145f8998d9fa}"/>
     </node>
     <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024978803100019" lon="-72.3653636431100011">
-        <tag k="bdw-id" v="{19a73972-2edb-44b8-93d7-dd70ec0ba05a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-187"/>
+        <tag k="bdw-id" v="{19a73972-2edb-44b8-93d7-dd70ec0ba05a}"/>
     </node>
     <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029593477100011" lon="-72.3653755295199943">
-        <tag k="bdw-id" v="{24bd8d78-8ac7-40b4-bf34-f2f1e0e9d174}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-186"/>
+        <tag k="bdw-id" v="{24bd8d78-8ac7-40b4-bf34-f2f1e0e9d174}"/>
     </node>
     <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028953822399995" lon="-72.3653253606699991">
-        <tag k="bdw-id" v="{bfe364dd-a50a-4f35-9324-8004397ffda9}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-185"/>
+        <tag k="bdw-id" v="{bfe364dd-a50a-4f35-9324-8004397ffda9}"/>
     </node>
     <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028264479300015" lon="-72.3652641111099939">
-        <tag k="bdw-id" v="{fad979c8-3563-4e4d-b0f2-0922deb597f3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-184"/>
+        <tag k="bdw-id" v="{fad979c8-3563-4e4d-b0f2-0922deb597f3}"/>
     </node>
     <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027073002500011" lon="-72.3609297702300012">
-        <tag k="bdw-id" v="{c00c4d6e-18cf-4014-b189-c7a024821a61}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-183"/>
+        <tag k="bdw-id" v="{c00c4d6e-18cf-4014-b189-c7a024821a61}"/>
     </node>
     <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024966756600008" lon="-72.3608927498199961">
-        <tag k="bdw-id" v="{ac868205-8c68-42e5-8503-34adf8ed90ef}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-182"/>
+        <tag k="bdw-id" v="{ac868205-8c68-42e5-8503-34adf8ed90ef}"/>
     </node>
     <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016897398499991" lon="-72.3648851958499932">
-        <tag k="bdw-id" v="{aaa495db-bb2c-4d14-b6f1-852d77945dd2}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-181"/>
+        <tag k="bdw-id" v="{aaa495db-bb2c-4d14-b6f1-852d77945dd2}"/>
     </node>
     <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016640244399994" lon="-72.3648701313099991">
-        <tag k="bdw-id" v="{d5d0a69d-76e9-4e17-8b74-0e4b84b56812}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-180"/>
+        <tag k="bdw-id" v="{d5d0a69d-76e9-4e17-8b74-0e4b84b56812}"/>
     </node>
     <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016019476799995" lon="-72.3648422017000001">
-        <tag k="bdw-id" v="{7b21e8df-b452-4ed2-a820-a45834862a9c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-179"/>
+        <tag k="bdw-id" v="{7b21e8df-b452-4ed2-a820-a45834862a9c}"/>
     </node>
     <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015621251499988" lon="-72.3648169241400012">
-        <tag k="bdw-id" v="{52359d05-ecca-42e8-9d49-0f9dc18d7e03}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-178"/>
+        <tag k="bdw-id" v="{52359d05-ecca-42e8-9d49-0f9dc18d7e03}"/>
     </node>
     <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015320594699999" lon="-72.3648214196999930">
-        <tag k="bdw-id" v="{048ace9f-5506-4de2-bdd3-9523b46c6c6a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-177"/>
+        <tag k="bdw-id" v="{048ace9f-5506-4de2-bdd3-9523b46c6c6a}"/>
     </node>
     <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015020998500017" lon="-72.3648431532299838">
-        <tag k="bdw-id" v="{b54181d4-a211-41c1-984f-3812a57be74d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-176"/>
+        <tag k="bdw-id" v="{b54181d4-a211-41c1-984f-3812a57be74d}"/>
     </node>
     <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013769878999989" lon="-72.3649754676700070">
-        <tag k="bdw-id" v="{2cb73e9b-5dc9-4d46-aeae-75de34976546}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175"/>
+        <tag k="bdw-id" v="{2cb73e9b-5dc9-4d46-aeae-75de34976546}"/>
     </node>
     <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013116965700004" lon="-72.3650257533199976">
-        <tag k="bdw-id" v="{39f5b7b6-9133-4b66-8695-b27845493733}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-174"/>
+        <tag k="bdw-id" v="{39f5b7b6-9133-4b66-8695-b27845493733}"/>
     </node>
     <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011985683099997" lon="-72.3651106152599937">
-        <tag k="bdw-id" v="{a3f0b378-1bf3-4e44-8e81-3b81b47a55b6}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-173"/>
+        <tag k="bdw-id" v="{a3f0b378-1bf3-4e44-8e81-3b81b47a55b6}"/>
     </node>
     <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006126074400001" lon="-72.3621489709500025">
-        <tag k="bdw-id" v="{4aa38a15-1d1a-496d-a6ac-c11d125801f3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-172"/>
+        <tag k="bdw-id" v="{4aa38a15-1d1a-496d-a6ac-c11d125801f3}"/>
     </node>
     <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005910945099982" lon="-72.3621499434400022">
-        <tag k="bdw-id" v="{7db3022e-6731-4b4e-8f6d-da72dced98aa}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171"/>
+        <tag k="bdw-id" v="{7db3022e-6731-4b4e-8f6d-da72dced98aa}"/>
     </node>
     <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005495876499994" lon="-72.3621442957399950">
-        <tag k="bdw-id" v="{6a4cec9f-62ae-4a45-bd74-fc3b5336cc88}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170"/>
+        <tag k="bdw-id" v="{6a4cec9f-62ae-4a45-bd74-fc3b5336cc88}"/>
     </node>
     <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003910035800018" lon="-72.3620746576300036">
-        <tag k="bdw-id" v="{bb1529f2-de86-427b-b4fb-cda4954c891d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-169"/>
+        <tag k="bdw-id" v="{bb1529f2-de86-427b-b4fb-cda4954c891d}"/>
     </node>
     <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002851133800005" lon="-72.3620377767099825">
-        <tag k="bdw-id" v="{ab8bb983-17c8-4cc2-8d8a-50cdb7f5b830}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-168"/>
+        <tag k="bdw-id" v="{ab8bb983-17c8-4cc2-8d8a-50cdb7f5b830}"/>
     </node>
     <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001765405099993" lon="-72.3620098119699833">
-        <tag k="bdw-id" v="{a43e29c7-5c4b-49ec-a12e-3fb954ce9b1e}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-167"/>
+        <tag k="bdw-id" v="{a43e29c7-5c4b-49ec-a12e-3fb954ce9b1e}"/>
     </node>
     <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000151722999997" lon="-72.3619831066999950">
-        <tag k="bdw-id" v="{607c8fb3-2d66-428a-8421-ca69d4fd6b36}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-166"/>
+        <tag k="bdw-id" v="{607c8fb3-2d66-428a-8421-ca69d4fd6b36}"/>
     </node>
     <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998794510700019" lon="-72.3619774456099947">
-        <tag k="bdw-id" v="{0813dba4-e3d7-4fdb-a9a6-eb05878ba17c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165"/>
+        <tag k="bdw-id" v="{0813dba4-e3d7-4fdb-a9a6-eb05878ba17c}"/>
     </node>
     <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998032185799987" lon="-72.3619853627400005">
-        <tag k="bdw-id" v="{a8c1b1d5-6513-4514-ab87-8cf7b65c72b7}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-164"/>
+        <tag k="bdw-id" v="{a8c1b1d5-6513-4514-ab87-8cf7b65c72b7}"/>
     </node>
     <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997383847400007" lon="-72.3620026328199941">
-        <tag k="bdw-id" v="{64c29c0a-72de-4ae5-982e-675d405758a0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-163"/>
+        <tag k="bdw-id" v="{64c29c0a-72de-4ae5-982e-675d405758a0}"/>
     </node>
     <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995928115399996" lon="-72.3620593355500006">
-        <tag k="bdw-id" v="{44c82af0-db6a-470f-90c0-69a4450fa828}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-162"/>
+        <tag k="bdw-id" v="{44c82af0-db6a-470f-90c0-69a4450fa828}"/>
     </node>
     <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013270798199986" lon="-72.3648078769700049">
-        <tag k="bdw-id" v="{5c313c81-5777-4a62-9640-7d07b261562b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-161"/>
+        <tag k="bdw-id" v="{5c313c81-5777-4a62-9640-7d07b261562b}"/>
     </node>
     <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013010982400001" lon="-72.3646917833000032">
-        <tag k="bdw-id" v="{49a05c15-a62c-4777-9905-b53a030e1b2c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-160"/>
+        <tag k="bdw-id" v="{49a05c15-a62c-4777-9905-b53a030e1b2c}"/>
     </node>
     <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012490775000018" lon="-72.3645015987799951">
-        <tag k="bdw-id" v="{18fe3d45-f033-4b11-beb4-2979965f70dc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-159"/>
+        <tag k="bdw-id" v="{18fe3d45-f033-4b11-beb4-2979965f70dc}"/>
     </node>
     <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018812826899969" lon="-72.3645933403099946">
-        <tag k="bdw-id" v="{2ac6ec6d-b9b4-42f3-b016-843d4db288c8}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-158"/>
+        <tag k="bdw-id" v="{2ac6ec6d-b9b4-42f3-b016-843d4db288c8}"/>
     </node>
     <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018605171900001" lon="-72.3645600612099855">
-        <tag k="bdw-id" v="{cbf15011-67eb-4a89-855a-e2ab76c6cf69}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-157"/>
+        <tag k="bdw-id" v="{cbf15011-67eb-4a89-855a-e2ab76c6cf69}"/>
     </node>
     <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018431562299989" lon="-72.3645263168699984">
-        <tag k="bdw-id" v="{9232806a-aae7-4c76-b722-c73c118779cd}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-156"/>
+        <tag k="bdw-id" v="{9232806a-aae7-4c76-b722-c73c118779cd}"/>
     </node>
     <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018131116899982" lon="-72.3644459178999995">
-        <tag k="bdw-id" v="{a4804903-408d-443e-b664-1640d62563ff}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-155"/>
+        <tag k="bdw-id" v="{a4804903-408d-443e-b664-1640d62563ff}"/>
     </node>
     <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017914866500004" lon="-72.3643983965900048">
-        <tag k="bdw-id" v="{b9d5b900-227f-45d6-b75f-91d3f7d503b0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-154"/>
+        <tag k="bdw-id" v="{b9d5b900-227f-45d6-b75f-91d3f7d503b0}"/>
     </node>
     <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016739074900000" lon="-72.3641703957000004">
-        <tag k="bdw-id" v="{44a846b4-3b66-4ef8-8469-38289351ef3b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153"/>
+        <tag k="bdw-id" v="{44a846b4-3b66-4ef8-8469-38289351ef3b}"/>
     </node>
     <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999122416799990" lon="-72.3598398665299953">
-        <tag k="bdw-id" v="{97da5ee2-a050-49e1-9ee1-1c25fb1d5df0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-152"/>
+        <tag k="bdw-id" v="{97da5ee2-a050-49e1-9ee1-1c25fb1d5df0}"/>
     </node>
     <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997171014199992" lon="-72.3598605828299952">
-        <tag k="bdw-id" v="{547715c1-5fd7-4c84-83e9-07a34d33e514}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-151"/>
+        <tag k="bdw-id" v="{547715c1-5fd7-4c84-83e9-07a34d33e514}"/>
     </node>
     <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996722981099985" lon="-72.3598742513199937">
-        <tag k="bdw-id" v="{fce33577-9e74-4dcb-bc0d-ee698213e37a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-150"/>
+        <tag k="bdw-id" v="{fce33577-9e74-4dcb-bc0d-ee698213e37a}"/>
     </node>
     <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996323785100005" lon="-72.3598990515200029">
-        <tag k="bdw-id" v="{a8fbb3ef-0ecc-4426-b7a3-ef431231e0b5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-149"/>
+        <tag k="bdw-id" v="{a8fbb3ef-0ecc-4426-b7a3-ef431231e0b5}"/>
     </node>
     <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008073074299999" lon="-72.3635727247900036">
-        <tag k="bdw-id" v="{7bc2131a-998c-4eb2-8327-308a3fc6230b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-148"/>
+        <tag k="bdw-id" v="{7bc2131a-998c-4eb2-8327-308a3fc6230b}"/>
     </node>
     <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004169135099989" lon="-72.3636700057400049">
-        <tag k="bdw-id" v="{c1643b44-18b1-4a64-aad9-6987e1964038}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-147"/>
+        <tag k="bdw-id" v="{c1643b44-18b1-4a64-aad9-6987e1964038}"/>
     </node>
     <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025105688900011" lon="-72.3604663040100036">
-        <tag k="bdw-id" v="{ef317431-bd4b-4aae-9cbb-efec060dbbba}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-146"/>
+        <tag k="bdw-id" v="{ef317431-bd4b-4aae-9cbb-efec060dbbba}"/>
     </node>
     <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025134469500003" lon="-72.3602217308899895">
-        <tag k="bdw-id" v="{4449e8a9-e837-44f4-93de-a2d440f3c7c5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-145"/>
+        <tag k="bdw-id" v="{4449e8a9-e837-44f4-93de-a2d440f3c7c5}"/>
     </node>
     <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009705876999988" lon="-72.3634189647799957">
-        <tag k="bdw-id" v="{bb8d560b-afba-41f3-a550-e4782b5e6a0c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144"/>
+        <tag k="bdw-id" v="{bb8d560b-afba-41f3-a550-e4782b5e6a0c}"/>
     </node>
     <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009115960299992" lon="-72.3632323317799973">
-        <tag k="bdw-id" v="{f02672bc-5098-44cc-8aae-7d17fab617bf}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-143"/>
+        <tag k="bdw-id" v="{f02672bc-5098-44cc-8aae-7d17fab617bf}"/>
     </node>
     <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008676288800002" lon="-72.3630775018600048">
-        <tag k="bdw-id" v="{763e8292-46a2-4045-b10a-601f81a4f3e3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-142"/>
+        <tag k="bdw-id" v="{763e8292-46a2-4045-b10a-601f81a4f3e3}"/>
     </node>
     <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028380173500004" lon="-72.3637438608899970">
-        <tag k="bdw-id" v="{c1b24ce7-377f-46f7-8fbe-d64e60a15d3c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-141"/>
+        <tag k="bdw-id" v="{c1b24ce7-377f-46f7-8fbe-d64e60a15d3c}"/>
     </node>
     <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027048353199978" lon="-72.3632830014399957">
-        <tag k="bdw-id" v="{9f9d7e20-ae6a-4b64-8731-6efbe69b7694}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-140"/>
+        <tag k="bdw-id" v="{9f9d7e20-ae6a-4b64-8731-6efbe69b7694}"/>
     </node>
     <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026376565999994" lon="-72.3638784585599950">
-        <tag k="bdw-id" v="{8aff790a-de78-4972-a6c7-8256771bcd55}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-139"/>
+        <tag k="bdw-id" v="{8aff790a-de78-4972-a6c7-8256771bcd55}"/>
     </node>
     <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021681667799973" lon="-72.3640271775699944">
-        <tag k="bdw-id" v="{a0749bc5-4981-4e42-a91f-cd65c6101338}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-138"/>
+        <tag k="bdw-id" v="{a0749bc5-4981-4e42-a91f-cd65c6101338}"/>
     </node>
     <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020382077799994" lon="-72.3640629748000066">
-        <tag k="bdw-id" v="{a02de9d0-d7c1-4d80-82a5-f52744f735dc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-137"/>
+        <tag k="bdw-id" v="{a02de9d0-d7c1-4d80-82a5-f52744f735dc}"/>
     </node>
     <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019855596399998" lon="-72.3638471517800070">
-        <tag k="bdw-id" v="{c01ea5a7-6169-48b2-a547-8e3cf0c6d9d0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136"/>
+        <tag k="bdw-id" v="{c01ea5a7-6169-48b2-a547-8e3cf0c6d9d0}"/>
     </node>
     <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017943246200025" lon="-72.3646545002600021">
-        <tag k="bdw-id" v="{e75e3182-39f4-4a2e-9000-b3da70366cc8}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-135"/>
+        <tag k="bdw-id" v="{e75e3182-39f4-4a2e-9000-b3da70366cc8}"/>
     </node>
     <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017613183100000" lon="-72.3646789551700067">
-        <tag k="bdw-id" v="{9d2e75b8-7b3e-4212-a6d3-13ffce9bd5b5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-134"/>
+        <tag k="bdw-id" v="{9d2e75b8-7b3e-4212-a6d3-13ffce9bd5b5}"/>
     </node>
     <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016925778499994" lon="-72.3647298860600046">
-        <tag k="bdw-id" v="{43170a0b-5530-4103-a1db-21ce1da0f13b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-133"/>
+        <tag k="bdw-id" v="{43170a0b-5530-4103-a1db-21ce1da0f13b}"/>
     </node>
     <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015033074300012" lon="-72.3647676287800010">
-        <tag k="bdw-id" v="{47cef29e-8cb0-4bcb-bd96-f32e89861003}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-132"/>
+        <tag k="bdw-id" v="{47cef29e-8cb0-4bcb-bd96-f32e89861003}"/>
     </node>
     <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019125718900012" lon="-72.3653594478400066">
-        <tag k="bdw-id" v="{53fe45e8-12b6-4cd8-a776-1b0f38d075aa}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-131"/>
+        <tag k="bdw-id" v="{53fe45e8-12b6-4cd8-a776-1b0f38d075aa}"/>
     </node>
     <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019170361199976" lon="-72.3652935094499981">
-        <tag k="bdw-id" v="{953fa01d-77bb-40e9-b414-c9276745c00a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-130"/>
+        <tag k="bdw-id" v="{953fa01d-77bb-40e9-b414-c9276745c00a}"/>
     </node>
     <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019098487599980" lon="-72.3652112486099952">
-        <tag k="bdw-id" v="{65abc668-4648-4d8f-8f0e-0ff31c7651b3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-129"/>
+        <tag k="bdw-id" v="{65abc668-4648-4d8f-8f0e-0ff31c7651b3}"/>
     </node>
     <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018988007800004" lon="-72.3651629165800045">
-        <tag k="bdw-id" v="{00eae29a-18ee-4083-9d9b-6ce3beb4ebcb}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-128"/>
+        <tag k="bdw-id" v="{00eae29a-18ee-4083-9d9b-6ce3beb4ebcb}"/>
     </node>
     <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018695400000006" lon="-72.3650857263500029">
-        <tag k="bdw-id" v="{1ebc0ac8-8992-4d6b-8c91-b6bc962193b5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
+        <tag k="bdw-id" v="{1ebc0ac8-8992-4d6b-8c91-b6bc962193b5}"/>
     </node>
     <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018368800699992" lon="-72.3650283159600036">
-        <tag k="bdw-id" v="{0a8b03e8-8cf1-4cb4-a6c6-743c9423e16f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
+        <tag k="bdw-id" v="{0a8b03e8-8cf1-4cb4-a6c6-743c9423e16f}"/>
     </node>
     <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017855075299995" lon="-72.3649637669900017">
-        <tag k="bdw-id" v="{73f1a3d4-f061-477d-aa78-0167bc45d078}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-125"/>
+        <tag k="bdw-id" v="{73f1a3d4-f061-477d-aa78-0167bc45d078}"/>
     </node>
     <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017530332899975" lon="-72.3649325465199951">
-        <tag k="bdw-id" v="{7f41aff8-101a-456d-85b7-4d65109fab2c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
+        <tag k="bdw-id" v="{7f41aff8-101a-456d-85b7-4d65109fab2c}"/>
     </node>
     <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012823693799994" lon="-72.3648179282999990">
-        <tag k="bdw-id" v="{aa207c4c-6123-4b19-9124-f867b4665a24}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-123"/>
+        <tag k="bdw-id" v="{aa207c4c-6123-4b19-9124-f867b4665a24}"/>
     </node>
     <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012374695599979" lon="-72.3648322397200019">
-        <tag k="bdw-id" v="{f567cdc7-60ea-4580-85d9-914239eddac4}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
+        <tag k="bdw-id" v="{f567cdc7-60ea-4580-85d9-914239eddac4}"/>
     </node>
     <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006060287499993" lon="-72.3650699608899970">
-        <tag k="bdw-id" v="{ee9ae638-b3fc-41a5-886d-82cc4f355eb9}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
+        <tag k="bdw-id" v="{ee9ae638-b3fc-41a5-886d-82cc4f355eb9}"/>
     </node>
     <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008923923800001" lon="-72.3607497208700039">
-        <tag k="bdw-id" v="{00282eb6-07d9-4490-a60e-d8541a07ec51}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-120"/>
+        <tag k="bdw-id" v="{00282eb6-07d9-4490-a60e-d8541a07ec51}"/>
     </node>
     <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008460567700006" lon="-72.3607534871499922">
-        <tag k="bdw-id" v="{27b64afd-85ec-4d9e-889c-96f38249e170}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119"/>
+        <tag k="bdw-id" v="{27b64afd-85ec-4d9e-889c-96f38249e170}"/>
     </node>
     <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017029639099981" lon="-72.3648606462199950">
-        <tag k="bdw-id" v="{e813d633-c35d-4d36-af1b-170d39b085e7}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-118"/>
+        <tag k="bdw-id" v="{e813d633-c35d-4d36-af1b-170d39b085e7}"/>
     </node>
     <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017121249399993" lon="-72.3648359878300056">
-        <tag k="bdw-id" v="{e7e8ea7e-62f1-461a-9f9e-cdb3307f77dd}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117"/>
+        <tag k="bdw-id" v="{e7e8ea7e-62f1-461a-9f9e-cdb3307f77dd}"/>
     </node>
     <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017322410099993" lon="-72.3647497908099950">
-        <tag k="bdw-id" v="{52724a1d-a920-4605-b298-1cd4bca5d8e5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-116"/>
+        <tag k="bdw-id" v="{52724a1d-a920-4605-b298-1cd4bca5d8e5}"/>
     </node>
     <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005652468600010" lon="-72.3649338501799946">
-        <tag k="bdw-id" v="{ce494fa3-d0a3-4cd6-9cca-b5bef17f4acc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-115"/>
+        <tag k="bdw-id" v="{ce494fa3-d0a3-4cd6-9cca-b5bef17f4acc}"/>
     </node>
     <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005029935499989" lon="-72.3647064545199896">
-        <tag k="bdw-id" v="{efbcf4d1-45de-4f80-a7f3-200b90b4f26b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114"/>
+        <tag k="bdw-id" v="{efbcf4d1-45de-4f80-a7f3-200b90b4f26b}"/>
     </node>
     <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023699280499995" lon="-72.3596330036399991">
-        <tag k="bdw-id" v="{f8906d8b-524d-4fc9-a16b-2f3c32d399d8}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-113"/>
+        <tag k="bdw-id" v="{f8906d8b-524d-4fc9-a16b-2f3c32d399d8}"/>
     </node>
     <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014893720299993" lon="-72.3597033407099985">
-        <tag k="bdw-id" v="{f32070c6-9028-4e04-b9b2-6e6a295d1ee3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
+        <tag k="bdw-id" v="{f32070c6-9028-4e04-b9b2-6e6a295d1ee3}"/>
     </node>
     <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012677290700005" lon="-72.3606008227500013">
-        <tag k="bdw-id" v="{e4fbe1ff-f723-431b-96fb-40f240a591ea}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-111"/>
+        <tag k="bdw-id" v="{e4fbe1ff-f723-431b-96fb-40f240a591ea}"/>
     </node>
     <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012565179399992" lon="-72.3599581959600044">
-        <tag k="bdw-id" v="{10a8a646-89e4-4325-a1c0-0bba91edd235}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-110"/>
+        <tag k="bdw-id" v="{10a8a646-89e4-4325-a1c0-0bba91edd235}"/>
     </node>
     <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006222338299990" lon="-72.3620713771800013">
-        <tag k="bdw-id" v="{29b4e035-bf6f-4c0a-8ea4-3d453ca11958}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-109"/>
+        <tag k="bdw-id" v="{29b4e035-bf6f-4c0a-8ea4-3d453ca11958}"/>
     </node>
     <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006166110400009" lon="-72.3620127005400064">
-        <tag k="bdw-id" v="{3236cbd6-48d9-454d-a8c4-1371a982eaf6}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-108"/>
+        <tag k="bdw-id" v="{3236cbd6-48d9-454d-a8c4-1371a982eaf6}"/>
     </node>
     <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006200294399987" lon="-72.3618202711599992">
-        <tag k="bdw-id" v="{f5a74281-96eb-4f5e-b481-651edb664c2b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-107"/>
+        <tag k="bdw-id" v="{f5a74281-96eb-4f5e-b481-651edb664c2b}"/>
     </node>
     <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006146626000005" lon="-72.3617239950699940">
-        <tag k="bdw-id" v="{65842328-7e41-408d-a5ae-934a30e075e0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-106"/>
+        <tag k="bdw-id" v="{65842328-7e41-408d-a5ae-934a30e075e0}"/>
     </node>
     <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006174317799978" lon="-72.3616800897999894">
-        <tag k="bdw-id" v="{a0dccbbc-e9eb-46d7-b79b-120abe29eded}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105"/>
+        <tag k="bdw-id" v="{a0dccbbc-e9eb-46d7-b79b-120abe29eded}"/>
     </node>
     <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021432854499992" lon="-72.3644346259099933">
-        <tag k="bdw-id" v="{ff09ca3d-4dc3-47a8-8646-aa0fa7e82936}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-104"/>
+        <tag k="bdw-id" v="{ff09ca3d-4dc3-47a8-8646-aa0fa7e82936}"/>
     </node>
     <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021206720000004" lon="-72.3643814086800035">
-        <tag k="bdw-id" v="{4d5d8d79-a11f-4de2-b6dc-15547a6d7cbd}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-103"/>
+        <tag k="bdw-id" v="{4d5d8d79-a11f-4de2-b6dc-15547a6d7cbd}"/>
     </node>
     <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021015211100012" lon="-72.3643231872499939">
-        <tag k="bdw-id" v="{5a9206d5-800f-4011-965d-f301a8d427eb}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-102"/>
+        <tag k="bdw-id" v="{5a9206d5-800f-4011-965d-f301a8d427eb}"/>
     </node>
     <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026129862400001" lon="-72.3604632380500021">
-        <tag k="bdw-id" v="{824ffa86-73f5-400e-849e-67fa91014a0f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
+        <tag k="bdw-id" v="{824ffa86-73f5-400e-849e-67fa91014a0f}"/>
     </node>
     <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020204485399999" lon="-72.3645026282299995">
-        <tag k="bdw-id" v="{6d7b17e4-660a-4bad-bd27-3f9ac8c26f45}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-100"/>
+        <tag k="bdw-id" v="{6d7b17e4-660a-4bad-bd27-3f9ac8c26f45}"/>
     </node>
     <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008388564899990" lon="-72.3604372371499949">
-        <tag k="bdw-id" v="{83b1e61c-ba23-4c55-968d-955604dab858}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-99"/>
+        <tag k="bdw-id" v="{83b1e61c-ba23-4c55-968d-955604dab858}"/>
     </node>
     <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008414641999989" lon="-72.3603488479899966">
-        <tag k="bdw-id" v="{f58efa1d-1534-4d88-a24a-65f0e8a8b94c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-98"/>
+        <tag k="bdw-id" v="{f58efa1d-1534-4d88-a24a-65f0e8a8b94c}"/>
     </node>
     <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014684370100017" lon="-72.3607199184299930">
-        <tag k="bdw-id" v="{d24f3529-f6f0-414e-8d8e-60da4d196983}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-97"/>
+        <tag k="bdw-id" v="{d24f3529-f6f0-414e-8d8e-60da4d196983}"/>
     </node>
     <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011480890199993" lon="-72.3597396552600003">
-        <tag k="bdw-id" v="{1f08e79d-65f6-4645-9193-d71b5f53fc5d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-96"/>
+        <tag k="bdw-id" v="{1f08e79d-65f6-4645-9193-d71b5f53fc5d}"/>
     </node>
     <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011314008299978" lon="-72.3606690550100069">
-        <tag k="bdw-id" v="{0fdb3dcf-8b32-41f0-90be-c389007acb55}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
+        <tag k="bdw-id" v="{0fdb3dcf-8b32-41f0-90be-c389007acb55}"/>
     </node>
     <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7010350738799991" lon="-72.3606303437099996">
-        <tag k="bdw-id" v="{c3670158-c9c6-4ff0-8a58-c1b76a1ec4e5}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
+        <tag k="bdw-id" v="{c3670158-c9c6-4ff0-8a58-c1b76a1ec4e5}"/>
     </node>
     <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008914643399997" lon="-72.3605619019399882">
-        <tag k="bdw-id" v="{d8cb4c59-7766-4836-be2c-e8c19fba607f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
+        <tag k="bdw-id" v="{d8cb4c59-7766-4836-be2c-e8c19fba607f}"/>
     </node>
     <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027208787900010" lon="-72.3596191073200004">
-        <tag k="bdw-id" v="{3eeb7ede-2b3d-4c29-9e44-9d07960fa336}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
+        <tag k="bdw-id" v="{3eeb7ede-2b3d-4c29-9e44-9d07960fa336}"/>
     </node>
     <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009478563300000" lon="-72.3643993500499931">
-        <tag k="bdw-id" v="{0c5f531f-dc9d-4838-be76-22f347450aa0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-91"/>
+        <tag k="bdw-id" v="{0c5f531f-dc9d-4838-be76-22f347450aa0}"/>
     </node>
     <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007024150600003" lon="-72.3644763970700069">
-        <tag k="bdw-id" v="{3f4b8bd2-df1c-4138-b4fd-3260d8fe0ec3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-90"/>
+        <tag k="bdw-id" v="{3f4b8bd2-df1c-4138-b4fd-3260d8fe0ec3}"/>
     </node>
     <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005803708500009" lon="-72.3645073528099942">
-        <tag k="bdw-id" v="{eb14e619-d0c3-4d9a-979f-ccbb797c6951}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-89"/>
+        <tag k="bdw-id" v="{eb14e619-d0c3-4d9a-979f-ccbb797c6951}"/>
     </node>
     <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008241934799990" lon="-72.3605447727200044">
-        <tag k="bdw-id" v="{9967ecd7-f1a3-4fc8-914e-e2f78db509fc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-88"/>
+        <tag k="bdw-id" v="{9967ecd7-f1a3-4fc8-914e-e2f78db509fc}"/>
     </node>
     <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007832027999976" lon="-72.3605486476500062">
-        <tag k="bdw-id" v="{138c095d-54fd-445b-90c5-923650b541e3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
+        <tag k="bdw-id" v="{138c095d-54fd-445b-90c5-923650b541e3}"/>
     </node>
     <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007356230099999" lon="-72.3605422724999983">
-        <tag k="bdw-id" v="{22806f5a-e73a-4ba9-af2e-160f454900fe}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
+        <tag k="bdw-id" v="{22806f5a-e73a-4ba9-af2e-160f454900fe}"/>
     </node>
     <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004424406699998" lon="-72.3603875287600005">
-        <tag k="bdw-id" v="{00d30ebe-52c8-45c5-bc86-5b1dc30bbe06}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
+        <tag k="bdw-id" v="{00d30ebe-52c8-45c5-bc86-5b1dc30bbe06}"/>
     </node>
     <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999463079099986" lon="-72.3601460936800009">
-        <tag k="bdw-id" v="{caee4c3f-bf77-40c2-b541-e49caf11c2fe}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
+        <tag k="bdw-id" v="{caee4c3f-bf77-40c2-b541-e49caf11c2fe}"/>
     </node>
     <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998361407499969" lon="-72.3600846000900049">
-        <tag k="bdw-id" v="{af319fcf-ad29-45dc-8031-c484298dc8ab}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
+        <tag k="bdw-id" v="{af319fcf-ad29-45dc-8031-c484298dc8ab}"/>
     </node>
     <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997747674000001" lon="-72.3600422314799943">
-        <tag k="bdw-id" v="{59ba072e-e835-424e-9638-3a46a515d8f3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
+        <tag k="bdw-id" v="{59ba072e-e835-424e-9638-3a46a515d8f3}"/>
     </node>
     <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996897282199992" lon="-72.3599654490699891">
-        <tag k="bdw-id" v="{e030d272-c409-4fc0-9339-9554f98ca67d}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
+        <tag k="bdw-id" v="{e030d272-c409-4fc0-9339-9554f98ca67d}"/>
     </node>
     <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000669276699982" lon="-72.3637773729799960">
-        <tag k="bdw-id" v="{698ee339-549a-4414-833d-70c41bf96aa3}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
+        <tag k="bdw-id" v="{698ee339-549a-4414-833d-70c41bf96aa3}"/>
     </node>
     <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997781354999999" lon="-72.3638605285700010">
-        <tag k="bdw-id" v="{119ff15b-1a2e-4924-a6b3-d30e2cf7f7a0}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
+        <tag k="bdw-id" v="{119ff15b-1a2e-4924-a6b3-d30e2cf7f7a0}"/>
     </node>
     <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997060737399972" lon="-72.3638749536899866">
-        <tag k="bdw-id" v="{249b4a4c-a063-4402-a9c1-dc9b0daf2923}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
+        <tag k="bdw-id" v="{249b4a4c-a063-4402-a9c1-dc9b0daf2923}"/>
     </node>
     <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996463546499987" lon="-72.3638948664100070">
-        <tag k="bdw-id" v="{022159b5-d615-40cd-8e0b-7e15a2f3fffd}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
+        <tag k="bdw-id" v="{022159b5-d615-40cd-8e0b-7e15a2f3fffd}"/>
     </node>
     <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025429482899987" lon="-72.3619990111400000">
-        <tag k="bdw-id" v="{628254ce-ddf5-4a6d-8e2b-604d49b8740c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
+        <tag k="bdw-id" v="{628254ce-ddf5-4a6d-8e2b-604d49b8740c}"/>
     </node>
     <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025063127400015" lon="-72.3607880166299964">
-        <tag k="bdw-id" v="{0f9afdde-b63b-4bc1-9563-1baa4b85e28c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
+        <tag k="bdw-id" v="{0f9afdde-b63b-4bc1-9563-1baa4b85e28c}"/>
     </node>
     <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005030098099985" lon="-72.3651013186299963">
-        <tag k="bdw-id" v="{b42fe56c-6b69-4eb8-9dc8-4cc15abf7100}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
+        <tag k="bdw-id" v="{b42fe56c-6b69-4eb8-9dc8-4cc15abf7100}"/>
     </node>
     <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003987303299999" lon="-72.3651280253599936">
-        <tag k="bdw-id" v="{de968008-487e-45f7-b75d-cc6a7e3c3b02}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
+        <tag k="bdw-id" v="{de968008-487e-45f7-b75d-cc6a7e3c3b02}"/>
     </node>
     <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996794169599996" lon="-72.3652826818200055">
-        <tag k="bdw-id" v="{12b490fd-a953-4a29-858b-871368ccd8ba}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
+        <tag k="bdw-id" v="{12b490fd-a953-4a29-858b-871368ccd8ba}"/>
     </node>
     <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994617584999991" lon="-72.3653356666000036">
-        <tag k="bdw-id" v="{b6be1c87-29d1-4959-9da4-9d17d7e664b8}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
+        <tag k="bdw-id" v="{b6be1c87-29d1-4959-9da4-9d17d7e664b8}"/>
     </node>
     <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005950625799988" lon="-72.3622759602600070">
-        <tag k="bdw-id" v="{dbc43ee4-a923-4289-afe8-1459523ab536}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
+        <tag k="bdw-id" v="{dbc43ee4-a923-4289-afe8-1459523ab536}"/>
     </node>
     <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004419767799988" lon="-72.3623265571600029">
-        <tag k="bdw-id" v="{2e997e60-15a4-40d4-b464-f033b5e1e192}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
+        <tag k="bdw-id" v="{2e997e60-15a4-40d4-b464-f033b5e1e192}"/>
     </node>
     <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002421877699998" lon="-72.3623841271899977">
-        <tag k="bdw-id" v="{0489272e-8d70-46b9-b3a7-bc232913d425}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
+        <tag k="bdw-id" v="{0489272e-8d70-46b9-b3a7-bc232913d425}"/>
     </node>
     <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001300551699998" lon="-72.3624071531999959">
-        <tag k="bdw-id" v="{c64c8768-ce14-47a8-9c38-8ace6941987b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
+        <tag k="bdw-id" v="{c64c8768-ce14-47a8-9c38-8ace6941987b}"/>
     </node>
     <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263536499997" lon="-72.3629389733599879">
-        <tag k="bdw-id" v="{c626b399-6782-461d-917a-0cf0996b1fdb}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
+        <tag k="bdw-id" v="{c626b399-6782-461d-917a-0cf0996b1fdb}"/>
     </node>
     <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002326456700017" lon="-72.3629951913199960">
-        <tag k="bdw-id" v="{90fcd827-fbd0-48ae-a4d6-09673f960de9}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
+        <tag k="bdw-id" v="{90fcd827-fbd0-48ae-a4d6-09673f960de9}"/>
     </node>
     <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263687200001" lon="-72.3630515204099964">
-        <tag k="bdw-id" v="{7931c590-92d0-45e3-9827-de3955aed059}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
+        <tag k="bdw-id" v="{7931c590-92d0-45e3-9827-de3955aed059}"/>
     </node>
     <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001738660599983" lon="-72.3633648031100023">
-        <tag k="bdw-id" v="{0767e414-fe2f-4e87-86b1-83c5065f4304}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
+        <tag k="bdw-id" v="{0767e414-fe2f-4e87-86b1-83c5065f4304}"/>
     </node>
     <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001659247899985" lon="-72.3634536496399789">
-        <tag k="bdw-id" v="{39843252-90f8-4328-a1f2-80fab8e6b8b6}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
+        <tag k="bdw-id" v="{39843252-90f8-4328-a1f2-80fab8e6b8b6}"/>
     </node>
     <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001675363100013" lon="-72.3635159822700018">
-        <tag k="bdw-id" v="{105fc6d8-94f1-4ef4-ba69-3046dff39d16}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
+        <tag k="bdw-id" v="{105fc6d8-94f1-4ef4-ba69-3046dff39d16}"/>
     </node>
     <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001798178699969" lon="-72.3636234875299920">
-        <tag k="bdw-id" v="{ec320852-50a3-4e2c-aeda-0fd3e6195a7c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
+        <tag k="bdw-id" v="{ec320852-50a3-4e2c-aeda-0fd3e6195a7c}"/>
     </node>
     <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025861574699990" lon="-72.3629225343800044">
-        <tag k="bdw-id" v="{cc54749b-a8ec-4890-85c3-09a892963506}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
+        <tag k="bdw-id" v="{cc54749b-a8ec-4890-85c3-09a892963506}"/>
     </node>
     <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024048346499994" lon="-72.3623002673199949">
-        <tag k="bdw-id" v="{1b331fd7-7f67-4919-90e4-05086bf62cbf}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
+        <tag k="bdw-id" v="{1b331fd7-7f67-4919-90e4-05086bf62cbf}"/>
     </node>
     <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013730528799984" lon="-72.3620810506499907">
-        <tag k="bdw-id" v="{a7735e22-4c30-4d65-a692-ff1ed1f9376f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
+        <tag k="bdw-id" v="{a7735e22-4c30-4d65-a692-ff1ed1f9376f}"/>
     </node>
     <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008919916799989" lon="-72.3622094409199974">
-        <tag k="bdw-id" v="{85994d76-029a-4614-9df7-7b500fa1d7f1}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
+        <tag k="bdw-id" v="{85994d76-029a-4614-9df7-7b500fa1d7f1}"/>
     </node>
     <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025805898900002" lon="-72.3650112703899993">
-        <tag k="bdw-id" v="{12c8cfe5-2c80-4416-a6c6-7dd032a41850}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
+        <tag k="bdw-id" v="{12c8cfe5-2c80-4416-a6c6-7dd032a41850}"/>
     </node>
     <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025182392699998" lon="-72.3649374931300002">
-        <tag k="bdw-id" v="{f6efc0ea-6a32-4bce-b27b-56022d012add}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
+        <tag k="bdw-id" v="{f6efc0ea-6a32-4bce-b27b-56022d012add}"/>
     </node>
     <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022252799000022" lon="-72.3645673879100002">
-        <tag k="bdw-id" v="{133a2d8b-e32e-4e50-ad73-c4854fcc925b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
+        <tag k="bdw-id" v="{133a2d8b-e32e-4e50-ad73-c4854fcc925b}"/>
     </node>
     <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021796015300001" lon="-72.3645015413899984">
-        <tag k="bdw-id" v="{8746ed36-9f0b-4eb7-9558-3fae339f6750}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
+        <tag k="bdw-id" v="{8746ed36-9f0b-4eb7-9558-3fae339f6750}"/>
     </node>
     <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026958136299992" lon="-72.3650447362499989">
-        <tag k="bdw-id" v="{ddd4701d-ab0c-42dc-8c75-900e0dc3af5e}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
+        <tag k="bdw-id" v="{ddd4701d-ab0c-42dc-8c75-900e0dc3af5e}"/>
     </node>
     <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992193064799999" lon="-72.3588999086399838">
-        <tag k="bdw-id" v="{bbac7ebe-6c98-42a8-ae6e-b09b73364b98}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
+        <tag k="bdw-id" v="{bbac7ebe-6c98-42a8-ae6e-b09b73364b98}"/>
     </node>
     <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991501087799987" lon="-72.3586803331299961">
-        <tag k="bdw-id" v="{3e41468b-4ec7-41ce-a48d-39b762301e90}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
+        <tag k="bdw-id" v="{3e41468b-4ec7-41ce-a48d-39b762301e90}"/>
     </node>
     <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013292813500005" lon="-72.3648242249600031">
-        <tag k="bdw-id" v="{98c4d4ed-44cc-405e-972f-de5696f366be}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
+        <tag k="bdw-id" v="{98c4d4ed-44cc-405e-972f-de5696f366be}"/>
     </node>
     <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013324558299985" lon="-72.3648735912399985">
-        <tag k="bdw-id" v="{9d22553e-4320-44c6-a1b3-e20179af825f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
+        <tag k="bdw-id" v="{9d22553e-4320-44c6-a1b3-e20179af825f}"/>
     </node>
     <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013304654399999" lon="-72.3649230197300000">
-        <tag k="bdw-id" v="{dd91b33a-be42-4891-bc91-2be90c51b853}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
+        <tag k="bdw-id" v="{dd91b33a-be42-4891-bc91-2be90c51b853}"/>
     </node>
     <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992473837099986" lon="-72.3588367156799990">
-        <tag k="bdw-id" v="{d51893a6-3df0-4d94-ae99-a0291cf1f8b2}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
+        <tag k="bdw-id" v="{d51893a6-3df0-4d94-ae99-a0291cf1f8b2}"/>
     </node>
     <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991559975199992" lon="-72.3588277695599942">
-        <tag k="bdw-id" v="{a05ed439-4959-4ec7-a534-1e3cb1be92fc}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
+        <tag k="bdw-id" v="{a05ed439-4959-4ec7-a534-1e3cb1be92fc}"/>
     </node>
     <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995335028499996" lon="-72.3597741646800046">
-        <tag k="bdw-id" v="{26a7a9c4-a267-4a2a-8720-d176d5fa1034}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
+        <tag k="bdw-id" v="{26a7a9c4-a267-4a2a-8720-d176d5fa1034}"/>
     </node>
     <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993052853000004" lon="-72.3595089049200055">
-        <tag k="bdw-id" v="{9893a976-8d41-4fa8-8b7f-7784f22cb53f}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
+        <tag k="bdw-id" v="{9893a976-8d41-4fa8-8b7f-7784f22cb53f}"/>
     </node>
     <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992779188700000" lon="-72.3594700869700063">
-        <tag k="bdw-id" v="{de4ac387-e204-40b6-a872-bac62a736235}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
+        <tag k="bdw-id" v="{de4ac387-e204-40b6-a872-bac62a736235}"/>
     </node>
     <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992564190600010" lon="-72.3594277203900020">
-        <tag k="bdw-id" v="{a0f095b9-7fbc-4361-b994-d85f4e67855b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
+        <tag k="bdw-id" v="{a0f095b9-7fbc-4361-b994-d85f4e67855b}"/>
     </node>
     <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992412347999988" lon="-72.3593826898599985">
-        <tag k="bdw-id" v="{66fa7879-ad20-47e4-9140-c3c7de8a9f52}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
+        <tag k="bdw-id" v="{66fa7879-ad20-47e4-9140-c3c7de8a9f52}"/>
     </node>
     <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988183784600013" lon="-72.3644868463200055">
-        <tag k="bdw-id" v="{347874d6-7887-4085-9a1a-24efd90a2479}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
+        <tag k="bdw-id" v="{347874d6-7887-4085-9a1a-24efd90a2479}"/>
     </node>
     <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988550299999998" lon="-72.3644932968399814">
-        <tag k="bdw-id" v="{62350f3f-463b-42fb-8b9e-e32eb8a3b174}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
+        <tag k="bdw-id" v="{62350f3f-463b-42fb-8b9e-e32eb8a3b174}"/>
     </node>
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988897343599980" lon="-72.3645093670400001">
-        <tag k="bdw-id" v="{517b3307-09b5-4b3a-b497-e5bf7adf0d64}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
+        <tag k="bdw-id" v="{517b3307-09b5-4b3a-b497-e5bf7adf0d64}"/>
     </node>
     <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994340143300004" lon="-72.3648455978899960">
-        <tag k="bdw-id" v="{f354a4b8-acc1-4762-bfe4-1cdc0422cb72}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
+        <tag k="bdw-id" v="{f354a4b8-acc1-4762-bfe4-1cdc0422cb72}"/>
     </node>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994883816500002" lon="-72.3648748282899987">
-        <tag k="bdw-id" v="{b778ee8d-262a-40b4-aa1d-4e2b3ff58d14}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
+        <tag k="bdw-id" v="{b778ee8d-262a-40b4-aa1d-4e2b3ff58d14}"/>
     </node>
     <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995300524399983" lon="-72.3648891177899998">
-        <tag k="bdw-id" v="{083899ed-ba61-47ce-8baf-6616ec0677ec}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
+        <tag k="bdw-id" v="{083899ed-ba61-47ce-8baf-6616ec0677ec}"/>
     </node>
     <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995468363599979" lon="-72.3648901012099941">
-        <tag k="bdw-id" v="{4132d23d-4212-4639-a6b3-e5b6935de61c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
+        <tag k="bdw-id" v="{4132d23d-4212-4639-a6b3-e5b6935de61c}"/>
     </node>
     <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995612977999981" lon="-72.3648866791999978">
-        <tag k="bdw-id" v="{06bf1610-0e90-49fc-9114-36b379c4660a}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
+        <tag k="bdw-id" v="{06bf1610-0e90-49fc-9114-36b379c4660a}"/>
     </node>
     <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995737206600010" lon="-72.3648786283799978">
-        <tag k="bdw-id" v="{575d3611-dc51-40ab-b2d8-c2561e00890b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
+        <tag k="bdw-id" v="{575d3611-dc51-40ab-b2d8-c2561e00890b}"/>
     </node>
     <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996182300299996" lon="-72.3648208084500055">
-        <tag k="bdw-id" v="{fd69d246-ec48-48f9-9317-26fae1eae0fe}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="bdw-id" v="{fd69d246-ec48-48f9-9317-26fae1eae0fe}"/>
     </node>
     <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996632180000013" lon="-72.3647774958599967">
-        <tag k="bdw-id" v="{9058c10d-26e0-4c35-ad74-e9aaed0ea42b}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
+        <tag k="bdw-id" v="{9058c10d-26e0-4c35-ad74-e9aaed0ea42b}"/>
     </node>
     <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996960073499991" lon="-72.3647552536900065">
-        <tag k="bdw-id" v="{15f50f45-3907-4fb8-907a-bc3bc30b02ee}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
+        <tag k="bdw-id" v="{15f50f45-3907-4fb8-907a-bc3bc30b02ee}"/>
     </node>
     <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997367568100019" lon="-72.3647365293199982">
-        <tag k="bdw-id" v="{3bafbefa-9894-45a8-a7cb-69912c23d12c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
+        <tag k="bdw-id" v="{3bafbefa-9894-45a8-a7cb-69912c23d12c}"/>
     </node>
     <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999384750299988" lon="-72.3646676866299856">
-        <tag k="bdw-id" v="{c4a1cf21-416f-414f-b333-94cc84807c1c}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
+        <tag k="bdw-id" v="{c4a1cf21-416f-414f-b333-94cc84807c1c}"/>
     </node>
     <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000524529499996" lon="-72.3646327131999954">
-        <tag k="bdw-id" v="{3d83ceeb-0418-4a95-b4ab-5fc7705850f7}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
+        <tag k="bdw-id" v="{3d83ceeb-0418-4a95-b4ab-5fc7705850f7}"/>
     </node>
     <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003252868600010" lon="-72.3645614283999947">
-        <tag k="bdw-id" v="{2b1399b5-2753-4066-bc56-b8e3aefe90e7}"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
+        <tag k="bdw-id" v="{2b1399b5-2753-4066-bc56-b8e3aefe90e7}"/>
     </node>
     <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3644779235235234">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991389118199240" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992284381644600" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3587000267866642">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3648749865446348">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993110867921271" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3595948439905925">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3604333847607819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019046245402620" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3637694387719250">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007915076878293" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999976" lon="-72.3609894875373385">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029956433356528" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024584100726941" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3592806677495304">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3629401351312538">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3643537384355255">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024697672642928" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007453994198976" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999766979966902" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014734418771242" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3587182734695205">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-1426" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-880"/>
@@ -1350,42 +1076,37 @@
         <nd ref="-189"/>
         <nd ref="-188"/>
         <nd ref="-222"/>
-        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-        <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1426"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
     <way visible="true" id="-1425" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-202"/>
         <nd ref="-192"/>
         <nd ref="-879"/>
-        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-        <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1425"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
     <way visible="true" id="-1424" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-879"/>
         <nd ref="-880"/>
-        <tag k="bdw-id" v="{40ea34f9-03b9-46b5-b9ad-7e71a1b00175}"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
         <tag k="bridge" v="yes"/>
         <tag k="layer" v="1"/>
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1424"/>
+        <tag k="bdw-id" v="{40ea34f9-03b9-46b5-b9ad-7e71a1b00175}"/>
     </way>
     <way visible="true" id="-1421" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-876"/>
         <nd ref="-214"/>
-        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1421"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
+        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
     <way visible="true" id="-1420" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-231"/>
@@ -1395,32 +1116,28 @@
         <nd ref="-106"/>
         <nd ref="-105"/>
         <nd ref="-875"/>
-        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1420"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
+        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
     <way visible="true" id="-1419" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-875"/>
         <nd ref="-876"/>
-        <tag k="bdw-id" v="{206c3cb6-55ad-4745-95a6-7b713f797b58}"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="secondary"/>
         <tag k="bridge" v="yes"/>
         <tag k="layer" v="1"/>
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1419"/>
+        <tag k="bdw-id" v="{206c3cb6-55ad-4745-95a6-7b713f797b58}"/>
     </way>
     <way visible="true" id="-1416" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-872"/>
         <nd ref="-162"/>
-        <tag k="bdw-id" v="{7a909337-b6e1-43dc-bd38-80f089cc6bbb}"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:16Z"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1416"/>
+        <tag k="bdw-id" v="{7a909337-b6e1-43dc-bd38-80f089cc6bbb}"/>
     </way>
     <way visible="true" id="-1415" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-231"/>
@@ -1433,47 +1150,41 @@
         <nd ref="-166"/>
         <nd ref="-165"/>
         <nd ref="-871"/>
-        <tag k="bdw-id" v="{7a909337-b6e1-43dc-bd38-80f089cc6bbb}"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:16Z"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1415"/>
+        <tag k="bdw-id" v="{7a909337-b6e1-43dc-bd38-80f089cc6bbb}"/>
     </way>
     <way visible="true" id="-1414" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-871"/>
         <nd ref="-164"/>
         <nd ref="-163"/>
         <nd ref="-872"/>
-        <tag k="bdw-id" v="{607c2a36-d410-462c-bcfe-cf528efb36d2}"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1414"/>
+        <tag k="highway" v="residential"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
+        <tag k="bdw-id" v="{607c2a36-d410-462c-bcfe-cf528efb36d2}"/>
     </way>
     <way visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-260"/>
         <nd ref="-259"/>
         <nd ref="-258"/>
-        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
-        <tag k="name" v="Avenida Los Leones"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-168"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida Los Leones"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
+        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
     <way visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-174"/>
         <nd ref="-173"/>
         <nd ref="-12"/>
         <tag k="oneway" v="no"/>
-        <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-122"/>
+        <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
     </way>
     <way visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-268"/>
@@ -1485,22 +1196,20 @@
         <nd ref="-262"/>
         <nd ref="-261"/>
         <nd ref="-260"/>
-        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="name" v="Avenida 9"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-81"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Avenida 9"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
+        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
     <way visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-253"/>
         <nd ref="-252"/>
         <nd ref="-251"/>
-        <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-80"/>
+        <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
     <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-250"/>
@@ -1508,21 +1217,19 @@
         <nd ref="-248"/>
         <nd ref="-247"/>
         <nd ref="-254"/>
-        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-79"/>
+        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
     <way visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-245"/>
         <nd ref="-244"/>
         <nd ref="-268"/>
-        <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-78"/>
+        <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
     </way>
     <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-256"/>
@@ -1531,167 +1238,151 @@
         <nd ref="-241"/>
         <nd ref="-240"/>
         <nd ref="-254"/>
-        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="name" v="Avenida 9"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-77"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Avenida 9"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
+        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
     <way visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-254"/>
         <nd ref="-239"/>
         <nd ref="-251"/>
-        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="name" v="Avenida 9"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-76"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Avenida 9"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
+        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
     <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-236"/>
         <nd ref="-235"/>
         <nd ref="-256"/>
-        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-75"/>
+        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
     <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-251"/>
         <nd ref="-234"/>
         <nd ref="-268"/>
-        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="name" v="Avenida 9"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-74"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Avenida 9"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
+        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
     <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-233"/>
         <nd ref="-232"/>
         <nd ref="-231"/>
-        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-73"/>
+        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
     <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-230"/>
         <nd ref="-229"/>
         <nd ref="-228"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-72"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
     <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-227"/>
         <nd ref="-226"/>
         <nd ref="-225"/>
-        <tag k="bdw-id" v="{9cbc6adc-20c7-4565-a103-a9cc523d8c95}"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{9cbc6adc-20c7-4565-a103-a9cc523d8c95}"/>
     </way>
     <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-253"/>
         <nd ref="-221"/>
         <nd ref="-245"/>
-        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="name" v="Avenida 10"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-69"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 10"/>
+        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
+        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
     <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-220"/>
         <nd ref="-219"/>
         <nd ref="-218"/>
         <nd ref="-217"/>
-        <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-68"/>
+        <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
     </way>
     <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
         <nd ref="-215"/>
         <nd ref="-214"/>
-        <tag k="bdw-id" v="{ce5ed05b-ab6e-4533-becd-513a7bbb445a}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:16Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-67"/>
+        <tag k="bdw-id" v="{ce5ed05b-ab6e-4533-becd-513a7bbb445a}"/>
     </way>
     <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-205"/>
         <nd ref="-204"/>
-        <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-66"/>
+        <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
     <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-225"/>
         <nd ref="-203"/>
         <nd ref="-202"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-65"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-227"/>
         <nd ref="-200"/>
         <nd ref="-199"/>
         <nd ref="-198"/>
-        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-64"/>
+        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
     <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-228"/>
         <nd ref="-197"/>
         <nd ref="-196"/>
         <nd ref="-225"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-63"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-195"/>
         <nd ref="-194"/>
         <nd ref="-193"/>
-        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-62"/>
+        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
     <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-161"/>
         <nd ref="-160"/>
         <nd ref="-159"/>
         <nd ref="-195"/>
-        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-59"/>
+        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
     <way visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-158"/>
@@ -1700,10 +1391,9 @@
         <nd ref="-155"/>
         <nd ref="-154"/>
         <nd ref="-153"/>
-        <tag k="bdw-id" v="{6aa81513-dca3-45e8-9132-c60073bb31b1}"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{6aa81513-dca3-45e8-9132-c60073bb31b1}"/>
     </way>
     <way visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-245"/>
@@ -1711,33 +1401,30 @@
         <nd ref="-151"/>
         <nd ref="-150"/>
         <nd ref="-149"/>
-        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="name" v="Avenida 10"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-57"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 10"/>
+        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
+        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
     <way visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-193"/>
         <nd ref="-148"/>
         <nd ref="-147"/>
         <nd ref="-217"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-56"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
     <way visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-146"/>
         <nd ref="-145"/>
         <nd ref="-236"/>
-        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-55"/>
+        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
     <way visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-193"/>
@@ -1745,52 +1432,47 @@
         <nd ref="-143"/>
         <nd ref="-142"/>
         <nd ref="-233"/>
-        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-54"/>
+        <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
     <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-228"/>
         <nd ref="-193"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-53"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
     <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-208"/>
         <nd ref="-141"/>
         <nd ref="-140"/>
         <nd ref="-230"/>
-        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-52"/>
+        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
     <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-208"/>
         <nd ref="-139"/>
         <nd ref="-138"/>
         <nd ref="-137"/>
-        <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-51"/>
+        <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
     </way>
     <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-137"/>
         <nd ref="-136"/>
         <nd ref="-228"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-50"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-158"/>
@@ -1799,22 +1481,20 @@
         <nd ref="-133"/>
         <nd ref="-132"/>
         <nd ref="-161"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-49"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-161"/>
         <nd ref="-123"/>
         <nd ref="-122"/>
         <nd ref="-121"/>
-        <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-48"/>
+        <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
     </way>
     <way visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-181"/>
@@ -1822,76 +1502,69 @@
         <nd ref="-117"/>
         <nd ref="-116"/>
         <nd ref="-134"/>
-        <tag k="bdw-id" v="{06fdfdf2-6ac0-45a9-8895-42ee0c3a20d1}"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{06fdfdf2-6ac0-45a9-8895-42ee0c3a20d1}"/>
     </way>
     <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-121"/>
         <nd ref="-115"/>
         <nd ref="-114"/>
         <nd ref="-220"/>
-        <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-45"/>
+        <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
     </way>
     <way visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-236"/>
         <nd ref="-113"/>
         <nd ref="-112"/>
         <nd ref="-250"/>
-        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="name" v="Avenida 10"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-44"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 10"/>
+        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
+        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
     <way visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-224"/>
         <nd ref="-111"/>
         <nd ref="-110"/>
         <nd ref="-250"/>
-        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-43"/>
+        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
     <way visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-104"/>
         <nd ref="-103"/>
         <nd ref="-102"/>
         <nd ref="-137"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-41"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-104"/>
         <nd ref="-100"/>
         <nd ref="-158"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-40"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
         <nd ref="-99"/>
         <nd ref="-98"/>
         <nd ref="-253"/>
-        <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-39"/>
+        <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
     <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-182"/>
@@ -1902,23 +1575,21 @@
         <nd ref="-120"/>
         <nd ref="-119"/>
         <nd ref="-214"/>
-        <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="name" v="Avenida 12"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-38"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 12"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
+        <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
     <way visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-250"/>
         <nd ref="-96"/>
         <nd ref="-253"/>
-        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="name" v="Avenida 10"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-37"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 10"/>
+        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
+        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
     <way visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-222"/>
@@ -1926,12 +1597,11 @@
         <nd ref="-94"/>
         <nd ref="-93"/>
         <nd ref="-216"/>
-        <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="name" v="Avenida 12"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-36"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 12"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
+        <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
     <way visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-195"/>
@@ -1939,11 +1609,10 @@
         <nd ref="-90"/>
         <nd ref="-89"/>
         <nd ref="-220"/>
-        <tag k="bdw-id" v="{b63b8bca-9850-40b8-a253-3bbd2aca3dd2}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-35"/>
+        <tag k="bdw-id" v="{b63b8bca-9850-40b8-a253-3bbd2aca3dd2}"/>
     </way>
     <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
@@ -1956,12 +1625,11 @@
         <nd ref="-82"/>
         <nd ref="-81"/>
         <nd ref="-149"/>
-        <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
-        <tag k="name" v="Avenida 12"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-34"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 12"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
+        <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
     </way>
     <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-217"/>
@@ -1969,29 +1637,26 @@
         <nd ref="-79"/>
         <nd ref="-78"/>
         <nd ref="-77"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-33"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
     <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-76"/>
         <nd ref="-227"/>
-        <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
     </way>
     <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-182"/>
         <nd ref="-75"/>
         <nd ref="-146"/>
-        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-31"/>
+        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
     <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-233"/>
@@ -2007,33 +1672,30 @@
         <nd ref="-61"/>
         <nd ref="-60"/>
         <nd ref="-217"/>
-        <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-12T16:14:18Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-30"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-12T16:14:18Z"/>
+        <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
     </way>
     <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-230"/>
         <nd ref="-59"/>
         <nd ref="-58"/>
         <nd ref="-227"/>
-        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
     <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-202"/>
         <nd ref="-57"/>
         <nd ref="-56"/>
         <nd ref="-233"/>
-        <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-28"/>
+        <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
     </way>
     <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-204"/>
@@ -2042,11 +1704,10 @@
         <nd ref="-53"/>
         <nd ref="-52"/>
         <nd ref="-104"/>
-        <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-27"/>
+        <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
     <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-161"/>
@@ -2055,11 +1716,10 @@
         <nd ref="-46"/>
         <nd ref="-174"/>
         <tag k="oneway" v="no"/>
-        <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
-        <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-25"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
+        <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
     </way>
     <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-149"/>
@@ -2069,20 +1729,18 @@
         <nd ref="-40"/>
         <nd ref="-39"/>
         <nd ref="-258"/>
-        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
-        <tag k="name" v="Avenida Los Leones"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-24"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida Los Leones"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
+        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
     <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-178"/>
         <nd ref="-132"/>
-        <tag k="bdw-id" v="{94c9cf4a-94e3-4fc4-9d48-0d3b7c7055e3}"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{94c9cf4a-94e3-4fc4-9d48-0d3b7c7055e3}"/>
     </way>
     <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-22"/>
@@ -2103,57 +1761,47 @@
         <nd ref="-24"/>
         <nd ref="-23"/>
         <nd ref="-220"/>
-        <tag k="bdw-id" v="{d6bb5ef0-cba5-4f65-bb54-309479757568}"/>
-        <tag k="source:datetime" v="2012-07-12T16:24:57Z;2012-07-12T16:14:19Z;2012-07-12T16:24:56Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-22"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:24:57Z;2012-07-12T16:14:19Z;2012-07-12T16:24:56Z"/>
+        <tag k="bdw-id" v="{d6bb5ef0-cba5-4f65-bb54-309479757568}"/>
     </way>
     <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21"/>
         <nd ref="-49"/>
         <nd ref="-44"/>
         <nd ref="-50"/>
-        <tag k="bdw-id" v="{97de30bd-cf94-4781-9242-24a38ad7d345}"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-21"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{97de30bd-cf94-4781-9242-24a38ad7d345}"/>
     </way>
     <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-260"/>
         <nd ref="-50"/>
         <nd ref="-45"/>
         <nd ref="-20"/>
-        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-20"/>
+        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
     <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19"/>
         <nd ref="-49"/>
-        <tag k="bdw-id" v="{6e1509b9-a960-4bd6-845e-6ac143dc8d18}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-19"/>
+        <tag k="bdw-id" v="{6e1509b9-a960-4bd6-845e-6ac143dc8d18}"/>
     </way>
     <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-18"/>
         <nd ref="-51"/>
         <nd ref="-204"/>
-        <tag k="bdw-id" v="{efc93331-7a05-42f4-a7fc-78ab5793d04d}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="bdw-id" v="{efc93331-7a05-42f4-a7fc-78ab5793d04d}"/>
     </way>
     <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-121"/>
@@ -2162,36 +1810,30 @@
         <nd ref="-72"/>
         <nd ref="-71"/>
         <nd ref="-17"/>
-        <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:19Z;2012-07-12T16:24:57Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:19Z;2012-07-12T16:24:57Z"/>
+        <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
     </way>
     <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-16"/>
         <nd ref="-92"/>
         <nd ref="-236"/>
-        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
-        <tag k="name" v="Avenida 10"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-16"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 10"/>
+        <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
+        <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15"/>
         <nd ref="-101"/>
         <nd ref="-146"/>
-        <tag k="bdw-id" v="{d3f5dac4-74c6-42fe-b0bf-bad11de41657}"/>
-        <tag k="name" v="Avenida 11"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:23Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Avenida 11"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:23Z"/>
+        <tag k="bdw-id" v="{d3f5dac4-74c6-42fe-b0bf-bad11de41657}"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-14"/>
@@ -2204,22 +1846,18 @@
         <nd ref="-125"/>
         <nd ref="-124"/>
         <nd ref="-181"/>
-        <tag k="bdw-id" v="{6cdcf24d-4846-4e30-9360-c782f3239ee5}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="bdw-id" v="{6cdcf24d-4846-4e30-9360-c782f3239ee5}"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-13"/>
         <nd ref="-208"/>
-        <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-181"/>
@@ -2230,24 +1868,20 @@
         <nd ref="-176"/>
         <nd ref="-175"/>
         <nd ref="-174"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-12"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
         <nd ref="-183"/>
         <nd ref="-182"/>
-        <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
-        <tag k="name" v="Avenida 12"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 12"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
+        <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
@@ -2255,46 +1889,38 @@
         <nd ref="-185"/>
         <nd ref="-184"/>
         <nd ref="-205"/>
-        <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-205"/>
         <nd ref="-187"/>
         <nd ref="-9"/>
-        <tag k="bdw-id" v="{e1882670-308b-4243-9802-b0f59e00fcd8}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="bdw-id" v="{e1882670-308b-4243-9802-b0f59e00fcd8}"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-258"/>
         <nd ref="-201"/>
         <nd ref="-8"/>
-        <tag k="bdw-id" v="{841e511f-12b8-465b-8dcf-3f2e88245c4f}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:30:24Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="bdw-id" v="{841e511f-12b8-465b-8dcf-3f2e88245c4f}"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7"/>
         <nd ref="-207"/>
         <nd ref="-206"/>
         <nd ref="-230"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-6"/>
@@ -2304,68 +1930,56 @@
         <nd ref="-210"/>
         <nd ref="-209"/>
         <nd ref="-208"/>
-        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-256"/>
         <nd ref="-237"/>
         <nd ref="-5"/>
-        <tag k="bdw-id" v="{7b9e474f-b2b4-4427-bae9-a57622382722}"/>
-        <tag k="name" v="Calle 16"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:25Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Calle 16"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:25Z"/>
+        <tag k="bdw-id" v="{7b9e474f-b2b4-4427-bae9-a57622382722}"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-251"/>
         <nd ref="-238"/>
         <nd ref="-4"/>
-        <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-268"/>
         <nd ref="-246"/>
         <nd ref="-3"/>
-        <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
+        <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
         <nd ref="-255"/>
         <nd ref="-254"/>
-        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
+        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1"/>
         <nd ref="-257"/>
         <nd ref="-256"/>
-        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
-        <tag k="name" v="Avenida 9"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Avenida 9"/>
+        <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
+        <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2927-multiple-types-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-multiple-types-1/Expected.osm
@@ -3,815 +3,612 @@
     <bounds minlat="10.5063" minlon="-66.90266" maxlat="10.50933" maxlon="-66.89794699999999"/>
     <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075377200199984" lon="-66.8999424799399947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-203"/>
     </node>
     <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073352537799973" lon="-66.8990133738400061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-202"/>
     </node>
     <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072683640099989" lon="-66.8990233080599950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-201"/>
     </node>
     <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072011718899994" lon="-66.8990308773600049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-200"/>
     </node>
     <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071682123500008" lon="-66.8990337162099991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-199"/>
     </node>
     <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071000859000012" lon="-66.8990379307799969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-198"/>
     </node>
     <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070321465099976" lon="-66.8990445452599971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-197"/>
     </node>
     <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069644769599986" lon="-66.8990535515700060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-196"/>
     </node>
     <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068971596799976" lon="-66.8990649387500014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-195"/>
     </node>
     <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068302767099979" lon="-66.8990786929099954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-194"/>
     </node>
     <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067639095099956" lon="-66.8990947973099992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-193"/>
     </node>
     <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066981389500000" lon="-66.8991132323200048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-192"/>
     </node>
     <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066330451599992" lon="-66.8991339754799839">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-191"/>
     </node>
     <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065991354400001" lon="-66.8991457931099944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-190"/>
     </node>
     <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065369998999980" lon="-66.8991808702199791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-189"/>
     </node>
     <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064761136999998" lon="-66.8992181171399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-188"/>
     </node>
     <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064165510099983" lon="-66.8992574884999840">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-187"/>
     </node>
     <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063583844000004" lon="-66.8992989363299984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-186"/>
     </node>
     <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063016847399968" lon="-66.8993424101299894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-185"/>
     </node>
     <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080110682999983" lon="-66.9023204815299977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-184"/>
     </node>
     <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080157422199978" lon="-66.9023084269200012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-183"/>
     </node>
     <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080198679799981" lon="-66.9022961697200031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-182"/>
     </node>
     <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080234370099976" lon="-66.9022837353600011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-181"/>
     </node>
     <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080264419200002" lon="-66.9022711496699998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-180"/>
     </node>
     <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080288764500001" lon="-66.9022584387400059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-179"/>
     </node>
     <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080307355600002" lon="-66.9022456289699790">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-178"/>
     </node>
     <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080320153899986" lon="-66.9022327469400011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-177"/>
     </node>
     <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080327132899995" lon="-66.9022198193700035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-176"/>
     </node>
     <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080328278100001" lon="-66.9022068730999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175"/>
     </node>
     <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080323586999977" lon="-66.9021939349899952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-174"/>
     </node>
     <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080313069499987" lon="-66.9021810318999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-173"/>
     </node>
     <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080296747399977" lon="-66.9021681905900039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-172"/>
     </node>
     <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080274654399997" lon="-66.9021554377300021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171"/>
     </node>
     <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077602018099991" lon="-66.9019608399800063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170"/>
     </node>
     <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072674942200024" lon="-66.9016812216199952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-169"/>
     </node>
     <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067556583899986" lon="-66.9013769333299990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-168"/>
     </node>
     <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073261783799996" lon="-66.8987263520100015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-167"/>
     </node>
     <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072803441799998" lon="-66.8984187934499914">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-166"/>
     </node>
     <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066152618600004" lon="-66.8984401191300009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165"/>
     </node>
     <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089760357599982" lon="-66.9011001908299932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-164"/>
     </node>
     <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084638829199992" lon="-66.9006832217600049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-163"/>
     </node>
     <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084490193099978" lon="-66.9006774795900014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-162"/>
     </node>
     <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084339664399984" lon="-66.9006722650899945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-161"/>
     </node>
     <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084187426400000" lon="-66.9006675846000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-160"/>
     </node>
     <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084033664499987" lon="-66.9006634438400027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-159"/>
     </node>
     <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083878566299962" lon="-66.9006598478399894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-158"/>
     </node>
     <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083722320499984" lon="-66.9006568009799878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-157"/>
     </node>
     <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083565117600006" lon="-66.9006543069800017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-156"/>
     </node>
     <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083407149099983" lon="-66.9006523688800030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-155"/>
     </node>
     <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083248607400002" lon="-66.9006509890400025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-154"/>
     </node>
     <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083089685799980" lon="-66.9006501691300031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153"/>
     </node>
     <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082930577799978" lon="-66.9006499101599985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-152"/>
     </node>
     <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082771477199994" lon="-66.9006502124399987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-151"/>
     </node>
     <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082595245399979" lon="-66.9006512038099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-150"/>
     </node>
     <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074846600500003" lon="-66.9007861025600050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-149"/>
     </node>
     <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067216292700003" lon="-66.9009464602499975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-148"/>
     </node>
     <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066933640299993" lon="-66.9009582118199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-147"/>
     </node>
     <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066655218899978" lon="-66.9009709529899936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-146"/>
     </node>
     <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066381367599977" lon="-66.9009846682399996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-145"/>
     </node>
     <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066112420100026" lon="-66.9009993408800057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144"/>
     </node>
     <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065848703999976" lon="-66.9010149530000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-143"/>
     </node>
     <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065590540699976" lon="-66.9010314856100052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-142"/>
     </node>
     <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065338244599982" lon="-66.9010489185500035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-141"/>
     </node>
     <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065092123199975" lon="-66.9010672305900016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-140"/>
     </node>
     <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064852476399988" lon="-66.9010863994100049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-139"/>
     </node>
     <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064619595999975" lon="-66.9011064016600017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-138"/>
     </node>
     <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064393765799995" lon="-66.9011272129699961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-137"/>
     </node>
     <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064175260899990" lon="-66.9011488079799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136"/>
     </node>
     <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064042021799988" lon="-66.9011627459599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-135"/>
     </node>
     <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063870420499974" lon="-66.9012000042399961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-134"/>
     </node>
     <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063726633800005" lon="-66.9012384457499962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-133"/>
     </node>
     <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063611453199997" lon="-66.9012778588000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-132"/>
     </node>
     <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063525512999991" lon="-66.9013180263899869">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-131"/>
     </node>
     <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063469286300002" lon="-66.9013587273300061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-130"/>
     </node>
     <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063443082899983" lon="-66.9013997375199949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-129"/>
     </node>
     <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063447046999983" lon="-66.9014408311499977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-128"/>
     </node>
     <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063481156700007" lon="-66.9014817819400065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
     </node>
     <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063545224200006" lon="-66.9015223644099990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
     </node>
     <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063638896899985" lon="-66.9015623550899932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-125"/>
     </node>
     <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063761658800008" lon="-66.9016015337900001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
     </node>
     <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063912833999993" lon="-66.9016396847899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-123"/>
     </node>
     <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064091590199986" lon="-66.9016765979999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
     </node>
     <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064296942999995" lon="-66.9017120701799968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
     </node>
     <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064527761799980" lon="-66.9017459059999879">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-120"/>
     </node>
     <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069241426099982" lon="-66.9024637357100005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069578427000003" lon="-66.9025617388099789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-118"/>
     </node>
     <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085585902499989" lon="-66.9016759834800041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117"/>
     </node>
     <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075739353999982" lon="-66.9000768396799970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-116"/>
     </node>
     <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082147958999990" lon="-66.9025298977699805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-115"/>
     </node>
     <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080246836499995" lon="-66.9021427997700044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114"/>
     </node>
     <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081916148999976" lon="-66.9021967271600033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-113"/>
     </node>
     <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082880034400006" lon="-66.9022063841899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
     </node>
     <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080058559099996" lon="-66.9023323085500010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-111"/>
     </node>
     <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082208136300004" lon="-66.9023667924499961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-110"/>
     </node>
     <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078633333099969" lon="-66.9023475808800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-109"/>
     </node>
     <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069272716599986" lon="-66.9024728352599993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-108"/>
     </node>
     <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068978317999964" lon="-66.9024770390499839">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-107"/>
     </node>
     <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068682494899992" lon="-66.9024800535400033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-106"/>
     </node>
     <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068385717700004" lon="-66.9024818739499807">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105"/>
     </node>
     <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068088458200002" lon="-66.9024824973800065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-104"/>
     </node>
     <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067791188999990" lon="-66.9024819228500007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-103"/>
     </node>
     <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067494382799982" lon="-66.9024801512699980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-102"/>
     </node>
     <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067198511599980" lon="-66.9024771854400058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
     </node>
     <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066904045599987" lon="-66.9024730300999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-100"/>
     </node>
     <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066611453200007" lon="-66.9024676918500063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-99"/>
     </node>
     <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066321199499981" lon="-66.9024611791700039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-98"/>
     </node>
     <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066033745999992" lon="-66.9024535024200020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-97"/>
     </node>
     <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065749549799996" lon="-66.9024446738000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-96"/>
     </node>
     <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065469062699979" lon="-66.9024347073599870">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
     </node>
     <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065192730599986" lon="-66.9024236189400057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
     </node>
     <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064920992999991" lon="-66.9024114261700049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
     </node>
     <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079992294599975" lon="-66.8988626414400045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
     </node>
     <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077623694300009" lon="-66.8989987836200015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-91"/>
     </node>
     <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076509287499977" lon="-66.8990451847499941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-90"/>
     </node>
     <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076327100599993" lon="-66.8990532784499976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-89"/>
     </node>
     <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076153222500022" lon="-66.8990630618999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-88"/>
     </node>
     <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075989183999976" lon="-66.8990744489599933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
     <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075836429000002" lon="-66.8990873393999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
     <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075696302299981" lon="-66.8991016197300041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
     <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075570037400006" lon="-66.8991171642500007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
     <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075458745900008" lon="-66.8991338361200008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
     <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075363407599998" lon="-66.8991514885699985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
     <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075284861499991" lon="-66.8991699662099961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
     <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075223799299984" lon="-66.8991891063699882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075180758400002" lon="-66.8992087405599989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075156117800006" lon="-66.8992286959399962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075150094399987" lon="-66.8992487968399985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075162741099994" lon="-66.8992688663099955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075193946700001" lon="-66.8992887276699975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075177010099985" lon="-66.8993920471500019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076342153300022" lon="-66.8999983574800012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078674621299974" lon="-66.9008672305400012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081310488200010" lon="-66.9019488675299954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076487450999974" lon="-66.9000524823700005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077129303400003" lon="-66.9000381607200012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085709374999983" lon="-66.8998653134499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076185124599988" lon="-66.8999166434399939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076767757899994" lon="-66.8998738871599983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085450696200002" lon="-66.8997414667800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091091437099990" lon="-66.9021158291200067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088988646400008" lon="-66.9021110002500023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086704276400003" lon="-66.9021656548400045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083125509399959" lon="-66.9022836681899804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
     <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088045681099977" lon="-66.9026277258600004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
     <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082851248800004" lon="-66.9023496594799951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088878673099977" lon="-66.9000970889999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
     <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088469021400002" lon="-66.9000703169800062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088091845399987" lon="-66.9000390495800019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087751952799984" lon="-66.9000036853699811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087453675999960" lon="-66.8999646751099988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
     <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087200817199982" lon="-66.8999225160499975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
     <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086996599300004" lon="-66.8998777455900040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
     <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086843625499977" lon="-66.8998309343899962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
     <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086771310000007" lon="-66.8997959613599846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086743845699999" lon="-66.8997826791299985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086698531699980" lon="-66.8997335949199936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086708260999977" lon="-66.8996843073999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086772909799997" lon="-66.8996354448299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
     <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086891653900025" lon="-66.8995876300299983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
     <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087062979699990" lon="-66.8995414724900002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
     <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087284703399977" lon="-66.8994975605500031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
     <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087553998799983" lon="-66.8994564539499947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
     <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092547383599975" lon="-66.8988241885100052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
     <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091938274399990" lon="-66.9008290948000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
     <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089872306800007" lon="-66.9011045272900020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
     <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078442156499978" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
     <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080166959699994" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
     <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079621843600020" lon="-66.8980172303800060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073355844799998" lon="-66.8983959509299950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072800635700006" lon="-66.8983993553400040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072735327399993" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092991859399962" lon="-66.8979525441699963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092608681199984" lon="-66.8979827626999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092215299599978" lon="-66.8980116115399994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091812193800003" lon="-66.8980390555200017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091399855100001" lon="-66.8980650612299996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091240928199969" lon="-66.8980745550099982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084822232099988" lon="-66.8985161486299944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083496723199996" lon="-66.8985560080299990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079699015599992" lon="-66.8987880248100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079104082800008" lon="-66.8988204772399939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078498304099988" lon="-66.8988508118599867">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077882417299975" lon="-66.8988789917100064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077257173099987" lon="-66.8989049824500057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076623333000008" lon="-66.8989287524299954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075981669399976" lon="-66.8989502726900014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075332963999983" lon="-66.8989695169999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074678007199971" lon="-66.8989864619200034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074017596899996" lon="-66.8990010867999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9012373024223024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9006735384839999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093300000000003" lon="-66.9003953972457026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.8987901743431763">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5088619095409896" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9021468873523020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9023145890520965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082281497036991" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9003284747380604">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5069729286564915" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999995" lon="-66.8984462481496678">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9011125992666820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.8993437981101806">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999960" lon="-66.9001776895871814">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-113"/>
@@ -820,24 +617,22 @@
         <nd ref="-70"/>
         <nd ref="-73"/>
         <nd ref="-67"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z;2019-01-17T19:50:05.698Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e};{a7d782db-4c62-48d0-bf4c-962db1dd717d}"/>
-        <tag k="name" v="Av. Caracas"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-06-03T13:47:09.000Z;2019-01-17T19:50:06Z;2013-09-16T04:28:30.000Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-99"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z;2019-01-17T19:50:05.698Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Caracas"/>
+        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e};{a7d782db-4c62-48d0-bf4c-962db1dd717d}"/>
+        <tag k="source:datetime" v="2015-06-03T13:47:09.000Z;2019-01-17T19:50:06Z;2013-09-16T04:28:30.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
@@ -851,24 +646,22 @@
         <nd ref="-48"/>
         <nd ref="-49"/>
         <nd ref="-50"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="30"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{107ebc5f-b346-4cc5-b826-b11beec19cc4}"/>
-        <tag k="name" v="Av. Galipán"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-12-29T19:56:30.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-98"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Galipán"/>
+        <tag k="uuid" v="{107ebc5f-b346-4cc5-b826-b11beec19cc4}"/>
+        <tag k="source:datetime" v="2014-12-29T19:56:30.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
@@ -880,28 +673,26 @@
         <nd ref="-112"/>
         <nd ref="-61"/>
         <nd ref="-59"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. La Estrella"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z;2019-01-17T19:50:05.683Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-09-16T04:23:02.000Z;2013-09-16T04:23:01.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{aacc4e7a-d622-499b-86c7-837fdbc1409e};{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{97c786e4-418b-41f2-95e9-de855060fd96};{bbd46957-74bf-4942-8ce7-cc9763ce1c89}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-96"/>
+        <tag k="name" v="Av. La Estrella"/>
+        <tag k="source:datetime" v="2013-09-16T04:23:02.000Z;2013-09-16T04:23:01.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{aacc4e7a-d622-499b-86c7-837fdbc1409e};{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{97c786e4-418b-41f2-95e9-de855060fd96};{bbd46957-74bf-4942-8ce7-cc9763ce1c89}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z;2019-01-17T19:50:05.683Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-114"/>
@@ -920,120 +711,110 @@
         <nd ref="-183"/>
         <nd ref="-184"/>
         <nd ref="-111"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. del Parque"/>
-        <tag k="lanes" v="1"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="left"/>
-        <tag k="maxspeed" v="20"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.683Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2015-08-19T15:26:01.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{5ee48c4d-213f-4ef9-84c5-9de9189b059d}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-92"/>
+        <tag k="name" v="Av. del Parque"/>
+        <tag k="source:datetime" v="2015-08-19T15:26:01.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="1"/>
+        <tag k="maxspeed" v="20"/>
+        <tag k="uuid" v="{5ee48c4d-213f-4ef9-84c5-9de9189b059d}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.683Z"/>
+        <tag k="sidewalk" v="left"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
         <nd ref="-118"/>
         <nd ref="-108"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{b1425c50-fb2e-4126-b6ec-a89f09d0f018}"/>
-        <tag k="name" v="Av. Este 3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-06-24T22:17:51.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-89"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Este 3"/>
+        <tag k="uuid" v="{b1425c50-fb2e-4126-b6ec-a89f09d0f018}"/>
+        <tag k="source:datetime" v="2015-06-24T22:17:51.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-67"/>
         <nd ref="-74"/>
         <nd ref="-15"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z;2019-01-17T19:50:05.687Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e};{1b715755-566c-4390-8057-da195ad4be34}"/>
-        <tag k="name" v="Av. Caracas"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2013-09-19T22:51:49.000Z;2019-01-17T19:50:06Z;2013-09-19T22:51:47.000Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-74"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z;2019-01-17T19:50:05.687Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Caracas"/>
+        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e};{1b715755-566c-4390-8057-da195ad4be34}"/>
+        <tag k="source:datetime" v="2013-09-19T22:51:49.000Z;2019-01-17T19:50:06Z;2013-09-19T22:51:47.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-15"/>
         <nd ref="-167"/>
         <nd ref="-166"/>
         <nd ref="-34"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{687f45bc-1a13-43d8-aa49-e5fed619e8bb}"/>
-        <tag k="name" v="Av. Caracas"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-09-19T22:51:43.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Caracas"/>
+        <tag k="uuid" v="{687f45bc-1a13-43d8-aa49-e5fed619e8bb}"/>
+        <tag k="source:datetime" v="2013-09-19T22:51:43.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-39"/>
         <nd ref="-117"/>
         <nd ref="-112"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Gamboa"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.687Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="residential"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2015-11-10T15:06:00.000Z;2013-09-16T04:28:31.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{e38c5179-c190-4c82-b23a-ed238baa6be7}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-28"/>
+        <tag k="name" v="Av. Gamboa"/>
+        <tag k="source:datetime" v="2015-11-10T15:06:00.000Z;2013-09-16T04:28:31.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{e38c5179-c190-4c82-b23a-ed238baa6be7}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.687Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="residential"/>
     </way>
     <way visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-74"/>
@@ -1056,163 +837,151 @@
         <nd ref="-91"/>
         <nd ref="-92"/>
         <nd ref="-26"/>
-        <tag k="bicycle:conditional" v="yes @ (su 06:00-13:00)"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line;Yahoo"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Distribuidor: San Bernardino"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="foot:conditional" v="yes @ (su 06:00-13:00)"/>
         <tag k="maxspeed:conditional" v="110 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="90|70"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxspeed" v="90"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (su 06:00-13:00)"/>
-        <tag k="hgv:lanes" v="no|yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z;2019-01-17T19:50:05.702Z"/>
-        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway_link"/>
+        <tag k="bicycle:conditional" v="yes @ (su 06:00-13:00)"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2014-09-30T01:43:33.000Z;2019-01-17T19:50:06Z;2014-09-30T01:43:34.000Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="uuid" v="{b523db3f-f1e1-428b-98b0-7a7ebb41d081};{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e}"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="destination" v="Cota Mil"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-20"/>
+        <tag k="name" v="Distribuidor: San Bernardino"/>
+        <tag k="foot:conditional" v="yes @ (su 06:00-13:00)"/>
+        <tag k="source:datetime" v="2014-09-30T01:43:33.000Z;2019-01-17T19:50:06Z;2014-09-30T01:43:34.000Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="90"/>
+        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="uuid" v="{b523db3f-f1e1-428b-98b0-7a7ebb41d081};{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (su 06:00-13:00)"/>
+        <tag k="maxspeed:lanes" v="90|70"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z;2019-01-17T19:50:05.702Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line;Yahoo"/>
+        <tag k="destination" v="Cota Mil"/>
+        <tag k="highway" v="motorway_link"/>
     </way>
     <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-50"/>
         <nd ref="-68"/>
         <nd ref="-69"/>
         <nd ref="-70"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Vollmer"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-05-22T00:04:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{2a41df55-8b90-43dc-98e5-d4d685716783}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-19"/>
+        <tag k="name" v="Av. Vollmer"/>
+        <tag k="source:datetime" v="2014-05-22T00:04:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{2a41df55-8b90-43dc-98e5-d4d685716783}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-67"/>
         <nd ref="-66"/>
         <nd ref="-65"/>
         <nd ref="-50"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Vollmer"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-05-13T02:51:39.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{9ae6dc04-2cd3-4bec-b4d4-065d76631678}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="name" v="Av. Vollmer"/>
+        <tag k="source:datetime" v="2014-05-13T02:51:39.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{9ae6dc04-2cd3-4bec-b4d4-065d76631678}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-38"/>
         <nd ref="-36"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{c9ef4822-ea03-48cd-8878-41a8214dcd9e}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="San Fidel"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-20T18:41:02.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="San Fidel"/>
+        <tag k="uuid" v="{c9ef4822-ea03-48cd-8878-41a8214dcd9e}"/>
+        <tag k="source:datetime" v="2013-11-20T18:41:02.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-37"/>
         <nd ref="-36"/>
         <nd ref="-35"/>
         <nd ref="-34"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{c10b9054-e0ba-402c-92b0-d7440aaeb30c}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Real de Sarría"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-09-09T18:54:21.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-16"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Real de Sarría"/>
+        <tag k="uuid" v="{c10b9054-e0ba-402c-92b0-d7440aaeb30c}"/>
+        <tag k="source:datetime" v="2015-09-09T18:54:21.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-15" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-34"/>
         <nd ref="-33"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{0b4417a0-bbc5-44db-87f8-346150a3c499}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Santa Rosa"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-14T04:07:24.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-15"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Santa Rosa"/>
+        <tag k="uuid" v="{0b4417a0-bbc5-44db-87f8-346150a3c499}"/>
+        <tag k="source:datetime" v="2013-11-14T04:07:24.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-14" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-15"/>
@@ -1233,89 +1002,83 @@
         <nd ref="-30"/>
         <nd ref="-31"/>
         <nd ref="-32"/>
-        <tag k="bicycle:conditional" v="yes @ (su 06:00-13:00)"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line;Yahoo"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Distribuidor: San Bernardino"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="foot:conditional" v="yes @ (su 06:00-13:00)"/>
         <tag k="maxspeed:conditional" v="110 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="90|70"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxspeed" v="90"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="motor_vehicle:conditional" v="no @ (su 06:00-13:00)"/>
-        <tag k="hgv:lanes" v="no|yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
-        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway_link"/>
+        <tag k="bicycle:conditional" v="yes @ (su 06:00-13:00)"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2014-09-30T01:43:33.000Z;2019-01-17T19:50:06Z;2014-09-30T01:43:32.000Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="uuid" v="{b523db3f-f1e1-428b-98b0-7a7ebb41d081}"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="destination" v="Cota Mil"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="name" v="Distribuidor: San Bernardino"/>
+        <tag k="foot:conditional" v="yes @ (su 06:00-13:00)"/>
+        <tag k="source:datetime" v="2014-09-30T01:43:33.000Z;2019-01-17T19:50:06Z;2014-09-30T01:43:32.000Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="90"/>
+        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="uuid" v="{b523db3f-f1e1-428b-98b0-7a7ebb41d081}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (su 06:00-13:00)"/>
+        <tag k="maxspeed:lanes" v="90|70"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line;Yahoo"/>
+        <tag k="destination" v="Cota Mil"/>
+        <tag k="highway" v="motorway_link"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-39"/>
         <nd ref="-14"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{c7d8cb44-5c28-4bc3-a670-8079088ad5a2}"/>
-        <tag k="name" v="Av. Ávila"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-08-13T22:29:11.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.706Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Ávila"/>
+        <tag k="uuid" v="{c7d8cb44-5c28-4bc3-a670-8079088ad5a2}"/>
+        <tag k="source:datetime" v="2014-08-13T22:29:11.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-13"/>
         <nd ref="-40"/>
         <nd ref="-39"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Gamboa"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2015-11-10T15:06:00.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{4db3121f-d384-4ab6-acfb-4df9f98984ea}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-12"/>
+        <tag k="name" v="Av. Gamboa"/>
+        <tag k="source:datetime" v="2015-11-10T15:06:00.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{4db3121f-d384-4ab6-acfb-4df9f98984ea}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="residential"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-12"/>
@@ -1328,52 +1091,48 @@
         <nd ref="-52"/>
         <nd ref="-51"/>
         <nd ref="-50"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="30"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{107ebc5f-b346-4cc5-b826-b11beec19cc4}"/>
-        <tag k="name" v="Av. Galipán"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2016-01-14T02:57:05.000Z;2014-12-29T19:56:30.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Galipán"/>
+        <tag k="uuid" v="{107ebc5f-b346-4cc5-b826-b11beec19cc4}"/>
+        <tag k="source:datetime" v="2016-01-14T02:57:05.000Z;2014-12-29T19:56:30.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
         <nd ref="-60"/>
         <nd ref="-59"/>
         <nd ref="-110"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Anauco"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z;2019-01-17T19:50:05.698Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2015-10-16T14:01:17.000Z;2013-11-15T19:16:15.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{faf5da74-68a5-4e0c-b0a8-16eeaddc10ba};{92b34cef-2a96-4143-8222-83a6836ecbe4}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="name" v="Av. Anauco"/>
+        <tag k="source:datetime" v="2015-10-16T14:01:17.000Z;2013-11-15T19:16:15.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{faf5da74-68a5-4e0c-b0a8-16eeaddc10ba};{92b34cef-2a96-4143-8222-83a6836ecbe4}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z;2019-01-17T19:50:05.698Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-61"/>
@@ -1381,23 +1140,21 @@
         <nd ref="-63"/>
         <nd ref="-64"/>
         <nd ref="-9"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.703Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{a3b42bcf-8c21-4490-997b-c89e30fdf213}"/>
-        <tag k="name" v="Av. Cajigal"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-14T03:59:32.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.703Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Cajigal"/>
+        <tag k="uuid" v="{a3b42bcf-8c21-4490-997b-c89e30fdf213}"/>
+        <tag k="source:datetime" v="2013-11-14T03:59:32.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-109"/>
@@ -1418,74 +1175,68 @@
         <nd ref="-94"/>
         <nd ref="-93"/>
         <nd ref="-8"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.683Z;2019-01-17T19:50:05.699Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{dba47928-0f15-4818-a0cc-a2a9ca31af5d}"/>
-        <tag k="name" v="Av. del Parque"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-07-08T17:49:21.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.683Z;2019-01-17T19:50:05.699Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. del Parque"/>
+        <tag k="uuid" v="{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{dba47928-0f15-4818-a0cc-a2a9ca31af5d}"/>
+        <tag k="source:datetime" v="2015-07-08T17:49:21.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-110"/>
         <nd ref="-115"/>
         <nd ref="-7"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.690Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="30"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{e7702591-e5cb-4327-b1db-b460daebea57}"/>
-        <tag k="name" v="Av. Este 5"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-13T13:09:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.690Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Este 5"/>
+        <tag k="uuid" v="{e7702591-e5cb-4327-b1db-b460daebea57}"/>
+        <tag k="source:datetime" v="2013-11-13T13:09:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-70"/>
         <nd ref="-116"/>
         <nd ref="-6"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Vollmer"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.687Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-05-22T00:04:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{a99c21f0-9fb5-483a-863d-44554e3acc76}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="name" v="Av. Vollmer"/>
+        <tag k="source:datetime" v="2014-05-22T00:04:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{a99c21f0-9fb5-483a-863d-44554e3acc76}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.687Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-108"/>
@@ -1536,66 +1287,60 @@
         <nd ref="-163"/>
         <nd ref="-164"/>
         <nd ref="-39"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{b1425c50-fb2e-4126-b6ec-a89f09d0f018}"/>
-        <tag k="name" v="Av. Ávila"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-05-09T04:22:43.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Ávila"/>
+        <tag k="uuid" v="{b1425c50-fb2e-4126-b6ec-a89f09d0f018}"/>
+        <tag k="source:datetime" v="2015-05-09T04:22:43.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-34"/>
         <nd ref="-165"/>
         <nd ref="-4"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{41d4846b-b90b-4201-b1c3-6762482781a6}"/>
-        <tag k="name" v="Real de Sarría"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-04-28T19:47:31.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Real de Sarría"/>
+        <tag k="uuid" v="{41d4846b-b90b-4201-b1c3-6762482781a6}"/>
+        <tag k="source:datetime" v="2014-04-28T19:47:31.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-110"/>
         <nd ref="-111"/>
         <nd ref="-109"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.683Z;2019-01-17T19:50:05.699Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{e6345511-b279-4ad6-b6a3-a74e013e4a31}"/>
-        <tag k="name" v="Av. del Parque"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-07-08T17:49:21.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.683Z;2019-01-17T19:50:05.699Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. del Parque"/>
+        <tag k="uuid" v="{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{e6345511-b279-4ad6-b6a3-a74e013e4a31}"/>
+        <tag k="source:datetime" v="2015-07-08T17:49:21.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
@@ -1618,50 +1363,46 @@
         <nd ref="-201"/>
         <nd ref="-202"/>
         <nd ref="-15"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.682Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{4ac922de-397e-4108-bb88-c474be633e7e}"/>
-        <tag k="name" v="Av. El Lago"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-14T03:48:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.682Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. El Lago"/>
+        <tag k="uuid" v="{4ac922de-397e-4108-bb88-c474be633e7e}"/>
+        <tag k="source:datetime" v="2013-11-14T03:48:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1"/>
         <nd ref="-203"/>
         <nd ref="-67"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Vollmer"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.682Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-05-22T01:04:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8216f6ed-220f-46a4-bc23-8d7fbd8c6096}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="name" v="Av. Vollmer"/>
+        <tag k="source:datetime" v="2014-05-22T01:04:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8216f6ed-220f-46a4-bc23-8d7fbd8c6096}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.682Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2927-name-preservation-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-name-preservation-1/Expected.osm
@@ -1,353 +1,266 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="10.50529998962702" minlon="-66.91539999999999" maxlat="10.50997398962358" maxlon="-66.9121"/>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750360060814" lon="-66.9152038258099822">
+    <bounds minlat="10.5053" minlon="-66.91539999999999" maxlat="10.509974" maxlon="-66.9121"/>
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369126661086" lon="-66.9150022248399949">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055091461481" lon="-66.9148632606599989">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195199992" lon="-66.9148632606599989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764455961477" lon="-66.9147604025199882">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063683057462534" lon="-66.9141438720999986">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063683161199997" lon="-66.9141438720999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063046110562919" lon="-66.9137310251299908">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063046214299991" lon="-66.9137310251299908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062701614363245" lon="-66.9134486574999841">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062701718099962" lon="-66.9134486574999841">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061558089164002" lon="-66.9128470437499914">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061558192900009" lon="-66.9128470437499914">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109562551114" lon="-66.9153991168199980">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136562651849" lon="-66.9149047513499795">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077143203452401" lon="-66.9144740333299808">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077143307200007" lon="-66.9144740333299808">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076331277253292" lon="-66.9140663332899948">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076331381000010" lon="-66.9140663332899948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075232870653839" lon="-66.9135307329499938">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075232974400006" lon="-66.9135307329499938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074059385754914" lon="-66.9129728706199955">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074059489500016" lon="-66.9129728706199955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072912111355539" lon="-66.9124406098300000">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072912215099983" lon="-66.9124406098300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976772968140" lon="-66.9152554077300010">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033718668118" lon="-66.9152220781300002">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066751167982" lon="-66.9152027445999948">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145596567969" lon="-66.9151838086699939">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299979" lon="-66.9151838086699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264750468102" lon="-66.9151688920699996">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463369967670" lon="-66.9151444806499995">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699981" lon="-66.9151444806499995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635205667614" lon="-66.9151187383999968">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125484068055" lon="-66.9148776470100017">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054585443569160" lon="-66.9141921468900023">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054585547299997" lon="-66.9141921468900023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090706260342355" lon="-66.9122308439799980">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090706364099997" lon="-66.9122308439799980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086560319845628" lon="-66.9123156418699949">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086560423599984" lon="-66.9123156418699949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084297578547066" lon="-66.9123656226399959">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084297682300001" lon="-66.9123656226399959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080861265549803" lon="-66.9124369873999996">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080861369300003" lon="-66.9124369873999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073236037155304" lon="-66.9126214131100028">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073236140899997" lon="-66.9126214131100028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067621539959521" lon="-66.9127523923900043">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067621643700004" lon="-66.9127523923900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062531452163235" lon="-66.9128357700700036">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062531555899987" lon="-66.9128357700700036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059741190065381" lon="-66.9128861039500009">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059741293800002" lon="-66.9128861039500009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055539007668504" lon="-66.9129797883599906">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055539111399998" lon="-66.9129797883599906">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229442841900" lon="-66.9153896753699939">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546600005" lon="-66.9153896753699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320353742612" lon="-66.9149623942000034">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457499988" lon="-66.9149623942000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089687841243276" lon="-66.9146354390299933">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089687944999994" lon="-66.9146354390299933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088704676043978" lon="-66.9141622602300004">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088704779800004" lon="-66.9141622602300004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087785375444529" lon="-66.9135799125899950">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087785479200004" lon="-66.9135799125899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087181834745085" lon="-66.9132615540100062">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087181938499974" lon="-66.9132615540100062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086206437245728" lon="-66.9126907318800050">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086206540999996" lon="-66.9126907318800050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911060950604" lon="-66.9153835618100032">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164699986" lon="-66.9153835618100032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714740551327" lon="-66.9148101529700057">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844300016" lon="-66.9148101529700057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077674540952142" lon="-66.9143090046700024">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077674644700014" lon="-66.9143090046700024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076714352752614" lon="-66.9138736961400014">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076714456500007" lon="-66.9138736961400014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075811760853455" lon="-66.9134289360400061">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075811864599995" lon="-66.9134289360400061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074945952953964" lon="-66.9130123914499961">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074946056699989" lon="-66.9130123914499961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074074627454657" lon="-66.9126005575199940">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074074731200007" lon="-66.9126005575199940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054666576968980" lon="-66.9142282606800052">
+    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054666680699977" lon="-66.9142282606800052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073259965855321" lon="-66.9122176839899936">
+    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073260069600014" lon="-66.9122176839899936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072371478956104" lon="-66.9122143048799956">
+    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072371582699979" lon="-66.9122143048799956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085595677946184" lon="-66.9122740378600014">
+    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085595781700007" lon="-66.9122740378600014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091017154942126" lon="-66.9122257277799974">
+    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091017258699981" lon="-66.9122257277799974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061393035763935" lon="-66.9127610980299892">
+    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061393139499994" lon="-66.9127610980299892">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097398638737598" lon="-66.9121124348600063">
+    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097398742500001" lon="-66.9121124348600063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739896235764" lon="-66.9133403110199936">
+    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9133403110199936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099533618136061" lon="-66.9133447353499946">
+    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099533721900009" lon="-66.9133447353499946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095799451038481" lon="-66.9134116472999949">
+    <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095799554799996" lon="-66.9134116472999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087610406944609" lon="-66.9135981024499955">
+    <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087610510700014" lon="-66.9135981024499955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081582561049398" lon="-66.9137211045599969">
+    <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081582664799988" lon="-66.9137211045599969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075320701553672" lon="-66.9138658912099942">
+    <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075320805299999" lon="-66.9138658912099942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064590855561857" lon="-66.9140936995999880">
+    <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064590959299995" lon="-66.9140936995999880">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056531131567610" lon="-66.9142396904399988">
+    <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056531235300028" lon="-66.9142396904399988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054783748569136" lon="-66.9142804157000057">
+    <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054783852299991" lon="-66.9142804157000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089405935943283" lon="-66.9144997629800002">
+    <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089406039699984" lon="-66.9144997629800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093437090940220" lon="-66.9144127489399949">
+    <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093437194699995" lon="-66.9144127489399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097353031337377" lon="-66.9143263374599968">
+    <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097353135099976" lon="-66.9143263374599968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099296481936229" lon="-66.9142859718599965">
+    <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099296585699999" lon="-66.9142859718599965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739896235764" lon="-66.9142793794799928">
+    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9142793794799928">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099738083435508" lon="-66.9132791853800057">
+    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099738187200042" lon="-66.9132791853800057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098883073736538" lon="-66.9128676939699858">
+    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098883177500007" lon="-66.9128676939699858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097656419037424" lon="-66.9122512857699974">
+    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097656522800023" lon="-66.9122512857699974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999896270176" lon="-66.9130318683858576">
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9130318683858576">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5056288619997691" lon="-66.9153999999999911">
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5056288723729843" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999896270176" lon="-66.9134683360734925">
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9134683360734925">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999896270176" lon="-66.9152942938446245">
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9152942938446245">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079111304592434" lon="-66.9153999999999911">
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079111408341266" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5066138745892133" lon="-66.9153999999999911">
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5066138849631390" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097897830178137" lon="-66.9120999999999952">
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097897933941198" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060273477728945" lon="-66.9120999999999952">
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060273581464099" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5096175656387487" lon="-66.9120999999999952">
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5096175760148949" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5085220238124677" lon="-66.9120999999999952">
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5085220341878234" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097376041733259" lon="-66.9120999999999952">
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097376145495947" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5072141954278173" lon="-66.9120999999999952">
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5072142058022049" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5073020317808403" lon="-66.9120999999999952">
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5073020421552741" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999896270176" lon="-66.9142674929639298">
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9142674929639298">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079935523037111" lon="-66.9153999999999911">
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079935626786458" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5091249858607654" lon="-66.9153999999999911">
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5091249962365421" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-25"/>
@@ -357,6 +270,7 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Este 2"/>
         <tag k="source:datetime" v="2014-06-22T20:55:22.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -375,9 +289,6 @@
         <tag k="source" v="osm:line"/>
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-75"/>
     </way>
     <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24"/>
@@ -389,6 +300,7 @@
         <nd ref="-7"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z;2019-01-17T19:50:05.676Z"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -400,9 +312,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-74"/>
     </way>
     <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-6"/>
@@ -410,6 +319,7 @@
         <nd ref="-17"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.696Z;2019-01-17T19:50:05.685Z"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -421,9 +331,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-19"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-33"/>
@@ -439,6 +346,7 @@
         <tag k="surface" v="paved"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Bulevar Panteón"/>
         <tag k="source:datetime" v="2015-07-01T16:10:48.000Z;2015-07-01T16:10:50.000Z;2014-09-04T18:33:58.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -456,9 +364,6 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-18"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-20"/>
@@ -468,6 +373,7 @@
         <nd ref="-24"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.709Z"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -479,9 +385,6 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-17"/>
     </way>
     <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-17"/>
@@ -489,6 +392,7 @@
         <nd ref="-19"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.696Z;2019-01-17T19:50:05.710Z"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -500,9 +404,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-16"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-8"/>
@@ -520,6 +421,7 @@
         <tag k="sidewalk" v="both"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.686Z;2019-01-17T19:50:05.675Z"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -531,9 +433,6 @@
         <tag k="attribution" v="osm"/>
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-15"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15"/>
@@ -548,6 +447,7 @@
         <nd ref="-25"/>
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Oeste 2"/>
         <tag k="source:datetime" v="2013-12-19T16:36:19.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -567,33 +467,28 @@
         <tag k="source" v="osm:line"/>
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-71"/>
         <nd ref="-13"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="highway" v="pedestrian"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="name" v="Av. Sur 2"/>
-        <tag k="uuid" v="{fdc60078-3a67-4381-9d4c-642c5ac1287f}"/>
-        <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="motor_vehicle" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="name" v="Av. Sur 2"/>
+        <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="uuid" v="{fdc60078-3a67-4381-9d4c-642c5ac1287f}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="no"/>
+        <tag k="highway" v="pedestrian"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-12"/>
@@ -608,6 +503,7 @@
         <nd ref="-5"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Urdaneta"/>
         <tag k="source:datetime" v="2014-09-04T18:33:58.000Z;2014-09-04T18:34:00.000Z;2014-05-07T19:27:30.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -627,9 +523,6 @@
         <tag k="source" v="osm:line"/>
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-12"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
@@ -644,6 +537,7 @@
         <nd ref="-35"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -658,14 +552,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
         <nd ref="-34"/>
         <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.704Z"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -676,15 +568,13 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-10"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-35"/>
         <nd ref="-9"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.694Z"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -697,14 +587,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-9"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-40"/>
         <nd ref="-3"/>
         <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur"/>
         <tag k="source:datetime" v="2013-11-14T15:44:07.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
@@ -724,9 +612,6 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4"/>
@@ -741,6 +626,7 @@
         <nd ref="-2"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Urdaneta"/>
         <tag k="source:datetime" v="2015-06-12T14:47:39.000Z;2014-04-28T19:26:59.000Z;2015-06-12T14:47:38.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
@@ -761,9 +647,6 @@
         <tag k="source" v="osm:line"/>
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1"/>
@@ -773,6 +656,7 @@
         <nd ref="-24"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -785,8 +669,5 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2927-unmarked-ref-divided-road-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-unmarked-ref-divided-road-1/Expected.osm
@@ -3,271 +3,204 @@
     <bounds minlat="10.4997" minlon="-66.92059999999999" maxlat="10.5029" maxlon="-66.91669999999999"/>
     <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998810231100013" lon="-66.9189074321199939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998604597799989" lon="-66.9188191467099927">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4997972783799991" lon="-66.9185478879700071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000853238699996" lon="-66.9187692859299972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5004951816999998" lon="-66.9186780643999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011153773500006" lon="-66.9185667172800009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002144495099987" lon="-66.9203518304800014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
     <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001903106799990" lon="-66.9201516782899972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
     <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001468854300004" lon="-66.9199419429599942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000569472900001" lon="-66.9196014045700025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
     <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000239723099984" lon="-66.9194572242199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311725999975" lon="-66.9202954139200017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011785931099979" lon="-66.9176940783000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5009767157099994" lon="-66.9167081692999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
     <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000006" lon="-66.9179020508999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
     <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699997" lon="-66.9171032446199803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
     <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
     <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800004" lon="-66.9191175683799884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579600003" lon="-66.9184036784899945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768699987" lon="-66.9184060968199930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014790620700023" lon="-66.9185278235199945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611200013" lon="-66.9182588634100028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
     <node visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
     <node visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654500014" lon="-66.9182879955099850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
     <node visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
     <node visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
     <node visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439092000015" lon="-66.9179112165300012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
     <node visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799974" lon="-66.9172775671599993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
     <node visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
     <node visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328599982" lon="-66.9184260814800069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
     <node visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905700006" lon="-66.9183505367499976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
     <node visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014555671500016" lon="-66.9184526182300061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013612691200020" lon="-66.9185075180800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013524818399997" lon="-66.9184683888800009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014334137999992" lon="-66.9188287745400032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013709919200000" lon="-66.9185508130999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5008864321500006" lon="-66.9200366815399974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002040527599974" lon="-66.9202656235199953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099994" lon="-66.9194331024600046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226899997" lon="-66.9196067043800014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930899984" lon="-66.9197283843299999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800021" lon="-66.9199025736400017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5011113656299990" lon="-66.9173657575999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5008601733099987" lon="-66.9174064675100055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5000216885800004" lon="-66.9176102020399810">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800002" lon="-66.9178452289699948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5025802255145120" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5023860765049317" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022740980780522" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9198328378480340">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5018478484657400" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9181414315535363">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9182340475983892">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5028999999999986" lon="-66.9195911270657859">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022209583745791" lon="-66.9166999999999916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5009748792788962" lon="-66.9166999999999916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9199789801348146">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5002515743978755" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9181243895426690">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4996999999999989" lon="-66.9188525813828505">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9176873631122788">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-1"/>
@@ -275,82 +208,76 @@
         <nd ref="-19"/>
         <nd ref="-20"/>
         <nd ref="-39"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sur 4"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z;2019-01-17T19:50:05.631Z;2019-01-17T19:50:05.672Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2015-08-24T16:13:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108};{bd5d6e86-1289-412d-81b9-41087b55e1fd};{95ca7b93-cd09-4c19-a70c-b1ed653fb9ae}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-87"/>
+        <tag k="name" v="Av. Sur 4"/>
+        <tag k="source:datetime" v="2015-08-24T16:13:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108};{bd5d6e86-1289-412d-81b9-41087b55e1fd};{95ca7b93-cd09-4c19-a70c-b1ed653fb9ae}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z;2019-01-17T19:50:05.631Z;2019-01-17T19:50:05.672Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-66"/>
         <nd ref="-2"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{ddce01c4-a4e6-4e3b-a63f-05da6203a4ed}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-85"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{ddce01c4-a4e6-4e3b-a63f-05da6203a4ed}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-28"/>
         <nd ref="-50"/>
         <nd ref="-49"/>
         <nd ref="-45"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-69"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24"/>
@@ -362,78 +289,72 @@
         <nd ref="-20"/>
         <nd ref="-54"/>
         <nd ref="-6"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.668Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-05-11T03:32:46.000Z;2019-01-17T19:50:06Z;2014-06-22T17:21:17.000Z;2014-06-22T17:21:18.000Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{d420f044-9a4d-4dae-8ab3-3dec2959e07c};{7c809bd2-1b65-4e0e-9713-1e7ddc4f43a7};{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-67"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2015-05-11T03:32:46.000Z;2019-01-17T19:50:06Z;2014-06-22T17:21:17.000Z;2014-06-22T17:21:18.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{d420f044-9a4d-4dae-8ab3-3dec2959e07c};{7c809bd2-1b65-4e0e-9713-1e7ddc4f43a7};{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-17"/>
         <nd ref="-16"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{a439f440-165f-401c-9395-166374e5bdd7}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-04-18T01:17:19.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{a439f440-165f-401c-9395-166374e5bdd7}"/>
+        <tag k="source:datetime" v="2013-04-18T01:17:19.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-64"/>
         <nd ref="-63"/>
         <nd ref="-62"/>
         <nd ref="-35"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z;2019-01-17T19:50:05.659Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2014-04-16T16:34:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{ddce01c4-a4e6-4e3b-a63f-05da6203a4ed};{7600039c-cde1-43ff-894f-ec25be435bb8}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-27"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:34:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{ddce01c4-a4e6-4e3b-a63f-05da6203a4ed};{7600039c-cde1-43ff-894f-ec25be435bb8}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z;2019-01-17T19:50:05.659Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-45"/>
@@ -441,61 +362,57 @@
         <nd ref="-38"/>
         <nd ref="-47"/>
         <nd ref="-35"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z;2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:59.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{a13e065e-90dc-4199-a2eb-a12efaf01eba};{e7c51f67-fb91-4865-a8bc-dd68ca0a5ffc}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-25"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:59.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{a13e065e-90dc-4199-a2eb-a12efaf01eba};{e7c51f67-fb91-4865-a8bc-dd68ca0a5ffc}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z;2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-37"/>
         <nd ref="-44"/>
         <nd ref="-42"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{c7000abf-95fe-4c00-9be5-00533f4d7ef0}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-24"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{c7000abf-95fe-4c00-9be5-00533f4d7ef0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-39"/>
@@ -503,303 +420,279 @@
         <nd ref="-17"/>
         <nd ref="-41"/>
         <nd ref="-37"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2013-04-18T01:17:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-23"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{337b5b66-e2e1-4cb7-83e6-bad10ea5d108}"/>
+        <tag k="source:datetime" v="2013-04-18T01:17:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-38"/>
         <nd ref="-37"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{7839e6b8-9f99-4b27-96f9-6342a40197de}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-22"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{7839e6b8-9f99-4b27-96f9-6342a40197de}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-35"/>
         <nd ref="-36"/>
         <nd ref="-37"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{449793a7-7d3a-4607-b9a0-74834a4e876a}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-21"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{449793a7-7d3a-4607-b9a0-74834a4e876a}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-24"/>
         <nd ref="-31"/>
         <nd ref="-30"/>
         <nd ref="-29"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{80712126-af56-4518-8afe-f507ca285392}"/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{80712126-af56-4518-8afe-f507ca285392}"/>
+        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-28"/>
         <nd ref="-27"/>
         <nd ref="-26"/>
         <nd ref="-24"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{60cb34a4-b2a7-4427-baa6-7bfd0f871bc1}"/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{60cb34a4-b2a7-4427-baa6-7bfd0f871bc1}"/>
+        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-22"/>
         <nd ref="-21"/>
         <nd ref="-15"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z;2019-01-17T19:50:05.669Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c};{35fb46ac-4c0c-4d19-a3d2-94876d592c26}"/>
-        <tag k="name" v="La Amargura"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z;2019-01-17T19:50:05.669Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="La Amargura"/>
+        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c};{35fb46ac-4c0c-4d19-a3d2-94876d592c26}"/>
+        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21"/>
         <nd ref="-14"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-13"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-13"/>
         <nd ref="-22"/>
         <nd ref="-23"/>
         <nd ref="-12"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:11.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{6f44fd8f-d8fd-4e57-b362-afb57ca0c781}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-12"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:11.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{6f44fd8f-d8fd-4e57-b362-afb57ca0c781}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
         <nd ref="-25"/>
         <nd ref="-24"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{8bd0e392-a3b6-4f60-80ed-05254da2cb8e}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8bd0e392-a3b6-4f60-80ed-05254da2cb8e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-42"/>
         <nd ref="-43"/>
         <nd ref="-10"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{40a71cf9-24ff-42b7-af9f-a80a93b7a29e}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{40a71cf9-24ff-42b7-af9f-a80a93b7a29e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-9"/>
         <nd ref="-46"/>
         <nd ref="-45"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{0d03894e-5353-42d2-9f60-0316286dab1b}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{0d03894e-5353-42d2-9f60-0316286dab1b}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-8"/>
         <nd ref="-51"/>
         <nd ref="-28"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-45"/>
@@ -808,55 +701,51 @@
         <nd ref="-16"/>
         <nd ref="-52"/>
         <nd ref="-7"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="40"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980};{bdf0d568-d4fa-4c77-ad37-c4b60ea708f2}"/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:45.000Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="3"/>
-        <tag k="surface" v="asphalt"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980};{bdf0d568-d4fa-4c77-ad37-c4b60ea708f2}"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:45.000Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
         <nd ref="-56"/>
         <nd ref="-21"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
         <tag k="lit" v="yes"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="destination" v="San Martín"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+        <tag k="destination" v="San Martín"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-57"/>
@@ -866,23 +755,21 @@
         <nd ref="-29"/>
         <nd ref="-61"/>
         <nd ref="-4"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z;2019-01-17T19:50:05.634Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{7e90f50b-e78f-4a6a-8256-0e1e59279114};{fd83c40a-9c01-4531-b6e7-6c73969725e9}"/>
-        <tag k="name" v="Av. Oeste 12"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-04-16T14:32:15.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z;2019-01-17T19:50:05.634Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 12"/>
+        <tag k="uuid" v="{7e90f50b-e78f-4a6a-8256-0e1e59279114};{fd83c40a-9c01-4531-b6e7-6c73969725e9}"/>
+        <tag k="source:datetime" v="2014-04-16T14:32:15.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
@@ -890,51 +777,47 @@
         <nd ref="-66"/>
         <nd ref="-67"/>
         <nd ref="-57"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{fd83c40a-9c01-4531-b6e7-6c73969725e9}"/>
-        <tag k="name" v="Av. Oeste 12"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-04-16T14:32:15.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 12"/>
+        <tag k="uuid" v="{fd83c40a-9c01-4531-b6e7-6c73969725e9}"/>
+        <tag k="source:datetime" v="2014-04-16T14:32:15.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-66"/>
         <nd ref="-64"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2014-04-16T16:34:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{ddce01c4-a4e6-4e3b-a63f-05da6203a4ed}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:34:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{ddce01c4-a4e6-4e3b-a63f-05da6203a4ed}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.634Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
 </osm>

--- a/test-files/cases/attribute/unifying/highway-2927-way-member-tags-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-way-member-tags-1/Expected.osm
@@ -3,1143 +3,858 @@
     <bounds minlat="10.4953" minlon="-66.90266" maxlat="10.4986" maxlon="-66.89794699999999"/>
     <node visible="true" id="-1809" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4970356391966728" lon="-66.9015098172667422">
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1809"/>
     </node>
     <node visible="true" id="-1807" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4960253697085815" lon="-66.9010837897166226">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1807"/>
     </node>
     <node visible="true" id="-1805" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4966018270344055" lon="-66.8989322499832042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1805"/>
     </node>
     <node visible="true" id="-1804" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4966684789968543" lon="-66.8999130454100310">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1804"/>
     </node>
     <node visible="true" id="-1801" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4969606967081628" lon="-66.8980858001478538">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1801"/>
     </node>
     <node visible="true" id="-1799" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4974491016364286" lon="-66.8981350034610642">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1799"/>
     </node>
     <node visible="true" id="-342" timestamp="2019-01-10T17:16:05Z" version="1" changeset="749" lat="10.4963607999999979" lon="-66.8996161999999970">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-342"/>
     </node>
     <node visible="true" id="-341" timestamp="2019-01-10T17:16:05Z" version="1" changeset="749" lat="10.4960977000000018" lon="-66.9008881000000031">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-341"/>
     </node>
     <node visible="true" id="-277" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965255552600016" lon="-66.9022163124700029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-277"/>
     </node>
     <node visible="true" id="-276" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966321991699996" lon="-66.9016561960600029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-276"/>
     </node>
     <node visible="true" id="-275" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966905865199998" lon="-66.9012790260800045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-275"/>
     </node>
     <node visible="true" id="-274" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967194419199998" lon="-66.9008953271499962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-274"/>
     </node>
     <node visible="true" id="-273" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967125643799974" lon="-66.9005743449900052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-273"/>
     </node>
     <node visible="true" id="-272" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966920457700006" lon="-66.9002044356600010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-272"/>
     </node>
     <node visible="true" id="-271" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966671838199996" lon="-66.8998970313599983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-271"/>
     </node>
     <node visible="true" id="-270" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966261936399974" lon="-66.8994522898200046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-270"/>
     </node>
     <node visible="true" id="-269" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966029409599990" lon="-66.8991006614599968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-269"/>
     </node>
     <node visible="true" id="-268" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966009892599992" lon="-66.8988055979099983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-268"/>
     </node>
     <node visible="true" id="-267" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966118733300000" lon="-66.8985815736800049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-267"/>
     </node>
     <node visible="true" id="-266" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966216231299985" lon="-66.8984517497899986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-266"/>
     </node>
     <node visible="true" id="-265" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966358509199988" lon="-66.8983223487999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-265"/>
     </node>
     <node visible="true" id="-264" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966545393799997" lon="-66.8981935283599967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-264"/>
     </node>
     <node visible="true" id="-263" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966776657499974" lon="-66.8980654453999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-263"/>
     </node>
     <node visible="true" id="-262" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966806536599986" lon="-66.8980505477599934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-262"/>
     </node>
     <node visible="true" id="-261" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966990112899996" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-261"/>
     </node>
     <node visible="true" id="-260" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4961183409699998" lon="-66.9022581171700068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-260"/>
     </node>
     <node visible="true" id="-259" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4961861367399987" lon="-66.9018063572100061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-259"/>
     </node>
     <node visible="true" id="-258" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962462924499995" lon="-66.9013065590699938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-258"/>
     </node>
     <node visible="true" id="-257" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962758852199975" lon="-66.9009832957400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-257"/>
     </node>
     <node visible="true" id="-256" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962849855000027" lon="-66.9006983957699930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-256"/>
     </node>
     <node visible="true" id="-255" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963099247099994" lon="-66.9004096897500062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-255"/>
     </node>
     <node visible="true" id="-254" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963460312199981" lon="-66.8999643088399978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-254"/>
     </node>
     <node visible="true" id="-253" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963674937399976" lon="-66.8995190268099975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-253"/>
     </node>
     <node visible="true" id="-252" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964042595200002" lon="-66.8991735198899988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-252"/>
     </node>
     <node visible="true" id="-251" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964342904600016" lon="-66.8989168392400018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-251"/>
     </node>
     <node visible="true" id="-250" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964691859899997" lon="-66.8986576595900004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-250"/>
     </node>
     <node visible="true" id="-249" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965177537999974" lon="-66.8982516526500035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-249"/>
     </node>
     <node visible="true" id="-248" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965645345300000" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-248"/>
     </node>
     <node visible="true" id="-247" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972940122799994" lon="-66.8990818915400069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-247"/>
     </node>
     <node visible="true" id="-246" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972619845899970" lon="-66.8988943461300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-246"/>
     </node>
     <node visible="true" id="-245" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971868237599999" lon="-66.8985026652599970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-245"/>
     </node>
     <node visible="true" id="-244" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971740993299978" lon="-66.8984207946800069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-244"/>
     </node>
     <node visible="true" id="-243" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971642103599976" lon="-66.8983385252700060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-243"/>
     </node>
     <node visible="true" id="-242" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971571688999994" lon="-66.8982559572600053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-242"/>
     </node>
     <node visible="true" id="-241" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971529835200013" lon="-66.8981731912499953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-241"/>
     </node>
     <node visible="true" id="-240" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971516593299992" lon="-66.8980903280699977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-240"/>
     </node>
     <node visible="true" id="-239" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971531979399995" lon="-66.8980074686800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-239"/>
     </node>
     <node visible="true" id="-238" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971537632699992" lon="-66.8979929326399940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-238"/>
     </node>
     <node visible="true" id="-237" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971585263300007" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-237"/>
     </node>
     <node visible="true" id="-236" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985650466399978" lon="-66.8986611001000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-236"/>
     </node>
     <node visible="true" id="-235" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985223443700004" lon="-66.8986437803999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-235"/>
     </node>
     <node visible="true" id="-234" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984803225899999" lon="-66.8986248374099972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-234"/>
     </node>
     <node visible="true" id="-233" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984390417300002" lon="-66.8986042983499942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-233"/>
     </node>
     <node visible="true" id="-232" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983985611399984" lon="-66.8985821927699931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-232"/>
     </node>
     <node visible="true" id="-231" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983589390100001" lon="-66.8985585524399937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-231"/>
     </node>
     <node visible="true" id="-230" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983202322999993" lon="-66.8985334113500016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-230"/>
     </node>
     <node visible="true" id="-229" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982824966700026" lon="-66.8985068056500012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-229"/>
     </node>
     <node visible="true" id="-228" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982457863600001" lon="-66.8984787735799813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-228"/>
     </node>
     <node visible="true" id="-227" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982101541599988" lon="-66.8984493554499977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-227"/>
     </node>
     <node visible="true" id="-226" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981756512799986" lon="-66.8984185935500051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-226"/>
     </node>
     <node visible="true" id="-225" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981423273400001" lon="-66.8983865321200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-225"/>
     </node>
     <node visible="true" id="-224" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981102302499991" lon="-66.8983532172299959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-224"/>
     </node>
     <node visible="true" id="-223" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980794061400022" lon="-66.8983186968000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-223"/>
     </node>
     <node visible="true" id="-222" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980561794799989" lon="-66.8982908470299975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-222"/>
     </node>
     <node visible="true" id="-221" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980091004699965" lon="-66.8982382300000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-221"/>
     </node>
     <node visible="true" id="-220" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979638674700002" lon="-66.8981839848499931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-220"/>
     </node>
     <node visible="true" id="-219" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979205355899978" lon="-66.8981281776799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-219"/>
     </node>
     <node visible="true" id="-218" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978791576099990" lon="-66.8980708764700012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-218"/>
     </node>
     <node visible="true" id="-217" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978397839499991" lon="-66.8980121510300023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-217"/>
     </node>
     <node visible="true" id="-216" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977995503699990" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-216"/>
     </node>
     <node visible="true" id="-215" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973441388099999" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-215"/>
     </node>
     <node visible="true" id="-214" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973472980199993" lon="-66.8979612051699917">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-214"/>
     </node>
     <node visible="true" id="-213" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973568530499985" lon="-66.8979980984800022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-213"/>
     </node>
     <node visible="true" id="-212" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973676765100024" lon="-66.8980346323699990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-212"/>
     </node>
     <node visible="true" id="-211" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973797552199990" lon="-66.8980707623299935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-211"/>
     </node>
     <node visible="true" id="-210" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973930744599979" lon="-66.8981064443500060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-210"/>
     </node>
     <node visible="true" id="-209" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974076180099978" lon="-66.8981416349499938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-209"/>
     </node>
     <node visible="true" id="-208" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974233681299989" lon="-66.8981762912499960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-208"/>
     </node>
     <node visible="true" id="-207" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974403056599996" lon="-66.8982103710399940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-207"/>
     </node>
     <node visible="true" id="-206" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974584099400019" lon="-66.8982438327900013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-206"/>
     </node>
     <node visible="true" id="-205" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974776589300003" lon="-66.8982766357299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-205"/>
     </node>
     <node visible="true" id="-204" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974980291699982" lon="-66.8983087399099929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-204"/>
     </node>
     <node visible="true" id="-203" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975194958399989" lon="-66.8983401061999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-203"/>
     </node>
     <node visible="true" id="-202" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975420327900011" lon="-66.8983706963900033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-202"/>
     </node>
     <node visible="true" id="-201" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975656125700016" lon="-66.8984004732100033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-201"/>
     </node>
     <node visible="true" id="-200" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975725955900003" lon="-66.8984088960999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-200"/>
     </node>
     <node visible="true" id="-199" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977151716199977" lon="-66.8985644712499976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-199"/>
     </node>
     <node visible="true" id="-198" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983789342400016" lon="-66.8987121958899991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-198"/>
     </node>
     <node visible="true" id="-197" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980557712199989" lon="-66.8983983944699929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-197"/>
     </node>
     <node visible="true" id="-196" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980061847199977" lon="-66.8983495882200003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-196"/>
     </node>
     <node visible="true" id="-195" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979583141299990" lon="-66.8982990631200067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-195"/>
     </node>
     <node visible="true" id="-194" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979122177900006" lon="-66.8982468807000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-194"/>
     </node>
     <node visible="true" id="-193" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978679518399982" lon="-66.8981931045599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-193"/>
     </node>
     <node visible="true" id="-192" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978255702199998" lon="-66.8981378001999900">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-192"/>
     </node>
     <node visible="true" id="-191" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977851245599982" lon="-66.8980810350099944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-191"/>
     </node>
     <node visible="true" id="-190" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977466641499984" lon="-66.8980228781500017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-190"/>
     </node>
     <node visible="true" id="-189" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977278161999976" lon="-66.8979926842300046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-189"/>
     </node>
     <node visible="true" id="-188" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977014156699990" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-188"/>
     </node>
     <node visible="true" id="-187" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979060636200003" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-187"/>
     </node>
     <node visible="true" id="-186" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979235978800016" lon="-66.8979751215899938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-186"/>
     </node>
     <node visible="true" id="-185" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979665330799961" lon="-66.8980389297399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-185"/>
     </node>
     <node visible="true" id="-184" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980116459900010" lon="-66.8981011849700025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-184"/>
     </node>
     <node visible="true" id="-183" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980588816299996" lon="-66.8981618114499952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-183"/>
     </node>
     <node visible="true" id="-182" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981081824599993" lon="-66.8982207353000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-182"/>
     </node>
     <node visible="true" id="-181" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981277215599995" lon="-66.8982429745800005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-181"/>
     </node>
     <node visible="true" id="-180" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982180172900001" lon="-66.8983219769200019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-180"/>
     </node>
     <node visible="true" id="-179" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983109866599982" lon="-66.8983977470099944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-179"/>
     </node>
     <node visible="true" id="-178" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984065163999993" lon="-66.8984701925199943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-178"/>
     </node>
     <node visible="true" id="-177" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985044901200020" lon="-66.8985392251900066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-177"/>
     </node>
     <node visible="true" id="-176" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985655291700013" lon="-66.8985797046599941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-176"/>
     </node>
     <node visible="true" id="-175" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985894030699978" lon="-66.8985925448899934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175"/>
     </node>
     <node visible="true" id="-174" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982779118200007" lon="-66.8987583619200024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-174"/>
     </node>
     <node visible="true" id="-173" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982200921499995" lon="-66.8986946857999811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-173"/>
     </node>
     <node visible="true" id="-172" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981601083800005" lon="-66.8986330874400039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-172"/>
     </node>
     <node visible="true" id="-171" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980980336199998" lon="-66.8985736418899961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171"/>
     </node>
     <node visible="true" id="-170" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980339434700003" lon="-66.8985164215600037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170"/>
     </node>
     <node visible="true" id="-169" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979924468799979" lon="-66.8984814478599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-169"/>
     </node>
     <node visible="true" id="-168" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979338934099982" lon="-66.8984224753200039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-168"/>
     </node>
     <node visible="true" id="-167" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978774124499985" lon="-66.8983614739200050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-167"/>
     </node>
     <node visible="true" id="-166" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978230728199975" lon="-66.8982985179600007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-166"/>
     </node>
     <node visible="true" id="-165" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977709406999988" lon="-66.8982336841500000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165"/>
     </node>
     <node visible="true" id="-164" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977210796299989" lon="-66.8981670514800015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-164"/>
     </node>
     <node visible="true" id="-163" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976702019799966" lon="-66.8980936891099986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-163"/>
     </node>
     <node visible="true" id="-162" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976396325099994" lon="-66.8980441594499950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-162"/>
     </node>
     <node visible="true" id="-161" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976107923500006" lon="-66.8979935819800033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-161"/>
     </node>
     <node visible="true" id="-160" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975863325000009" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-160"/>
     </node>
     <node visible="true" id="-159" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979886416799975" lon="-66.8986379866099981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-159"/>
     </node>
     <node visible="true" id="-158" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979398743499992" lon="-66.8985984505400069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-158"/>
     </node>
     <node visible="true" id="-157" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975203752300015" lon="-66.8982062276299985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-157"/>
     </node>
     <node visible="true" id="-156" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972609674800008" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-156"/>
     </node>
     <node visible="true" id="-155" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969159754600021" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-155"/>
     </node>
     <node visible="true" id="-154" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969668168800006" lon="-66.8981047951799894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-154"/>
     </node>
     <node visible="true" id="-153" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970539977099975" lon="-66.8984253776999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153"/>
     </node>
     <node visible="true" id="-152" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972046468099975" lon="-66.8990350387600046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-152"/>
     </node>
     <node visible="true" id="-151" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979138786000004" lon="-66.8987390725000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-151"/>
     </node>
     <node visible="true" id="-150" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980115386599984" lon="-66.8988506781099943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-150"/>
     </node>
     <node visible="true" id="-149" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978145000900014" lon="-66.8986508031099874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-149"/>
     </node>
     <node visible="true" id="-148" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983787414899989" lon="-66.8990110065399932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-148"/>
     </node>
     <node visible="true" id="-147" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982239350800004" lon="-66.8988287410700053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-147"/>
     </node>
     <node visible="true" id="-146" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984569345600001" lon="-66.8988036110699937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-146"/>
     </node>
     <node visible="true" id="-145" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983334969600026" lon="-66.8988240382300035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-145"/>
     </node>
     <node visible="true" id="-144" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955907653199993" lon="-66.9021525317999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144"/>
     </node>
     <node visible="true" id="-143" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955716818199996" lon="-66.9021487105000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-143"/>
     </node>
     <node visible="true" id="-142" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955524082200000" lon="-66.9021460350499808">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-142"/>
     </node>
     <node visible="true" id="-141" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955330118599974" lon="-66.9021445148199803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-141"/>
     </node>
     <node visible="true" id="-140" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955135604899983" lon="-66.9021441551000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-140"/>
     </node>
     <node visible="true" id="-139" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954941220699975" lon="-66.9021449571600044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-139"/>
     </node>
     <node visible="true" id="-138" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954747644899999" lon="-66.9021469181899988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-138"/>
     </node>
     <node visible="true" id="-137" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954555553799977" lon="-66.9021500313399997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-137"/>
     </node>
     <node visible="true" id="-136" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954365618499992" lon="-66.9021542857399965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136"/>
     </node>
     <node visible="true" id="-135" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954178502299964" lon="-66.9021596665199922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-135"/>
     </node>
     <node visible="true" id="-134" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953994859099975" lon="-66.9021661548899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-134"/>
     </node>
     <node visible="true" id="-133" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953815330300007" lon="-66.9021737281800029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-133"/>
     </node>
     <node visible="true" id="-132" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953640543100004" lon="-66.9021823599299950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-132"/>
     </node>
     <node visible="true" id="-131" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953471108099983" lon="-66.9021920200000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-131"/>
     </node>
     <node visible="true" id="-130" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953307617000018" lon="-66.9022026746300043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-130"/>
     </node>
     <node visible="true" id="-129" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953150641199997" lon="-66.9022142865999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-129"/>
     </node>
     <node visible="true" id="-128" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959739620200008" lon="-66.9009545499399962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-128"/>
     </node>
     <node visible="true" id="-127" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959280306299974" lon="-66.9009321611899992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-127"/>
     </node>
     <node visible="true" id="-126" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958813539300007" lon="-66.9009114058000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126"/>
     </node>
     <node visible="true" id="-125" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958339887999976" lon="-66.9008923090400032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-125"/>
     </node>
     <node visible="true" id="-124" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4957859929299993" lon="-66.9008748941899967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-124"/>
     </node>
     <node visible="true" id="-123" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4957374247999997" lon="-66.9008591824500058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-123"/>
     </node>
     <node visible="true" id="-122" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4956883435900004" lon="-66.9008451929699959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-122"/>
     </node>
     <node visible="true" id="-121" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4956388091000008" lon="-66.9008329427999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-121"/>
     </node>
     <node visible="true" id="-120" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955276566999984" lon="-66.9008007124700015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-120"/>
     </node>
     <node visible="true" id="-119" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954583077499990" lon="-66.9007799777599956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-118" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953882848899980" lon="-66.9007617011800022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-118"/>
     </node>
     <node visible="true" id="-117" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953176734299998" lon="-66.9007459049900035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117"/>
     </node>
     <node visible="true" id="-116" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962700263799977" lon="-66.9010472963699954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-116"/>
     </node>
     <node visible="true" id="-115" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958056912499984" lon="-66.9025679482599855">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-115"/>
     </node>
     <node visible="true" id="-114" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958359980800005" lon="-66.9024133217100001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114"/>
     </node>
     <node visible="true" id="-113" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958652051300003" lon="-66.9022966327299997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-113"/>
     </node>
     <node visible="true" id="-112" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958832425599979" lon="-66.9022122862100019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112"/>
     </node>
     <node visible="true" id="-111" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958903640100001" lon="-66.9021789848799955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-111"/>
     </node>
     <node visible="true" id="-110" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959114440500016" lon="-66.9020605215000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-110"/>
     </node>
     <node visible="true" id="-109" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959284195800020" lon="-66.9019413869200008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-109"/>
     </node>
     <node visible="true" id="-108" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959412699199994" lon="-66.9018217262899952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-108"/>
     </node>
     <node visible="true" id="-107" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959432879799994" lon="-66.9017984121000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-107"/>
     </node>
     <node visible="true" id="-106" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4960279313800005" lon="-66.9011267369299958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-106"/>
     </node>
     <node visible="true" id="-105" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4960190921399974" lon="-66.9009785447500036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105"/>
     </node>
     <node visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979196457599997" lon="-66.9025488747499963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-104"/>
     </node>
     <node visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977696920400021" lon="-66.9017350473800008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-103"/>
     </node>
     <node visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977218078700005" lon="-66.9014588562699970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-102"/>
     </node>
     <node visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977064766999995" lon="-66.9013704279399803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-101"/>
     </node>
     <node visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975172582699994" lon="-66.9003151283900053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-100"/>
     </node>
     <node visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979151350299986" lon="-66.9025243939500029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-99"/>
     </node>
     <node visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972461277600004" lon="-66.9026599894099974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-98"/>
     </node>
     <node visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971623784400023" lon="-66.9022121940199952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-97"/>
     </node>
     <node visible="true" id="-96" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970543100399976" lon="-66.9016132887300046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-96"/>
     </node>
     <node visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970123355900000" lon="-66.9013806718899957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95"/>
     </node>
     <node visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969015647500008" lon="-66.9007254838600005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94"/>
     </node>
     <node visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968865948899985" lon="-66.9006477751899951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93"/>
     </node>
     <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968689501500005" lon="-66.9005706417599981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-92"/>
     </node>
     <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968486520300015" lon="-66.9004941775500015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-91"/>
     </node>
     <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968257252499981" lon="-66.9004184757300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-90"/>
     </node>
     <node visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968001977600007" lon="-66.9003436285199911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-89"/>
     </node>
     <node visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967953031299999" lon="-66.9003301835499968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-88"/>
     </node>
     <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967135008600021" lon="-66.9000319800299934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
     <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966736602000008" lon="-66.8999771078400016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
     <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977457145699979" lon="-66.9015967475500020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
     <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979862840700005" lon="-66.9015477735400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
     <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977592115799983" lon="-66.9016745969899915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
     <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980731694399996" lon="-66.8989307704899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
     <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982483097799975" lon="-66.8989086649000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
     <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972986925499985" lon="-66.8992315182200059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973390934099999" lon="-66.8991661363299954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973478783399976" lon="-66.8991494384300012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973577867000003" lon="-66.8991333953999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973687708999979" lon="-66.8991180842899951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973807782000002" lon="-66.8991035786399948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973937509399988" lon="-66.8990899481100030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974076267900003" lon="-66.8990772581699957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974223391400017" lon="-66.8990655697400030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974378173199980" lon="-66.8990549389800009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974539870000001" lon="-66.8990454169299937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974707705299988" lon="-66.8990370493200004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974880872899963" lon="-66.8990298763399949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975058541300008" lon="-66.8990239324400022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975239857199956" lon="-66.8990192461599946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975423949800017" lon="-66.8990158400099943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975609935100014" lon="-66.8990137303500063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977432723199993" lon="-66.8986003190399998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977239683400008" lon="-66.8985883402699955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977039965199985" lon="-66.8985775370200031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-61"/>
     </node>
     <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976834268800001" lon="-66.8985679471799983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-60"/>
     </node>
     <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976623315499982" lon="-66.8985596043700070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976407844999997" lon="-66.8985525378400041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-58"/>
     </node>
     <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976188612799994" lon="-66.8985467723800014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975966387699984" lon="-66.8985423281900040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975741948899977" lon="-66.8985392208600018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975516083400020" lon="-66.8985374612900046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54"/>
     </node>
     <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975289583099975" lon="-66.8985370556499959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53"/>
     </node>
     <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975063242399980" lon="-66.8985380053599812">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-52"/>
     </node>
     <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974837854799983" lon="-66.8985403070799975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-51"/>
     </node>
     <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974614210599988" lon="-66.8985439527599794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974393094099998" lon="-66.8985489295900067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974175280600015" lon="-66.8985552201399969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973997838400006" lon="-66.8985664589399960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973831906699981" lon="-66.8985793687899957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-46"/>
     </node>
     <node visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973679021499979" lon="-66.8985938301700003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-45"/>
     </node>
     <node visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973540598100001" lon="-66.8986097092199969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-44"/>
     </node>
     <node visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973417917899976" lon="-66.8986268589300010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-43"/>
     </node>
     <node visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973312116699979" lon="-66.8986451205699808">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42"/>
     </node>
     <node visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973224173700004" lon="-66.8986643250599968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41"/>
     </node>
     <node visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973154903199983" lon="-66.8986842946400060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40"/>
     </node>
     <node visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973104946299998" lon="-66.8987048444499948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-39"/>
     </node>
     <node visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973074765499987" lon="-66.8987257842500043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-38"/>
     </node>
     <node visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973064640199976" lon="-66.8987469201999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-37"/>
     </node>
     <node visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973074664100015" lon="-66.8987680566499989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973104744399990" lon="-66.8987889979199934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973154602699985" lon="-66.8988095501800046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973223777499989" lon="-66.8988295231499990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973309210999997" lon="-66.8988466650699820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973408521400007" lon="-66.8988630257099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973521014100015" lon="-66.8988784906400014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973645902299975" lon="-66.8988929517099820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973782312399972" lon="-66.8989063077499964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973929290399965" lon="-66.8989184653599978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974085808299993" lon="-66.8989293394899960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974250771200008" lon="-66.8989388540999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974423025500023" lon="-66.8989469426300047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974601366199991" lon="-66.8989535485099935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974784545999977" lon="-66.8989586255299997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974971283699983" lon="-66.8989621381799964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975160273199979" lon="-66.8989640618899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975350192499981" lon="-66.8989643832200045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975539713399986" lon="-66.8989630999000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976622110699989" lon="-66.8989826400199945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8988753224482480">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.9015157811893317">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.9014250645420958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4972461297405815" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4972460760916597" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4979393027591037" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4957905455867380" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4953000000000003" lon="-66.9007426004998393">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4953000000000003" lon="-66.9022314112524441">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8989876058872994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8989771105911757">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8992280761345768">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8985977731945383">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4"/>
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8986737444705426">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4960415504698421" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4964387863919075" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1"/>
     </node>
     <way visible="true" id="-3167" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-1804"/>
@@ -1154,61 +869,57 @@
         <nd ref="-94"/>
         <nd ref="-95"/>
         <nd ref="-1809"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="albertoq2004@hotmail.com;Yahoo;osm:line"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Distribuidor: San Agustín del Norte"/>
-        <tag k="lanes" v="2"/>
-        <tag k="cycleway" v="no"/>
         <tag k="alt_name" v="Av. Este 10 bis"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="maxspeed:conditional" v="60 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="50|30"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="hgv:lanes" v="no|yes"/>
-        <tag k="incline" v="10%"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z"/>
-        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway_link"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2015-12-15T02:07:00.000Z;2015-06-10T00:02:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="maxweight" v="20"/>
-        <tag k="uuid" v="{22a82dc7-8817-40e1-9204-b335c659de38}"/>
-        <tag k="overtaking" v="no"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="destination" v="San Agustín del Norte"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3167"/>
+        <tag k="name" v="Distribuidor: San Agustín del Norte"/>
+        <tag k="source:datetime" v="2015-12-15T02:07:00.000Z;2015-06-10T00:02:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="incline" v="10%"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="uuid" v="{22a82dc7-8817-40e1-9204-b335c659de38}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="maxspeed:lanes" v="50|30"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;Yahoo;osm:line"/>
+        <tag k="destination" v="San Agustín del Norte"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="maxweight" v="20"/>
     </way>
     <way visible="true" id="-3164" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1807"/>
         <nd ref="-105"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3164"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-3160" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1805"/>
@@ -1220,43 +931,41 @@
         <nd ref="-263"/>
         <nd ref="-262"/>
         <nd ref="-261"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="ref" v="L-07"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Autopista: Francisco Fajardo"/>
-        <tag k="lanes" v="4"/>
-        <tag k="destination:lanes" v="San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao;Parque Central"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="90|70|40|40"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="maxspeed" v="90"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="hgv:lanes" v="no|no|no|yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.711Z"/>
-        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway"/>
         <tag k="lit" v="yes"/>
-        <tag k="turn:lanes" v="through|through|through|through;slight_right"/>
-        <tag k="source:datetime" v="2015-12-15T02:06:59.000Z;2015-12-15T02:06:58.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="maxweight" v="20"/>
-        <tag k="uuid" v="{f86f74fc-c5c9-46a2-bcd5-4076e546644c}"/>
-        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
-        <tag k="overtaking" v="yes"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3160"/>
+        <tag k="name" v="Autopista: Francisco Fajardo"/>
+        <tag k="ref" v="L-07"/>
+        <tag k="source:datetime" v="2015-12-15T02:06:59.000Z;2015-12-15T02:06:58.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="90"/>
+        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="uuid" v="{f86f74fc-c5c9-46a2-bcd5-4076e546644c}"/>
+        <tag k="destination:lanes" v="San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao;Parque Central"/>
+        <tag k="maxspeed:lanes" v="90|70|40|40"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="through|through|through|through;slight_right"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.711Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|no|no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="maxweight" v="20"/>
     </way>
     <way visible="true" id="-3158" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1805"/>
@@ -1264,44 +973,42 @@
         <nd ref="-270"/>
         <nd ref="-271"/>
         <nd ref="-1804"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="ref" v="L-07"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Autopista: Francisco Fajardo"/>
-        <tag k="lanes" v="4"/>
-        <tag k="destination:lanes" v="San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao;Parque Central"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="90|70|40|40"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="maxspeed" v="90"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="hgv:lanes" v="no|no|no|yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.711Z"/>
-        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway"/>
         <tag k="lit" v="yes"/>
-        <tag k="turn:lanes" v="through|through|through|through;slight_right"/>
-        <tag k="source:datetime" v="2015-12-15T02:06:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="maxweight" v="20"/>
-        <tag k="uuid" v="{f86f74fc-c5c9-46a2-bcd5-4076e546644c}"/>
-        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
-        <tag k="overtaking" v="yes"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3158"/>
+        <tag k="name" v="Autopista: Francisco Fajardo"/>
+        <tag k="ref" v="L-07"/>
+        <tag k="source:datetime" v="2015-12-15T02:06:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="lanes" v="4"/>
+        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
+        <tag k="maxspeed" v="90"/>
+        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="uuid" v="{f86f74fc-c5c9-46a2-bcd5-4076e546644c}"/>
+        <tag k="destination:lanes" v="San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao;Parque Central"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="maxspeed:lanes" v="90|70|40|40"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="through|through|through|through;slight_right"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.711Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|no|no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="maxweight" v="20"/>
     </way>
     <way visible="true" id="-3155" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-80"/>
@@ -1309,52 +1016,48 @@
         <nd ref="-153"/>
         <nd ref="-154"/>
         <nd ref="-1801"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="destination:ref" v="A-01"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="destination:ref" v="A-01"/>
         <tag k="destination:symbol" v="motorway"/>
-        <tag k="source:datetime" v="2014-11-30T21:06:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="lanes" v="3"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3155"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-11-30T21:06:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
     <way visible="true" id="-3154" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-1801"/>
         <nd ref="-155"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="lanes" v="3"/>
-        <tag k="layer" v="2"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
         <tag k="destination:ref" v="A-01"/>
-        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="2"/>
+        <tag k="destination:symbol" v="motorway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3154"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
     <way visible="true" id="-3151" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-147"/>
@@ -1362,53 +1065,49 @@
         <nd ref="-158"/>
         <nd ref="-157"/>
         <nd ref="-1799"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="lanes" v="3"/>
-        <tag k="layer" v="-1"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.713Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2014-09-05T04:44:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{0b879342-4f8f-4441-bac0-749e8971415a};{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
+        <tag k="layer" v="-1"/>
         <tag k="destination:ref" v="A-01"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="destination:symbol" v="motorway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3151"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2014-09-05T04:44:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{0b879342-4f8f-4441-bac0-749e8971415a};{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
     <way visible="true" id="-3150" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-156"/>
         <nd ref="-1799"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="lanes" v="3"/>
-        <tag k="layer" v="2"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
         <tag k="destination:ref" v="A-01"/>
-        <tag k="uuid" v="{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="layer" v="2"/>
+        <tag k="destination:symbol" v="motorway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3150"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
     <way visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-99"/>
@@ -1419,31 +1118,29 @@
         <nd ref="-101"/>
         <nd ref="-100"/>
         <nd ref="-80"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="lanes" v="3"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="destination:lanes" v="Bellas Artes;San Bernardino;Los Caobos;Plaza Venezuela|Los Caobos;Plaza Venezuela;Chuao;Los Ruices|Chuao;Los Ruices"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z"/>
         <tag k="service" v="drive-through"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="primary"/>
-        <tag k="turn:lanes" v="left;through|through;slight_right|slight_right"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2014-12-01T08:26:38.000Z;2014-09-04T15:01:21.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{9c369f56-06a5-41c8-8f12-a57e98565cfc}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-92"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2014-12-01T08:26:38.000Z;2014-09-04T15:01:21.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{9c369f56-06a5-41c8-8f12-a57e98565cfc}"/>
+        <tag k="destination:lanes" v="Bellas Artes;San Bernardino;Los Caobos;Plaza Venezuela|Los Caobos;Plaza Venezuela;Chuao;Los Ruices|Chuao;Los Ruices"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="left;through|through;slight_right|slight_right"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="-89" timestamp="2019-01-10T17:16:06Z" version="1">
         <nd ref="-112"/>
@@ -1456,43 +1153,42 @@
         <nd ref="-1807"/>
         <nd ref="-341"/>
         <nd ref="-342"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Distribuidor: San Agustín del Norte"/>
-        <tag k="lanes" v="2"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="maxspeed:conditional" v="60 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="50|30"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="hgv:lanes" v="no|yes"/>
-        <tag k="incline" v="10%"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
-        <tag k="bus:lanes" v="no|yes"/>
-        <tag k="lit" v="yes"/>
-        <tag k="highway" v="motorway_link"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source:datetime" v="2015-12-15T02:07:00.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="maxweight" v="20"/>
         <tag k="destination:ref" v="L-07"/>
-        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
-        <tag k="overtaking" v="no"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="destination:symbol" v="motorway"/>
+        <tag k="lit" v="yes"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-89"/>
+        <tag k="name" v="Distribuidor: San Agustín del Norte"/>
+        <tag k="source:datetime" v="2015-12-15T02:07:00.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="incline" v="10%"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="maxspeed:lanes" v="50|30"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="maxweight" v="20"/>
     </way>
     <way visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-80"/>
@@ -1507,24 +1203,22 @@
         <nd ref="-239"/>
         <nd ref="-238"/>
         <nd ref="-237"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="destination" v="Plaza Venezuela"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="60"/>
-        <tag k="uuid" v="{d6f907cb-cc8a-41be-87c4-2fb2d0482594}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-10-17T04:22:36.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary_link"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="60"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-31"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
+        <tag k="highway" v="tertiary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{d6f907cb-cc8a-41be-87c4-2fb2d0482594}"/>
+        <tag k="destination" v="Plaza Venezuela"/>
+        <tag k="source:datetime" v="2014-10-17T04:22:36.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-63"/>
@@ -1545,25 +1239,23 @@
         <nd ref="-213"/>
         <nd ref="-214"/>
         <nd ref="-215"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="60"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
+        <tag k="highway" v="tertiary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{d2585762-bf3c-4d4e-841e-a614bc878dde}"/>
         <tag k="destination" v="Plaza Venezuela"/>
         <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="60"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{d2585762-bf3c-4d4e-841e-a614bc878dde}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
         <tag k="source:datetime" v="2014-11-30T23:21:49.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary_link"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="lanes" v="2"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-30"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-188"/>
@@ -1578,26 +1270,24 @@
         <nd ref="-197"/>
         <nd ref="-198"/>
         <nd ref="-146"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.712Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="destination" v="Centro"/>
-        <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{0c96907a-31ed-4a7e-a65d-1f539a3fee9b};{de06a6f1-d8f2-4e5d-82bb-df9b89ae10e3}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
+        <tag k="layer" v="-1"/>
         <tag k="destination:symbol" v="centre"/>
-        <tag k="source:datetime" v="2014-10-17T04:22:35.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="lanes" v="2"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="source:datetime" v="2014-10-17T04:22:35.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="uuid" v="{0c96907a-31ed-4a7e-a65d-1f539a3fee9b};{de06a6f1-d8f2-4e5d-82bb-df9b89ae10e3}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.712Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="destination" v="Centro"/>
     </way>
     <way visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-160"/>
@@ -1616,24 +1306,22 @@
         <nd ref="-173"/>
         <nd ref="-174"/>
         <nd ref="-145"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.712Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="uuid" v="{dcb33d08-3dfa-4573-bd67-04e49f5077a7};{9d0eafa4-ccb5-4671-ae40-969b40abd855}"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-10-17T04:22:36.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-28"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.712Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="uuid" v="{dcb33d08-3dfa-4573-bd67-04e49f5077a7};{9d0eafa4-ccb5-4671-ae40-969b40abd855}"/>
+        <tag k="layer" v="-1"/>
+        <tag k="source:datetime" v="2014-10-17T04:22:36.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-82"/>
@@ -1641,89 +1329,81 @@
         <nd ref="-151"/>
         <nd ref="-149"/>
         <nd ref="-63"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="destination:lanes" v="Los Caobos;Plaza Venezuela|Los Caobos;Plaza Venezuela;Bellas Artes;San Bernardino"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="destination" v="Bellas Artes;Colegio de Ingenieros"/>
-        <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{93cc50db-b0c3-4ae9-9dcb-a6a5eb211f78};{a704fbf2-494e-4894-a205-2c5e007a4dbd}"/>
-        <tag k="turn:lanes" v="through|through;slight_right"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2014-11-30T23:21:49.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="layer" v="-1"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-24"/>
+        <tag k="source:datetime" v="2014-11-30T23:21:49.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{93cc50db-b0c3-4ae9-9dcb-a6a5eb211f78};{a704fbf2-494e-4894-a205-2c5e007a4dbd}"/>
+        <tag k="destination:lanes" v="Los Caobos;Plaza Venezuela|Los Caobos;Plaza Venezuela;Bellas Artes;San Bernardino"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="through|through;slight_right"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="destination" v="Bellas Artes;Colegio de Ingenieros"/>
     </way>
     <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-105"/>
         <nd ref="-116"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="service" v="parking_aisle"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{d2ce194a-e59a-44c4-86b8-3e27f9c64f43}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-12-10T14:05:24.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="service"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-23"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="service" v="parking_aisle"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{d2ce194a-e59a-44c4-86b8-3e27f9c64f43}"/>
+        <tag k="source:datetime" v="2013-12-10T14:05:24.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-96"/>
         <nd ref="-102"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.651Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{5e377d6d-519d-4593-b04c-512b7e66f8f0}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Av. Sur 21"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-09-04T15:01:21.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-22"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.651Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 21"/>
+        <tag k="uuid" v="{5e377d6d-519d-4593-b04c-512b7e66f8f0}"/>
+        <tag k="source:datetime" v="2014-09-04T15:01:21.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-12"/>
         <nd ref="-98"/>
         <nd ref="-99"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z;2019-01-17T19:50:05.652Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{8c42bbbc-4fa7-4783-af94-380567b82677};{91e682fc-aab4-4f57-9433-93fc6aba65a7}"/>
-        <tag k="name" v="Av. Sur 19"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-09-08T18:26:40.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-20"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z;2019-01-17T19:50:05.652Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 19"/>
+        <tag k="uuid" v="{8c42bbbc-4fa7-4783-af94-380567b82677};{91e682fc-aab4-4f57-9433-93fc6aba65a7}"/>
+        <tag k="source:datetime" v="2015-09-08T18:26:40.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-1809"/>
@@ -1731,23 +1411,21 @@
         <nd ref="-97"/>
         <nd ref="-98"/>
         <nd ref="-13"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z;2019-01-17T19:50:05.652Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{22a82dc7-8817-40e1-9204-b335c659de38};{a83901bd-313c-47d3-8568-691619ebbd2d}"/>
-        <tag k="name" v="Av. Este 10 bis"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2015-06-10T00:02:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-19"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z;2019-01-17T19:50:05.652Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Este 10 bis"/>
+        <tag k="uuid" v="{22a82dc7-8817-40e1-9204-b335c659de38};{a83901bd-313c-47d3-8568-691619ebbd2d}"/>
+        <tag k="source:datetime" v="2015-06-10T00:02:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-80"/>
@@ -1768,30 +1446,28 @@
         <nd ref="-65"/>
         <nd ref="-64"/>
         <nd ref="-17"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sur 25"/>
-        <tag k="lanes" v="3"/>
-        <tag k="destination:lanes" v="Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio;San Bernardino"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="left"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.657Z"/>
-        <tag k="lit" v="yes"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="turn:lanes" v="through|through|through;slight_right"/>
-        <tag k="source:datetime" v="2014-12-07T00:24:04.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{977359ab-12a8-4a75-a522-803dd1962a81}"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="name" v="Av. Sur 25"/>
+        <tag k="source:datetime" v="2014-12-07T00:24:04.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{977359ab-12a8-4a75-a522-803dd1962a81}"/>
+        <tag k="destination:lanes" v="Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio;San Bernardino"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="through|through|through;slight_right"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.657Z"/>
+        <tag k="sidewalk" v="left"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
         <nd ref="-63"/>
@@ -1841,121 +1517,111 @@
         <nd ref="-19"/>
         <nd ref="-18"/>
         <nd ref="-17"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.657Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="destination" v="Bellas Artes;Colegio de Ingenieros"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="30"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{4cffc09e-5c44-4c33-927e-f92110b30575}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-11-30T23:21:49.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary_link"/>
-        <tag k="lanes" v="2"/>
-        <tag k="surface" v="asphalt"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="30"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.657Z"/>
+        <tag k="highway" v="secondary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{4cffc09e-5c44-4c33-927e-f92110b30575}"/>
+        <tag k="destination" v="Bellas Artes;Colegio de Ingenieros"/>
+        <tag k="source:datetime" v="2014-11-30T23:21:49.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-17"/>
         <nd ref="-82"/>
         <nd ref="-81"/>
         <nd ref="-16"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Sur 25"/>
-        <tag k="lanes" v="3"/>
-        <tag k="destination:lanes" v="Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio;San Bernardino"/>
-        <tag k="cycleway" v="no"/>
         <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="left"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.657Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
         <tag k="lit" v="yes"/>
-        <tag k="turn:lanes" v="through|through|through;slight_right"/>
-        <tag k="source:datetime" v="2014-12-07T00:24:04.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="uuid" v="{3eb4e182-ecd1-4d24-b49e-9ec888a0de8b}"/>
-        <tag k="osm_id" v="-999999"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-16"/>
+        <tag k="name" v="Av. Sur 25"/>
+        <tag k="source:datetime" v="2014-12-07T00:24:04.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{3eb4e182-ecd1-4d24-b49e-9ec888a0de8b}"/>
+        <tag k="destination:lanes" v="Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio|Bellas Artes;La Hoyada;Centro;Capitolio;San Bernardino"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="through|through|through;slight_right"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.657Z"/>
+        <tag k="sidewalk" v="left"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-83"/>
         <nd ref="-15"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.656Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{ece7cc35-e067-46b2-a785-9818027199f4}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Av. Sur 21"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2013-08-02T20:39:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-15"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.656Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 21"/>
+        <tag k="uuid" v="{ece7cc35-e067-46b2-a785-9818027199f4}"/>
+        <tag k="source:datetime" v="2013-08-02T20:39:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85"/>
         <nd ref="-84"/>
         <nd ref="-14"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.656Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{86e7e9c0-56f8-44fc-8f61-27745e3e939e}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="name" v="Av. Sur 21"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-08-18T16:11:08.000Z;2014-09-04T15:01:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.656Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 21"/>
+        <tag k="uuid" v="{86e7e9c0-56f8-44fc-8f61-27745e3e939e}"/>
+        <tag k="source:datetime" v="2015-08-18T16:11:08.000Z;2014-09-04T15:01:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-11"/>
         <nd ref="-104"/>
         <nd ref="-99"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.649Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="service" v="parking_aisle"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="20"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{19693054-3f36-4ca3-915e-a0284c23e3a4}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-09-04T15:01:21.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="service"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="20"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.649Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="service" v="parking_aisle"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{19693054-3f36-4ca3-915e-a0284c23e3a4}"/>
+        <tag k="source:datetime" v="2014-09-04T15:01:21.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10"/>
@@ -1963,29 +1629,27 @@
         <nd ref="-114"/>
         <nd ref="-113"/>
         <nd ref="-112"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Av. Leonardo Ruíz Pineda"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2013-11-11T16:52:07.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="yes"/>
-        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-10"/>
+        <tag k="name" v="Av. Leonardo Ruíz Pineda"/>
+        <tag k="source:datetime" v="2013-11-11T16:52:07.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105"/>
@@ -2002,22 +1666,20 @@
         <nd ref="-118"/>
         <nd ref="-117"/>
         <nd ref="-9"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="no"/>
-        <tag k="service" v="parking_aisle"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{d2ce194a-e59a-44c4-86b8-3e27f9c64f43};{fda12f7a-21e1-44f2-b0af-e26a3c8af46b}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="source:datetime" v="2013-12-10T14:05:24.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="service"/>
+        <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-9"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="service" v="parking_aisle"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{d2ce194a-e59a-44c4-86b8-3e27f9c64f43};{fda12f7a-21e1-44f2-b0af-e26a3c8af46b}"/>
+        <tag k="source:datetime" v="2013-12-10T14:05:24.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112"/>
@@ -2038,89 +1700,81 @@
         <nd ref="-130"/>
         <nd ref="-129"/>
         <nd ref="-8"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{8f68fc57-cb08-49d9-a928-e0fae7bb1985}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2009-01-17T18:10:43.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{8f68fc57-cb08-49d9-a928-e0fae7bb1985}"/>
+        <tag k="source:datetime" v="2009-01-17T18:10:43.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-145"/>
         <nd ref="-7"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
         <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="uuid" v="{dcb33d08-3dfa-4573-bd67-04e49f5077a7}"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-10-17T04:22:36.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="lanes" v="3"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="uuid" v="{dcb33d08-3dfa-4573-bd67-04e49f5077a7}"/>
+        <tag k="layer" v="-1"/>
+        <tag k="source:datetime" v="2014-10-17T04:22:36.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-146"/>
         <nd ref="-6"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="60"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{0c96907a-31ed-4a7e-a65d-1f539a3fee9b}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2014-10-17T04:22:35.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="60"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{0c96907a-31ed-4a7e-a65d-1f539a3fee9b}"/>
+        <tag k="layer" v="-1"/>
+        <tag k="source:datetime" v="2014-10-17T04:22:35.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
         <nd ref="-148"/>
         <nd ref="-147"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-        <tag k="layer" v="-1"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="uuid" v="{0b879342-4f8f-4441-bac0-749e8971415a}"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="layer" v="-1"/>
         <tag k="destination:symbol" v="motorway"/>
-        <tag k="source:datetime" v="2014-09-05T04:44:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="lanes" v="3"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-09-05T04:44:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{0b879342-4f8f-4441-bac0-749e8971415a}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-187"/>
@@ -2137,20 +1791,18 @@
         <nd ref="-176"/>
         <nd ref="-175"/>
         <nd ref="-4"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="uuid" v="{fad92ca0-648c-4a9b-9778-89b75bacec9d}"/>
         <tag k="source" v="osm:line"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{fad92ca0-648c-4a9b-9778-89b75bacec9d}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-216"/>
@@ -2175,23 +1827,21 @@
         <nd ref="-235"/>
         <nd ref="-236"/>
         <nd ref="-3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="maxspeed" v="50"/>
         <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="uuid" v="{f9c8d427-58df-45b3-a630-2b3589f66293}"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-06-24T22:17:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="50"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{f9c8d427-58df-45b3-a630-2b3589f66293}"/>
+        <tag k="source:datetime" v="2015-06-24T22:17:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
@@ -2209,41 +1859,39 @@
         <nd ref="-250"/>
         <nd ref="-249"/>
         <nd ref="-248"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="ref" v="L-07"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Autopista: Francisco Fajardo"/>
-        <tag k="lanes" v="4"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="90|70|40|40"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="maxspeed" v="90"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="hgv:lanes" v="no|no|no|yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
-        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway"/>
         <tag k="lit" v="yes"/>
-        <tag k="source:datetime" v="2015-12-15T02:06:53.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="maxweight" v="20"/>
-        <tag k="uuid" v="{7cc0b66d-1dd7-450e-a845-fbd96f0a9f49}"/>
-        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
-        <tag k="overtaking" v="yes"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
+        <tag k="name" v="Autopista: Francisco Fajardo"/>
+        <tag k="ref" v="L-07"/>
+        <tag k="source:datetime" v="2015-12-15T02:06:53.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="90"/>
+        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="uuid" v="{7cc0b66d-1dd7-450e-a845-fbd96f0a9f49}"/>
+        <tag k="maxspeed:lanes" v="90|70|40|40"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|no|no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="maxweight" v="20"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1"/>
@@ -2255,42 +1903,40 @@
         <nd ref="-272"/>
         <nd ref="-86"/>
         <nd ref="-1804"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="minspeed" v="40"/>
-        <tag k="toll" v="no"/>
-        <tag k="ref" v="L-07"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="name" v="Autopista: Francisco Fajardo"/>
-        <tag k="lanes" v="4"/>
-        <tag k="destination:lanes" v="San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao;Parque Central"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="surface" v="asphalt"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
-        <tag k="maxspeed:lanes" v="90|70|40|40"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="maxspeed" v="90"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="hgv:lanes" v="no|no|no|yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.711Z"/>
-        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="highway" v="motorway"/>
         <tag k="lit" v="yes"/>
-        <tag k="turn:lanes" v="through|through|through|through;slight_right"/>
-        <tag k="source:datetime" v="2015-12-15T02:06:59.000Z;2015-12-15T02:06:58.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="foot" v="no"/>
-        <tag k="maxweight" v="20"/>
-        <tag k="uuid" v="{f86f74fc-c5c9-46a2-bcd5-4076e546644c}"/>
-        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
-        <tag k="overtaking" v="yes"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="osm_id" v="-999999"/>
+        <tag k="toll" v="no"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="name" v="Autopista: Francisco Fajardo"/>
+        <tag k="ref" v="L-07"/>
+        <tag k="source:datetime" v="2015-12-15T02:06:59.000Z;2015-12-15T02:06:58.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="wikipedia" v="es:Autopista Francisco Fajardo"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="90"/>
+        <tag k="bus:lanes" v="no|no|no|yes"/>
+        <tag k="uuid" v="{f86f74fc-c5c9-46a2-bcd5-4076e546644c}"/>
+        <tag k="destination:lanes" v="San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao|San Agustín;Centro;La Paz;Antímano;Caricuao;Parque Central"/>
+        <tag k="maxspeed:lanes" v="90|70|40|40"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="turn:lanes" v="through|through|through|through;slight_right"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.711Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|no|no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="maxweight" v="20"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-1/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-1/Expected.osm
@@ -2,35 +2,35 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="30.47277798838" minlon="31.526667" maxlat="30.48055598838" maxlon="31.5325"/>
     <node visible="true" id="-118178" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.4805559883799972" lon="31.5266669999999998">
+        <tag k="int_name" v="‘Izbat as Sab‘īn, Izbat al Sabin"/>
+        <tag k="name:de" v="Izbat al Sabin"/>
+        <tag k="name" v="عزبة السبعين"/>
+        <tag k="name:ar" v="عزبة السبعين"/>
+        <tag k="name:en" v="Izbat al Sabin"/>
+        <tag k="uuid" v="GeoNames.org:415707"/>
+        <tag k="name:fr" v="Izbat al Sabin"/>
+        <tag k="alt_name" v="`Izbat as Sab`in;‘Izbat as Sab‘īn"/>
         <tag k="REF1" v="000dd8"/>
         <tag k="REF2" v="000dd8"/>
-        <tag k="place" v="village"/>
-        <tag k="name:ar" v="عزبة السبعين"/>
         <tag k="is_in" v="Egypt, جمهورية مصر العربية"/>
-        <tag k="name:fr" v="Izbat al Sabin"/>
         <tag k="name:ar1" v="عزبة السبعين"/>
-        <tag k="name:de" v="Izbat al Sabin"/>
-        <tag k="int_name" v="‘Izbat as Sab‘īn, Izbat al Sabin"/>
-        <tag k="alt_name" v="`Izbat as Sab`in;‘Izbat as Sab‘īn"/>
-        <tag k="uuid" v="GeoNames.org:415707"/>
-        <tag k="name" v="عزبة السبعين"/>
-        <tag k="name:en" v="Izbat al Sabin"/>
+        <tag k="place" v="village"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-118176" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.4727779883799954" lon="31.5324999999999953">
+        <tag k="int_name" v="‘Izbat Ḩawḑ an Nadá, Izbat Hawd an Nada"/>
+        <tag k="name:de" v="Izbat Hawd an Nada"/>
+        <tag k="name" v="عزبة حوض الندى"/>
+        <tag k="name:ar" v="عزبة حوض الندى"/>
+        <tag k="name:en" v="Izbat Hawd an Nada"/>
+        <tag k="uuid" v="GeoNames.org:415705"/>
+        <tag k="name:fr" v="Izbat Hawd an Nada"/>
+        <tag k="alt_name" v="`Izbat Hawd an Nada;‘Izbat Ḩawḑ an Nadá"/>
         <tag k="REF1" v="000de8"/>
         <tag k="REF2" v="000de8"/>
-        <tag k="place" v="village"/>
-        <tag k="name:ar" v="عزبة حوض الندى"/>
         <tag k="is_in" v="Egypt, جمهورية مصر العربية"/>
-        <tag k="name:fr" v="Izbat Hawd an Nada"/>
         <tag k="name:ar1" v="عزبة حوض الندى"/>
-        <tag k="name:de" v="Izbat Hawd an Nada"/>
-        <tag k="int_name" v="‘Izbat Ḩawḑ an Nadá, Izbat Hawd an Nada"/>
-        <tag k="alt_name" v="`Izbat Hawd an Nada;‘Izbat Ḩawḑ an Nadá"/>
-        <tag k="uuid" v="GeoNames.org:415705"/>
-        <tag k="name" v="عزبة حوض الندى"/>
-        <tag k="name:en" v="Izbat Hawd an Nada"/>
+        <tag k="place" v="village"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-10/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-10/Expected.osm
@@ -2,19 +2,19 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.0529244" minlon="11.6691004" maxlat="48.0529244" maxlon="11.6691004"/>
     <node visible="true" id="-140945" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0529244000000020" lon="11.6691003999999996">
+        <tag k="source" v="navteq"/>
+        <tag k="historic" v="memorial"/>
+        <tag k="wheelchair" v="yes"/>
+        <tag k="addr:street" v="ROSENHEIMER LANDSTRASSE"/>
+        <tag k="name" v="Ottosäule"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="uuid" v="{52819123}"/>
+        <tag k="alt_name" v="OTTOSÄULE"/>
+        <tag k="language" v="GER"/>
+        <tag k="addr:housenumber" v="128"/>
         <tag k="REF1" v="01628c"/>
         <tag k="REF2" v="01628c"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="historic" v="memorial"/>
-        <tag k="addr:street" v="ROSENHEIMER LANDSTRASSE"/>
-        <tag k="wheelchair" v="yes"/>
         <tag k="access" v="yes"/>
-        <tag k="alt_name" v="OTTOSÄULE"/>
-        <tag k="addr:housenumber" v="128"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{52819123}"/>
-        <tag k="name" v="Ottosäule"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-11/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-11/Expected.osm
@@ -2,26 +2,26 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.09572379999999" minlon="11.4977454" maxlat="48.09572379999999" maxlon="11.4977454"/>
     <node visible="true" id="-140961" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0957237999999876" lon="11.4977453999999994">
-        <tag k="leisure" v="sports_centre"/>
-        <tag k="addr:city" v="München"/>
-        <tag k="source" v="navteq"/>
-        <tag k="sport" v="10pin"/>
-        <tag k="building" v="public"/>
-        <tag k="language" v="GER"/>
-        <tag k="addr:housenumber" v="74"/>
-        <tag k="name" v="Hollywood Super Bowling"/>
-        <tag k="alt_name" v="HOLLYWOOD SUPER BOWLING"/>
-        <tag k="layer" v="1"/>
-        <tag k="website" v="http://hsb-muc.bowlingag.com"/>
         <tag k="addr:country" v="DE"/>
-        <tag k="REF1" v="0134fd"/>
-        <tag k="phone" v="+4989753921"/>
-        <tag k="REF2" v="0134fd"/>
         <tag k="addr:street" v="Forstenrieder Allee;FORSTENRIEDER ALLEE"/>
+        <tag k="alt_name" v="HOLLYWOOD SUPER BOWLING"/>
+        <tag k="website" v="http://hsb-muc.bowlingag.com"/>
+        <tag k="layer" v="1"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="addr:housenumber" v="74"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="Hollywood Super Bowling"/>
+        <tag k="REF1" v="0134fd"/>
+        <tag k="REF2" v="0134fd"/>
+        <tag k="uuid" v="{52916756}"/>
+        <tag k="addr:city" v="München"/>
+        <tag k="language" v="GER"/>
+        <tag k="building" v="public"/>
         <tag k="addr:postcode" v="81476"/>
         <tag k="access" v="yes"/>
-        <tag k="uuid" v="{52916756}"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="error:circular" v="15"/>
+        <tag k="phone" v="+4989753921"/>
+        <tag k="source" v="navteq"/>
+        <tag k="sport" v="10pin"/>
+        <tag k="leisure" v="sports_centre"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-12/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-12/Expected.osm
@@ -2,18 +2,18 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.1603975" minlon="11.513151" maxlat="48.1603975" maxlon="11.513151"/>
     <node visible="true" id="-140983" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1603975000000020" lon="11.5131510000000006">
-        <tag k="REF1" v="00deca"/>
-        <tag k="addr:language" v="GER"/>
+        <tag k="source" v="navteq"/>
         <tag k="addr:street" v="Stievestraße;STIEVESTRASSE"/>
-        <tag k="access" v="yes"/>
+        <tag k="name" v="Park Club Nymphenburg"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="alt_name" v="PARK CLUB NYMPENBURG"/>
+        <tag k="language" v="GER"/>
+        <tag k="sport" v="squash;batminton"/>
         <tag k="leisure" v="sports_centre"/>
         <tag k="phone" v="89-1782055"/>
-        <tag k="alt_name" v="PARK CLUB NYMPENBURG"/>
         <tag k="addr:housenumber" v="15"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="name" v="Park Club Nymphenburg"/>
-        <tag k="sport" v="squash;batminton"/>
+        <tag k="REF1" v="00deca"/>
+        <tag k="access" v="yes"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-13/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-13/Expected.osm
@@ -2,38 +2,38 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.1766691" minlon="11.5285062" maxlat="48.17668349999999" maxlon="11.5285066"/>
     <node visible="true" id="-208780" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1766690999999980" lon="11.5285062000000007">
+        <tag k="source" v="navteq"/>
+        <tag k="wheelchair" v="no"/>
+        <tag k="addr:street" v="GEORG-BRAUCHLE-RING"/>
+        <tag k="name" v="Georg-Brauchle-Ring"/>
+        <tag k="addr:language" v="GER"/>
         <tag k="station" v="light_rail"/>
+        <tag k="railway" v="subway_entrance"/>
+        <tag k="uuid" v="{31c4a84b-5604-55da-8266-07af71bb3740};{5c7b69a5-dc0f-5bc2-80fb-c2503e83d9b7}"/>
+        <tag k="alt_name" v="U-BAHN-GEORG-BRAUCHLE-RING"/>
+        <tag k="language" v="GER"/>
         <tag k="REF1" v="01163b"/>
         <tag k="REF2" v="0045a8;01163b"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="addr:street" v="GEORG-BRAUCHLE-RING"/>
-        <tag k="wheelchair" v="no"/>
         <tag k="access" v="yes"/>
-        <tag k="alt_name" v="U-BAHN-GEORG-BRAUCHLE-RING"/>
-        <tag k="uuid" v="{31c4a84b-5604-55da-8266-07af71bb3740};{5c7b69a5-dc0f-5bc2-80fb-c2503e83d9b7}"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="name" v="Georg-Brauchle-Ring"/>
-        <tag k="railway" v="subway_entrance"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-208779" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1766834999999887" lon="11.5285066000000000">
-        <tag k="REF1" v="0045a8"/>
         <tag k="wheelchair" v="no"/>
-        <tag k="description" v="Georg-Brauchle-Ring"/>
-        <tag k="uuid" v="{40822740-275a-5758-bb90-4e25b9d30d49}"/>
         <tag k="railway" v="subway_entrance"/>
+        <tag k="uuid" v="{40822740-275a-5758-bb90-4e25b9d30d49}"/>
+        <tag k="description" v="Georg-Brauchle-Ring"/>
+        <tag k="REF1" v="0045a8"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-208779" role="reviewee"/>
         <member type="node" ref="-208780" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (44m) - very close together, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (44m) - very close together, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-14/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-14/Expected.osm
@@ -2,43 +2,43 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="30.12132148822" minlon="31.3138683" maxlat="30.12159799975" maxlon="31.31399900035"/>
     <node visible="true" id="-430185" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.1215979997499979" lon="31.3139990003500017">
-        <tag k="REF2" v="0020a1"/>
-        <tag k="source:abs_vert_accuracy" v="-32765"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="transport" v="station"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="condition" v="functional"/>
-        <tag k="source:horiz_accuracy_cat" v="accurate"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
         <tag k="source:review_source_type" v="NA"/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="source" v="mgcp"/>
-        <tag k="uuid" v="mgcp:18687c00-c473-11e2-83e9-002481c154f7"/>
+        <tag k="transport" v="station"/>
+        <tag k="source:abs_vert_accuracy" v="-32765"/>
         <tag k="source:description" v="IKONOS - 1m resolution"/>
-        <tag k="source:date_time" v="2007-04-29"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
         <tag k="error:circular" v="28.65"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="0020a1"/>
+        <tag k="uuid" v="mgcp:18687c00-c473-11e2-83e9-002481c154f7"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
+        <tag k="source:horiz_accuracy_cat" v="accurate"/>
+        <tag k="source:date_time" v="2007-04-29"/>
+        <tag k="source" v="mgcp"/>
     </node>
     <node visible="true" id="-430184" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.1213214882200013" lon="31.3138682999999993">
-        <tag k="REF1" v="0020a1"/>
-        <tag k="name:ar" v="المطرية"/>
         <tag k="int_name" v="El-Matareyya"/>
         <tag k="name" v="المطرية"/>
+        <tag k="name:ar" v="المطرية"/>
         <tag k="railway" v="station"/>
         <tag k="name:en" v="El-Matareyya"/>
+        <tag k="REF1" v="0020a1"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-430184" role="reviewee"/>
         <member type="node" ref="-430185" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (33m) - very close together, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (33m) - very close together, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-15/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-15/Expected.osm
@@ -2,72 +2,72 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="31.5656075" minlon="35.75" maxlat="31.566667" maxlon="35.7704385"/>
     <node visible="true" id="-951427" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.5656074999999987" lon="35.7517369999999985">
-        <tag k="source" v="mgcp"/>
-        <tag k="source:text" v="Hill"/>
-        <tag k="source:horiz_accuracy_cat" v="accurate"/>
-        <tag k="source:date_time" v="2010-11-01T00:00:00Z"/>
-        <tag k="name" v="Al ‘Āşī"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="source:copyright" v="Copyright 2012 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
         <tag k="source:review_source_type" v="NA"/>
-        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
-        <tag k="REF2" v="0006de"/>
-        <tag k="place" v="locality"/>
-        <tag k="name:id" v="-1440057"/>
-        <tag k="name:feature_id" v="-970038"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="uuid" v="mgcp:0786A6D0-CD75-48A3-A93C-6D206389DFD5"/>
         <tag k="source:abs_vert_accuracy" v="-32765"/>
+        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
         <tag k="error:circular" v="28.65"/>
+        <tag k="name" v="Al ‘Āşī"/>
+        <tag k="name:id" v="-1440057"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="0006de"/>
+        <tag k="uuid" v="mgcp:0786A6D0-CD75-48A3-A93C-6D206389DFD5"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="source:copyright" v="Copyright 2012 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
+        <tag k="place" v="locality"/>
+        <tag k="source:text" v="Hill"/>
+        <tag k="name:feature_id" v="-970038"/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="source:horiz_accuracy_cat" v="accurate"/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
+        <tag k="source:date_time" v="2010-11-01T00:00:00Z"/>
+        <tag k="source" v="mgcp"/>
     </node>
     <node visible="true" id="-951426" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.5661085000000021" lon="35.7704384999999974">
-        <tag k="source" v="mgcp"/>
-        <tag k="source:text" v="Hill"/>
-        <tag k="source:horiz_accuracy_cat" v="accurate"/>
-        <tag k="source:date_time" v="2010-11-01T00:00:00Z"/>
-        <tag k="name" v="Umm al ‘Iz̧ām"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="source:copyright" v="Copyright 2012 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
         <tag k="source:review_source_type" v="NA"/>
-        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
-        <tag k="REF2" v="00097b"/>
-        <tag k="place" v="locality"/>
-        <tag k="name:id" v="-1450810"/>
-        <tag k="name:feature_id" v="-974490"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="uuid" v="mgcp:0942E189-8A20-488F-AAAA-373EFFA9176F"/>
         <tag k="source:abs_vert_accuracy" v="-32765"/>
+        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
         <tag k="error:circular" v="28.65"/>
+        <tag k="name" v="Umm al ‘Iz̧ām"/>
+        <tag k="name:id" v="-1450810"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="00097b"/>
+        <tag k="uuid" v="mgcp:0942E189-8A20-488F-AAAA-373EFFA9176F"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="source:copyright" v="Copyright 2012 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
+        <tag k="place" v="locality"/>
+        <tag k="source:text" v="Hill"/>
+        <tag k="name:feature_id" v="-974490"/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="source:horiz_accuracy_cat" v="accurate"/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
+        <tag k="source:date_time" v="2010-11-01T00:00:00Z"/>
+        <tag k="source" v="mgcp"/>
     </node>
     <node visible="true" id="-951425" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.5666670000000025" lon="35.7500000000000000">
-        <tag k="REF1" v="0006de"/>
+        <tag k="int_name" v="El ‘Asi; Al Asi"/>
+        <tag k="name:de" v="Al Asi"/>
+        <tag k="name" v="العاصي"/>
         <tag k="name:ar" v="العاصي"/>
-        <tag k="is_in" v="Jordan, الأردن"/>
+        <tag k="name:en" v="Al Asi"/>
         <tag k="name:fr" v="Al Asi"/>
         <tag k="natural" v="peak"/>
-        <tag k="name:de" v="Al Asi"/>
-        <tag k="int_name" v="El ‘Asi; Al Asi"/>
-        <tag k="name" v="العاصي"/>
-        <tag k="name:en" v="Al Asi"/>
+        <tag k="REF1" v="0006de"/>
+        <tag k="is_in" v="Jordan, الأردن"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-951425" role="reviewee"/>
         <member type="node" ref="-951427" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (200m) - similar names and generic type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (200m) - similar names and generic type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-16/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-16/Expected.osm
@@ -2,44 +2,44 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="30.16352458824" minlon="31.46648899977" maxlat="30.16354000036999" maxlon="31.4665112"/>
     <node visible="true" id="-2231903" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.1635400003699949" lon="31.4664889997700001">
-        <tag k="controlling_authority" v="unknown"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="building" v="guardhouse"/>
-        <tag k="source:horiz_accuracy_cat" v="accurate"/>
-        <tag k="source:date_time" v="2007-04-29"/>
-        <tag k="material" v="unknown"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
-        <tag k="source:description" v="IKONOS - 1m resolution"/>
         <tag k="source:review_source_type" v="NA"/>
-        <tag k="width" v="11"/>
-        <tag k="REF2" v="001285"/>
-        <tag k="length" v="25"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="uuid" v="mgcp:2956feb1-c46e-11e2-8540-002481c154f7"/>
+        <tag k="controlling_authority" v="unknown"/>
         <tag k="source:abs_vert_accuracy" v="-32765"/>
-        <tag k="angle" v="164"/>
+        <tag k="source:description" v="IKONOS - 1m resolution"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
         <tag k="error:circular" v="28.65"/>
+        <tag k="length" v="25"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="001285"/>
+        <tag k="uuid" v="mgcp:2956feb1-c46e-11e2-8540-002481c154f7"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="width" v="11"/>
+        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
+        <tag k="building" v="guardhouse"/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="material" v="unknown"/>
+        <tag k="source:horiz_accuracy_cat" v="accurate"/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
+        <tag k="source:date_time" v="2007-04-29"/>
+        <tag k="angle" v="164"/>
+        <tag k="source" v="mgcp"/>
     </node>
     <node visible="true" id="-2231902" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.1635245882400014" lon="31.4665111999999993">
-        <tag k="REF1" v="001285"/>
         <tag k="barrier" v="toll_booth"/>
+        <tag k="REF1" v="001285"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2231902" role="reviewee"/>
         <member type="node" ref="-2231903" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (2.7m) - very close together, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (2.7m) - very close together, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-17/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-17/Expected.osm
@@ -2,18 +2,18 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.85805124128" minlon="-104.78692875516" maxlat="38.87519552958001" maxlon="-104.71793999702"/>
     <node visible="true" id="-2232983" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8751955295800116" lon="-104.7179399970199967">
+        <tag k="amenity" v="cafe"/>
+        <tag k="name" v="Starbucks"/>
+        <tag k="uuid" v="{87f8a061-d9f1-5bc9-ac28-27f07c8febae}"/>
         <tag k="note" v="1-d"/>
         <tag k="poi" v="yes"/>
-        <tag k="uuid" v="{87f8a061-d9f1-5bc9-ac28-27f07c8febae}"/>
-        <tag k="name" v="Starbucks"/>
-        <tag k="amenity" v="cafe"/>
         <tag k="error:circular" v="1000"/>
     </node>
     <node visible="true" id="-2232982" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8580512412800019" lon="-104.7869287551600053">
-        <tag k="place" v="city"/>
-        <tag k="poi" v="yes"/>
-        <tag k="uuid" v="{f6224e55-cfa6-5364-bb78-e482e2d6e1c5};{b18057ff-736d-5d20-b873-837f0c172e33}"/>
         <tag k="name" v="Colorado Springs"/>
+        <tag k="uuid" v="{f6224e55-cfa6-5364-bb78-e482e2d6e1c5};{b18057ff-736d-5d20-b873-837f0c172e33}"/>
+        <tag k="poi" v="yes"/>
+        <tag k="place" v="city"/>
         <tag k="error:circular" v="20000"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-18/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-18/Expected.osm
@@ -2,35 +2,35 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="31.658611" minlon="35.62" maxlat="31.658611" maxlon="35.62"/>
     <node visible="true" id="-183178" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.6586109999999969" lon="35.6199999999999974">
+        <tag k="alt_name" v="‘Abd al Khāliq, Tall"/>
+        <tag k="source:review_source_type" v="NA"/>
+        <tag k="source:abs_vert_accuracy" v="-32765"/>
+        <tag k="name:ar" v="تل عبد الخالق"/>
+        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="natural" v="peak"/>
+        <tag k="name:de" v="Tall Abd al Khaliq"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
+        <tag k="name:fr" v="Tall Abd al Khaliq"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="تل عبد الخالق"/>
+        <tag k="name:en" v="Tall Abd al Khaliq"/>
+        <tag k="name:id" v="-1439206"/>
+        <tag k="int_name" v="Tall ‘Abd al Khāliq; Tall Abd al Khaliq"/>
+        <tag k="REF1" v="000243"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="000243"/>
+        <tag k="uuid" v="mgcp:2332161C-75B7-4A45-9DC6-303D87147E43"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="source:copyright" v="Copyright 2012 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
+        <tag k="place" v="locality"/>
+        <tag k="source:text" v="Hill"/>
+        <tag k="name:feature_id" v="-969685"/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="source:horiz_accuracy_cat" v="accurate"/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
+        <tag k="source:date_time" v="2010-11-01T00:00:00Z"/>
         <tag k="is_in" v="Jordan, الأردن"/>
         <tag k="source" v="mgcp"/>
-        <tag k="source:text" v="Hill"/>
-        <tag k="name:de" v="Tall Abd al Khaliq"/>
-        <tag k="int_name" v="Tall ‘Abd al Khāliq; Tall Abd al Khaliq"/>
-        <tag k="source:horiz_accuracy_cat" v="accurate"/>
-        <tag k="source:date_time" v="2010-11-01T00:00:00Z"/>
-        <tag k="name" v="تل عبد الخالق"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="alt_name" v="‘Abd al Khāliq, Tall"/>
-        <tag k="source:copyright" v="Copyright 2012 by the National Geospatial-Intelligence Agency, U.S. Government. No domestic copyright claimed under Title 17 U.S.C. All rights reserved."/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
-        <tag k="source:review_source_type" v="NA"/>
-        <tag k="source:description" v="Very High Resolution Commercial Monoscopic Imagery"/>
-        <tag k="name:fr" v="Tall Abd al Khaliq"/>
-        <tag k="REF1" v="000243"/>
-        <tag k="REF2" v="000243"/>
-        <tag k="name:id" v="-1439206"/>
-        <tag k="name:feature_id" v="-969685"/>
-        <tag k="name:en" v="Tall Abd al Khaliq"/>
-        <tag k="place" v="locality"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="uuid" v="mgcp:2332161C-75B7-4A45-9DC6-303D87147E43"/>
-        <tag k="source:abs_vert_accuracy" v="-32765"/>
-        <tag k="natural" v="peak"/>
-        <tag k="name:ar" v="تل عبد الخالق"/>
-        <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-19/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-19/Expected.osm
@@ -3,23 +3,23 @@
     <bounds minlat="31.1525" minlon="29.8502609592" maxlat="31.15275958431" maxlon="29.850278"/>
     <node visible="true" id="-7180" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.1527595843100009" lon="29.8502609591999999">
         <tag k="source" v="geonames"/>
-        <tag k="uuid" v="{33d3977e-0451-5e0f-a8ad-687038806b1c};GeoNames.org:7931938"/>
-        <tag k="name" v="Al Maks"/>
         <tag k="amenity" v="pub"/>
+        <tag k="name" v="Al Maks"/>
+        <tag k="uuid" v="{33d3977e-0451-5e0f-a8ad-687038806b1c};GeoNames.org:7931938"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-7179" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.1524999999999963" lon="29.8502779999999994">
-        <tag k="place" v="village"/>
-        <tag k="name:ar" v="المكس"/>
-        <tag k="is_in" v="Egypt, جمهورية مصر العربية"/>
-        <tag k="name:fr" v="Al Maks"/>
-        <tag k="name:ar1" v="المكس"/>
-        <tag k="name:de" v="Al Maks"/>
         <tag k="int_name" v="El Maks, Al Maks"/>
         <tag k="is_in:country_code" v="EG"/>
         <tag k="source" v="geonames"/>
+        <tag k="name:de" v="Al Maks"/>
         <tag k="name" v="المكس"/>
+        <tag k="name:ar" v="المكس"/>
         <tag k="name:en" v="Al Maks"/>
+        <tag k="name:fr" v="Al Maks"/>
+        <tag k="is_in" v="Egypt, جمهورية مصر العربية"/>
+        <tag k="name:ar1" v="المكس"/>
+        <tag k="place" v="village"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-2/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-2/Expected.osm
@@ -2,41 +2,41 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.0479399" minlon="11.7012814" maxlat="48.04854" maxlon="11.70194"/>
     <node visible="true" id="-3200080" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0485399999999956" lon="11.7019400000000005">
-        <tag k="REF2" v="010227"/>
-        <tag k="addr:language" v="GER"/>
+        <tag k="source" v="navteq"/>
+        <tag k="amenity" v="post_office"/>
         <tag k="addr:street" v="JÄGER-VON-FALL-STRASSE"/>
-        <tag k="access" v="yes"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="name" v="POST, JÄGER-VON-FALL-STRASSE"/>
+        <tag k="uuid" v="{eff02ebc-5aa8-56c7-9601-9f9f2e5f1320}"/>
+        <tag k="language" v="GER"/>
         <tag k="hoot:mismatch" v="2"/>
         <tag k="phone" v="1802-3333"/>
         <tag k="addr:housenumber" v="5"/>
+        <tag k="REF2" v="010227"/>
+        <tag k="access" v="yes"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{eff02ebc-5aa8-56c7-9601-9f9f2e5f1320}"/>
-        <tag k="name" v="POST, JÄGER-VON-FALL-STRASSE"/>
-        <tag k="amenity" v="post_office"/>
         <tag k="error:circular" v="150"/>
     </node>
     <node visible="true" id="-3200079" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0479399000000029" lon="11.7012813999999992">
-        <tag k="REF1" v="010227"/>
+        <tag k="source" v="survey"/>
+        <tag k="amenity" v="post_office"/>
         <tag k="wheelchair" v="no"/>
+        <tag k="uuid" v="{801c0abc-9e5d-585e-87c4-21a99d3d3e40}"/>
         <tag k="hoot:mismatch" v="1"/>
         <tag k="operator" v="Deutsche Post"/>
+        <tag k="REF1" v="010227"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="source" v="survey"/>
-        <tag k="uuid" v="{801c0abc-9e5d-585e-87c4-21a99d3d3e40}"/>
-        <tag k="amenity" v="post_office"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3200079" role="reviewee"/>
         <member type="node" ref="-3200080" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (83m) - similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (83m) - similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-20/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-20/Expected.osm
@@ -2,40 +2,40 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="31.7833" minlon="35.833333" maxlat="31.78333299999999" maxlon="35.83667"/>
     <node visible="true" id="-292923" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.7832999999999970" lon="35.8366699999999980">
-        <tag k="REF2" v="000263"/>
-        <tag k="place" v="populated"/>
-        <tag k="hoot:mismatch" v="2"/>
-        <tag k="alt_name" v="Khirbat Masuh;Khirbat Māsūḩ;Masuh;Māsūḩ;maswh;ماسوح"/>
-        <tag k="hoot:wrong" v="1"/>
-        <tag k="uuid" v="{33e41748-afd1-5a87-bcf2-120630cae28d}"/>
         <tag k="name" v="Māsūḩ"/>
+        <tag k="uuid" v="{33e41748-afd1-5a87-bcf2-120630cae28d}"/>
+        <tag k="alt_name" v="Khirbat Masuh;Khirbat Māsūḩ;Masuh;Māsūḩ;maswh;ماسوح"/>
+        <tag k="hoot:mismatch" v="2"/>
+        <tag k="REF2" v="000263"/>
+        <tag k="hoot:wrong" v="1"/>
+        <tag k="place" v="populated"/>
         <tag k="error:circular" v="1000"/>
     </node>
     <node visible="true" id="-292922" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.7833329999999918" lon="35.8333330000000032">
-        <tag k="REF1" v="000263"/>
-        <tag k="place" v="locality"/>
+        <tag k="int_name" v="Khirbat Māsūḩ; Khirbat Masuh"/>
         <tag k="historic" v="ruins"/>
+        <tag k="name:de" v="Khirbat Masuh"/>
+        <tag k="name" v="خربة ماسوح"/>
         <tag k="name:ar" v="خربة ماسوح"/>
-        <tag k="is_in" v="Jordan, الأردن"/>
+        <tag k="name:en" v="Khirbat Masuh"/>
+        <tag k="uuid" v="{501aee30-3fac-558b-8985-8c78bdcd7464}"/>
         <tag k="name:fr" v="Khirbat Masuh"/>
         <tag k="hoot:mismatch" v="1"/>
-        <tag k="name:de" v="Khirbat Masuh"/>
-        <tag k="int_name" v="Khirbat Māsūḩ; Khirbat Masuh"/>
+        <tag k="REF1" v="000263"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="uuid" v="{501aee30-3fac-558b-8985-8c78bdcd7464}"/>
-        <tag k="name" v="خربة ماسوح"/>
-        <tag k="name:en" v="Khirbat Masuh"/>
+        <tag k="is_in" v="Jordan, الأردن"/>
+        <tag k="place" v="locality"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-292922" role="reviewee"/>
         <member type="node" ref="-292923" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (320m) - very similar names, very close together"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (320m) - very similar names, very close together"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-21/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-21/Expected.osm
@@ -2,20 +2,20 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="31.89083299999999" minlon="35.611944" maxlat="31.89083299999999" maxlon="35.611944"/>
     <node visible="true" id="-376463" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.8908329999999935" lon="35.6119440000000012">
+        <tag k="int_name" v="El Kherse‘e; Al Khersee"/>
+        <tag k="name:de" v="Al Khersee"/>
+        <tag k="historic" v="ruins"/>
+        <tag k="name" v="الخرسعة"/>
+        <tag k="name:ar" v="الخرسعة"/>
+        <tag k="name:en" v="Al Khersee"/>
+        <tag k="uuid" v="GeoNames.org:248622"/>
+        <tag k="name:fr" v="Al Khersee"/>
+        <tag k="alt_name" v="Al Kharsa`ah;Al Kharsa‘ah;El Kherse`e;Khirbat Khursa`a;Khirbat Khursa‘a;Khirbat al Kharsa`ah;Khirbat al Kharsa‘ah;Khirbat el Kharsa'a;Khirbat el Kharsa’a"/>
         <tag k="REF1" v="0007f1"/>
         <tag k="REF2" v="none"/>
-        <tag k="place" v="locality"/>
-        <tag k="historic" v="ruins"/>
-        <tag k="name:ar" v="الخرسعة"/>
         <tag k="poi" v="yes"/>
         <tag k="is_in" v="Jordan, الأردن"/>
-        <tag k="name:fr" v="Al Khersee"/>
-        <tag k="name:de" v="Al Khersee"/>
-        <tag k="int_name" v="El Kherse‘e; Al Khersee"/>
-        <tag k="alt_name" v="Al Kharsa`ah;Al Kharsa‘ah;El Kherse`e;Khirbat Khursa`a;Khirbat Khursa‘a;Khirbat al Kharsa`ah;Khirbat al Kharsa‘ah;Khirbat el Kharsa'a;Khirbat el Kharsa’a"/>
-        <tag k="uuid" v="GeoNames.org:248622"/>
-        <tag k="name" v="الخرسعة"/>
-        <tag k="name:en" v="Al Khersee"/>
+        <tag k="place" v="locality"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-22/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-22/Expected.osm
@@ -2,34 +2,34 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="31.5" minlon="35.78333" maxlat="31.5" maxlon="35.783333"/>
     <node visible="true" id="-376470" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.5000000000000000" lon="35.7833299999999994">
+        <tag k="name" v="‘Arab Banī Ḩamīdah"/>
+        <tag k="uuid" v="GeoNames.org:250376"/>
+        <tag k="alt_name" v="`Arab Bani Hamida;`Arab Bani Hamidah;‘Arab Banī Hamīda;‘Arab Banī Ḩamīdah"/>
         <tag k="REF2" v="000612"/>
         <tag k="place" v="tribal_area"/>
-        <tag k="alt_name" v="`Arab Bani Hamida;`Arab Bani Hamidah;‘Arab Banī Hamīda;‘Arab Banī Ḩamīdah"/>
-        <tag k="uuid" v="GeoNames.org:250376"/>
-        <tag k="name" v="‘Arab Banī Ḩamīdah"/>
         <tag k="error:circular" v="1000"/>
     </node>
     <node visible="true" id="-376469" timestamp="1970-01-01T00:00:00Z" version="1" lat="31.5000000000000000" lon="35.7833329999999989">
-        <tag k="REF1" v="000612"/>
-        <tag k="place" v="locality"/>
-        <tag k="name:ar" v="عرب بني حميدة"/>
-        <tag k="is_in" v="Jordan, الأردن"/>
-        <tag k="name:fr" v="Arab Bani Hamida"/>
-        <tag k="name:de" v="Arab Bani Hamida"/>
         <tag k="int_name" v="‘Arab Banī Hamīda; Arab Bani Hamida"/>
+        <tag k="name:de" v="Arab Bani Hamida"/>
         <tag k="name" v="Arab Bani Hamida - عرب بني حميدة"/>
+        <tag k="name:ar" v="عرب بني حميدة"/>
         <tag k="name:en" v="Arab Bani Hamida"/>
+        <tag k="name:fr" v="Arab Bani Hamida"/>
+        <tag k="REF1" v="000612"/>
+        <tag k="is_in" v="Jordan, الأردن"/>
+        <tag k="place" v="locality"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-376469" role="reviewee"/>
         <member type="node" ref="-376470" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (0.3m) - very similar names and generic type, very close together, generic type to place match"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (0.3m) - very similar names and generic type, very close together, generic type to place match"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-23/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-23/Expected.osm
@@ -2,53 +2,53 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="30.73052500013" minlon="31.41357699957999" maxlat="30.7333329885" maxlon="31.416667"/>
     <node visible="true" id="-3302721" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.7305250001300010" lon="31.4135769995799947">
-        <tag k="hoot:mismatch" v="2"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="religion" v="islam"/>
-        <tag k="source:horiz_accuracy_cat" v="accurate"/>
-        <tag k="source:date_time" v="2007-04-29"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
         <tag k="source:review_source_type" v="NA"/>
-        <tag k="hoot:wrong" v="1"/>
-        <tag k="source:description" v="IKONOS - 1m resolution"/>
-        <tag k="landuse" v="cemetary"/>
-        <tag k="REF2" v="000105"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="uuid" v="{a1b7812d-6a20-58ef-bc87-2b1f24a7da56}"/>
         <tag k="source:abs_vert_accuracy" v="-32765"/>
+        <tag k="source:description" v="IKONOS - 1m resolution"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
         <tag k="error:circular" v="28.65"/>
+        <tag k="landuse" v="cemetary"/>
+        <tag k="hoot:mismatch" v="2"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="000105"/>
+        <tag k="uuid" v="{a1b7812d-6a20-58ef-bc87-2b1f24a7da56}"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
+        <tag k="hoot:wrong" v="1"/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="source:horiz_accuracy_cat" v="accurate"/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
+        <tag k="religion" v="islam"/>
+        <tag k="source:date_time" v="2007-04-29"/>
+        <tag k="source" v="mgcp"/>
     </node>
     <node visible="true" id="-3302720" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.7333329884999991" lon="31.4166670000000003">
-        <tag k="REF1" v="000105"/>
+        <tag k="int_name" v="Sīdī ‘Askar, Sidi Askar"/>
+        <tag k="amenity" v="grave_yard"/>
+        <tag k="name:de" v="Sidi Askar"/>
+        <tag k="name" v="سيدي عسكر"/>
         <tag k="name:ar" v="سيدي عسكر"/>
-        <tag k="is_in" v="Egypt, جمهورية مصر العربية"/>
+        <tag k="name:en" v="Sidi Askar"/>
+        <tag k="uuid" v="{95df6cd2-0da8-5265-9936-573328ef8fbf}"/>
+        <tag k="alt_name" v="سيدي عسكر"/>
         <tag k="name:fr" v="Sidi Askar"/>
         <tag k="hoot:mismatch" v="1"/>
-        <tag k="name:ar1" v="سيدي عسكر"/>
-        <tag k="name:de" v="Sidi Askar"/>
-        <tag k="int_name" v="Sīdī ‘Askar, Sidi Askar"/>
-        <tag k="alt_name" v="سيدي عسكر"/>
+        <tag k="REF1" v="000105"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="uuid" v="{95df6cd2-0da8-5265-9936-573328ef8fbf}"/>
-        <tag k="name" v="سيدي عسكر"/>
-        <tag k="amenity" v="grave_yard"/>
-        <tag k="name:en" v="Sidi Askar"/>
+        <tag k="is_in" v="Egypt, جمهورية مصر العربية"/>
+        <tag k="name:ar1" v="سيدي عسكر"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3302720" role="reviewee"/>
         <member type="node" ref="-3302721" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (430m) - similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (430m) - similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-24/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-24/Expected.osm
@@ -2,44 +2,44 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="30.03000218818" minlon="31.2618605" maxlat="30.03008199998" maxlon="31.26189299956"/>
     <node visible="true" id="-3692884" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0300819999800019" lon="31.2618929995600006">
-        <tag k="source" v="mgcp"/>
+        <tag k="source:review_source_type" v="NA"/>
+        <tag k="source:abs_vert_accuracy" v="-32765"/>
+        <tag k="source:description" v="IKONOS - 1m resolution"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
+        <tag k="error:circular" v="28.65"/>
+        <tag k="length" v="12"/>
+        <tag k="source:abs_horiz_accuracy" v="25"/>
+        <tag k="REF2" v="00216d"/>
+        <tag k="uuid" v="mgcp:eb2555cf-c470-11e2-b9a8-002481c154f7"/>
+        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
+        <tag k="width" v="12"/>
+        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
+        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
+        <tag k="source:vertical_source_category" v="no_elevations"/>
         <tag k="source:horiz_accuracy_cat" v="accurate"/>
         <tag k="source:date_time" v="2007-04-29"/>
-        <tag k="source:vertical_source_category" v="no_elevations"/>
-        <tag k="shape" v="unknown"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:abs_horiz_accuracy" v="25"/>
-        <tag k="source:copyright" v="Copyright 2013 by the Bundeswehr GeoInformation Office. All rights reserved."/>
-        <tag k="source:abs_vert_accuracy_eval" v="NA"/>
-        <tag k="source:review_source_type" v="NA"/>
-        <tag k="source:description" v="IKONOS - 1m resolution"/>
-        <tag k="width" v="12"/>
-        <tag k="REF2" v="00216d"/>
-        <tag k="length" v="12"/>
-        <tag k="source:abs_horiz_accuracy_eval" v="emc_product_specification"/>
-        <tag k="source:commercial_distribution_restriction" v="Limited distribution. Official use only by MGCP members."/>
-        <tag k="uuid" v="mgcp:eb2555cf-c470-11e2-b9a8-002481c154f7"/>
-        <tag k="source:abs_vert_accuracy" v="-32765"/>
+        <tag k="source" v="mgcp"/>
         <tag k="historic" v="monument"/>
-        <tag k="error:circular" v="28.65"/>
+        <tag k="shape" v="unknown"/>
     </node>
     <node visible="true" id="-3692883" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0300021881800028" lon="31.2618604999999974">
-        <tag k="REF1" v="00216d"/>
-        <tag k="artwork" v="statue"/>
         <tag k="name" v="ابراهيم باشا"/>
         <tag k="tourism" v="artwork"/>
         <tag k="name:en" v="Ibrahim Pasha"/>
+        <tag k="artwork" v="statue"/>
+        <tag k="REF1" v="00216d"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3692883" role="reviewee"/>
         <member type="node" ref="-3692884" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (9.4m) - very close together, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (9.4m) - very close together, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-25/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-25/Expected.osm
@@ -2,20 +2,20 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.87677999999998" minlon="-76.97969139999999" maxlat="38.8812188" maxlon="-76.97775"/>
     <node visible="true" id="-6700017" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8767799999999824" lon="-76.9777500000000003">
-        <tag k="REF2" v="none"/>
         <tag k="bridge" v="yes"/>
-        <tag k="uuid" v="GeoNames.org:4139243"/>
         <tag k="name" v="John Phillip Sousa Bridge"/>
+        <tag k="uuid" v="GeoNames.org:4139243"/>
+        <tag k="REF2" v="none"/>
         <tag k="error:circular" v="1000"/>
     </node>
     <node visible="true" id="-6700016" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8812187999999992" lon="-76.9796913999999930">
-        <tag k="REF1" v="003ac5"/>
-        <tag k="historic" v="tomb"/>
-        <tag k="cemetery" v="grave"/>
-        <tag k="source" v="survey"/>
-        <tag k="name" v="John Philip Sousa"/>
         <tag k="wikipedia" v="en:John Philip Sousa"/>
+        <tag k="source" v="survey"/>
+        <tag k="historic" v="tomb"/>
+        <tag k="name" v="John Philip Sousa"/>
         <tag k="tourism" v="attraction"/>
+        <tag k="REF1" v="003ac5"/>
+        <tag k="cemetery" v="grave"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-26/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-26/Expected.osm
@@ -2,32 +2,32 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.04327039999999" minlon="11.5177994" maxlat="48.04349999999999" maxlon="11.52006"/>
     <node visible="true" id="-3886602" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0434999999999945" lon="11.5200600000000009">
-        <tag k="REF2" v="none"/>
-        <tag k="addr:language" v="GER"/>
+        <tag k="source" v="navteq"/>
         <tag k="historic" v="monument"/>
         <tag k="addr:street" v="ZEILLERSTRASSE"/>
-        <tag k="access" v="yes"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{52818661}"/>
+        <tag k="addr:language" v="GER"/>
         <tag k="name" v="BURG GRÜNWALD"/>
+        <tag k="uuid" v="{52818661}"/>
+        <tag k="language" v="GER"/>
+        <tag k="REF2" v="none"/>
+        <tag k="access" v="yes"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-3886601" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0432703999999902" lon="11.5177993999999995">
-        <tag k="REF1" v="004166"/>
         <tag k="historic" v="memorial"/>
         <tag k="name" v="St. Nepomuk"/>
+        <tag k="REF1" v="004166"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3886601" role="reviewee"/>
         <member type="node" ref="-3886602" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (170m) - similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (170m) - similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-27/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-27/Expected.osm
@@ -2,34 +2,34 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.10652" minlon="11.66883" maxlat="48.10690590000001" maxlon="11.6689581"/>
     <node visible="true" id="-3956422" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1065200000000033" lon="11.6688299999999998">
-        <tag k="REF2" v="01358a"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="addr:street" v="FRIEDENSPROMENADE"/>
-        <tag k="access" v="yes"/>
-        <tag k="phone" v="89-4309044"/>
-        <tag k="addr:housenumber" v="13"/>
-        <tag k="language" v="GER"/>
         <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{52813480}"/>
+        <tag k="addr:street" v="FRIEDENSPROMENADE"/>
+        <tag k="addr:language" v="GER"/>
         <tag k="name" v="FRIEDENSPROMENADE"/>
         <tag k="tourism" v="hotel"/>
+        <tag k="uuid" v="{52813480}"/>
+        <tag k="language" v="GER"/>
+        <tag k="phone" v="89-4309044"/>
+        <tag k="addr:housenumber" v="13"/>
+        <tag k="REF2" v="01358a"/>
+        <tag k="access" v="yes"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-3956421" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1069059000000081" lon="11.6689580999999993">
-        <tag k="REF1" v="01358a"/>
         <tag k="name" v="Amiga"/>
         <tag k="tourism" v="hotel"/>
+        <tag k="REF1" v="01358a"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3956421" role="reviewee"/>
         <member type="node" ref="-3956422" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (44m) - very close together, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (44m) - very close together, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-28/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-28/Expected.osm
@@ -4,22 +4,23 @@
     <node visible="true" id="-3956422" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1065200000000033" lon="11.6688299999999998">
         <tag k="name" v="Cheap &amp; Good"/>
         <tag k="tourism" v="hotel"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-3956421" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1069059000000081" lon="11.6689580999999993">
-        <tag k="REF1" v="01358a"/>
         <tag k="name" v="Food &amp; More"/>
         <tag k="tourism" v="hotel"/>
+        <tag k="REF1" v="01358a"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3956421" role="reviewee"/>
         <member type="node" ref="-3956422" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (44m) - very close together, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (44m) - very close together, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-29/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-29/Expected.osm
@@ -2,26 +2,26 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.92149559999999" minlon="-77.0438362" maxlat="38.9223335" maxlon="-77.0435882"/>
     <node visible="true" id="-916985" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9214955999999930" lon="-77.0438362000000012">
-        <tag k="addr:full" v="1841 COLUMBIA ROAD NW"/>
         <tag k="source:ingest:datetime" v="2015-06-01T17:43:03.071Z"/>
         <tag k="name" v="COLUMBIA ROAD APARTMENTS"/>
+        <tag k="addr:full" v="1841 COLUMBIA ROAD NW"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-916984" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9223335000000006" lon="-77.0435882000000021">
+        <tag k="amenity" v="school"/>
         <tag k="source:ingest:datetime" v="2015-06-01T19:33:35.298Z"/>
         <tag k="name" v="Columbian School"/>
-        <tag k="amenity" v="school"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-916984" role="reviewee"/>
         <member type="node" ref="-916985" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (96m) - similar names and generic type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (96m) - similar names and generic type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-3/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-3/Expected.osm
@@ -2,50 +2,50 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.04804000000001" minlon="11.70149" maxlat="48.04808300000001" maxlon="11.7021625"/>
     <node visible="true" id="-3200104" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0480400000000074" lon="11.7014899999999979">
-        <tag k="REF2" v="none"/>
-        <tag k="addr:language" v="GER"/>
+        <tag k="source" v="navteq"/>
         <tag k="addr:street" v="TAUFKIRCHNER STRASSE"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="name" v="HOHENBRUNN"/>
+        <tag k="uuid" v="{52900336}"/>
+        <tag k="language" v="GER"/>
+        <tag k="REF2" v="none"/>
         <tag k="access" v="yes"/>
         <tag k="poi" v="yes"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{52900336}"/>
-        <tag k="name" v="HOHENBRUNN"/>
         <tag k="error:circular" v="150"/>
     </node>
     <node visible="true" id="-3200103" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0480830000000054" lon="11.7021624999999982">
-        <tag k="is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
-        <tag k="openGeoDB:license_plate_code" v="M"/>
-        <tag k="openGeoDB:community_identification_number" v="09184129"/>
+        <tag k="openGeoDB:name" v="Hohenbrunn"/>
+        <tag k="openGeoDB:postal_codes" v="85662"/>
+        <tag k="openGeoDB:is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
+        <tag k="openGeoDB:is_in_loc_id" v="225"/>
         <tag k="openGeoDB:telephone_area_code" v="08124"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="Hohenbrunn"/>
+        <tag k="opengeodb:lat" v="48.0479938"/>
+        <tag k="openGeoDB:layer" v="6"/>
+        <tag k="openGeoDB:auto_update" v="population"/>
+        <tag k="REF1" v="00f002"/>
+        <tag k="place" v="village"/>
+        <tag k="openGeoDB:version" v="0.2.6.11 / 2007-12-04 / http://fa-technik.adfc.de/code/opengeodb/dump/"/>
+        <tag k="openGeoDB:loc_id" v="18494"/>
         <tag k="population" v="8569"/>
         <tag k="openGeoDB:sort_name" v="HOHENBRUNN"/>
-        <tag k="openGeoDB:is_in_loc_id" v="225"/>
-        <tag k="openGeoDB:is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
-        <tag k="openGeoDB:loc_id" v="18494"/>
-        <tag k="opengeodb:lon" v="11.7023783"/>
-        <tag k="name" v="Hohenbrunn"/>
-        <tag k="openGeoDB:version" v="0.2.6.11 / 2007-12-04 / http://fa-technik.adfc.de/code/opengeodb/dump/"/>
-        <tag k="openGeoDB:name" v="Hohenbrunn"/>
-        <tag k="openGeoDB:layer" v="6"/>
-        <tag k="openGeoDB:postal_codes" v="85662"/>
-        <tag k="REF1" v="00f002"/>
-        <tag k="openGeoDB:auto_update" v="population"/>
-        <tag k="openGeoDB:type" v="Gemeinde"/>
         <tag k="openGeoDB:population" v="8569"/>
-        <tag k="place" v="village"/>
-        <tag k="opengeodb:lat" v="48.0479938"/>
-        <tag k="error:circular" v="15"/>
+        <tag k="openGeoDB:type" v="Gemeinde"/>
+        <tag k="is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
+        <tag k="opengeodb:lon" v="11.7023783"/>
+        <tag k="openGeoDB:license_plate_code" v="M"/>
+        <tag k="openGeoDB:community_identification_number" v="09184129"/>
     </node>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3200103" role="reviewee"/>
         <member type="node" ref="-3200104" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Somewhat similar (50m) - very similar names and generic type, generic type to place match"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Somewhat similar (50m) - very similar names and generic type, generic type to place match"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-30/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-30/Expected.osm
@@ -2,30 +2,30 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.9212924" minlon="-77.0350296" maxlat="38.9217453" maxlon="-77.0332861"/>
     <node visible="true" id="185" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9212923999999987" lon="-77.0332860999999980">
-        <tag k="source:ingest:datetime" v="2015-06-01T17:43:03.094Z;2015-06-01T19:33:35.307Z"/>
-        <tag k="addr:full" v="1424 CHAPIN STREET NW"/>
-        <tag k="alt_name" v="Meridian Manor"/>
-        <tag k="name" v="MERIDIAN MANOR"/>
         <tag k="amenity" v="building"/>
+        <tag k="source:ingest:datetime" v="2015-06-01T17:43:03.094Z;2015-06-01T19:33:35.307Z"/>
+        <tag k="name" v="MERIDIAN MANOR"/>
+        <tag k="alt_name" v="Meridian Manor"/>
+        <tag k="addr:full" v="1424 CHAPIN STREET NW"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="213" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9217452999999978" lon="-77.0350296000000014">
-        <tag k="source:ingest:datetime" v="2015-06-01T17:43:03.101Z;2015-06-01T19:33:35.307Z"/>
-        <tag k="addr:full" v="2401 15TH STREET NW"/>
-        <tag k="alt_name" v="Meridian Hall"/>
-        <tag k="name" v="MERIDIAN HALL"/>
         <tag k="amenity" v="building"/>
+        <tag k="source:ingest:datetime" v="2015-06-01T17:43:03.101Z;2015-06-01T19:33:35.307Z"/>
+        <tag k="name" v="MERIDIAN HALL"/>
+        <tag k="alt_name" v="Meridian Hall"/>
+        <tag k="addr:full" v="2401 15TH STREET NW"/>
         <tag k="error:circular" v="15"/>
     </node>
     <relation visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="185" role="reviewee"/>
         <member type="node" ref="213" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="0"/>
-        <tag k="hoot:review:note" v="Multiple overlapping high confidence reviews: Very similar (160m) - very similar names, similar POI type"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Multiple overlapping high confidence reviews: Very similar (160m) - very similar names, similar POI type"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="0"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-31/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-31/Expected.osm
@@ -2,20 +2,20 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="-23.5337806" minlon="-46.31339" maxlat="-23.53253" maxlon="-46.3069421"/>
     <node visible="true" id="-20449830" timestamp="1970-01-01T00:00:00Z" version="1" lat="-23.5325300000000013" lon="-46.3133899999999983">
-        <tag k="ele" v="741"/>
         <tag k="is_in:country_code" v="BR"/>
         <tag k="source" v="geonames"/>
-        <tag k="uuid" v="GeoNames.org:8504807"/>
+        <tag k="ele" v="741"/>
         <tag k="name" v="Suzano"/>
         <tag k="railway" v="station"/>
+        <tag k="uuid" v="GeoNames.org:8504807"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-20449829" timestamp="1970-01-01T00:00:00Z" version="1" lat="-23.5337806000000000" lon="-46.3069421000000006">
-        <tag k="operator" v="Radial"/>
+        <tag k="highway" v="bus_stop"/>
         <tag k="name" v="Terminal Norte de Suzano"/>
         <tag k="shelter" v="yes"/>
-        <tag k="highway" v="bus_stop"/>
         <tag k="source:datetime" v="2014-06-18T23:59:00.000Z"/>
+        <tag k="operator" v="Radial"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-32/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-32/Expected.osm
@@ -2,19 +2,19 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="56.9183414" minlon="24.1733195" maxlat="56.91949000000001" maxlon="24.18586"/>
     <node visible="true" id="-561408" timestamp="1970-01-01T00:00:00Z" version="1" lat="56.9194900000000104" lon="24.1858600000000017">
-        <tag k="ele" v="12"/>
-        <tag k="alt_name" v="Dzelzcela Stacija Janavartis;Dzelzceļa Stacija Jāņavārtis;Janavarti;Jāņavārti;Pieturas Punkts Janavartis;Pieturas Punkts Jāņavārtis;Stacija Janavarti;Stacija Jāņavārti;Yanyavarti"/>
         <tag k="is_in:country_code" v="LV"/>
         <tag k="source" v="geonames"/>
-        <tag k="uuid" v="GeoNames.org:459481"/>
+        <tag k="ele" v="12"/>
         <tag k="name" v="Dzelzceļa Stacija Jāņavārti"/>
         <tag k="railway" v="station"/>
+        <tag k="uuid" v="GeoNames.org:459481"/>
+        <tag k="alt_name" v="Dzelzcela Stacija Janavartis;Dzelzceļa Stacija Jāņavārtis;Janavarti;Jāņavārti;Pieturas Punkts Janavartis;Pieturas Punkts Jāņavārtis;Stacija Janavarti;Stacija Jāņavārti;Yanyavarti"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-561407" timestamp="1970-01-01T00:00:00Z" version="1" lat="56.9183414000000027" lon="24.1733195000000016">
         <tag k="public_transport" v="stop_position"/>
-        <tag k="tram" v="yes"/>
         <tag k="name" v="Ķengaraga iela"/>
+        <tag k="tram" v="yes"/>
         <tag k="railway" v="tram_stop"/>
         <tag k="source:datetime" v="2014-07-19T14:55:53.000Z"/>
         <tag k="error:circular" v="15"/>

--- a/test-files/cases/hoot-js/poi/poi-generic-33/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-33/Expected.osm
@@ -2,21 +2,24 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="2.255955" minlon="22.3062313" maxlat="2.8672986" maxlon="22.9900745"/>
     <node visible="true" id="-340017" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.2559549999999997" lon="22.9900744999999986">
-        <tag k="use" v="residential"/>
-        <tag k="place" v="village"/>
         <tag k="name" v="somewhere"/>
         <tag k="landuse" v="built_up_area"/>
+        <tag k="use" v="residential"/>
+        <tag k="place" v="village"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-339997" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.2666934000000003" lon="22.3062313000000003">
-        <tag k="use" v="residential"/>
-        <tag k="place" v="village"/>
         <tag k="name" v="Place1"/>
         <tag k="landuse" v="built_up_area"/>
-    </node>
-    <node visible="true" id="-339988" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.8672985999999998" lon="22.3670612999999996">
         <tag k="use" v="residential"/>
         <tag k="place" v="village"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-339988" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.8672985999999998" lon="22.3670612999999996">
         <tag k="name" v="Place2"/>
         <tag k="landuse" v="built_up_area"/>
+        <tag k="use" v="residential"/>
+        <tag k="place" v="village"/>
+        <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-34/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-34/Expected.osm
@@ -2,28 +2,28 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.132867" minlon="11.6921556" maxlat="48.13300000000001" maxlon="11.69265"/>
     <node visible="true" id="-2477477" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1330000000000098" lon="11.6926500000000004">
-        <tag k="REF2" v="013e59"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="addr:street" v="WILLY-BRANDT-PLATZ"/>
-        <tag k="brand" v="NOVOTEL"/>
-        <tag k="access" v="yes"/>
-        <tag k="phone" v="89-994000"/>
-        <tag k="addr:housenumber" v="1"/>
-        <tag k="language" v="GER"/>
         <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{a063031e-dadb-56bf-b772-bd3a88fba577}"/>
+        <tag k="addr:street" v="WILLY-BRANDT-PLATZ"/>
+        <tag k="addr:language" v="GER"/>
         <tag k="name" v="DORINT NOVOTEL MÜNCHEN MESSE"/>
         <tag k="tourism" v="hotel"/>
+        <tag k="uuid" v="{a063031e-dadb-56bf-b772-bd3a88fba577}"/>
+        <tag k="language" v="GER"/>
+        <tag k="brand" v="NOVOTEL"/>
+        <tag k="phone" v="89-994000"/>
+        <tag k="addr:housenumber" v="1"/>
+        <tag k="REF2" v="013e59"/>
+        <tag k="access" v="yes"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2477476" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1328669999999974" lon="11.6921555999999995">
-        <tag k="REF1" v="013e59"/>
         <tag k="website" v="http://www.novotel.com/gb/hotel-5563-novotel-muenchen-messe/index.shtml"/>
         <tag k="email" v="h5563@accor.com"/>
-        <tag k="internet_access" v="yes"/>
-        <tag k="uuid" v="{74924da5-f54b-5469-bf03-62eb1c09baa2}"/>
         <tag k="name" v="Novotel München Messe"/>
         <tag k="tourism" v="hotel"/>
+        <tag k="uuid" v="{74924da5-f54b-5469-bf03-62eb1c09baa2}"/>
+        <tag k="internet_access" v="yes"/>
+        <tag k="REF1" v="013e59"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-4/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-4/Expected.osm
@@ -2,41 +2,41 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.04808299999999" minlon="11.70201" maxlat="48.04809999999998" maxlon="11.7021625"/>
     <node visible="true" id="-3200104" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0480999999999838" lon="11.7020099999999978">
-        <tag k="REF2" v="none"/>
-        <tag k="addr:language" v="GER"/>
+        <tag k="source" v="navteq"/>
+        <tag k="amenity" v="townhall"/>
         <tag k="addr:street" v="PFARRER-WENK-PLATZ"/>
-        <tag k="access" v="yes"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="name" v="RATHAUS HOHENBRUNN"/>
+        <tag k="uuid" v="{52820107}"/>
+        <tag k="language" v="GER"/>
         <tag k="phone" v="8102-8000"/>
         <tag k="addr:housenumber" v="1"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="uuid" v="{52820107}"/>
-        <tag k="name" v="RATHAUS HOHENBRUNN"/>
-        <tag k="amenity" v="townhall"/>
+        <tag k="REF2" v="none"/>
+        <tag k="access" v="yes"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-3200103" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.0480829999999912" lon="11.7021624999999982">
-        <tag k="is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
-        <tag k="openGeoDB:license_plate_code" v="M"/>
-        <tag k="openGeoDB:community_identification_number" v="09184129"/>
+        <tag k="openGeoDB:name" v="Hohenbrunn"/>
+        <tag k="openGeoDB:postal_codes" v="85662"/>
+        <tag k="openGeoDB:is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
+        <tag k="openGeoDB:is_in_loc_id" v="225"/>
         <tag k="openGeoDB:telephone_area_code" v="08124"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="Hohenbrunn"/>
+        <tag k="opengeodb:lat" v="48.0479938"/>
+        <tag k="openGeoDB:layer" v="6"/>
+        <tag k="openGeoDB:auto_update" v="population"/>
+        <tag k="REF1" v="00f002"/>
+        <tag k="place" v="village"/>
+        <tag k="openGeoDB:version" v="0.2.6.11 / 2007-12-04 / http://fa-technik.adfc.de/code/opengeodb/dump/"/>
+        <tag k="openGeoDB:loc_id" v="18494"/>
         <tag k="population" v="8569"/>
         <tag k="openGeoDB:sort_name" v="HOHENBRUNN"/>
-        <tag k="openGeoDB:is_in_loc_id" v="225"/>
-        <tag k="openGeoDB:is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
-        <tag k="openGeoDB:loc_id" v="18494"/>
-        <tag k="opengeodb:lon" v="11.7023783"/>
-        <tag k="name" v="Hohenbrunn"/>
-        <tag k="openGeoDB:version" v="0.2.6.11 / 2007-12-04 / http://fa-technik.adfc.de/code/opengeodb/dump/"/>
-        <tag k="openGeoDB:name" v="Hohenbrunn"/>
-        <tag k="openGeoDB:layer" v="6"/>
-        <tag k="openGeoDB:postal_codes" v="85662"/>
-        <tag k="REF1" v="00f002"/>
-        <tag k="openGeoDB:auto_update" v="population"/>
-        <tag k="openGeoDB:type" v="Gemeinde"/>
         <tag k="openGeoDB:population" v="8569"/>
-        <tag k="place" v="village"/>
-        <tag k="opengeodb:lat" v="48.0479938"/>
-        <tag k="error:circular" v="15"/>
+        <tag k="openGeoDB:type" v="Gemeinde"/>
+        <tag k="is_in" v="München,Oberbayern,Bayern,Bundesrepublik Deutschland,Europe"/>
+        <tag k="opengeodb:lon" v="11.7023783"/>
+        <tag k="openGeoDB:license_plate_code" v="M"/>
+        <tag k="openGeoDB:community_identification_number" v="09184129"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-5/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-5/Expected.osm
@@ -2,22 +2,22 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.12251329999999" minlon="11.6606558" maxlat="48.12251329999999" maxlon="11.6606558"/>
     <node visible="true" id="-3333079" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1225132999999943" lon="11.6606557999999989">
+        <tag k="source" v="navteq"/>
+        <tag k="amenity" v="fuel"/>
+        <tag k="addr:street" v="KREILLERSTRASSE"/>
+        <tag k="name" v="Shell"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="uuid" v="{4e3fcbeb-1935-5e6b-822e-7fb3f44792cb};{38f8cf84-5825-5b27-8094-2d3d1193e6dd}"/>
+        <tag k="alt_name" v="SHELL"/>
+        <tag k="language" v="GER"/>
+        <tag k="hoot:mismatch" v="1"/>
+        <tag k="brand" v="SHELL"/>
+        <tag k="phone" v="89-425016"/>
+        <tag k="addr:housenumber" v="194"/>
         <tag k="REF1" v="01a8ce"/>
         <tag k="REF2" v="01a8ce"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="addr:street" v="KREILLERSTRASSE"/>
-        <tag k="brand" v="SHELL"/>
         <tag k="access" v="yes"/>
-        <tag k="hoot:mismatch" v="1"/>
-        <tag k="phone" v="89-425016"/>
-        <tag k="alt_name" v="SHELL"/>
-        <tag k="uuid" v="{4e3fcbeb-1935-5e6b-822e-7fb3f44792cb};{38f8cf84-5825-5b27-8094-2d3d1193e6dd}"/>
-        <tag k="addr:housenumber" v="194"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="name" v="Shell"/>
-        <tag k="amenity" v="fuel"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-6/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-6/Expected.osm
@@ -2,22 +2,22 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.1262332" minlon="11.5515365" maxlat="48.1262332" maxlon="11.5515365"/>
     <node visible="true" id="-1737417" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1262332000000015" lon="11.5515364999999992">
+        <tag k="source" v="navteq"/>
+        <tag k="wheelchair" v="no"/>
+        <tag k="addr:street" v="LINDWURMSTRASSE"/>
+        <tag k="name" v="Poccistraße"/>
+        <tag k="addr:language" v="GER"/>
         <tag k="station" v="subway_entrance"/>
+        <tag k="railway" v="subway_entrance"/>
+        <tag k="uuid" v="{175cdcb6-5790-5ec7-98fd-4f10a0cdf1da};{e32e4c85-51aa-5b5e-bfb4-a5a3e174b715}"/>
+        <tag k="ref" v="U3,U6"/>
+        <tag k="alt_name" v="U-BAHN-POCCISTRASSE"/>
+        <tag k="language" v="GER"/>
+        <tag k="hoot:mismatch" v="2"/>
         <tag k="REF1" v="00c1f7"/>
         <tag k="REF2" v="002c1e"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="addr:street" v="LINDWURMSTRASSE"/>
-        <tag k="wheelchair" v="no"/>
         <tag k="access" v="yes"/>
-        <tag k="hoot:mismatch" v="2"/>
-        <tag k="alt_name" v="U-BAHN-POCCISTRASSE"/>
-        <tag k="uuid" v="{175cdcb6-5790-5ec7-98fd-4f10a0cdf1da};{e32e4c85-51aa-5b5e-bfb4-a5a3e174b715}"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="name" v="Poccistraße"/>
-        <tag k="ref" v="U3,U6"/>
-        <tag k="railway" v="subway_entrance"/>
         <tag k="error:circular" v="15"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-7/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-7/Expected.osm
@@ -2,23 +2,23 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.132867" minlon="11.6921556" maxlat="48.132867" maxlon="11.6921556"/>
     <node visible="true" id="-2477476" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1328669999999974" lon="11.6921555999999995">
-        <tag k="REF1" v="013e59"/>
-        <tag k="REF2" v="013e59"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="website" v="http://www.novotel.com/gb/hotel-5563-novotel-muenchen-messe/index.shtml"/>
         <tag k="addr:street" v="WILLY-BRANDT-PLATZ"/>
-        <tag k="brand" v="NOVOTEL"/>
-        <tag k="access" v="yes"/>
-        <tag k="email" v="h5563@accor.com"/>
-        <tag k="phone" v="89-994000"/>
-        <tag k="internet_access" v="yes"/>
         <tag k="alt_name" v="DORINT NOVOTEL MÜNCHEN MESSE"/>
-        <tag k="uuid" v="{74924da5-f54b-5469-bf03-62eb1c09baa2};{a063031e-dadb-56bf-b772-bd3a88fba577}"/>
+        <tag k="website" v="http://www.novotel.com/gb/hotel-5563-novotel-muenchen-messe/index.shtml"/>
+        <tag k="addr:language" v="GER"/>
         <tag k="addr:housenumber" v="1"/>
-        <tag k="language" v="GER"/>
-        <tag k="source" v="navteq"/>
-        <tag k="name" v="Novotel München Messe"/>
-        <tag k="tourism" v="hotel"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="Novotel München Messe"/>
+        <tag k="brand" v="NOVOTEL"/>
+        <tag k="REF1" v="013e59"/>
+        <tag k="tourism" v="hotel"/>
+        <tag k="REF2" v="013e59"/>
+        <tag k="uuid" v="{74924da5-f54b-5469-bf03-62eb1c09baa2};{a063031e-dadb-56bf-b772-bd3a88fba577}"/>
+        <tag k="language" v="GER"/>
+        <tag k="internet_access" v="yes"/>
+        <tag k="email" v="h5563@accor.com"/>
+        <tag k="access" v="yes"/>
+        <tag k="phone" v="89-994000"/>
+        <tag k="source" v="navteq"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-8/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-8/Expected.osm
@@ -2,34 +2,34 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.19067499999999" minlon="11.6165934" maxlat="48.19067499999999" maxlon="11.6165934"/>
     <node visible="true" id="-1804986" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1906749999999917" lon="11.6165933999999993">
-        <tag k="hoot:mismatch" v="1"/>
-        <tag k="addr:city" v="München"/>
-        <tag k="source" v="navteq"/>
-        <tag k="language" v="GER"/>
-        <tag k="note" v="LPG mit ACME Anschluß"/>
-        <tag k="name" v="Auto-Friedl"/>
-        <tag k="addr:housenumber" v="36"/>
-        <tag k="fuel:octane_91" v="yes"/>
-        <tag k="brand" v="Sprint;SPRINT"/>
-        <tag k="addr:full" v="SITULISTRASSE 36 80939 MÜNCHEN"/>
-        <tag k="alt_name" v="SPRINT"/>
-        <tag k="fuel:octane_95" v="yes"/>
-        <tag k="shop" v="kiosk"/>
-        <tag k="fuel:octane_98" v="yes"/>
-        <tag k="hoot:wrong" v="1"/>
-        <tag k="amenity" v="fuel"/>
-        <tag k="phone" v="+49 89 3256423"/>
-        <tag k="REF1" v="01d659"/>
-        <tag k="fuel:lpg" v="yes"/>
-        <tag k="REF2" v="01d659"/>
-        <tag k="fuel:biodiesel" v="yes"/>
         <tag k="addr:street" v="Situlistraße;FREISINGER LANDSTRASSE"/>
+        <tag k="alt_name" v="SPRINT"/>
+        <tag k="amenity" v="fuel"/>
+        <tag k="addr:language" v="GER"/>
+        <tag k="addr:housenumber" v="36"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="Auto-Friedl"/>
+        <tag k="fuel:diesel" v="yes"/>
+        <tag k="hoot:mismatch" v="1"/>
+        <tag k="brand" v="Sprint;SPRINT"/>
+        <tag k="REF1" v="01d659"/>
+        <tag k="REF2" v="01d659"/>
+        <tag k="uuid" v="{722338b3-e645-58bc-9c27-b54c293380a3};{5d55c2a2-1fa6-5c9f-8adf-6d0f1facb169}"/>
+        <tag k="addr:city" v="München"/>
+        <tag k="operator" v="Sprint"/>
+        <tag k="language" v="GER"/>
+        <tag k="hoot:wrong" v="1"/>
+        <tag k="addr:full" v="SITULISTRASSE 36 80939 MÜNCHEN"/>
+        <tag k="fuel:octane_91" v="yes"/>
         <tag k="addr:postcode" v="80939"/>
         <tag k="access" v="yes"/>
-        <tag k="uuid" v="{722338b3-e645-58bc-9c27-b54c293380a3};{5d55c2a2-1fa6-5c9f-8adf-6d0f1facb169}"/>
-        <tag k="operator" v="Sprint"/>
-        <tag k="fuel:diesel" v="yes"/>
-        <tag k="addr:language" v="GER"/>
-        <tag k="error:circular" v="15"/>
+        <tag k="fuel:octane_95" v="yes"/>
+        <tag k="note" v="LPG mit ACME Anschluß"/>
+        <tag k="fuel:lpg" v="yes"/>
+        <tag k="phone" v="+49 89 3256423"/>
+        <tag k="fuel:octane_98" v="yes"/>
+        <tag k="shop" v="kiosk"/>
+        <tag k="source" v="navteq"/>
+        <tag k="fuel:biodiesel" v="yes"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/poi/poi-generic-9/Expected.osm
+++ b/test-files/cases/hoot-js/poi/poi-generic-9/Expected.osm
@@ -2,25 +2,25 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="48.1458483" minlon="11.6376592" maxlat="48.1458483" maxlon="11.6376592"/>
     <node visible="true" id="-1939932" timestamp="1970-01-01T00:00:00Z" version="1" lat="48.1458482999999973" lon="11.6376591999999999">
-        <tag k="cuisine" v="malaysian"/>
-        <tag k="addr:city" v="München"/>
-        <tag k="source" v="navteq"/>
-        <tag k="language" v="GER"/>
-        <tag k="addr:housenumber" v="5"/>
-        <tag k="name" v="Champor"/>
+        <tag k="addr:country" v="DE"/>
+        <tag k="addr:street" v="Warthestraße;WARTHESTRASSE"/>
         <tag k="alt_name" v="NITAYA'S RESTAURANT"/>
         <tag k="website" v="http://www.champor.de/"/>
-        <tag k="addr:country" v="DE"/>
         <tag k="amenity" v="restaurant"/>
-        <tag k="REF1" v="01c422"/>
-        <tag k="phone" v="89-99317764"/>
-        <tag k="REVIEW" v="01c422"/>
-        <tag k="REF2" v="none"/>
-        <tag k="addr:street" v="Warthestraße;WARTHESTRASSE"/>
-        <tag k="addr:postcode" v="81927"/>
-        <tag k="access" v="yes"/>
-        <tag k="uuid" v="{c50e9a71-63a7-5197-a808-2c9422815b5d};{1d139ba7-b5d9-5688-b3e7-164cedf3b78b}"/>
         <tag k="addr:language" v="GER"/>
+        <tag k="addr:housenumber" v="5"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="Champor"/>
+        <tag k="REF1" v="01c422"/>
+        <tag k="REF2" v="none"/>
+        <tag k="uuid" v="{c50e9a71-63a7-5197-a808-2c9422815b5d};{1d139ba7-b5d9-5688-b3e7-164cedf3b78b}"/>
+        <tag k="addr:city" v="München"/>
+        <tag k="language" v="GER"/>
+        <tag k="addr:postcode" v="81927"/>
+        <tag k="REVIEW" v="01c422"/>
+        <tag k="access" v="yes"/>
+        <tag k="phone" v="89-99317764"/>
+        <tag k="source" v="navteq"/>
+        <tag k="cuisine" v="malaysian"/>
     </node>
 </osm>

--- a/test-files/cases/hoot-js/polygon-building/polygon-building-1/Expected.osm
+++ b/test-files/cases/hoot-js/polygon-building/polygon-building-1/Expected.osm
@@ -2,13 +2,13 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="-0.36489295359" minlon="42.54567562958" maxlat="-0.3647451386" maxlon="42.54592270335"/>
     <node visible="true" id="-2557" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648210368599999" lon="42.5458087341999942">
-        <tag k="REF2" v="00011f"/>
         <tag k="source:name" v="IDP/City Graphic"/>
-        <tag k="operational_status" v="operational"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
         <tag k="amenity" v="police"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="building" v="yes"/>
+        <tag k="operational_status" v="operational"/>
+        <tag k="REF2" v="00011f"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2555" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3647638722800001" lon="42.5456756295800034"/>
@@ -22,14 +22,15 @@
         <nd ref="-2549"/>
         <nd ref="-2555"/>
         <tag k="building:levels" v="2"/>
+        <tag k="amenity" v="police"/>
         <tag k="roof:shape" v="flat"/>
+        <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="source:res_owner" v="USA"/>
+        <tag k="building" v="yes"/>
+        <tag k="height" v="9"/>
         <tag k="REF2" v="00011f"/>
         <tag k="condition" v="functional"/>
-        <tag k="height" v="9"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
-        <tag k="source:res_owner" v="USA"/>
-        <tag k="amenity" v="police"/>
-        <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-js/polygon-building/polygon-building-2/Expected.osm
+++ b/test-files/cases/hoot-js/polygon-building/polygon-building-2/Expected.osm
@@ -10,13 +10,13 @@
     <node visible="true" id="-2559" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648715411900000" lon="42.5459218490300017"/>
     <node visible="true" id="-2558" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648909615100000" lon="42.5457104141399967"/>
     <node visible="true" id="-2557" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648210368600000" lon="42.5458087341999942">
-        <tag k="REF2" v="00011f"/>
         <tag k="source:name" v="IDP/City Graphic"/>
-        <tag k="operational_status" v="operational"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
         <tag k="amenity" v="police"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="building" v="yes"/>
+        <tag k="operational_status" v="operational"/>
+        <tag k="REF2" v="00011f"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2555" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3647638722800001" lon="42.5456756295800034"/>
@@ -30,14 +30,15 @@
         <nd ref="-2562"/>
         <nd ref="-2565"/>
         <tag k="building:levels" v="2"/>
-        <tag k="roof:shape" v="flat"/>
-        <tag k="condition" v="functional"/>
-        <tag k="height" v="9"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
-        <tag k="source:res_owner" v="USA"/>
         <tag k="amenity" v="police"/>
+        <tag k="roof:shape" v="flat"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="source:res_owner" v="USA"/>
+        <tag k="building" v="yes"/>
+        <tag k="height" v="9"/>
+        <tag k="condition" v="functional"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2560" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2561"/>
@@ -46,14 +47,15 @@
         <nd ref="-2558"/>
         <nd ref="-2561"/>
         <tag k="building:levels" v="2"/>
-        <tag k="roof:shape" v="flat"/>
-        <tag k="condition" v="functional"/>
-        <tag k="height" v="9"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
-        <tag k="source:res_owner" v="USA"/>
         <tag k="amenity" v="police"/>
+        <tag k="roof:shape" v="flat"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="source:res_owner" v="USA"/>
+        <tag k="building" v="yes"/>
+        <tag k="height" v="9"/>
+        <tag k="condition" v="functional"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2559" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2555"/>
@@ -61,27 +63,28 @@
         <nd ref="-2551"/>
         <nd ref="-2549"/>
         <nd ref="-2555"/>
-        <tag k="REF2" v="00011f"/>
         <tag k="building" v="yes"/>
+        <tag k="REF2" v="00011f"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2559" role="reviewee"/>
         <member type="way" ref="-2560" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2559" role="reviewee"/>
         <member type="way" ref="-2561" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/polygon-building/polygon-building-3/Expected.osm
+++ b/test-files/cases/hoot-js/polygon-building/polygon-building-3/Expected.osm
@@ -6,13 +6,13 @@
     <node visible="true" id="-2559" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648393784800000" lon="42.5457465603900005"/>
     <node visible="true" id="-2558" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648566886600000" lon="42.5455351254999954"/>
     <node visible="true" id="-2557" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648210368600001" lon="42.5458087341999942">
-        <tag k="REF2" v="00011f"/>
         <tag k="source:name" v="IDP/City Graphic"/>
-        <tag k="operational_status" v="operational"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
         <tag k="amenity" v="police"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="building" v="yes"/>
+        <tag k="operational_status" v="operational"/>
+        <tag k="REF2" v="00011f"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2555" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3647638722800000" lon="42.5456756295800034"/>
@@ -26,14 +26,15 @@
         <nd ref="-2561"/>
         <nd ref="-2558"/>
         <tag k="building:levels" v="2"/>
-        <tag k="roof:shape" v="flat"/>
-        <tag k="condition" v="functional"/>
-        <tag k="height" v="9"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
-        <tag k="source:res_owner" v="USA"/>
         <tag k="amenity" v="police"/>
+        <tag k="roof:shape" v="flat"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="source:res_owner" v="USA"/>
+        <tag k="building" v="yes"/>
+        <tag k="height" v="9"/>
+        <tag k="condition" v="functional"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2559" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2555"/>
@@ -41,17 +42,18 @@
         <nd ref="-2551"/>
         <nd ref="-2549"/>
         <nd ref="-2555"/>
-        <tag k="REF2" v="00011f"/>
         <tag k="building" v="yes"/>
+        <tag k="REF2" v="00011f"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2559" role="reviewee"/>
         <member type="way" ref="-2560" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Not sufficiently similar to call a match"/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Not sufficiently similar to call a match"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-js/polygon-building/polygon-building-4/Expected.osm
+++ b/test-files/cases/hoot-js/polygon-building/polygon-building-4/Expected.osm
@@ -6,13 +6,13 @@
     <node visible="true" id="-2559" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3650047981699999" lon="42.5457015218499990"/>
     <node visible="true" id="-2558" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3650242184900000" lon="42.5454900869599939"/>
     <node visible="true" id="-2557" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3648210368600000" lon="42.5458087341999942">
-        <tag k="REF2" v="00011f"/>
         <tag k="source:name" v="IDP/City Graphic"/>
-        <tag k="operational_status" v="operational"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
         <tag k="amenity" v="police"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="building" v="yes"/>
+        <tag k="operational_status" v="operational"/>
+        <tag k="REF2" v="00011f"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2555" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3647638722800000" lon="42.5456756295800034"/>
@@ -26,14 +26,15 @@
         <nd ref="-2558"/>
         <nd ref="-2561"/>
         <tag k="building:levels" v="2"/>
-        <tag k="roof:shape" v="flat"/>
-        <tag k="condition" v="functional"/>
-        <tag k="height" v="9"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="building" v="yes"/>
-        <tag k="source:res_owner" v="USA"/>
         <tag k="amenity" v="police"/>
+        <tag k="roof:shape" v="flat"/>
         <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="source:res_owner" v="USA"/>
+        <tag k="building" v="yes"/>
+        <tag k="height" v="9"/>
+        <tag k="condition" v="functional"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2559" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2555"/>
@@ -41,7 +42,8 @@
         <nd ref="-2551"/>
         <nd ref="-2549"/>
         <nd ref="-2555"/>
-        <tag k="REF2" v="00011f"/>
         <tag k="building" v="yes"/>
+        <tag k="REF2" v="00011f"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-001/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-001/Expected.osm
@@ -3,78 +3,69 @@
     <bounds minlat="30.01377658509" minlon="-90.01849311751" maxlat="30.01977087609999" maxlon="-90.01445907515"/>
     <node visible="true" id="-4472531" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0151481186722080" lon="-90.0183690155489700">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472531"/>
     </node>
     <node visible="true" id="-4472481" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183065931999948" lon="-90.0149955169499805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472481"/>
     </node>
     <node visible="true" id="-4472479" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182380814099936" lon="-90.0160040275400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472479"/>
     </node>
     <node visible="true" id="-4472477" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183402684600011" lon="-90.0144590751500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472477"/>
     </node>
     <node visible="true" id="-4472475" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0168446111399909" lon="-90.0149526016100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472475"/>
     </node>
     <node visible="true" id="-4472473" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182938198199984" lon="-90.0150920764800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472473"/>
     </node>
     <node visible="true" id="-4472471" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0197708760999902" lon="-90.0152422801800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472471"/>
     </node>
     <node visible="true" id="-4472469" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0165357225800058" lon="-90.0184931175100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472469"/>
     </node>
     <node visible="true" id="-4472467" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0137765850900031" lon="-90.0182463542799951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472467"/>
     </node>
     <way visible="true" id="-4472607" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472467"/>
         <nd ref="-4472531"/>
         <nd ref="-4472469"/>
-        <tag k="note" v="1c;1a;1b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472607"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1c;1a;1b"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472491" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472479"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2c;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472491"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2c;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472489" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472473"/>
         <nd ref="-4472481"/>
         <nd ref="-4472477"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472489"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472487" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472475"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2b;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472487"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2b;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472485" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472471"/>
         <nd ref="-4472473"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472485"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-002/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-002/Expected.osm
@@ -3,92 +3,76 @@
     <bounds minlat="30.00854725156" minlon="-90.01061278742" maxlat="30.01048862035" maxlon="-90.00780987900001"/>
     <node visible="true" id="-4472965" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0103449749300033" lon="-90.0106127874200013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472965"/>
     </node>
     <node visible="true" id="-4472963" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0104886203499994" lon="-90.0087888511399825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472963"/>
     </node>
     <node visible="true" id="-4472961" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0094670210699981" lon="-90.0104947702299967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472961"/>
     </node>
     <node visible="true" id="-4472959" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0096690905099948" lon="-90.0087111012300056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472959"/>
     </node>
     <node visible="true" id="-4472957" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0104239439400011" lon="-90.0096901075200009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472957"/>
     </node>
     <node visible="true" id="-4472955" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0089932014799992" lon="-90.0078098790000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472955"/>
     </node>
     <node visible="true" id="-4472953" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0086494485899955" lon="-90.0085501686899789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472953"/>
     </node>
     <node visible="true" id="-4472951" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0085472515599960" lon="-90.0091509835099970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472951"/>
     </node>
     <node visible="true" id="-4472949" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0086401579599915" lon="-90.0094406620799816">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472949"/>
     </node>
     <node visible="true" id="-4472947" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0089932014799992" lon="-90.0095157639400014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472947"/>
     </node>
     <node visible="true" id="-4472945" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0095831529799995" lon="-90.0096096412499946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472945"/>
     </node>
     <way visible="true" id="-4472977" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472957"/>
         <nd ref="-4472945"/>
-        <tag k="note" v="1c;2c"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1c;2c"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472977"/>
     </way>
     <way visible="true" id="-4472975" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472961"/>
         <nd ref="-4472945"/>
-        <tag k="note" v="1d;2d"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1d;2d"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472975"/>
     </way>
     <way visible="true" id="-4472973" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472963"/>
         <nd ref="-4472957"/>
-        <tag k="note" v="1b;2b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1b;2b"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472973"/>
     </way>
     <way visible="true" id="-4472971" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472957"/>
         <nd ref="-4472965"/>
-        <tag k="note" v="1a;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1a;2a"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472971"/>
     </way>
     <way visible="true" id="-4472969" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472945"/>
         <nd ref="-4472959"/>
-        <tag k="note" v="1e;2e"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1e;2e"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472969"/>
     </way>
     <way visible="true" id="-4472967" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472945"/>
@@ -97,10 +81,9 @@
         <nd ref="-4472951"/>
         <nd ref="-4472953"/>
         <nd ref="-4472955"/>
-        <tag k="note" v="1f;2f"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1f;2f"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472967"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-003/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-003/Expected.osm
@@ -3,60 +3,48 @@
     <bounds minlat="0.00320735725" minlon="-0.0003766650199999997" maxlat="0.00625601899" maxlon="0.0059850847"/>
     <node visible="true" id="-724226" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046141443100000" lon="0.0016072457300000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-724226"/>
     </node>
     <node visible="true" id="-724225" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046444844100000" lon="0.0008514702700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-724225"/>
     </node>
     <node visible="true" id="-724224" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0049668960300000" lon="0.0002672429200000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-724224"/>
     </node>
     <node visible="true" id="-724223" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0057639654600000" lon="-0.0003766650200000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-724223"/>
     </node>
     <node visible="true" id="-724222" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724222"/>
     </node>
     <node visible="true" id="-724220" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724220"/>
     </node>
     <node visible="true" id="-724218" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724218"/>
     </node>
     <node visible="true" id="-724216" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724216"/>
     </node>
     <node visible="true" id="-724214" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062191150700000" lon="0.0006813779300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724214"/>
     </node>
     <node visible="true" id="-724212" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0052548516500000" lon="0.0005686718200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724212"/>
     </node>
     <node visible="true" id="-724210" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0041966664700000" lon="0.0005937176200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724210"/>
     </node>
     <node visible="true" id="-724208" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032073572500000" lon="0.0007878225900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-724208"/>
     </node>
     <way visible="true" id="-724227" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-724223"/>
         <nd ref="-724224"/>
         <nd ref="-724225"/>
         <nd ref="-724226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-724227"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-724226" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-724216"/>
@@ -64,19 +52,17 @@
         <nd ref="-724220"/>
         <nd ref="-724222"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-724226"/>
     </way>
     <way visible="true" id="-724224" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-724208"/>
         <nd ref="-724210"/>
         <nd ref="-724212"/>
         <nd ref="-724214"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-724224"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-004/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-004/Expected.osm
@@ -3,39 +3,30 @@
     <bounds minlat="-0.0009806089100000011" minlon="0.0017728795" maxlat="0.01055288979" maxlon="0.00893974199"/>
     <node visible="true" id="-1018689" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0048427069810808" lon="0.0056549112103702">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018689"/>
     </node>
     <node visible="true" id="-1018670" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0090293950900000" lon="0.0017728795000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018670"/>
     </node>
     <node visible="true" id="-1018668" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0105528897900000" lon="0.0054206837600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018668"/>
     </node>
     <node visible="true" id="-1018666" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0007284812700000" lon="0.0089397419900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018666"/>
     </node>
     <node visible="true" id="-1018663" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0009806089100000" lon="0.0049968947400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018663"/>
     </node>
     <node visible="true" id="-1018574" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018574"/>
     </node>
     <node visible="true" id="-1018572" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018572"/>
     </node>
     <node visible="true" id="-1018570" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018570"/>
     </node>
     <node visible="true" id="-1018568" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018568"/>
     </node>
     <way visible="true" id="-1018722" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018568"/>
@@ -44,37 +35,36 @@
         <nd ref="-1018572"/>
         <nd ref="-1018574"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="400"/>
-        <tag k="hoot:id" v="-1018722"/>
     </way>
     <way visible="true" id="-1018671" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018670"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018671"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018669" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018668"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018669"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018667" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018666"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018667"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018664" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018663"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018664"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-005/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-005/Expected.osm
@@ -3,443 +3,333 @@
     <bounds minlat="38.88932131124" minlon="-77.05504778748001" maxlat="38.89246497495999" maxlon="-77.05195146739"/>
     <node visible="true" id="-3218" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922220501699911" lon="-77.0550477874800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3218"/>
     </node>
     <node visible="true" id="-3216" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921495043399901" lon="-77.0546779563500053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3216"/>
     </node>
     <node visible="true" id="-3214" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921307105799983" lon="-77.0545648707499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3214"/>
     </node>
     <node visible="true" id="-3212" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920775075999927" lon="-77.0542447319599830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3212"/>
     </node>
     <node visible="true" id="-3210" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920710351700052" lon="-77.0542154486799973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3210"/>
     </node>
     <node visible="true" id="-3208" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920639320899824" lon="-77.0541862801999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3208"/>
     </node>
     <node visible="true" id="-3206" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920561081099834" lon="-77.0541575722400012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3206"/>
     </node>
     <node visible="true" id="-3204" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920475633600020" lon="-77.0541290942900048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3204"/>
     </node>
     <node visible="true" id="-3202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920384779399839" lon="-77.0541009617400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3202"/>
     </node>
     <node visible="true" id="-3200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920285815899902" lon="-77.0540731743899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3200"/>
     </node>
     <node visible="true" id="-3198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920181445299988" lon="-77.0540458469999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3198"/>
     </node>
     <node visible="true" id="-3196" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920069866299940" lon="-77.0540188663100025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3196"/>
     </node>
     <node visible="true" id="-3194" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919952879499888" lon="-77.0539924608499973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3194"/>
     </node>
     <node visible="true" id="-3192" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919828684399960" lon="-77.0539664006600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3192"/>
     </node>
     <node visible="true" id="-3190" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919699081999894" lon="-77.0539408011400013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3190"/>
     </node>
     <node visible="true" id="-3188" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919563171099938" lon="-77.0539157774999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3188"/>
     </node>
     <node visible="true" id="-3186" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919449756599960" lon="-77.0538960579399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3186"/>
     </node>
     <node visible="true" id="-3184" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917364941500026" lon="-77.0535647337700027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3184"/>
     </node>
     <node visible="true" id="-3182" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916187500899966" lon="-77.0533780258199954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3182"/>
     </node>
     <node visible="true" id="-3180" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915141267099926" lon="-77.0531944145800054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3180"/>
     </node>
     <node visible="true" id="-3178" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914258660799845" lon="-77.0529949083099979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3178"/>
     </node>
     <node visible="true" id="-3176" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913819943099952" lon="-77.0528765840799963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3176"/>
     </node>
     <node visible="true" id="-3174" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913542716399974" lon="-77.0528018136899959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3174"/>
     </node>
     <node visible="true" id="-3172" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912993277400005" lon="-77.0526524600399938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3172"/>
     </node>
     <node visible="true" id="-3170" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912718535099842" lon="-77.0525820492999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3170"/>
     </node>
     <node visible="true" id="-3168" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912088384799901" lon="-77.0524337209899954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3168"/>
     </node>
     <node visible="true" id="-3166" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911757620799960" lon="-77.0523519128099821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3166"/>
     </node>
     <node visible="true" id="-3164" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911507110800017" lon="-77.0522899546400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3164"/>
     </node>
     <node visible="true" id="-3162" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911209678599974" lon="-77.0522241308899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3162"/>
     </node>
     <node visible="true" id="-3160" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911060082100022" lon="-77.0521991875600065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3160"/>
     </node>
     <node visible="true" id="-3158" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910830982699949" lon="-77.0521738861399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3158"/>
     </node>
     <node visible="true" id="-3156" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910589747099991" lon="-77.0521505217899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3156"/>
     </node>
     <node visible="true" id="-3154" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910316927499906" lon="-77.0521305584199894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3154"/>
     </node>
     <node visible="true" id="-3152" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909968552499947" lon="-77.0521087935299960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3152"/>
     </node>
     <node visible="true" id="-3150" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909545739400073" lon="-77.0520872112600017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3150"/>
     </node>
     <node visible="true" id="-3148" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908842149400016" lon="-77.0520611858700022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3148"/>
     </node>
     <node visible="true" id="-3146" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907976085799945" lon="-77.0520507334999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3146"/>
     </node>
     <node visible="true" id="-3144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907109987099915" lon="-77.0520506703099954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3144"/>
     </node>
     <node visible="true" id="-3142" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906230228399892" lon="-77.0520748474600055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3142"/>
     </node>
     <node visible="true" id="-3140" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905037313699964" lon="-77.0521247918500052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3140"/>
     </node>
     <node visible="true" id="-3138" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903116149099972" lon="-77.0522266902599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3138"/>
     </node>
     <node visible="true" id="-3136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8900091376999981" lon="-77.0523879893599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3136"/>
     </node>
     <node visible="true" id="-3134" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898711819200003" lon="-77.0524590890500036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3134"/>
     </node>
     <node visible="true" id="-3132" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898477543999874" lon="-77.0524718655800029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3132"/>
     </node>
     <node visible="true" id="-3130" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898238761599870" lon="-77.0524840668799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3130"/>
     </node>
     <node visible="true" id="-3128" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897997284399963" lon="-77.0524958061999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3128"/>
     </node>
     <node visible="true" id="-3126" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897753112299966" lon="-77.0525070842400055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3126"/>
     </node>
     <node visible="true" id="-3124" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897506234699932" lon="-77.0525177857499983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3124"/>
     </node>
     <node visible="true" id="-3122" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897255755800018" lon="-77.0525280259300018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3122"/>
     </node>
     <node visible="true" id="-3120" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897003477799856" lon="-77.0525376896400047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3120"/>
     </node>
     <node visible="true" id="-3118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896748493699960" lon="-77.0525468920900067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3118"/>
     </node>
     <node visible="true" id="-3116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896491721800004" lon="-77.0525555180699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3116"/>
     </node>
     <node visible="true" id="-3114" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896233138999960" lon="-77.0525636828500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3114"/>
     </node>
     <node visible="true" id="-3112" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895972768400071" lon="-77.0525712711600050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3112"/>
     </node>
     <node visible="true" id="-3110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895710587499934" lon="-77.0525782830199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3110"/>
     </node>
     <node visible="true" id="-3108" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895447513899910" lon="-77.0525847184700012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3108"/>
     </node>
     <node visible="true" id="-3106" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895182635099914" lon="-77.0525906927300070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3106"/>
     </node>
     <node visible="true" id="-3104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894916881099988" lon="-77.0525959753299787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3104"/>
     </node>
     <node visible="true" id="-3102" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894650205799977" lon="-77.0526007967999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3102"/>
     </node>
     <node visible="true" id="-3100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894383538699984" lon="-77.0526050419399979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3100"/>
     </node>
     <node visible="true" id="-3098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894115967800005" lon="-77.0526087106800048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3098"/>
     </node>
     <node visible="true" id="-3096" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893848410699974" lon="-77.0526118023799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3096"/>
     </node>
     <node visible="true" id="-3094" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893580845499898" lon="-77.0526142039300055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3094"/>
     </node>
     <node visible="true" id="-3092" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893313293599974" lon="-77.0526161429799998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3092"/>
     </node>
     <node visible="true" id="-3090" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893213112399962" lon="-77.0526166744499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3090"/>
     </node>
     <node visible="true" id="-3088" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924649749599922" lon="-77.0529468792900047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3088"/>
     </node>
     <node visible="true" id="-3086" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921842958999875" lon="-77.0527829676599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3086"/>
     </node>
     <node visible="true" id="-3084" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921735790099845" lon="-77.0527761581199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3084"/>
     </node>
     <node visible="true" id="-3082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921407082499897" lon="-77.0527544631899985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3082"/>
     </node>
     <node visible="true" id="-3080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921082882699878" lon="-77.0527319624400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3080"/>
     </node>
     <node visible="true" id="-3078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920761388999949" lon="-77.0527086543099955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3078"/>
     </node>
     <node visible="true" id="-3076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920443502199973" lon="-77.0526845388600066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3076"/>
     </node>
     <node visible="true" id="-3074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920081742899910" lon="-77.0526558195300026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3074"/>
     </node>
     <node visible="true" id="-3072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919818548399974" lon="-77.0526341208800005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3072"/>
     </node>
     <node visible="true" id="-3070" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919512382799937" lon="-77.0526077009899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3070"/>
     </node>
     <node visible="true" id="-3068" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919209823499941" lon="-77.0525805912100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3068"/>
     </node>
     <node visible="true" id="-3066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918911772000016" lon="-77.0525526741800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3066"/>
     </node>
     <node visible="true" id="-3064" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917937840700034" lon="-77.0524479730499792">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3064"/>
     </node>
     <node visible="true" id="-3062" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917422506299886" lon="-77.0523925716599933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3062"/>
     </node>
     <node visible="true" id="-3060" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916788012099914" lon="-77.0523261498599794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3060"/>
     </node>
     <node visible="true" id="-3058" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916623556899950" lon="-77.0523089339699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3058"/>
     </node>
     <node visible="true" id="-3056" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916373517199929" lon="-77.0522827590699961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3056"/>
     </node>
     <node visible="true" id="-3054" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914826580300002" lon="-77.0521270329400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3054"/>
     </node>
     <node visible="true" id="-3052" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914664488699984" lon="-77.0521137659799820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3052"/>
     </node>
     <node visible="true" id="-3050" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914452865000015" lon="-77.0520973824500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3050"/>
     </node>
     <node visible="true" id="-3048" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914236733499905" lon="-77.0520818047499887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3048"/>
     </node>
     <node visible="true" id="-3046" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914017895899917" lon="-77.0520670351800021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3046"/>
     </node>
     <node visible="true" id="-3044" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913795451799942" lon="-77.0520529562499945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3044"/>
     </node>
     <node visible="true" id="-3042" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913570301099938" lon="-77.0520397992799815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3042"/>
     </node>
     <node visible="true" id="-3040" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913341543400009" lon="-77.0520274489200006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3040"/>
     </node>
     <node visible="true" id="-3038" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913110979899983" lon="-77.0520160205799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3038"/>
     </node>
     <node visible="true" id="-3036" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912877710399911" lon="-77.0520053989300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3036"/>
     </node>
     <node visible="true" id="-3034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912641734699918" lon="-77.0519955839599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3034"/>
     </node>
     <node visible="true" id="-3032" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912403953199828" lon="-77.0519866910100006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3032"/>
     </node>
     <node visible="true" id="-3030" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912084200599892" lon="-77.0519766394199905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3030"/>
     </node>
     <node visible="true" id="-3028" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911813977699907" lon="-77.0519702792900034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3028"/>
     </node>
     <node visible="true" id="-3026" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911542849799901" lon="-77.0519648426799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3026"/>
     </node>
     <node visible="true" id="-3024" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911270816999988" lon="-77.0519603274299811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3024"/>
     </node>
     <node visible="true" id="-3022" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910997879299956" lon="-77.0519567342600027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3022"/>
     </node>
     <node visible="true" id="-3020" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910724036599902" lon="-77.0519540631599966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3020"/>
     </node>
     <node visible="true" id="-3018" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910447053799899" lon="-77.0519523046099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3018"/>
     </node>
     <node visible="true" id="-3016" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910175437999897" lon="-77.0519514873300011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3016"/>
     </node>
     <node visible="true" id="-3014" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909901583500002" lon="-77.0519514673899977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3014"/>
     </node>
     <node visible="true" id="-3012" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909626823599908" lon="-77.0519524847800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3012"/>
     </node>
     <node visible="true" id="-3010" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909352960399914" lon="-77.0519544243900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3010"/>
     </node>
     <node visible="true" id="-3008" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908763008300014" lon="-77.0519656466299949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3008"/>
     </node>
     <node visible="true" id="-3006" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908137429800007" lon="-77.0519891400499972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3006"/>
     </node>
     <node visible="true" id="-3004" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907401449599988" lon="-77.0520173333100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3004"/>
     </node>
     <node visible="true" id="-3002" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906647064799955" lon="-77.0520478787799874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3002"/>
     </node>
     <node visible="true" id="-3000" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905699460199941" lon="-77.0520913581299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3000"/>
     </node>
     <way visible="true" id="-3226" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3166"/>
@@ -469,11 +359,10 @@
         <nd ref="-3214"/>
         <nd ref="-3216"/>
         <nd ref="-3218"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3226"/>
     </way>
     <way visible="true" id="-3224" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -490,12 +379,11 @@
         <nd ref="-3162"/>
         <nd ref="-3164"/>
         <nd ref="-3166"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3224"/>
     </way>
     <way visible="true" id="-3222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3090"/>
@@ -524,12 +412,11 @@
         <nd ref="-3136"/>
         <nd ref="-3138"/>
         <nd ref="-3140"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3222"/>
     </way>
     <way visible="true" id="-3220" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -578,11 +465,10 @@
         <nd ref="-3084"/>
         <nd ref="-3086"/>
         <nd ref="-3088"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3220"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-006/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-006/Expected.osm
@@ -3,57 +3,50 @@
     <bounds minlat="38.85256682120001" minlon="-104.89916367283" maxlat="38.85335424982999" maxlon="-104.89826276519"/>
     <node visible="true" id="-1682758" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530188155899907" lon="-104.8986868588499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682758"/>
     </node>
     <node visible="true" id="-1682757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530214305399895" lon="-104.8991636728299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682757"/>
     </node>
     <node visible="true" id="-1682756" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8525668212000070" lon="-104.8986765855800058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682756"/>
     </node>
     <node visible="true" id="-1682755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533542498299909" lon="-104.8982627651899975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682755"/>
     </node>
     <node visible="true" id="-1682754" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8528283481400010" lon="-104.8986799434299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682754"/>
     </node>
     <node visible="true" id="-1682753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530240454899953" lon="-104.8989252658400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682753"/>
     </node>
     <node visible="true" id="-1682752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8531970813699985" lon="-104.8984693340700005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682752"/>
     </node>
     <way visible="true" id="-1682761" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682757"/>
         <nd ref="-1682753"/>
         <nd ref="-1682758"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682761"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682760" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682754"/>
         <nd ref="-1682756"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682760"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682759" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682752"/>
         <nd ref="-1682755"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682759"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-007/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-007/Expected.osm
@@ -3,110 +3,92 @@
     <bounds minlat="38.85407320977" minlon="-104.90305077439" maxlat="38.85460590869" maxlon="-104.90151585456"/>
     <node visible="true" id="-5011083" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545143584800030" lon="-104.9022746626800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011083"/>
     </node>
     <node visible="true" id="-5011082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9027146783799935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011082"/>
     </node>
     <node visible="true" id="-5011081" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545634736000025" lon="-104.9022320907299815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011081"/>
     </node>
     <node visible="true" id="-5011080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546017057599968" lon="-104.9021850918999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011080"/>
     </node>
     <node visible="true" id="-5011079" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9023815370599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011079"/>
     </node>
     <node visible="true" id="-5011078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545593122299948" lon="-104.9023202620900008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011078"/>
     </node>
     <node visible="true" id="-5011077" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540732097700001" lon="-104.9022759351200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011077"/>
     </node>
     <node visible="true" id="-5011076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9018489958900062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011076"/>
     </node>
     <node visible="true" id="-5011075" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543021280200023" lon="-104.9022871808499957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011075"/>
     </node>
     <node visible="true" id="-5011074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545933830200028" lon="-104.9030507743899960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011074"/>
     </node>
     <node visible="true" id="-5011073" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545946838899994" lon="-104.9022775123400066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011073"/>
     </node>
     <node visible="true" id="-5011072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9015158545600030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011072"/>
     </node>
     <way visible="true" id="-5011089" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011081"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1b;2b"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1b;2b"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011089"/>
     </way>
     <way visible="true" id="-5011088" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011076"/>
         <nd ref="-5011072"/>
-        <tag k="note" v="1c;2c"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1c;2c"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011088"/>
     </way>
     <way visible="true" id="-5011087" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011073"/>
         <nd ref="-5011080"/>
-        <tag k="note" v="1d;2d"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1d;2d"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011087"/>
     </way>
     <way visible="true" id="-5011086" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011077"/>
         <nd ref="-5011075"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1a;2a"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1a;2a"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011086"/>
     </way>
     <way visible="true" id="-5011085" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011078"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1e;2e"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1e;2e"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011085"/>
     </way>
     <way visible="true" id="-5011084" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011074"/>
         <nd ref="-5011082"/>
         <nd ref="-5011079"/>
-        <tag k="note" v="1f;2f"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1f;2f"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011084"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-008/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-008/Expected.osm
@@ -3,130 +3,107 @@
     <bounds minlat="38.89515050534" minlon="-77.0471701988" maxlat="38.89630425215999" maxlon="-77.04635609292001"/>
     <node visible="true" id="-5065111" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956904830300019" lon="-77.0467622909300047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5065111"/>
     </node>
     <node visible="true" id="-5064472" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8955972330399931" lon="-77.0467700836999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064472"/>
     </node>
     <node visible="true" id="-5064391" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957465845900003" lon="-77.0469658769900008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064391"/>
     </node>
     <node visible="true" id="-5064378" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956593997099915" lon="-77.0469580842199946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064378"/>
     </node>
     <node visible="true" id="-5064366" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953869293499963" lon="-77.0467776795399999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064366"/>
     </node>
     <node visible="true" id="-5064360" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956381720699937" lon="-77.0465752645099968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064360"/>
     </node>
     <node visible="true" id="-5064345" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957329382699939" lon="-77.0465635753599969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064345"/>
     </node>
     <node visible="true" id="-5064337" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8960199731399996" lon="-77.0467373020199915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064337"/>
     </node>
     <node visible="true" id="-5063238" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956260033899994" lon="-77.0463598359399953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063238"/>
     </node>
     <node visible="true" id="-5063236" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956711572899962" lon="-77.0471701988000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063236"/>
     </node>
     <node visible="true" id="-5063234" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957294203499941" lon="-77.0463560929200071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063234"/>
     </node>
     <node visible="true" id="-5063232" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957527255499969" lon="-77.0471664557900056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063232"/>
     </node>
     <node visible="true" id="-5063230" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8963042521599931" lon="-77.0467265493499980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063230"/>
     </node>
     <node visible="true" id="-5063228" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957352466499842" lon="-77.0467603385999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063228"/>
     </node>
     <node visible="true" id="-5063226" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956463954899974" lon="-77.0467659531199871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063226"/>
     </node>
     <node visible="true" id="-5063224" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951505053399984" lon="-77.0467866622300050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063224"/>
     </node>
     <way visible="true" id="-5063252" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063238"/>
         <nd ref="-5064360"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063252"/>
     </way>
     <way visible="true" id="-5063250" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063236"/>
         <nd ref="-5064378"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063250"/>
     </way>
     <way visible="true" id="-5063248" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063234"/>
         <nd ref="-5064345"/>
         <nd ref="-5063228"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063248"/>
     </way>
     <way visible="true" id="-5063246" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063232"/>
         <nd ref="-5064391"/>
         <nd ref="-5063228"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063246"/>
     </way>
     <way visible="true" id="-5063244" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063228"/>
         <nd ref="-5065111"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063244"/>
     </way>
     <way visible="true" id="-5063242" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063230"/>
         <nd ref="-5064337"/>
         <nd ref="-5063228"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063242"/>
     </way>
     <way visible="true" id="-5063240" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063224"/>
         <nd ref="-5064366"/>
         <nd ref="-5064472"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063240"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-009/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-009/Expected.osm
@@ -3,100 +3,87 @@
     <bounds minlat="38.85404329028999" minlon="-104.90225991354" maxlat="38.85465984758" maxlon="-104.90220753865"/>
     <node visible="true" id="-5703869" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544960219599957" lon="-104.9022127761400043">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703869"/>
     </node>
     <node visible="true" id="-5703868" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543450483499981" lon="-104.9022466425199980">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703868"/>
     </node>
     <node visible="true" id="-5703867" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544919433099878" lon="-104.9022529302200013">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703867"/>
     </node>
     <node visible="true" id="-5703866" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546550891699951" lon="-104.9022599135399787">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703866"/>
     </node>
     <node visible="true" id="-5703865" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543451117299909" lon="-104.9022075386500035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703865"/>
     </node>
     <node visible="true" id="-5703864" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546598475800025" lon="-104.9022232511200059">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703864"/>
     </node>
     <node visible="true" id="-5703861" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544905837600041" lon="-104.9022302344399975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703861"/>
     </node>
     <node visible="true" id="-5703840" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541982798299941" lon="-104.9022249969499967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703840"/>
     </node>
     <node visible="true" id="-5703793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546564487100028" lon="-104.9022407094099947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703793"/>
     </node>
     <node visible="true" id="-5703791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543192802099995" lon="-104.9022232511200059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703791"/>
     </node>
     <node visible="true" id="-5703790" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540432902899937" lon="-104.9022145219699951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703790"/>
     </node>
     <way visible="true" id="-5703827" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703866"/>
         <nd ref="-5703867"/>
         <nd ref="-5703868"/>
         <nd ref="-5703791"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703827"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5703826" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703864"/>
         <nd ref="-5703869"/>
         <nd ref="-5703865"/>
         <nd ref="-5703791"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703826"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5703824" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703791"/>
         <nd ref="-5703861"/>
         <nd ref="-5703793"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703824"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5703792" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703790"/>
         <nd ref="-5703840"/>
         <nd ref="-5703791"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5703792"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5703827" role="reviewee"/>
         <member type="way" ref="-5703824" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5703826" role="reviewee"/>
         <member type="way" ref="-5703824" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-010/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-010/Expected.osm
@@ -3,93 +3,80 @@
     <bounds minlat="1.74551142222" minlon="2.09764924671" maxlat="1.74616769826" maxlon="2.09884500232"/>
     <node visible="true" id="-7129701" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7456685204099998" lon="2.0983905387099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129701"/>
     </node>
     <node visible="true" id="-7129687" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7460138447199998" lon="2.0984280325600002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129687"/>
     </node>
     <node visible="true" id="-7129676" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458585283500001" lon="2.0986292733999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129676"/>
     </node>
     <node visible="true" id="-7129663" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458241550600002" lon="2.0980191824799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129663"/>
     </node>
     <node visible="true" id="-7118508" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7455114222200001" lon="2.0983890610999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118508"/>
     </node>
     <node visible="true" id="-7118506" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7461676982600001" lon="2.0984539303799998">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118506"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7118504" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458002946200000" lon="2.0976492467100001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118504"/>
     </node>
     <node visible="true" id="-7118502" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458459612199997" lon="2.0983895303800000">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118502"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7118500" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458802402199998" lon="2.0988450023200000">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118500"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-7129650" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118502"/>
         <nd ref="-7129663"/>
         <nd ref="-7118504"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="tertiary"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7129650"/>
     </way>
     <way visible="true" id="-7118514" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118506"/>
         <nd ref="-7129687"/>
         <nd ref="-7118502"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7118514"/>
     </way>
     <way visible="true" id="-7118512" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118508"/>
         <nd ref="-7129701"/>
         <nd ref="-7118502"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7118512"/>
     </way>
     <way visible="true" id="-7118510" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118500"/>
         <nd ref="-7129676"/>
         <nd ref="-7118502"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="tertiary"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7118510"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-011/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-011/Expected.osm
@@ -3,88 +3,69 @@
     <bounds minlat="-10.90610306842" minlon="86.50034470252999" maxlat="-10.90345071826" maxlon="86.50439140252999"/>
     <node visible="true" id="-7168549" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9057796608732431" lon="86.5021039151042430">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168549"/>
     </node>
     <node visible="true" id="-7168548" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9056062712935411" lon="86.5020971203931310">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168548"/>
     </node>
     <node visible="true" id="-7168540" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9050023393024720" lon="86.5010551672644965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168540"/>
     </node>
     <node visible="true" id="-7168535" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049092765823818" lon="86.5025693613028608">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168535"/>
     </node>
     <node visible="true" id="-7168534" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048835002277720" lon="86.5028992701427200">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168534"/>
     </node>
     <node visible="true" id="-7168533" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048272344234576" lon="86.5036476798343017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168533"/>
     </node>
     <node visible="true" id="-7168367" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049161101499976" lon="86.5024879755000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168367"/>
     </node>
     <node visible="true" id="-7168365" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049066790799998" lon="86.5025978937800062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168365"/>
     </node>
     <node visible="true" id="-7168363" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9050488502600000" lon="86.5003447025299863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168363"/>
     </node>
     <node visible="true" id="-7168361" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049547352899996" lon="86.5017823025300032">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168361"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168359" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9061030684200002" lon="86.5020398025300068">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168359"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168357" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9057869954900006" lon="86.5021042025300062">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168357"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168355" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9043331569599999" lon="86.5021149025299962">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168355"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168353" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9042383348600005" lon="86.5019432025300006">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168353"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168351" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9034507182599985" lon="86.5019973025300004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168351"/>
     </node>
     <node visible="true" id="-7168349" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049653039899965" lon="86.5020720025299994">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168349"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168347" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049125592499987" lon="86.5025333025299972">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168347"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168345" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048283059299997" lon="86.5036169025299984">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168345"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7168343" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048013409099998" lon="86.5043914025299898">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7168343"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-7168711" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7168349"/>
@@ -92,31 +73,29 @@
         <nd ref="-7168549"/>
         <nd ref="-7168357"/>
         <nd ref="-7168359"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7168711"/>
     </way>
     <way visible="true" id="-7168706" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7168349"/>
         <nd ref="-7168361"/>
         <nd ref="-7168540"/>
         <nd ref="-7168363"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
-        <tag k="name" v="Salam"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="Salam"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7168706"/>
     </way>
     <way visible="true" id="-7168702" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7168343"/>
@@ -128,31 +107,29 @@
         <nd ref="-7168347"/>
         <nd ref="-7168367"/>
         <nd ref="-7168349"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
-        <tag k="alt_name" v="SALAM;SALEM"/>
-        <tag k="name" v="Salam"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="Salam"/>
+        <tag k="alt_name" v="SALAM;SALEM"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7168702"/>
     </way>
     <way visible="true" id="-7168371" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7168351"/>
         <nd ref="-7168353"/>
         <nd ref="-7168355"/>
         <nd ref="-7168349"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="1"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7168371"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-012/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-012/Expected.osm
@@ -3,193 +3,149 @@
     <bounds minlat="-1.78022160047" minlon="-3.58724003701" maxlat="-1.77447206058" maxlon="-3.58351785726"/>
     <node visible="true" id="-7180832" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7789348376207117" lon="-3.5855636020965438">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180832"/>
     </node>
     <node visible="true" id="-7180831" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792547149044082" lon="-3.5851371371201668">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180831"/>
     </node>
     <node visible="true" id="-7180822" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7747342801971944" lon="-3.5859691291431277">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180822"/>
     </node>
     <node visible="true" id="-7180821" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7754774849233219" lon="-3.5856759575194492">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180821"/>
     </node>
     <node visible="true" id="-7180820" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7755302840950817" lon="-3.5856597040399163">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180820"/>
     </node>
     <node visible="true" id="-7180819" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7766966869363325" lon="-3.5859450849151848">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180819"/>
     </node>
     <node visible="true" id="-7180818" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7767373664936790" lon="-3.5859648701184073">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180818"/>
     </node>
     <node visible="true" id="-7180817" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7770436067207056" lon="-3.5861074930491901">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180817"/>
     </node>
     <node visible="true" id="-7180816" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778863213877329" lon="-3.5863409760513978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180816"/>
     </node>
     <node visible="true" id="-7180604" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7794949934299997" lon="-3.5838878680099997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180604"/>
     </node>
     <node visible="true" id="-7180603" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7797735041299998" lon="-3.5837324820099998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180603"/>
     </node>
     <node visible="true" id="-7180602" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7802216004699998" lon="-3.5835178572599999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180602"/>
     </node>
     <node visible="true" id="-7180601" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778789784699998" lon="-3.5862427170099997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180601"/>
     </node>
     <node visible="true" id="-7180600" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778989735400001" lon="-3.5859953660100001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180600"/>
     </node>
     <node visible="true" id="-7180599" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778999474199999" lon="-3.5858833450100001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180599"/>
     </node>
     <node visible="true" id="-7180598" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778743826199999" lon="-3.5856943960100001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180598"/>
     </node>
     <node visible="true" id="-7180597" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778336202500000" lon="-3.5855356310099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180597"/>
     </node>
     <node visible="true" id="-7180596" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777945899299998" lon="-3.5853824000099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180596"/>
     </node>
     <node visible="true" id="-7180595" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777597005499999" lon="-3.5851491500099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180595"/>
     </node>
     <node visible="true" id="-7180594" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777531553699997" lon="-3.5850495950099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180594"/>
     </node>
     <node visible="true" id="-7180593" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777609761399997" lon="-3.5849413140099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180593"/>
     </node>
     <node visible="true" id="-7180592" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7781471494499996" lon="-3.5849072310099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180592"/>
     </node>
     <node visible="true" id="-7180591" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7783233331500001" lon="-3.5848883350099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180591"/>
     </node>
     <node visible="true" id="-7180590" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7785457333499999" lon="-3.5848888660100000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180590"/>
     </node>
     <node visible="true" id="-7180589" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778174956999995" lon="-3.5865304610100002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180589"/>
     </node>
     <node visible="true" id="-7180588" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779293374100000" lon="-3.5865715390100004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180588"/>
     </node>
     <node visible="true" id="-7180587" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779217761399999" lon="-3.5866996250099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180587"/>
     </node>
     <node visible="true" id="-7180586" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778877668599999" lon="-3.5869529550099997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180586"/>
     </node>
     <node visible="true" id="-7180585" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778646203399999" lon="-3.5872311950100002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180585"/>
     </node>
     <node visible="true" id="-7180584" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779397499700000" lon="-3.5872400370099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-7180584"/>
     </node>
     <node visible="true" id="-7180539" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7744720605800000" lon="-3.5863642922299994">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180539"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180538" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7746651984199999" lon="-3.5860209922299999">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180538"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180537" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7748796508500000" lon="-3.5858599922300005">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180537"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180536" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7758554956599997" lon="-3.5855595922300001">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180536"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180535" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7760807062699999" lon="-3.5856454922299998">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180535"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180534" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7768527568899999" lon="-3.5860209922299999">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180534"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180533" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7775391476699998" lon="-3.5863320922299997">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180533"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180532" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779572963999997" lon="-3.5863427922299995">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180532"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180531" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7787294495199997" lon="-3.5861604922299999">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180531"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180530" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7789546609900000" lon="-3.5855059922299999">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180530"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180529" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792548760399998" lon="-3.5851411922299996">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180529"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180528" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792442187100002" lon="-3.5848729922300002">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180528"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180527" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792012877499999" lon="-3.5841433922300001">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180527"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7180526" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792870491299997" lon="-3.5840361922299997">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7180526"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-7180990" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7180526"/>
@@ -200,6 +156,7 @@
         <nd ref="-7180530"/>
         <nd ref="-7180832"/>
         <nd ref="-7180531"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
@@ -208,9 +165,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="2"/>
         <tag k="width" v="5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7180990"/>
     </way>
     <way visible="true" id="-7180982" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7180531"/>
@@ -229,6 +184,7 @@
         <nd ref="-7180822"/>
         <nd ref="-7180538"/>
         <nd ref="-7180539"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
@@ -237,15 +193,14 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="2"/>
         <tag k="width" v="5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7180982"/>
     </way>
     <way visible="true" id="-7180535" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7180602"/>
         <nd ref="-7180603"/>
         <nd ref="-7180604"/>
         <nd ref="-7180526"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="KEMANGGISAN RAYA"/>
@@ -253,9 +208,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="2"/>
         <tag k="width" v="5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-7180535"/>
     </way>
     <way visible="true" id="-7180534" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7180590"/>
@@ -271,14 +224,13 @@
         <nd ref="-7180600"/>
         <nd ref="-7180601"/>
         <nd ref="-7180816"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-7180534"/>
     </way>
     <way visible="true" id="-7180533" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7180584"/>
@@ -288,13 +240,12 @@
         <nd ref="-7180588"/>
         <nd ref="-7180589"/>
         <nd ref="-7180816"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-7180533"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-013/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-013/Expected.osm
@@ -3,31 +3,24 @@
     <bounds minlat="4.820276872559999" minlon="7.02391697157" maxlat="4.82650963291" maxlon="7.0251186012"/>
     <node visible="true" id="-7222829" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8225903864668611" lon="7.0243332909303637">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222829"/>
     </node>
     <node visible="true" id="-7222823" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8202768725599991" lon="7.0239169715700003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222823"/>
     </node>
     <node visible="true" id="-7222818" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8265096329099997" lon="7.0251186012000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222818"/>
     </node>
     <node visible="true" id="-7222816" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8257505862499990" lon="7.0251078723699987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222816"/>
     </node>
     <node visible="true" id="-7222814" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8247777223900004" lon="7.0248503803000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222814"/>
     </node>
     <node visible="true" id="-7222812" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8231634067600000" lon="7.0244641422000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222812"/>
     </node>
     <node visible="true" id="-7222811" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8213780333499994" lon="7.0240564464299995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222811"/>
     </node>
     <way visible="true" id="-7222819" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7222823"/>
@@ -37,10 +30,10 @@
         <nd ref="-7222814"/>
         <nd ref="-7222816"/>
         <nd ref="-7222818"/>
-        <tag k="alt_name" v="input2"/>
-        <tag k="name" v="input1"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-7222819"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input1"/>
+        <tag k="alt_name" v="input2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/iterative/highway-014/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/iterative/highway-014/Expected.osm
@@ -3,77 +3,65 @@
     <bounds minlat="6.454799836839999" minlon="3.39280892716" maxlat="6.45989568525" maxlon="3.39587737427"/>
     <node visible="true" id="-932" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4547998368399995" lon="3.3946757446299998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-932"/>
     </node>
     <node visible="true" id="-931" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4551516439200007" lon="3.3945469986000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-931"/>
     </node>
     <node visible="true" id="-927" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4571452127700004" lon="3.3958773742699999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-927"/>
     </node>
     <node visible="true" id="-926" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4575076789899990" lon="3.3950834404000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-926"/>
     </node>
     <node visible="true" id="-922" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4598956852500002" lon="3.3928089271599999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-922"/>
     </node>
     <node visible="true" id="-921" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4558979005599992" lon="3.3945469986000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-921"/>
     </node>
     <node visible="true" id="-919" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4561750813199987" lon="3.3944718967499998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-919"/>
     </node>
     <node visible="true" id="-917" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4567720855099999" lon="3.3942787776999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-917"/>
     </node>
     <node visible="true" id="-915" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4573051243699995" lon="3.3942358623500000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-915"/>
     </node>
     <node visible="true" id="-913" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4576782512399991" lon="3.3943324218800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-913"/>
     </node>
     <node visible="true" id="-911" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4579127879899989" lon="3.3940427433000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-911"/>
     </node>
     <node visible="true" id="-910" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4589042375899988" lon="3.3933560977999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-910"/>
     </node>
     <way visible="true" id="-928" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-921"/>
         <nd ref="-931"/>
         <nd ref="-932"/>
-        <tag k="name" v="input2c"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-928"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input2c"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-925" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-922"/>
         <nd ref="-910"/>
-        <tag k="name" v="input2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-925"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-915" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-913"/>
         <nd ref="-926"/>
         <nd ref="-927"/>
-        <tag k="name" v="input2b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-915"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input2b"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-912" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-910"/>
@@ -83,10 +71,10 @@
         <nd ref="-917"/>
         <nd ref="-919"/>
         <nd ref="-921"/>
-        <tag k="alt_name" v="input2a;input2c"/>
-        <tag k="name" v="input1"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-912"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input1"/>
+        <tag k="alt_name" v="input2a;input2c"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/single-sided/highway-001/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/single-sided/highway-001/Expected.osm
@@ -3,78 +3,69 @@
     <bounds minlat="30.01377658509" minlon="-90.01849311751" maxlat="30.01977087609999" maxlon="-90.01445907515"/>
     <node visible="true" id="-4472513" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0151481186722080" lon="-90.0183690155489700">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472513"/>
     </node>
     <node visible="true" id="-4472481" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183065931999948" lon="-90.0149955169499805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472481"/>
     </node>
     <node visible="true" id="-4472479" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182380814099936" lon="-90.0160040275400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472479"/>
     </node>
     <node visible="true" id="-4472477" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183402684600011" lon="-90.0144590751500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472477"/>
     </node>
     <node visible="true" id="-4472475" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0168446111399909" lon="-90.0149526016100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472475"/>
     </node>
     <node visible="true" id="-4472473" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182938198199984" lon="-90.0150920764800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472473"/>
     </node>
     <node visible="true" id="-4472471" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0197708760999902" lon="-90.0152422801800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472471"/>
     </node>
     <node visible="true" id="-4472469" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0165357225800058" lon="-90.0184931175100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472469"/>
     </node>
     <node visible="true" id="-4472467" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0137765850900031" lon="-90.0182463542799951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472467"/>
     </node>
     <way visible="true" id="-4472583" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472467"/>
         <nd ref="-4472513"/>
         <nd ref="-4472469"/>
-        <tag k="note" v="1c;1a;1b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472583"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1c;1a;1b"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472491" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472479"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2c;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472491"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2c;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472489" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472473"/>
         <nd ref="-4472481"/>
         <nd ref="-4472477"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472489"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472487" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472475"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2b;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472487"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2b;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472485" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472471"/>
         <nd ref="-4472473"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472485"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/single-sided/highway-003/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/single-sided/highway-003/Expected.osm
@@ -1,62 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="0.00320735725" minlon="-7.625761000000029e-05" maxlat="0.00625601899" maxlon="0.005985084699999999"/>
+    <bounds minlat="0.00320735725" minlon="-7.625761000000029e-5" maxlat="0.00625601899" maxlon="0.005985084699999999"/>
     <node visible="true" id="-4473250" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046141443100000" lon="0.0016072457300000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473250"/>
     </node>
     <node visible="true" id="-4473249" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046337555700000" lon="0.0007334530700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473249"/>
     </node>
     <node visible="true" id="-4473248" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0051170997300000" lon="0.0002994294300000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473248"/>
     </node>
     <node visible="true" id="-4473247" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0060751017000000" lon="-0.0000762576100000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473247"/>
     </node>
     <node visible="true" id="-4473246" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473246"/>
     </node>
     <node visible="true" id="-4473244" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473244"/>
     </node>
     <node visible="true" id="-4473242" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473242"/>
     </node>
     <node visible="true" id="-4473240" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473240"/>
     </node>
     <node visible="true" id="-4473230" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062191150700000" lon="0.0006813779300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473230"/>
     </node>
     <node visible="true" id="-4473228" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0052548516500000" lon="0.0005686718200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473228"/>
     </node>
     <node visible="true" id="-4473226" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0041966664700000" lon="0.0005937176200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473226"/>
     </node>
     <node visible="true" id="-4473224" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032073572500000" lon="0.0007878225900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473224"/>
     </node>
     <way visible="true" id="-4473253" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4473247"/>
         <nd ref="-4473248"/>
         <nd ref="-4473249"/>
         <nd ref="-4473250"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473253"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4473252" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4473240"/>
@@ -64,18 +52,17 @@
         <nd ref="-4473244"/>
         <nd ref="-4473246"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-4473252"/>
     </way>
     <way visible="true" id="-4473248" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4473224"/>
         <nd ref="-4473226"/>
         <nd ref="-4473228"/>
         <nd ref="-4473230"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473248"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/single-sided/highway-004/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/single-sided/highway-004/Expected.osm
@@ -3,39 +3,30 @@
     <bounds minlat="-0.0009806089100000011" minlon="0.0017728795" maxlat="0.01055288979" maxlon="0.00893974199"/>
     <node visible="true" id="-1018689" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0048427069810808" lon="0.0056549112103702">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018689"/>
     </node>
     <node visible="true" id="-1018670" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0090293950900000" lon="0.0017728795000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018670"/>
     </node>
     <node visible="true" id="-1018668" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0105528897900000" lon="0.0054206837600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018668"/>
     </node>
     <node visible="true" id="-1018666" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0007284812700000" lon="0.0089397419900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018666"/>
     </node>
     <node visible="true" id="-1018663" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0009806089100000" lon="0.0049968947400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018663"/>
     </node>
     <node visible="true" id="-1018574" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018574"/>
     </node>
     <node visible="true" id="-1018572" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018572"/>
     </node>
     <node visible="true" id="-1018570" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018570"/>
     </node>
     <node visible="true" id="-1018568" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018568"/>
     </node>
     <way visible="true" id="-1018722" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018568"/>
@@ -44,37 +35,36 @@
         <nd ref="-1018572"/>
         <nd ref="-1018574"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="400"/>
-        <tag k="hoot:id" v="-1018722"/>
     </way>
     <way visible="true" id="-1018671" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018670"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018671"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018669" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018668"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018669"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018667" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018666"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018667"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018664" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018663"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018664"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/single-sided/highway-005/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/single-sided/highway-005/Expected.osm
@@ -3,443 +3,333 @@
     <bounds minlat="38.88932131124" minlon="-77.05504778748001" maxlat="38.89246497495999" maxlon="-77.05195146739"/>
     <node visible="true" id="-3218" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922220501699911" lon="-77.0550477874800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3218"/>
     </node>
     <node visible="true" id="-3216" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921495043399901" lon="-77.0546779563500053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3216"/>
     </node>
     <node visible="true" id="-3214" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921307105799983" lon="-77.0545648707499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3214"/>
     </node>
     <node visible="true" id="-3212" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920775075999927" lon="-77.0542447319599830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3212"/>
     </node>
     <node visible="true" id="-3210" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920710351700052" lon="-77.0542154486799973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3210"/>
     </node>
     <node visible="true" id="-3208" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920639320899824" lon="-77.0541862801999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3208"/>
     </node>
     <node visible="true" id="-3206" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920561081099834" lon="-77.0541575722400012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3206"/>
     </node>
     <node visible="true" id="-3204" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920475633600020" lon="-77.0541290942900048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3204"/>
     </node>
     <node visible="true" id="-3202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920384779399839" lon="-77.0541009617400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3202"/>
     </node>
     <node visible="true" id="-3200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920285815899902" lon="-77.0540731743899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3200"/>
     </node>
     <node visible="true" id="-3198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920181445299988" lon="-77.0540458469999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3198"/>
     </node>
     <node visible="true" id="-3196" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920069866299940" lon="-77.0540188663100025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3196"/>
     </node>
     <node visible="true" id="-3194" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919952879499888" lon="-77.0539924608499973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3194"/>
     </node>
     <node visible="true" id="-3192" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919828684399960" lon="-77.0539664006600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3192"/>
     </node>
     <node visible="true" id="-3190" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919699081999894" lon="-77.0539408011400013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3190"/>
     </node>
     <node visible="true" id="-3188" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919563171099938" lon="-77.0539157774999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3188"/>
     </node>
     <node visible="true" id="-3186" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919449756599960" lon="-77.0538960579399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3186"/>
     </node>
     <node visible="true" id="-3184" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917364941500026" lon="-77.0535647337700027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3184"/>
     </node>
     <node visible="true" id="-3182" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916187500899966" lon="-77.0533780258199954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3182"/>
     </node>
     <node visible="true" id="-3180" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915141267099926" lon="-77.0531944145800054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3180"/>
     </node>
     <node visible="true" id="-3178" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914258660799845" lon="-77.0529949083099979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3178"/>
     </node>
     <node visible="true" id="-3176" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913819943099952" lon="-77.0528765840799963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3176"/>
     </node>
     <node visible="true" id="-3174" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913542716399974" lon="-77.0528018136899959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3174"/>
     </node>
     <node visible="true" id="-3172" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912993277400005" lon="-77.0526524600399938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3172"/>
     </node>
     <node visible="true" id="-3170" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912718535099842" lon="-77.0525820492999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3170"/>
     </node>
     <node visible="true" id="-3168" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912088384799901" lon="-77.0524337209899954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3168"/>
     </node>
     <node visible="true" id="-3166" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911757620799960" lon="-77.0523519128099821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3166"/>
     </node>
     <node visible="true" id="-3164" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911507110800017" lon="-77.0522899546400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3164"/>
     </node>
     <node visible="true" id="-3162" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911209678599974" lon="-77.0522241308899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3162"/>
     </node>
     <node visible="true" id="-3160" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911060082100022" lon="-77.0521991875600065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3160"/>
     </node>
     <node visible="true" id="-3158" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910830982699949" lon="-77.0521738861399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3158"/>
     </node>
     <node visible="true" id="-3156" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910589747099991" lon="-77.0521505217899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3156"/>
     </node>
     <node visible="true" id="-3154" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910316927499906" lon="-77.0521305584199894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3154"/>
     </node>
     <node visible="true" id="-3152" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909968552499947" lon="-77.0521087935299960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3152"/>
     </node>
     <node visible="true" id="-3150" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909545739400073" lon="-77.0520872112600017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3150"/>
     </node>
     <node visible="true" id="-3148" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908842149400016" lon="-77.0520611858700022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3148"/>
     </node>
     <node visible="true" id="-3146" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907976085799945" lon="-77.0520507334999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3146"/>
     </node>
     <node visible="true" id="-3144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907109987099915" lon="-77.0520506703099954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3144"/>
     </node>
     <node visible="true" id="-3142" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906230228399892" lon="-77.0520748474600055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3142"/>
     </node>
     <node visible="true" id="-3140" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905037313699964" lon="-77.0521247918500052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3140"/>
     </node>
     <node visible="true" id="-3138" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903116149099972" lon="-77.0522266902599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3138"/>
     </node>
     <node visible="true" id="-3136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8900091376999981" lon="-77.0523879893599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3136"/>
     </node>
     <node visible="true" id="-3134" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898711819200003" lon="-77.0524590890500036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3134"/>
     </node>
     <node visible="true" id="-3132" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898477543999874" lon="-77.0524718655800029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3132"/>
     </node>
     <node visible="true" id="-3130" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898238761599870" lon="-77.0524840668799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3130"/>
     </node>
     <node visible="true" id="-3128" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897997284399963" lon="-77.0524958061999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3128"/>
     </node>
     <node visible="true" id="-3126" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897753112299966" lon="-77.0525070842400055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3126"/>
     </node>
     <node visible="true" id="-3124" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897506234699932" lon="-77.0525177857499983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3124"/>
     </node>
     <node visible="true" id="-3122" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897255755800018" lon="-77.0525280259300018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3122"/>
     </node>
     <node visible="true" id="-3120" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897003477799856" lon="-77.0525376896400047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3120"/>
     </node>
     <node visible="true" id="-3118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896748493699960" lon="-77.0525468920900067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3118"/>
     </node>
     <node visible="true" id="-3116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896491721800004" lon="-77.0525555180699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3116"/>
     </node>
     <node visible="true" id="-3114" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896233138999960" lon="-77.0525636828500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3114"/>
     </node>
     <node visible="true" id="-3112" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895972768400071" lon="-77.0525712711600050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3112"/>
     </node>
     <node visible="true" id="-3110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895710587499934" lon="-77.0525782830199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3110"/>
     </node>
     <node visible="true" id="-3108" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895447513899910" lon="-77.0525847184700012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3108"/>
     </node>
     <node visible="true" id="-3106" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895182635099914" lon="-77.0525906927300070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3106"/>
     </node>
     <node visible="true" id="-3104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894916881099988" lon="-77.0525959753299787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3104"/>
     </node>
     <node visible="true" id="-3102" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894650205799977" lon="-77.0526007967999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3102"/>
     </node>
     <node visible="true" id="-3100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894383538699984" lon="-77.0526050419399979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3100"/>
     </node>
     <node visible="true" id="-3098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894115967800005" lon="-77.0526087106800048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3098"/>
     </node>
     <node visible="true" id="-3096" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893848410699974" lon="-77.0526118023799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3096"/>
     </node>
     <node visible="true" id="-3094" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893580845499898" lon="-77.0526142039300055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3094"/>
     </node>
     <node visible="true" id="-3092" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893313293599974" lon="-77.0526161429799998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3092"/>
     </node>
     <node visible="true" id="-3090" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893213112399962" lon="-77.0526166744499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3090"/>
     </node>
     <node visible="true" id="-3088" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924649749599922" lon="-77.0529468792900047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3088"/>
     </node>
     <node visible="true" id="-3086" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921842958999875" lon="-77.0527829676599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3086"/>
     </node>
     <node visible="true" id="-3084" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921735790099845" lon="-77.0527761581199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3084"/>
     </node>
     <node visible="true" id="-3082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921407082499897" lon="-77.0527544631899985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3082"/>
     </node>
     <node visible="true" id="-3080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921082882699878" lon="-77.0527319624400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3080"/>
     </node>
     <node visible="true" id="-3078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920761388999949" lon="-77.0527086543099955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3078"/>
     </node>
     <node visible="true" id="-3076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920443502199973" lon="-77.0526845388600066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3076"/>
     </node>
     <node visible="true" id="-3074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920081742899910" lon="-77.0526558195300026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3074"/>
     </node>
     <node visible="true" id="-3072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919818548399974" lon="-77.0526341208800005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3072"/>
     </node>
     <node visible="true" id="-3070" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919512382799937" lon="-77.0526077009899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3070"/>
     </node>
     <node visible="true" id="-3068" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919209823499941" lon="-77.0525805912100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3068"/>
     </node>
     <node visible="true" id="-3066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918911772000016" lon="-77.0525526741800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3066"/>
     </node>
     <node visible="true" id="-3064" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917937840700034" lon="-77.0524479730499792">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3064"/>
     </node>
     <node visible="true" id="-3062" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917422506299886" lon="-77.0523925716599933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3062"/>
     </node>
     <node visible="true" id="-3060" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916788012099914" lon="-77.0523261498599794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3060"/>
     </node>
     <node visible="true" id="-3058" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916623556899950" lon="-77.0523089339699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3058"/>
     </node>
     <node visible="true" id="-3056" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916373517199929" lon="-77.0522827590699961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3056"/>
     </node>
     <node visible="true" id="-3054" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914826580300002" lon="-77.0521270329400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3054"/>
     </node>
     <node visible="true" id="-3052" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914664488699984" lon="-77.0521137659799820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3052"/>
     </node>
     <node visible="true" id="-3050" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914452865000015" lon="-77.0520973824500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3050"/>
     </node>
     <node visible="true" id="-3048" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914236733499905" lon="-77.0520818047499887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3048"/>
     </node>
     <node visible="true" id="-3046" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914017895899917" lon="-77.0520670351800021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3046"/>
     </node>
     <node visible="true" id="-3044" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913795451799942" lon="-77.0520529562499945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3044"/>
     </node>
     <node visible="true" id="-3042" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913570301099938" lon="-77.0520397992799815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3042"/>
     </node>
     <node visible="true" id="-3040" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913341543400009" lon="-77.0520274489200006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3040"/>
     </node>
     <node visible="true" id="-3038" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913110979899983" lon="-77.0520160205799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3038"/>
     </node>
     <node visible="true" id="-3036" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912877710399911" lon="-77.0520053989300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3036"/>
     </node>
     <node visible="true" id="-3034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912641734699918" lon="-77.0519955839599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3034"/>
     </node>
     <node visible="true" id="-3032" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912403953199828" lon="-77.0519866910100006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3032"/>
     </node>
     <node visible="true" id="-3030" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912084200599892" lon="-77.0519766394199905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3030"/>
     </node>
     <node visible="true" id="-3028" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911813977699907" lon="-77.0519702792900034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3028"/>
     </node>
     <node visible="true" id="-3026" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911542849799901" lon="-77.0519648426799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3026"/>
     </node>
     <node visible="true" id="-3024" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911270816999988" lon="-77.0519603274299811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3024"/>
     </node>
     <node visible="true" id="-3022" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910997879299956" lon="-77.0519567342600027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3022"/>
     </node>
     <node visible="true" id="-3020" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910724036599902" lon="-77.0519540631599966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3020"/>
     </node>
     <node visible="true" id="-3018" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910447053799899" lon="-77.0519523046099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3018"/>
     </node>
     <node visible="true" id="-3016" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910175437999897" lon="-77.0519514873300011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3016"/>
     </node>
     <node visible="true" id="-3014" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909901583500002" lon="-77.0519514673899977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3014"/>
     </node>
     <node visible="true" id="-3012" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909626823599908" lon="-77.0519524847800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3012"/>
     </node>
     <node visible="true" id="-3010" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909352960399914" lon="-77.0519544243900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3010"/>
     </node>
     <node visible="true" id="-3008" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908763008300014" lon="-77.0519656466299949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3008"/>
     </node>
     <node visible="true" id="-3006" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908137429800007" lon="-77.0519891400499972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3006"/>
     </node>
     <node visible="true" id="-3004" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907401449599988" lon="-77.0520173333100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3004"/>
     </node>
     <node visible="true" id="-3002" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906647064799955" lon="-77.0520478787799874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3002"/>
     </node>
     <node visible="true" id="-3000" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905699460199941" lon="-77.0520913581299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3000"/>
     </node>
     <way visible="true" id="-3226" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3166"/>
@@ -469,11 +359,10 @@
         <nd ref="-3214"/>
         <nd ref="-3216"/>
         <nd ref="-3218"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3226"/>
     </way>
     <way visible="true" id="-3224" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -490,12 +379,11 @@
         <nd ref="-3162"/>
         <nd ref="-3164"/>
         <nd ref="-3166"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3224"/>
     </way>
     <way visible="true" id="-3222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3090"/>
@@ -524,12 +412,11 @@
         <nd ref="-3136"/>
         <nd ref="-3138"/>
         <nd ref="-3140"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3222"/>
     </way>
     <way visible="true" id="-3220" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -578,11 +465,10 @@
         <nd ref="-3084"/>
         <nd ref="-3086"/>
         <nd ref="-3088"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3220"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/single-sided/highway-006/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/single-sided/highway-006/Expected.osm
@@ -3,57 +3,50 @@
     <bounds minlat="38.85256682120001" minlon="-104.89916367283" maxlat="38.85335424982999" maxlon="-104.89826276519"/>
     <node visible="true" id="-1682758" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530188155899907" lon="-104.8986868588499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682758"/>
     </node>
     <node visible="true" id="-1682757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530214305399895" lon="-104.8991636728299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682757"/>
     </node>
     <node visible="true" id="-1682756" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8525668212000070" lon="-104.8986765855800058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682756"/>
     </node>
     <node visible="true" id="-1682755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533542498299909" lon="-104.8982627651899975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682755"/>
     </node>
     <node visible="true" id="-1682754" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8528283481400010" lon="-104.8986799434299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682754"/>
     </node>
     <node visible="true" id="-1682753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530240454899953" lon="-104.8989252658400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682753"/>
     </node>
     <node visible="true" id="-1682752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8531970813699985" lon="-104.8984693340700005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682752"/>
     </node>
     <way visible="true" id="-1682761" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682757"/>
         <nd ref="-1682753"/>
         <nd ref="-1682758"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682761"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682760" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682754"/>
         <nd ref="-1682756"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682760"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682759" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682752"/>
         <nd ref="-1682755"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682759"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/single-sided/highway-007/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/single-sided/highway-007/Expected.osm
@@ -3,110 +3,92 @@
     <bounds minlat="38.85407320977" minlon="-104.90305077439" maxlat="38.85460590869" maxlon="-104.90151585456"/>
     <node visible="true" id="-5011083" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545143584800030" lon="-104.9022746626800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011083"/>
     </node>
     <node visible="true" id="-5011082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9027146783799935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011082"/>
     </node>
     <node visible="true" id="-5011081" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545634736000025" lon="-104.9022320907299815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011081"/>
     </node>
     <node visible="true" id="-5011080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546017057599968" lon="-104.9021850918999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011080"/>
     </node>
     <node visible="true" id="-5011079" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9023815370599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011079"/>
     </node>
     <node visible="true" id="-5011078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545593122299948" lon="-104.9023202620900008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011078"/>
     </node>
     <node visible="true" id="-5011077" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540732097700001" lon="-104.9022759351200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011077"/>
     </node>
     <node visible="true" id="-5011076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9018489958900062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011076"/>
     </node>
     <node visible="true" id="-5011075" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543021280200023" lon="-104.9022871808499957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011075"/>
     </node>
     <node visible="true" id="-5011074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545933830200028" lon="-104.9030507743899960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011074"/>
     </node>
     <node visible="true" id="-5011073" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545946838899994" lon="-104.9022775123400066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011073"/>
     </node>
     <node visible="true" id="-5011072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9015158545600030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011072"/>
     </node>
     <way visible="true" id="-5011089" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011081"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1b;2b"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1b;2b"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011089"/>
     </way>
     <way visible="true" id="-5011088" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011076"/>
         <nd ref="-5011072"/>
-        <tag k="note" v="1c;2c"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1c;2c"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011088"/>
     </way>
     <way visible="true" id="-5011087" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011073"/>
         <nd ref="-5011080"/>
-        <tag k="note" v="1d;2d"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1d;2d"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011087"/>
     </way>
     <way visible="true" id="-5011086" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011077"/>
         <nd ref="-5011075"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1a;2a"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1a;2a"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011086"/>
     </way>
     <way visible="true" id="-5011085" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011078"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1e;2e"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1e;2e"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011085"/>
     </way>
     <way visible="true" id="-5011084" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011074"/>
         <nd ref="-5011082"/>
         <nd ref="-5011079"/>
-        <tag k="note" v="1f;2f"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1f;2f"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011084"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/vagabond/highway-001/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/vagabond/highway-001/Expected.osm
@@ -3,78 +3,69 @@
     <bounds minlat="30.01377658509" minlon="-90.01849311751" maxlat="30.01977087609999" maxlon="-90.01445907515"/>
     <node visible="true" id="-4472513" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0151481186722080" lon="-90.0183690155489700">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472513"/>
     </node>
     <node visible="true" id="-4472481" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183065931999948" lon="-90.0149955169499805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472481"/>
     </node>
     <node visible="true" id="-4472479" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182380814099936" lon="-90.0160040275400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472479"/>
     </node>
     <node visible="true" id="-4472477" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183402684600011" lon="-90.0144590751500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472477"/>
     </node>
     <node visible="true" id="-4472475" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0168446111399909" lon="-90.0149526016100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472475"/>
     </node>
     <node visible="true" id="-4472473" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182938198199984" lon="-90.0150920764800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472473"/>
     </node>
     <node visible="true" id="-4472471" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0197708760999902" lon="-90.0152422801800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472471"/>
     </node>
     <node visible="true" id="-4472469" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0165357225800058" lon="-90.0184931175100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472469"/>
     </node>
     <node visible="true" id="-4472467" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0137765850900031" lon="-90.0182463542799951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472467"/>
     </node>
     <way visible="true" id="-4472583" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472467"/>
         <nd ref="-4472513"/>
         <nd ref="-4472469"/>
-        <tag k="note" v="1c;1a;1b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472583"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1c;1a;1b"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472491" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472479"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2c;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472491"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2c;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472489" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472473"/>
         <nd ref="-4472481"/>
         <nd ref="-4472477"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472489"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472487" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472475"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2b;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472487"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2b;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472485" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472471"/>
         <nd ref="-4472473"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472485"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/vagabond/highway-003/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/vagabond/highway-003/Expected.osm
@@ -1,62 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="0.00320735725" minlon="-7.625761000000029e-05" maxlat="0.00625601899" maxlon="0.005985084699999999"/>
+    <bounds minlat="0.00320735725" minlon="-7.625761000000029e-5" maxlat="0.00625601899" maxlon="0.005985084699999999"/>
     <node visible="true" id="-4473250" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046141443100000" lon="0.0016072457300000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473250"/>
     </node>
     <node visible="true" id="-4473249" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046337555700000" lon="0.0007334530700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473249"/>
     </node>
     <node visible="true" id="-4473248" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0051170997300000" lon="0.0002994294300000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473248"/>
     </node>
     <node visible="true" id="-4473247" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0060751017000000" lon="-0.0000762576100000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473247"/>
     </node>
     <node visible="true" id="-4473246" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473246"/>
     </node>
     <node visible="true" id="-4473244" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473244"/>
     </node>
     <node visible="true" id="-4473242" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473242"/>
     </node>
     <node visible="true" id="-4473240" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473240"/>
     </node>
     <node visible="true" id="-4473230" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062191150700000" lon="0.0006813779300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473230"/>
     </node>
     <node visible="true" id="-4473228" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0052548516500000" lon="0.0005686718200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473228"/>
     </node>
     <node visible="true" id="-4473226" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0041966664700000" lon="0.0005937176200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473226"/>
     </node>
     <node visible="true" id="-4473224" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032073572500000" lon="0.0007878225900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473224"/>
     </node>
     <way visible="true" id="-4473253" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4473247"/>
         <nd ref="-4473248"/>
         <nd ref="-4473249"/>
         <nd ref="-4473250"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-4473253"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4473252" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4473240"/>
@@ -64,18 +52,17 @@
         <nd ref="-4473244"/>
         <nd ref="-4473246"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-4473252"/>
     </way>
     <way visible="true" id="-4473248" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4473224"/>
         <nd ref="-4473226"/>
         <nd ref="-4473228"/>
         <nd ref="-4473230"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4473248"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/vagabond/highway-004/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/vagabond/highway-004/Expected.osm
@@ -3,39 +3,30 @@
     <bounds minlat="-0.0009806089100000011" minlon="0.0017728795" maxlat="0.01055288979" maxlon="0.00893974199"/>
     <node visible="true" id="-1018689" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0048427069810808" lon="0.0056549112103702">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018689"/>
     </node>
     <node visible="true" id="-1018670" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0090293950900000" lon="0.0017728795000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018670"/>
     </node>
     <node visible="true" id="-1018668" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0105528897900000" lon="0.0054206837600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018668"/>
     </node>
     <node visible="true" id="-1018666" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0007284812700000" lon="0.0089397419900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018666"/>
     </node>
     <node visible="true" id="-1018663" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0009806089100000" lon="0.0049968947400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018663"/>
     </node>
     <node visible="true" id="-1018574" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018574"/>
     </node>
     <node visible="true" id="-1018572" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018572"/>
     </node>
     <node visible="true" id="-1018570" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018570"/>
     </node>
     <node visible="true" id="-1018568" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018568"/>
     </node>
     <way visible="true" id="-1018722" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018568"/>
@@ -44,37 +35,36 @@
         <nd ref="-1018572"/>
         <nd ref="-1018574"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="400"/>
-        <tag k="hoot:id" v="-1018722"/>
     </way>
     <way visible="true" id="-1018671" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018670"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018671"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018669" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018668"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018669"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018667" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018666"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018667"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018664" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018663"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018664"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/vagabond/highway-005/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/vagabond/highway-005/Expected.osm
@@ -3,443 +3,333 @@
     <bounds minlat="38.88932131124" minlon="-77.05504778748001" maxlat="38.89246497495999" maxlon="-77.05195146739"/>
     <node visible="true" id="-3218" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922220501699911" lon="-77.0550477874800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3218"/>
     </node>
     <node visible="true" id="-3216" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921495043399901" lon="-77.0546779563500053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3216"/>
     </node>
     <node visible="true" id="-3214" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921307105799983" lon="-77.0545648707499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3214"/>
     </node>
     <node visible="true" id="-3212" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920775075999927" lon="-77.0542447319599830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3212"/>
     </node>
     <node visible="true" id="-3210" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920710351700052" lon="-77.0542154486799973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3210"/>
     </node>
     <node visible="true" id="-3208" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920639320899824" lon="-77.0541862801999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3208"/>
     </node>
     <node visible="true" id="-3206" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920561081099834" lon="-77.0541575722400012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3206"/>
     </node>
     <node visible="true" id="-3204" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920475633600020" lon="-77.0541290942900048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3204"/>
     </node>
     <node visible="true" id="-3202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920384779399839" lon="-77.0541009617400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3202"/>
     </node>
     <node visible="true" id="-3200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920285815899902" lon="-77.0540731743899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3200"/>
     </node>
     <node visible="true" id="-3198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920181445299988" lon="-77.0540458469999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3198"/>
     </node>
     <node visible="true" id="-3196" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920069866299940" lon="-77.0540188663100025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3196"/>
     </node>
     <node visible="true" id="-3194" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919952879499888" lon="-77.0539924608499973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3194"/>
     </node>
     <node visible="true" id="-3192" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919828684399960" lon="-77.0539664006600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3192"/>
     </node>
     <node visible="true" id="-3190" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919699081999894" lon="-77.0539408011400013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3190"/>
     </node>
     <node visible="true" id="-3188" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919563171099938" lon="-77.0539157774999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3188"/>
     </node>
     <node visible="true" id="-3186" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919449756599960" lon="-77.0538960579399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3186"/>
     </node>
     <node visible="true" id="-3184" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917364941500026" lon="-77.0535647337700027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3184"/>
     </node>
     <node visible="true" id="-3182" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916187500899966" lon="-77.0533780258199954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3182"/>
     </node>
     <node visible="true" id="-3180" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915141267099926" lon="-77.0531944145800054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3180"/>
     </node>
     <node visible="true" id="-3178" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914258660799845" lon="-77.0529949083099979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3178"/>
     </node>
     <node visible="true" id="-3176" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913819943099952" lon="-77.0528765840799963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3176"/>
     </node>
     <node visible="true" id="-3174" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913542716399974" lon="-77.0528018136899959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3174"/>
     </node>
     <node visible="true" id="-3172" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912993277400005" lon="-77.0526524600399938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3172"/>
     </node>
     <node visible="true" id="-3170" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912718535099842" lon="-77.0525820492999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3170"/>
     </node>
     <node visible="true" id="-3168" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912088384799901" lon="-77.0524337209899954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3168"/>
     </node>
     <node visible="true" id="-3166" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911757620799960" lon="-77.0523519128099821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3166"/>
     </node>
     <node visible="true" id="-3164" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911507110800017" lon="-77.0522899546400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3164"/>
     </node>
     <node visible="true" id="-3162" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911209678599974" lon="-77.0522241308899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3162"/>
     </node>
     <node visible="true" id="-3160" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911060082100022" lon="-77.0521991875600065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3160"/>
     </node>
     <node visible="true" id="-3158" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910830982699949" lon="-77.0521738861399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3158"/>
     </node>
     <node visible="true" id="-3156" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910589747099991" lon="-77.0521505217899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3156"/>
     </node>
     <node visible="true" id="-3154" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910316927499906" lon="-77.0521305584199894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3154"/>
     </node>
     <node visible="true" id="-3152" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909968552499947" lon="-77.0521087935299960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3152"/>
     </node>
     <node visible="true" id="-3150" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909545739400073" lon="-77.0520872112600017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3150"/>
     </node>
     <node visible="true" id="-3148" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908842149400016" lon="-77.0520611858700022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3148"/>
     </node>
     <node visible="true" id="-3146" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907976085799945" lon="-77.0520507334999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3146"/>
     </node>
     <node visible="true" id="-3144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907109987099915" lon="-77.0520506703099954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3144"/>
     </node>
     <node visible="true" id="-3142" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906230228399892" lon="-77.0520748474600055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3142"/>
     </node>
     <node visible="true" id="-3140" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905037313699964" lon="-77.0521247918500052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3140"/>
     </node>
     <node visible="true" id="-3138" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903116149099972" lon="-77.0522266902599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3138"/>
     </node>
     <node visible="true" id="-3136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8900091376999981" lon="-77.0523879893599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3136"/>
     </node>
     <node visible="true" id="-3134" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898711819200003" lon="-77.0524590890500036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3134"/>
     </node>
     <node visible="true" id="-3132" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898477543999874" lon="-77.0524718655800029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3132"/>
     </node>
     <node visible="true" id="-3130" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898238761599870" lon="-77.0524840668799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3130"/>
     </node>
     <node visible="true" id="-3128" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897997284399963" lon="-77.0524958061999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3128"/>
     </node>
     <node visible="true" id="-3126" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897753112299966" lon="-77.0525070842400055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3126"/>
     </node>
     <node visible="true" id="-3124" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897506234699932" lon="-77.0525177857499983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3124"/>
     </node>
     <node visible="true" id="-3122" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897255755800018" lon="-77.0525280259300018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3122"/>
     </node>
     <node visible="true" id="-3120" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897003477799856" lon="-77.0525376896400047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3120"/>
     </node>
     <node visible="true" id="-3118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896748493699960" lon="-77.0525468920900067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3118"/>
     </node>
     <node visible="true" id="-3116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896491721800004" lon="-77.0525555180699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3116"/>
     </node>
     <node visible="true" id="-3114" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896233138999960" lon="-77.0525636828500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3114"/>
     </node>
     <node visible="true" id="-3112" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895972768400071" lon="-77.0525712711600050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3112"/>
     </node>
     <node visible="true" id="-3110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895710587499934" lon="-77.0525782830199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3110"/>
     </node>
     <node visible="true" id="-3108" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895447513899910" lon="-77.0525847184700012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3108"/>
     </node>
     <node visible="true" id="-3106" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895182635099914" lon="-77.0525906927300070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3106"/>
     </node>
     <node visible="true" id="-3104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894916881099988" lon="-77.0525959753299787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3104"/>
     </node>
     <node visible="true" id="-3102" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894650205799977" lon="-77.0526007967999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3102"/>
     </node>
     <node visible="true" id="-3100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894383538699984" lon="-77.0526050419399979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3100"/>
     </node>
     <node visible="true" id="-3098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894115967800005" lon="-77.0526087106800048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3098"/>
     </node>
     <node visible="true" id="-3096" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893848410699974" lon="-77.0526118023799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3096"/>
     </node>
     <node visible="true" id="-3094" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893580845499898" lon="-77.0526142039300055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3094"/>
     </node>
     <node visible="true" id="-3092" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893313293599974" lon="-77.0526161429799998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3092"/>
     </node>
     <node visible="true" id="-3090" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893213112399962" lon="-77.0526166744499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3090"/>
     </node>
     <node visible="true" id="-3088" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924649749599922" lon="-77.0529468792900047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3088"/>
     </node>
     <node visible="true" id="-3086" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921842958999875" lon="-77.0527829676599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3086"/>
     </node>
     <node visible="true" id="-3084" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921735790099845" lon="-77.0527761581199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3084"/>
     </node>
     <node visible="true" id="-3082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921407082499897" lon="-77.0527544631899985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3082"/>
     </node>
     <node visible="true" id="-3080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921082882699878" lon="-77.0527319624400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3080"/>
     </node>
     <node visible="true" id="-3078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920761388999949" lon="-77.0527086543099955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3078"/>
     </node>
     <node visible="true" id="-3076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920443502199973" lon="-77.0526845388600066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3076"/>
     </node>
     <node visible="true" id="-3074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920081742899910" lon="-77.0526558195300026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3074"/>
     </node>
     <node visible="true" id="-3072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919818548399974" lon="-77.0526341208800005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3072"/>
     </node>
     <node visible="true" id="-3070" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919512382799937" lon="-77.0526077009899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3070"/>
     </node>
     <node visible="true" id="-3068" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919209823499941" lon="-77.0525805912100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3068"/>
     </node>
     <node visible="true" id="-3066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918911772000016" lon="-77.0525526741800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3066"/>
     </node>
     <node visible="true" id="-3064" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917937840700034" lon="-77.0524479730499792">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3064"/>
     </node>
     <node visible="true" id="-3062" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917422506299886" lon="-77.0523925716599933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3062"/>
     </node>
     <node visible="true" id="-3060" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916788012099914" lon="-77.0523261498599794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3060"/>
     </node>
     <node visible="true" id="-3058" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916623556899950" lon="-77.0523089339699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3058"/>
     </node>
     <node visible="true" id="-3056" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916373517199929" lon="-77.0522827590699961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3056"/>
     </node>
     <node visible="true" id="-3054" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914826580300002" lon="-77.0521270329400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3054"/>
     </node>
     <node visible="true" id="-3052" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914664488699984" lon="-77.0521137659799820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3052"/>
     </node>
     <node visible="true" id="-3050" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914452865000015" lon="-77.0520973824500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3050"/>
     </node>
     <node visible="true" id="-3048" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914236733499905" lon="-77.0520818047499887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3048"/>
     </node>
     <node visible="true" id="-3046" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914017895899917" lon="-77.0520670351800021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3046"/>
     </node>
     <node visible="true" id="-3044" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913795451799942" lon="-77.0520529562499945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3044"/>
     </node>
     <node visible="true" id="-3042" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913570301099938" lon="-77.0520397992799815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3042"/>
     </node>
     <node visible="true" id="-3040" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913341543400009" lon="-77.0520274489200006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3040"/>
     </node>
     <node visible="true" id="-3038" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913110979899983" lon="-77.0520160205799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3038"/>
     </node>
     <node visible="true" id="-3036" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912877710399911" lon="-77.0520053989300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3036"/>
     </node>
     <node visible="true" id="-3034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912641734699918" lon="-77.0519955839599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3034"/>
     </node>
     <node visible="true" id="-3032" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912403953199828" lon="-77.0519866910100006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3032"/>
     </node>
     <node visible="true" id="-3030" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912084200599892" lon="-77.0519766394199905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3030"/>
     </node>
     <node visible="true" id="-3028" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911813977699907" lon="-77.0519702792900034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3028"/>
     </node>
     <node visible="true" id="-3026" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911542849799901" lon="-77.0519648426799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3026"/>
     </node>
     <node visible="true" id="-3024" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911270816999988" lon="-77.0519603274299811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3024"/>
     </node>
     <node visible="true" id="-3022" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910997879299956" lon="-77.0519567342600027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3022"/>
     </node>
     <node visible="true" id="-3020" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910724036599902" lon="-77.0519540631599966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3020"/>
     </node>
     <node visible="true" id="-3018" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910447053799899" lon="-77.0519523046099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3018"/>
     </node>
     <node visible="true" id="-3016" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910175437999897" lon="-77.0519514873300011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3016"/>
     </node>
     <node visible="true" id="-3014" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909901583500002" lon="-77.0519514673899977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3014"/>
     </node>
     <node visible="true" id="-3012" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909626823599908" lon="-77.0519524847800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3012"/>
     </node>
     <node visible="true" id="-3010" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909352960399914" lon="-77.0519544243900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3010"/>
     </node>
     <node visible="true" id="-3008" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908763008300014" lon="-77.0519656466299949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3008"/>
     </node>
     <node visible="true" id="-3006" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908137429800007" lon="-77.0519891400499972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3006"/>
     </node>
     <node visible="true" id="-3004" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907401449599988" lon="-77.0520173333100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3004"/>
     </node>
     <node visible="true" id="-3002" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906647064799955" lon="-77.0520478787799874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3002"/>
     </node>
     <node visible="true" id="-3000" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905699460199941" lon="-77.0520913581299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3000"/>
     </node>
     <way visible="true" id="-3226" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3166"/>
@@ -469,11 +359,10 @@
         <nd ref="-3214"/>
         <nd ref="-3216"/>
         <nd ref="-3218"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3226"/>
     </way>
     <way visible="true" id="-3224" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -490,12 +379,11 @@
         <nd ref="-3162"/>
         <nd ref="-3164"/>
         <nd ref="-3166"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3224"/>
     </way>
     <way visible="true" id="-3222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3090"/>
@@ -524,12 +412,11 @@
         <nd ref="-3136"/>
         <nd ref="-3138"/>
         <nd ref="-3140"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3222"/>
     </way>
     <way visible="true" id="-3220" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -578,11 +465,10 @@
         <nd ref="-3084"/>
         <nd ref="-3086"/>
         <nd ref="-3088"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3220"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/vagabond/highway-006/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/vagabond/highway-006/Expected.osm
@@ -3,57 +3,50 @@
     <bounds minlat="38.85256682120001" minlon="-104.89916367283" maxlat="38.85335424982999" maxlon="-104.89826276519"/>
     <node visible="true" id="-1682758" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530188155899907" lon="-104.8986868588499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682758"/>
     </node>
     <node visible="true" id="-1682757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530214305399895" lon="-104.8991636728299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682757"/>
     </node>
     <node visible="true" id="-1682756" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8525668212000070" lon="-104.8986765855800058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682756"/>
     </node>
     <node visible="true" id="-1682755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533542498299909" lon="-104.8982627651899975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682755"/>
     </node>
     <node visible="true" id="-1682754" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8528283481400010" lon="-104.8986799434299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682754"/>
     </node>
     <node visible="true" id="-1682753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530240454899953" lon="-104.8989252658400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682753"/>
     </node>
     <node visible="true" id="-1682752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8531970813699985" lon="-104.8984693340700005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682752"/>
     </node>
     <way visible="true" id="-1682761" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682757"/>
         <nd ref="-1682753"/>
         <nd ref="-1682758"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682761"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682760" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682754"/>
         <nd ref="-1682756"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682760"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682759" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682752"/>
         <nd ref="-1682755"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682759"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/hoot-rnd/network/vagabond/highway-007/Expected.osm
+++ b/test-files/cases/hoot-rnd/network/vagabond/highway-007/Expected.osm
@@ -3,110 +3,92 @@
     <bounds minlat="38.85407320977" minlon="-104.90305077439" maxlat="38.85460590869" maxlon="-104.90151585456"/>
     <node visible="true" id="-5011083" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545143584800030" lon="-104.9022746626800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011083"/>
     </node>
     <node visible="true" id="-5011082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9027146783799935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011082"/>
     </node>
     <node visible="true" id="-5011081" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545634736000025" lon="-104.9022320907299815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011081"/>
     </node>
     <node visible="true" id="-5011080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546017057599968" lon="-104.9021850918999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011080"/>
     </node>
     <node visible="true" id="-5011079" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9023815370599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011079"/>
     </node>
     <node visible="true" id="-5011078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545593122299948" lon="-104.9023202620900008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011078"/>
     </node>
     <node visible="true" id="-5011077" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540732097700001" lon="-104.9022759351200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011077"/>
     </node>
     <node visible="true" id="-5011076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9018489958900062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011076"/>
     </node>
     <node visible="true" id="-5011075" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543021280200023" lon="-104.9022871808499957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011075"/>
     </node>
     <node visible="true" id="-5011074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545933830200028" lon="-104.9030507743899960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011074"/>
     </node>
     <node visible="true" id="-5011073" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545946838899994" lon="-104.9022775123400066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011073"/>
     </node>
     <node visible="true" id="-5011072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9015158545600030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011072"/>
     </node>
     <way visible="true" id="-5011089" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011081"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1b;2b"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1b;2b"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011089"/>
     </way>
     <way visible="true" id="-5011088" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011076"/>
         <nd ref="-5011072"/>
-        <tag k="note" v="1c;2c"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1c;2c"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011088"/>
     </way>
     <way visible="true" id="-5011087" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011073"/>
         <nd ref="-5011080"/>
-        <tag k="note" v="1d;2d"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1d;2d"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011087"/>
     </way>
     <way visible="true" id="-5011086" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011077"/>
         <nd ref="-5011075"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1a;2a"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1a;2a"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011086"/>
     </way>
     <way visible="true" id="-5011085" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011078"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1e;2e"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1e;2e"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011085"/>
     </way>
     <way visible="true" id="-5011084" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011074"/>
         <nd ref="-5011082"/>
         <nd ref="-5011079"/>
-        <tag k="note" v="1f;2f"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1f;2f"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011084"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-001/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-001/Expected.osm
@@ -3,78 +3,69 @@
     <bounds minlat="30.01377658509" minlon="-90.01849311751" maxlat="30.01977087609999" maxlon="-90.01445907515"/>
     <node visible="true" id="-4472573" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0151481186722080" lon="-90.0183690155489700">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472573"/>
     </node>
     <node visible="true" id="-4472481" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183065931999948" lon="-90.0149955169499805">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472481"/>
     </node>
     <node visible="true" id="-4472479" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182380814099936" lon="-90.0160040275400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472479"/>
     </node>
     <node visible="true" id="-4472477" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0183402684600011" lon="-90.0144590751500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472477"/>
     </node>
     <node visible="true" id="-4472475" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0168446111399909" lon="-90.0149526016100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472475"/>
     </node>
     <node visible="true" id="-4472473" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0182938198199984" lon="-90.0150920764800020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472473"/>
     </node>
     <node visible="true" id="-4472471" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0197708760999902" lon="-90.0152422801800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472471"/>
     </node>
     <node visible="true" id="-4472469" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0165357225800058" lon="-90.0184931175100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472469"/>
     </node>
     <node visible="true" id="-4472467" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0137765850900031" lon="-90.0182463542799951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472467"/>
     </node>
     <way visible="true" id="-4472673" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472467"/>
         <nd ref="-4472573"/>
         <nd ref="-4472469"/>
-        <tag k="note" v="1c;1a;1b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472673"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1c;1a;1b"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472491" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472479"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2c;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472491"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2c;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472489" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472473"/>
         <nd ref="-4472481"/>
         <nd ref="-4472477"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472489"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472487" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472475"/>
         <nd ref="-4472473"/>
-        <tag k="note" v="2b;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-4472487"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2b;2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4472485" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472471"/>
         <nd ref="-4472473"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472485"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-002/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-002/Expected.osm
@@ -3,92 +3,76 @@
     <bounds minlat="30.00854725156" minlon="-90.01061278742" maxlat="30.01048862035" maxlon="-90.00780987900001"/>
     <node visible="true" id="-4472965" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0103449749300033" lon="-90.0106127874200013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472965"/>
     </node>
     <node visible="true" id="-4472963" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0104886203499994" lon="-90.0087888511399825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472963"/>
     </node>
     <node visible="true" id="-4472961" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0094670210699981" lon="-90.0104947702299967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472961"/>
     </node>
     <node visible="true" id="-4472959" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0096690905099948" lon="-90.0087111012300056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472959"/>
     </node>
     <node visible="true" id="-4472957" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0104239439400011" lon="-90.0096901075200009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472957"/>
     </node>
     <node visible="true" id="-4472955" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0089932014799992" lon="-90.0078098790000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472955"/>
     </node>
     <node visible="true" id="-4472953" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0086494485899955" lon="-90.0085501686899789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472953"/>
     </node>
     <node visible="true" id="-4472951" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0085472515599960" lon="-90.0091509835099970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472951"/>
     </node>
     <node visible="true" id="-4472949" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0086401579599915" lon="-90.0094406620799816">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472949"/>
     </node>
     <node visible="true" id="-4472947" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0089932014799992" lon="-90.0095157639400014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472947"/>
     </node>
     <node visible="true" id="-4472945" timestamp="1970-01-01T00:00:00Z" version="1" lat="30.0095831529799995" lon="-90.0096096412499946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-4472945"/>
     </node>
     <way visible="true" id="-4472977" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472957"/>
         <nd ref="-4472945"/>
-        <tag k="note" v="1c;2c"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1c;2c"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472977"/>
     </way>
     <way visible="true" id="-4472975" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472961"/>
         <nd ref="-4472945"/>
-        <tag k="note" v="1d;2d"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1d;2d"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472975"/>
     </way>
     <way visible="true" id="-4472973" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472963"/>
         <nd ref="-4472957"/>
-        <tag k="note" v="1b;2b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1b;2b"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472973"/>
     </way>
     <way visible="true" id="-4472971" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472957"/>
         <nd ref="-4472965"/>
-        <tag k="note" v="1a;2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1a;2a"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472971"/>
     </way>
     <way visible="true" id="-4472969" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472945"/>
         <nd ref="-4472959"/>
-        <tag k="note" v="1e;2e"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1e;2e"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472969"/>
     </way>
     <way visible="true" id="-4472967" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4472945"/>
@@ -97,10 +81,9 @@
         <nd ref="-4472951"/>
         <nd ref="-4472953"/>
         <nd ref="-4472955"/>
-        <tag k="note" v="1f;2f"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1f;2f"/>
         <tag k="error:circular" v="100"/>
-        <tag k="hoot:id" v="-4472967"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-003/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-003/Expected.osm
@@ -3,60 +3,48 @@
     <bounds minlat="0.00320735725" minlon="-0.0003766650199999997" maxlat="0.00625601899" maxlon="0.0059850847"/>
     <node visible="true" id="-175337" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046141443100000" lon="0.0016072457300000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-175337"/>
     </node>
     <node visible="true" id="-175336" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0046444844100000" lon="0.0008514702700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-175336"/>
     </node>
     <node visible="true" id="-175335" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0049668960300000" lon="0.0002672429200000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-175335"/>
     </node>
     <node visible="true" id="-175334" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0057639654600000" lon="-0.0003766650200000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-175334"/>
     </node>
     <node visible="true" id="-175333" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175333"/>
     </node>
     <node visible="true" id="-175331" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175331"/>
     </node>
     <node visible="true" id="-175329" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175329"/>
     </node>
     <node visible="true" id="-175327" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175327"/>
     </node>
     <node visible="true" id="-175325" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062191150700000" lon="0.0006813779300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175325"/>
     </node>
     <node visible="true" id="-175323" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0052548516500000" lon="0.0005686718200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175323"/>
     </node>
     <node visible="true" id="-175321" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0041966664700000" lon="0.0005937176200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175321"/>
     </node>
     <node visible="true" id="-175319" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032073572500000" lon="0.0007878225900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-175319"/>
     </node>
     <way visible="true" id="-175338" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-175334"/>
         <nd ref="-175335"/>
         <nd ref="-175336"/>
         <nd ref="-175337"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-175338"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-175337" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-175327"/>
@@ -64,19 +52,17 @@
         <nd ref="-175331"/>
         <nd ref="-175333"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-175337"/>
     </way>
     <way visible="true" id="-175335" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-175319"/>
         <nd ref="-175321"/>
         <nd ref="-175323"/>
         <nd ref="-175325"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-175335"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-004/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-004/Expected.osm
@@ -3,39 +3,30 @@
     <bounds minlat="-0.0009806089100000011" minlon="0.0017728795" maxlat="0.01055288979" maxlon="0.00893974199"/>
     <node visible="true" id="-1018689" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0048427069810808" lon="0.0056549112103702">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018689"/>
     </node>
     <node visible="true" id="-1018670" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0090293950900000" lon="0.0017728795000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018670"/>
     </node>
     <node visible="true" id="-1018668" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0105528897900000" lon="0.0054206837600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018668"/>
     </node>
     <node visible="true" id="-1018666" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0007284812700000" lon="0.0089397419900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018666"/>
     </node>
     <node visible="true" id="-1018663" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.0009806089100000" lon="0.0049968947400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018663"/>
     </node>
     <node visible="true" id="-1018574" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018574"/>
     </node>
     <node visible="true" id="-1018572" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018572"/>
     </node>
     <node visible="true" id="-1018570" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018570"/>
     </node>
     <node visible="true" id="-1018568" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1018568"/>
     </node>
     <way visible="true" id="-1018732" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018568"/>
@@ -44,37 +35,36 @@
         <nd ref="-1018572"/>
         <nd ref="-1018574"/>
         <tag k="source" v="1;2"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="400"/>
-        <tag k="hoot:id" v="-1018732"/>
     </way>
     <way visible="true" id="-1018671" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018670"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018671"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018669" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018668"/>
         <nd ref="-1018574"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018669"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018667" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018666"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018667"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1018664" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1018663"/>
         <nd ref="-1018568"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1018664"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-005/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-005/Expected.osm
@@ -3,443 +3,333 @@
     <bounds minlat="38.88932131124" minlon="-77.05504778748001" maxlat="38.89246497495999" maxlon="-77.05195146739"/>
     <node visible="true" id="-3218" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922220501699911" lon="-77.0550477874800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3218"/>
     </node>
     <node visible="true" id="-3216" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921495043399901" lon="-77.0546779563500053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3216"/>
     </node>
     <node visible="true" id="-3214" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921307105799983" lon="-77.0545648707499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3214"/>
     </node>
     <node visible="true" id="-3212" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920775075999927" lon="-77.0542447319599830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3212"/>
     </node>
     <node visible="true" id="-3210" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920710351700052" lon="-77.0542154486799973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3210"/>
     </node>
     <node visible="true" id="-3208" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920639320899824" lon="-77.0541862801999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3208"/>
     </node>
     <node visible="true" id="-3206" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920561081099834" lon="-77.0541575722400012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3206"/>
     </node>
     <node visible="true" id="-3204" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920475633600020" lon="-77.0541290942900048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3204"/>
     </node>
     <node visible="true" id="-3202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920384779399839" lon="-77.0541009617400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3202"/>
     </node>
     <node visible="true" id="-3200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920285815899902" lon="-77.0540731743899983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3200"/>
     </node>
     <node visible="true" id="-3198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920181445299988" lon="-77.0540458469999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3198"/>
     </node>
     <node visible="true" id="-3196" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920069866299940" lon="-77.0540188663100025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3196"/>
     </node>
     <node visible="true" id="-3194" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919952879499888" lon="-77.0539924608499973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3194"/>
     </node>
     <node visible="true" id="-3192" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919828684399960" lon="-77.0539664006600020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3192"/>
     </node>
     <node visible="true" id="-3190" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919699081999894" lon="-77.0539408011400013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3190"/>
     </node>
     <node visible="true" id="-3188" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919563171099938" lon="-77.0539157774999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3188"/>
     </node>
     <node visible="true" id="-3186" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919449756599960" lon="-77.0538960579399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3186"/>
     </node>
     <node visible="true" id="-3184" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917364941500026" lon="-77.0535647337700027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3184"/>
     </node>
     <node visible="true" id="-3182" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916187500899966" lon="-77.0533780258199954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3182"/>
     </node>
     <node visible="true" id="-3180" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915141267099926" lon="-77.0531944145800054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3180"/>
     </node>
     <node visible="true" id="-3178" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914258660799845" lon="-77.0529949083099979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3178"/>
     </node>
     <node visible="true" id="-3176" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913819943099952" lon="-77.0528765840799963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3176"/>
     </node>
     <node visible="true" id="-3174" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913542716399974" lon="-77.0528018136899959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3174"/>
     </node>
     <node visible="true" id="-3172" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912993277400005" lon="-77.0526524600399938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3172"/>
     </node>
     <node visible="true" id="-3170" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912718535099842" lon="-77.0525820492999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3170"/>
     </node>
     <node visible="true" id="-3168" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912088384799901" lon="-77.0524337209899954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3168"/>
     </node>
     <node visible="true" id="-3166" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911757620799960" lon="-77.0523519128099821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3166"/>
     </node>
     <node visible="true" id="-3164" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911507110800017" lon="-77.0522899546400026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3164"/>
     </node>
     <node visible="true" id="-3162" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911209678599974" lon="-77.0522241308899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3162"/>
     </node>
     <node visible="true" id="-3160" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911060082100022" lon="-77.0521991875600065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3160"/>
     </node>
     <node visible="true" id="-3158" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910830982699949" lon="-77.0521738861399967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3158"/>
     </node>
     <node visible="true" id="-3156" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910589747099991" lon="-77.0521505217899971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3156"/>
     </node>
     <node visible="true" id="-3154" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910316927499906" lon="-77.0521305584199894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3154"/>
     </node>
     <node visible="true" id="-3152" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909968552499947" lon="-77.0521087935299960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3152"/>
     </node>
     <node visible="true" id="-3150" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909545739400073" lon="-77.0520872112600017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3150"/>
     </node>
     <node visible="true" id="-3148" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908842149400016" lon="-77.0520611858700022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3148"/>
     </node>
     <node visible="true" id="-3146" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907976085799945" lon="-77.0520507334999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3146"/>
     </node>
     <node visible="true" id="-3144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907109987099915" lon="-77.0520506703099954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3144"/>
     </node>
     <node visible="true" id="-3142" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906230228399892" lon="-77.0520748474600055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3142"/>
     </node>
     <node visible="true" id="-3140" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905037313699964" lon="-77.0521247918500052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3140"/>
     </node>
     <node visible="true" id="-3138" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903116149099972" lon="-77.0522266902599995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3138"/>
     </node>
     <node visible="true" id="-3136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8900091376999981" lon="-77.0523879893599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3136"/>
     </node>
     <node visible="true" id="-3134" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898711819200003" lon="-77.0524590890500036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3134"/>
     </node>
     <node visible="true" id="-3132" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898477543999874" lon="-77.0524718655800029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3132"/>
     </node>
     <node visible="true" id="-3130" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898238761599870" lon="-77.0524840668799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3130"/>
     </node>
     <node visible="true" id="-3128" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897997284399963" lon="-77.0524958061999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3128"/>
     </node>
     <node visible="true" id="-3126" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897753112299966" lon="-77.0525070842400055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3126"/>
     </node>
     <node visible="true" id="-3124" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897506234699932" lon="-77.0525177857499983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3124"/>
     </node>
     <node visible="true" id="-3122" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897255755800018" lon="-77.0525280259300018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3122"/>
     </node>
     <node visible="true" id="-3120" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897003477799856" lon="-77.0525376896400047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3120"/>
     </node>
     <node visible="true" id="-3118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896748493699960" lon="-77.0525468920900067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3118"/>
     </node>
     <node visible="true" id="-3116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896491721800004" lon="-77.0525555180699939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3116"/>
     </node>
     <node visible="true" id="-3114" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896233138999960" lon="-77.0525636828500069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3114"/>
     </node>
     <node visible="true" id="-3112" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895972768400071" lon="-77.0525712711600050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3112"/>
     </node>
     <node visible="true" id="-3110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895710587499934" lon="-77.0525782830199972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3110"/>
     </node>
     <node visible="true" id="-3108" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895447513899910" lon="-77.0525847184700012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3108"/>
     </node>
     <node visible="true" id="-3106" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895182635099914" lon="-77.0525906927300070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3106"/>
     </node>
     <node visible="true" id="-3104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894916881099988" lon="-77.0525959753299787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3104"/>
     </node>
     <node visible="true" id="-3102" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894650205799977" lon="-77.0526007967999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3102"/>
     </node>
     <node visible="true" id="-3100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894383538699984" lon="-77.0526050419399979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3100"/>
     </node>
     <node visible="true" id="-3098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894115967800005" lon="-77.0526087106800048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3098"/>
     </node>
     <node visible="true" id="-3096" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893848410699974" lon="-77.0526118023799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3096"/>
     </node>
     <node visible="true" id="-3094" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893580845499898" lon="-77.0526142039300055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3094"/>
     </node>
     <node visible="true" id="-3092" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893313293599974" lon="-77.0526161429799998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3092"/>
     </node>
     <node visible="true" id="-3090" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893213112399962" lon="-77.0526166744499932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3090"/>
     </node>
     <node visible="true" id="-3088" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924649749599922" lon="-77.0529468792900047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3088"/>
     </node>
     <node visible="true" id="-3086" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921842958999875" lon="-77.0527829676599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3086"/>
     </node>
     <node visible="true" id="-3084" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921735790099845" lon="-77.0527761581199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3084"/>
     </node>
     <node visible="true" id="-3082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921407082499897" lon="-77.0527544631899985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3082"/>
     </node>
     <node visible="true" id="-3080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921082882699878" lon="-77.0527319624400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3080"/>
     </node>
     <node visible="true" id="-3078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920761388999949" lon="-77.0527086543099955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3078"/>
     </node>
     <node visible="true" id="-3076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920443502199973" lon="-77.0526845388600066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3076"/>
     </node>
     <node visible="true" id="-3074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920081742899910" lon="-77.0526558195300026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3074"/>
     </node>
     <node visible="true" id="-3072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919818548399974" lon="-77.0526341208800005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3072"/>
     </node>
     <node visible="true" id="-3070" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919512382799937" lon="-77.0526077009899950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3070"/>
     </node>
     <node visible="true" id="-3068" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919209823499941" lon="-77.0525805912100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3068"/>
     </node>
     <node visible="true" id="-3066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918911772000016" lon="-77.0525526741800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3066"/>
     </node>
     <node visible="true" id="-3064" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917937840700034" lon="-77.0524479730499792">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3064"/>
     </node>
     <node visible="true" id="-3062" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917422506299886" lon="-77.0523925716599933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3062"/>
     </node>
     <node visible="true" id="-3060" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916788012099914" lon="-77.0523261498599794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3060"/>
     </node>
     <node visible="true" id="-3058" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916623556899950" lon="-77.0523089339699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3058"/>
     </node>
     <node visible="true" id="-3056" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916373517199929" lon="-77.0522827590699961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3056"/>
     </node>
     <node visible="true" id="-3054" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914826580300002" lon="-77.0521270329400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3054"/>
     </node>
     <node visible="true" id="-3052" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914664488699984" lon="-77.0521137659799820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3052"/>
     </node>
     <node visible="true" id="-3050" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914452865000015" lon="-77.0520973824500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3050"/>
     </node>
     <node visible="true" id="-3048" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914236733499905" lon="-77.0520818047499887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3048"/>
     </node>
     <node visible="true" id="-3046" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914017895899917" lon="-77.0520670351800021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3046"/>
     </node>
     <node visible="true" id="-3044" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913795451799942" lon="-77.0520529562499945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3044"/>
     </node>
     <node visible="true" id="-3042" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913570301099938" lon="-77.0520397992799815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3042"/>
     </node>
     <node visible="true" id="-3040" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913341543400009" lon="-77.0520274489200006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3040"/>
     </node>
     <node visible="true" id="-3038" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913110979899983" lon="-77.0520160205799982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3038"/>
     </node>
     <node visible="true" id="-3036" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912877710399911" lon="-77.0520053989300067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3036"/>
     </node>
     <node visible="true" id="-3034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912641734699918" lon="-77.0519955839599930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3034"/>
     </node>
     <node visible="true" id="-3032" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912403953199828" lon="-77.0519866910100006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3032"/>
     </node>
     <node visible="true" id="-3030" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912084200599892" lon="-77.0519766394199905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3030"/>
     </node>
     <node visible="true" id="-3028" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911813977699907" lon="-77.0519702792900034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3028"/>
     </node>
     <node visible="true" id="-3026" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911542849799901" lon="-77.0519648426799932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3026"/>
     </node>
     <node visible="true" id="-3024" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911270816999988" lon="-77.0519603274299811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3024"/>
     </node>
     <node visible="true" id="-3022" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910997879299956" lon="-77.0519567342600027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3022"/>
     </node>
     <node visible="true" id="-3020" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910724036599902" lon="-77.0519540631599966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3020"/>
     </node>
     <node visible="true" id="-3018" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910447053799899" lon="-77.0519523046099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3018"/>
     </node>
     <node visible="true" id="-3016" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910175437999897" lon="-77.0519514873300011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3016"/>
     </node>
     <node visible="true" id="-3014" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909901583500002" lon="-77.0519514673899977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3014"/>
     </node>
     <node visible="true" id="-3012" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909626823599908" lon="-77.0519524847800028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3012"/>
     </node>
     <node visible="true" id="-3010" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909352960399914" lon="-77.0519544243900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3010"/>
     </node>
     <node visible="true" id="-3008" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908763008300014" lon="-77.0519656466299949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3008"/>
     </node>
     <node visible="true" id="-3006" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908137429800007" lon="-77.0519891400499972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3006"/>
     </node>
     <node visible="true" id="-3004" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907401449599988" lon="-77.0520173333100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3004"/>
     </node>
     <node visible="true" id="-3002" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906647064799955" lon="-77.0520478787799874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3002"/>
     </node>
     <node visible="true" id="-3000" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905699460199941" lon="-77.0520913581299993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-3000"/>
     </node>
     <way visible="true" id="-3226" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3166"/>
@@ -469,11 +359,10 @@
         <nd ref="-3214"/>
         <nd ref="-3216"/>
         <nd ref="-3218"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3226"/>
     </way>
     <way visible="true" id="-3224" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -490,12 +379,11 @@
         <nd ref="-3162"/>
         <nd ref="-3164"/>
         <nd ref="-3166"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3224"/>
     </way>
     <way visible="true" id="-3222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3090"/>
@@ -524,12 +412,11 @@
         <nd ref="-3136"/>
         <nd ref="-3138"/>
         <nd ref="-3140"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3222"/>
     </way>
     <way visible="true" id="-3220" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3140"/>
@@ -578,11 +465,10 @@
         <nd ref="-3084"/>
         <nd ref="-3086"/>
         <nd ref="-3088"/>
-        <tag k="note" v="2"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="note" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-3220"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-006/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-006/Expected.osm
@@ -3,57 +3,50 @@
     <bounds minlat="38.85256682120001" minlon="-104.89916367283" maxlat="38.85335424982999" maxlon="-104.89826276519"/>
     <node visible="true" id="-1682758" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530188155899907" lon="-104.8986868588499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682758"/>
     </node>
     <node visible="true" id="-1682757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530214305399895" lon="-104.8991636728299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682757"/>
     </node>
     <node visible="true" id="-1682756" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8525668212000070" lon="-104.8986765855800058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682756"/>
     </node>
     <node visible="true" id="-1682755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533542498299909" lon="-104.8982627651899975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682755"/>
     </node>
     <node visible="true" id="-1682754" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8528283481400010" lon="-104.8986799434299968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682754"/>
     </node>
     <node visible="true" id="-1682753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8530240454899953" lon="-104.8989252658400062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682753"/>
     </node>
     <node visible="true" id="-1682752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8531970813699985" lon="-104.8984693340700005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1682752"/>
     </node>
     <way visible="true" id="-1682761" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682757"/>
         <nd ref="-1682753"/>
         <nd ref="-1682758"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682761"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682760" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682754"/>
         <nd ref="-1682756"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682760"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1682759" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1682758"/>
         <nd ref="-1682752"/>
         <nd ref="-1682755"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-1682759"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-007/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-007/Expected.osm
@@ -3,110 +3,92 @@
     <bounds minlat="38.85407320977" minlon="-104.90305077439" maxlat="38.85460590869" maxlon="-104.90151585456"/>
     <node visible="true" id="-5011083" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545143584800030" lon="-104.9022746626800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011083"/>
     </node>
     <node visible="true" id="-5011082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9027146783799935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011082"/>
     </node>
     <node visible="true" id="-5011081" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545634736000025" lon="-104.9022320907299815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011081"/>
     </node>
     <node visible="true" id="-5011080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546017057599968" lon="-104.9021850918999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011080"/>
     </node>
     <node visible="true" id="-5011079" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545975859399988" lon="-104.9023815370599948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011079"/>
     </node>
     <node visible="true" id="-5011078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545593122299948" lon="-104.9023202620900008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011078"/>
     </node>
     <node visible="true" id="-5011077" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540732097700001" lon="-104.9022759351200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011077"/>
     </node>
     <node visible="true" id="-5011076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9018489958900062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011076"/>
     </node>
     <node visible="true" id="-5011075" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543021280200023" lon="-104.9022871808499957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011075"/>
     </node>
     <node visible="true" id="-5011074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545933830200028" lon="-104.9030507743899960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011074"/>
     </node>
     <node visible="true" id="-5011073" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545946838899994" lon="-104.9022775123400066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011073"/>
     </node>
     <node visible="true" id="-5011072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546059086899973" lon="-104.9015158545600030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5011072"/>
     </node>
     <way visible="true" id="-5011089" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011081"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1b;2b"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1b;2b"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011089"/>
     </way>
     <way visible="true" id="-5011088" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011080"/>
         <nd ref="-5011076"/>
         <nd ref="-5011072"/>
-        <tag k="note" v="1c;2c"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1c;2c"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011088"/>
     </way>
     <way visible="true" id="-5011087" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011073"/>
         <nd ref="-5011080"/>
-        <tag k="note" v="1d;2d"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1d;2d"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011087"/>
     </way>
     <way visible="true" id="-5011086" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011077"/>
         <nd ref="-5011075"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1a;2a"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1a;2a"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011086"/>
     </way>
     <way visible="true" id="-5011085" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011079"/>
         <nd ref="-5011078"/>
         <nd ref="-5011083"/>
-        <tag k="note" v="1e;2e"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1e;2e"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011085"/>
     </way>
     <way visible="true" id="-5011084" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5011074"/>
         <nd ref="-5011082"/>
         <nd ref="-5011079"/>
-        <tag k="note" v="1f;2f"/>
-        <tag k="highway" v="primary"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="primary"/>
+        <tag k="note" v="1f;2f"/>
         <tag k="error:circular" v="10"/>
-        <tag k="hoot:id" v="-5011084"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-008/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-008/Expected.osm
@@ -3,140 +3,116 @@
     <bounds minlat="38.89515050534" minlon="-77.0471701988" maxlat="38.89630425215999" maxlon="-77.04635609292001"/>
     <node visible="true" id="-5065111" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956904830300019" lon="-77.0467622909300047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5065111"/>
     </node>
     <node visible="true" id="-5064472" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8955972330399931" lon="-77.0467700836999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064472"/>
     </node>
     <node visible="true" id="-5064391" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957465845900003" lon="-77.0469658769900008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064391"/>
     </node>
     <node visible="true" id="-5064378" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956593997099915" lon="-77.0469580842199946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064378"/>
     </node>
     <node visible="true" id="-5064366" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953869293499963" lon="-77.0467776795399999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064366"/>
     </node>
     <node visible="true" id="-5064360" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956381720699937" lon="-77.0465752645099968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064360"/>
     </node>
     <node visible="true" id="-5064345" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957329382699939" lon="-77.0465635753599969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064345"/>
     </node>
     <node visible="true" id="-5064337" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8960199731399996" lon="-77.0467373020199915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5064337"/>
     </node>
     <node visible="true" id="-5063238" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956260033899994" lon="-77.0463598359399953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063238"/>
     </node>
     <node visible="true" id="-5063236" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956711572899962" lon="-77.0471701988000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063236"/>
     </node>
     <node visible="true" id="-5063234" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957294203499941" lon="-77.0463560929200071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063234"/>
     </node>
     <node visible="true" id="-5063232" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957527255499969" lon="-77.0471664557900056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063232"/>
     </node>
     <node visible="true" id="-5063230" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8963042521599931" lon="-77.0467265493499980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063230"/>
     </node>
     <node visible="true" id="-5063228" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8957352466499842" lon="-77.0467603385999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063228"/>
     </node>
     <node visible="true" id="-5063226" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8956463954899974" lon="-77.0467659531199871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063226"/>
     </node>
     <node visible="true" id="-5063224" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951505053399984" lon="-77.0467866622300050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5063224"/>
     </node>
     <way visible="true" id="-5063252" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063238"/>
         <nd ref="-5064360"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063252"/>
     </way>
     <way visible="true" id="-5063250" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063236"/>
         <nd ref="-5064378"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063250"/>
     </way>
     <way visible="true" id="-5063248" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063234"/>
         <nd ref="-5064345"/>
         <nd ref="-5063228"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063248"/>
     </way>
     <way visible="true" id="-5063246" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063232"/>
         <nd ref="-5064391"/>
         <nd ref="-5063228"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063246"/>
     </way>
     <way visible="true" id="-5063244" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063228"/>
         <nd ref="-5065111"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063244"/>
     </way>
     <way visible="true" id="-5063242" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063230"/>
         <nd ref="-5064337"/>
         <nd ref="-5063228"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063242"/>
     </way>
     <way visible="true" id="-5063240" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5063224"/>
         <nd ref="-5064366"/>
         <nd ref="-5064472"/>
         <nd ref="-5063226"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="25"/>
-        <tag k="hoot:id" v="-5063240"/>
     </way>
     <relation visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-5063226" role="reviewee"/>
         <member type="way" ref="-5063244" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-29"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/highway-009/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-009/Expected.osm
@@ -3,100 +3,87 @@
     <bounds minlat="38.85404329028999" minlon="-104.90225991354" maxlat="38.85465984758" maxlon="-104.90220753865"/>
     <node visible="true" id="-5703869" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544960219599957" lon="-104.9022127761400043">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703869"/>
     </node>
     <node visible="true" id="-5703868" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543450483499981" lon="-104.9022466425199980">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703868"/>
     </node>
     <node visible="true" id="-5703867" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544919433099878" lon="-104.9022529302200013">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703867"/>
     </node>
     <node visible="true" id="-5703866" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546550891699951" lon="-104.9022599135399787">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703866"/>
     </node>
     <node visible="true" id="-5703865" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543451117299909" lon="-104.9022075386500035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703865"/>
     </node>
     <node visible="true" id="-5703864" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546598475800025" lon="-104.9022232511200059">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703864"/>
     </node>
     <node visible="true" id="-5703861" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544905837600041" lon="-104.9022302344399975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703861"/>
     </node>
     <node visible="true" id="-5703840" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541982798299941" lon="-104.9022249969499967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703840"/>
     </node>
     <node visible="true" id="-5703793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546564487100028" lon="-104.9022407094099947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703793"/>
     </node>
     <node visible="true" id="-5703791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543192802099995" lon="-104.9022232511200059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703791"/>
     </node>
     <node visible="true" id="-5703790" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540432902899937" lon="-104.9022145219699951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703790"/>
     </node>
     <way visible="true" id="-5703827" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703866"/>
         <nd ref="-5703867"/>
         <nd ref="-5703868"/>
         <nd ref="-5703791"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703827"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5703826" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703864"/>
         <nd ref="-5703869"/>
         <nd ref="-5703865"/>
         <nd ref="-5703791"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5703826"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5703824" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703791"/>
         <nd ref="-5703861"/>
         <nd ref="-5703793"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5703824"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5703792" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5703790"/>
         <nd ref="-5703840"/>
         <nd ref="-5703791"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-5703792"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5703827" role="reviewee"/>
         <member type="way" ref="-5703824" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-8"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5703826" role="reviewee"/>
         <member type="way" ref="-5703824" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-7"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/highway-010/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-010/Expected.osm
@@ -3,93 +3,80 @@
     <bounds minlat="1.74551142222" minlon="2.09764924671" maxlat="1.74616769826" maxlon="2.09884500232"/>
     <node visible="true" id="-7129701" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7456685204099998" lon="2.0983905387099999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129701"/>
     </node>
     <node visible="true" id="-7129687" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7460138447199998" lon="2.0984280325600002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129687"/>
     </node>
     <node visible="true" id="-7129676" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458585283500001" lon="2.0986292733999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129676"/>
     </node>
     <node visible="true" id="-7129663" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458241550600002" lon="2.0980191824799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7129663"/>
     </node>
     <node visible="true" id="-7118508" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7455114222200001" lon="2.0983890610999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118508"/>
     </node>
     <node visible="true" id="-7118506" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7461676982600001" lon="2.0984539303799998">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118506"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7118504" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458002946200000" lon="2.0976492467100001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118504"/>
     </node>
     <node visible="true" id="-7118502" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458459612199997" lon="2.0983895303800000">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118502"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-7118500" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.7458802402199998" lon="2.0988450023200000">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7118500"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-7129650" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118502"/>
         <nd ref="-7129663"/>
         <nd ref="-7118504"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="tertiary"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7129650"/>
     </way>
     <way visible="true" id="-7118514" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118506"/>
         <nd ref="-7129687"/>
         <nd ref="-7118502"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7118514"/>
     </way>
     <way visible="true" id="-7118512" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118508"/>
         <nd ref="-7129701"/>
         <nd ref="-7118502"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7118512"/>
     </way>
     <way visible="true" id="-7118510" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7118500"/>
         <nd ref="-7129676"/>
         <nd ref="-7118502"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="tertiary"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7118510"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-011/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-011/Expected.osm
@@ -3,92 +3,72 @@
     <bounds minlat="-10.90610306842" minlon="86.50034470252999" maxlat="-10.90345071826" maxlon="86.50507272505"/>
     <node visible="true" id="-80212" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049068088013179" lon="86.5025964688462778">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80212"/>
     </node>
     <node visible="true" id="-80211" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048821142132351" lon="86.5029172912754660">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80211"/>
     </node>
     <node visible="true" id="-80210" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048273273471281" lon="86.5036450107546528">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80210"/>
     </node>
     <node visible="true" id="-80205" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9057796608732449" lon="86.5021039151042430">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80205"/>
     </node>
     <node visible="true" id="-80204" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9056062712935447" lon="86.5020971203931310">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80204"/>
     </node>
     <node visible="true" id="-80201" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9050023393024738" lon="86.5010551672644965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80201"/>
     </node>
     <node visible="true" id="-80033" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9047996019499980" lon="86.5050727250499989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-80033"/>
     </node>
     <node visible="true" id="-79647" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049161101499976" lon="86.5024879755000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79647"/>
     </node>
     <node visible="true" id="-79645" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049066790799998" lon="86.5025978937800062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79645"/>
     </node>
     <node visible="true" id="-79643" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9050488502600018" lon="86.5003447025299863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79643"/>
     </node>
     <node visible="true" id="-79641" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049547352899978" lon="86.5017823025300032">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79641"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79639" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9061030684200002" lon="86.5020398025300068">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79639"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79637" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9057869954900006" lon="86.5021042025300062">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79637"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79635" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9043331569599999" lon="86.5021149025299962">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79635"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79633" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9042383348600005" lon="86.5019432025300006">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79633"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79631" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9034507182600002" lon="86.5019973025300004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79631"/>
     </node>
     <node visible="true" id="-79629" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049653039899965" lon="86.5020720025299994">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79629"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79627" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9049125592499987" lon="86.5025333025299972">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79627"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79625" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048283059299980" lon="86.5036169025299984">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79625"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-79623" timestamp="1970-01-01T00:00:00Z" version="1" lat="-10.9048013409099998" lon="86.5043914025299898">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-79623"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-80410" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-79623"/>
@@ -100,17 +80,16 @@
         <nd ref="-79627"/>
         <nd ref="-79647"/>
         <nd ref="-79629"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
-        <tag k="alt_name" v="SALAM;SALEM"/>
-        <tag k="name" v="Salam"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="Salam"/>
+        <tag k="alt_name" v="SALAM;SALEM"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-80410"/>
     </way>
     <way visible="true" id="-80407" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-79629"/>
@@ -118,52 +97,49 @@
         <nd ref="-80205"/>
         <nd ref="-79637"/>
         <nd ref="-79639"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-80407"/>
     </way>
     <way visible="true" id="-80405" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-79629"/>
         <nd ref="-79641"/>
         <nd ref="-80201"/>
         <nd ref="-79643"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
-        <tag k="name" v="Salam"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="Salam"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-80405"/>
     </way>
     <way visible="true" id="-80034" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-80033"/>
         <nd ref="-79623"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-80034"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-79651" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-79631"/>
         <nd ref="-79633"/>
         <nd ref="-79635"/>
         <nd ref="-79629"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="1"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-79651"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-012/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-012/Expected.osm
@@ -3,238 +3,183 @@
     <bounds minlat="-1.78022160047" minlon="-3.58724003701" maxlat="-1.773242914599999" maxlon="-3.58351785726"/>
     <node visible="true" id="-930849" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7789556541828464" lon="-3.5855309496874908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930849"/>
     </node>
     <node visible="true" id="-930848" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792722363121296" lon="-3.5851167406122939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930848"/>
     </node>
     <node visible="true" id="-930836" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7747517061949203" lon="-3.5859463303624159">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930836"/>
     </node>
     <node visible="true" id="-930835" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7754949109129587" lon="-3.5856531587376690">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930835"/>
     </node>
     <node visible="true" id="-930834" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7755477100842203" lon="-3.5856369052581232">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930834"/>
     </node>
     <node visible="true" id="-930833" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7767141129156359" lon="-3.5859222861348514">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930833"/>
     </node>
     <node visible="true" id="-930832" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7767547924726759" lon="-3.5859420713379233">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930832"/>
     </node>
     <node visible="true" id="-930831" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7770610326968566" lon="-3.5860846942687110">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930831"/>
     </node>
     <node visible="true" id="-930830" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779037473556834" lon="-3.5863181772713468">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930830"/>
     </node>
     <node visible="true" id="-930202" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7794868872000000" lon="-3.5849001728300003">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930202"/>
     </node>
     <node visible="true" id="-930201" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7793313940999997" lon="-3.5849967323500000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930201"/>
     </node>
     <node visible="true" id="-930199" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7795809191600001" lon="-3.5856949379599996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930199"/>
     </node>
     <node visible="true" id="-930198" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7795734641800001" lon="-3.5862541989599999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930198"/>
     </node>
     <node visible="true" id="-930197" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7795832264799998" lon="-3.5851874969600002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930197"/>
     </node>
     <node visible="true" id="-930196" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7795826262000001" lon="-3.5853199469599994">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930196"/>
     </node>
     <node visible="true" id="-930195" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7795869516199996" lon="-3.5859697549600003">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930195"/>
     </node>
     <node visible="true" id="-930194" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7794949934299999" lon="-3.5838878680099997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930194"/>
     </node>
     <node visible="true" id="-930193" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7797735041299996" lon="-3.5837324820099998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930193"/>
     </node>
     <node visible="true" id="-930192" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7802216004699998" lon="-3.5835178572599999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930192"/>
     </node>
     <node visible="true" id="-930191" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777328684399998" lon="-3.5862775857299996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930191"/>
     </node>
     <node visible="true" id="-930190" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7776469672499997" lon="-3.5861965316899997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930190"/>
     </node>
     <node visible="true" id="-930189" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778999474199997" lon="-3.5858833450100001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930189"/>
     </node>
     <node visible="true" id="-930188" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778743826199999" lon="-3.5856943960100001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930188"/>
     </node>
     <node visible="true" id="-930187" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778336202500000" lon="-3.5855356310099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930187"/>
     </node>
     <node visible="true" id="-930186" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777945899299998" lon="-3.5853824000099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930186"/>
     </node>
     <node visible="true" id="-930185" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777597005499999" lon="-3.5851491500099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930185"/>
     </node>
     <node visible="true" id="-930184" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777531553699994" lon="-3.5850495950099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930184"/>
     </node>
     <node visible="true" id="-930183" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7777609761399997" lon="-3.5849413140099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930183"/>
     </node>
     <node visible="true" id="-930182" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7781471494499999" lon="-3.5849072310099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930182"/>
     </node>
     <node visible="true" id="-930181" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7783233331499999" lon="-3.5848883350099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930181"/>
     </node>
     <node visible="true" id="-930180" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7785457333499999" lon="-3.5848888660100000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930180"/>
     </node>
     <node visible="true" id="-930179" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7780051599500000" lon="-3.5863963505599994">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930179"/>
     </node>
     <node visible="true" id="-930178" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7780901924699999" lon="-3.5865111893099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930178"/>
     </node>
     <node visible="true" id="-930177" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779217761399999" lon="-3.5866996250099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930177"/>
     </node>
     <node visible="true" id="-930176" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778877668599997" lon="-3.5869529550099997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930176"/>
     </node>
     <node visible="true" id="-930175" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7778646203399999" lon="-3.5872311950100002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930175"/>
     </node>
     <node visible="true" id="-930174" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779397499699996" lon="-3.5872400370099999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-930174"/>
     </node>
     <node visible="true" id="-930129" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7739506497799997" lon="-3.5863234172499996">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930129"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-930128" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7732429145999995" lon="-3.5863113760299998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-930128"/>
     </node>
     <node visible="true" id="-928511" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7780418731799998" lon="-3.5840150438500000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-928511"/>
     </node>
     <node visible="true" id="-886317" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7743125744299997" lon="-3.5867371479999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886317"/>
     </node>
     <node visible="true" id="-886315" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7744894865800001" lon="-3.5863414934500000">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886315"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886313" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7746826244200000" lon="-3.5859981934499996">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886313"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886311" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7748970768399999" lon="-3.5858371934500002">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886311"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886309" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7758729216399998" lon="-3.5855367934500002">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886309"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886307" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7760981322499996" lon="-3.5856226934499995">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886307"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886305" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7768701828699998" lon="-3.5859981934499996">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886305"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886303" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7775565736399996" lon="-3.5863092934499994">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886303"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886301" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7779747223699995" lon="-3.5863199934500001">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886301"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886299" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7787468754799995" lon="-3.5861376934500004">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886299"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886297" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7789720869500001" lon="-3.5854831934499996">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886297"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886295" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792723019899999" lon="-3.5851183934500002">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886295"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886293" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792616446599996" lon="-3.5848501934499999">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886293"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886291" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7792187136999997" lon="-3.5841205934500002">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886291"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-886289" timestamp="1970-01-01T00:00:00Z" version="1" lat="-1.7793044750799998" lon="-3.5840133934499994">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-886289"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-931007" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-886289"/>
@@ -245,6 +190,7 @@
         <nd ref="-886297"/>
         <nd ref="-930849"/>
         <nd ref="-886299"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
@@ -253,9 +199,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="2"/>
         <tag k="width" v="5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-931007"/>
     </way>
     <way visible="true" id="-930999" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-886299"/>
@@ -274,6 +218,7 @@
         <nd ref="-930836"/>
         <nd ref="-886313"/>
         <nd ref="-886315"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
@@ -282,9 +227,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="2"/>
         <tag k="width" v="5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-930999"/>
     </way>
     <way visible="true" id="-930142" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-930848"/>
@@ -295,20 +238,20 @@
         <nd ref="-930199"/>
         <nd ref="-930195"/>
         <nd ref="-930198"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-930142"/>
     </way>
     <way visible="true" id="-930141" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-930192"/>
         <nd ref="-930193"/>
         <nd ref="-930194"/>
         <nd ref="-886289"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="KEMANGGISAN RAYA"/>
@@ -316,9 +259,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="2"/>
         <tag k="width" v="5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-930141"/>
     </way>
     <way visible="true" id="-930140" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-930180"/>
@@ -334,14 +275,13 @@
         <nd ref="-930190"/>
         <nd ref="-930191"/>
         <nd ref="-930830"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-930140"/>
     </way>
     <way visible="true" id="-930139" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-930174"/>
@@ -351,35 +291,34 @@
         <nd ref="-930178"/>
         <nd ref="-930179"/>
         <nd ref="-930830"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-930139"/>
     </way>
     <way visible="true" id="-930127" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-930128"/>
         <nd ref="-930129"/>
         <nd ref="-886315"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-930127"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-928512" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-928511"/>
         <nd ref="-886289"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-928512"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-886321" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-886317"/>
         <nd ref="-886315"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-886321"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-013/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-013/Expected.osm
@@ -3,31 +3,24 @@
     <bounds minlat="4.820276872559999" minlon="7.02391697157" maxlat="4.82650963291" maxlon="7.0251186012"/>
     <node visible="true" id="-7222830" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8225903864668611" lon="7.0243332909303637">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222830"/>
     </node>
     <node visible="true" id="-7222823" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8202768725599991" lon="7.0239169715700003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222823"/>
     </node>
     <node visible="true" id="-7222818" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8265096329099997" lon="7.0251186012000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222818"/>
     </node>
     <node visible="true" id="-7222816" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8257505862499990" lon="7.0251078723699987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222816"/>
     </node>
     <node visible="true" id="-7222814" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8247777223900004" lon="7.0248503803000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222814"/>
     </node>
     <node visible="true" id="-7222812" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8231634067600000" lon="7.0244641422000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222812"/>
     </node>
     <node visible="true" id="-7222811" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.8213780333499994" lon="7.0240564464299995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-7222811"/>
     </node>
     <way visible="true" id="-7222821" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-7222823"/>
@@ -37,10 +30,10 @@
         <nd ref="-7222814"/>
         <nd ref="-7222816"/>
         <nd ref="-7222818"/>
-        <tag k="alt_name" v="input2"/>
-        <tag k="name" v="input1"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-7222821"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input1"/>
+        <tag k="alt_name" v="input2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-014/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-014/Expected.osm
@@ -3,77 +3,65 @@
     <bounds minlat="6.454799836839999" minlon="3.39280892716" maxlat="6.45989568525" maxlon="3.39587737427"/>
     <node visible="true" id="-932" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4547998368399995" lon="3.3946757446299998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-932"/>
     </node>
     <node visible="true" id="-931" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4551516439200007" lon="3.3945469986000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-931"/>
     </node>
     <node visible="true" id="-927" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4571452127700004" lon="3.3958773742699999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-927"/>
     </node>
     <node visible="true" id="-926" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4575076789899990" lon="3.3950834404000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-926"/>
     </node>
     <node visible="true" id="-922" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4598956852500002" lon="3.3928089271599999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-922"/>
     </node>
     <node visible="true" id="-921" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4558979005599992" lon="3.3945469986000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-921"/>
     </node>
     <node visible="true" id="-919" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4561750813199987" lon="3.3944718967499998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-919"/>
     </node>
     <node visible="true" id="-917" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4567720855099999" lon="3.3942787776999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-917"/>
     </node>
     <node visible="true" id="-915" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4573051243699995" lon="3.3942358623500000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-915"/>
     </node>
     <node visible="true" id="-913" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4576782512399991" lon="3.3943324218800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-913"/>
     </node>
     <node visible="true" id="-911" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4579127879899989" lon="3.3940427433000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-911"/>
     </node>
     <node visible="true" id="-910" timestamp="1970-01-01T00:00:00Z" version="1" lat="6.4589042375899988" lon="3.3933560977999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-910"/>
     </node>
     <way visible="true" id="-932" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-921"/>
         <nd ref="-931"/>
         <nd ref="-932"/>
-        <tag k="name" v="input2c"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-932"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input2c"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-929" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-922"/>
         <nd ref="-910"/>
-        <tag k="name" v="input2a"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-929"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-915" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-913"/>
         <nd ref="-926"/>
         <nd ref="-927"/>
-        <tag k="name" v="input2b"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-915"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input2b"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-912" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-910"/>
@@ -83,10 +71,10 @@
         <nd ref="-917"/>
         <nd ref="-919"/>
         <nd ref="-921"/>
-        <tag k="alt_name" v="input2a;input2c"/>
-        <tag k="name" v="input1"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-912"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="input1"/>
+        <tag k="alt_name" v="input2a;input2c"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-015/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-015/Expected.osm
@@ -3,100 +3,76 @@
     <bounds minlat="0.6428473305199999" minlon="4.99757699849" maxlat="0.64446498076" maxlon="4.99967559349"/>
     <node visible="true" id="-54079" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6430536768200003" lon="4.9986029784899992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54079"/>
     </node>
     <node visible="true" id="-54024" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6436678625500000" lon="4.9986752704899997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54024"/>
     </node>
     <node visible="true" id="-54022" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6437526031700000" lon="4.9994300394900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54022"/>
     </node>
     <node visible="true" id="-54020" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6437523951699999" lon="4.9994954194899996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54020"/>
     </node>
     <node visible="true" id="-54018" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6437368176200000" lon="4.9995596074899993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54018"/>
     </node>
     <node visible="true" id="-54016" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6428473305199999" lon="4.9975769984899996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54016"/>
     </node>
     <node visible="true" id="-54014" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6429273718799999" lon="4.9977494074899997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54014"/>
     </node>
     <node visible="true" id="-54012" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6430256540700000" lon="4.9985793544899995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54012"/>
     </node>
     <node visible="true" id="-54010" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6430536768200003" lon="4.9986029784899992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54010"/>
     </node>
     <node visible="true" id="-54008" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6431140854899999" lon="4.9986093714899997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54008"/>
     </node>
     <node visible="true" id="-54006" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6433111189200000" lon="4.9985867104899997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54006"/>
     </node>
     <node visible="true" id="-54004" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6434170420200002" lon="4.9985576904900002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54004"/>
     </node>
     <node visible="true" id="-54002" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6435411214699999" lon="4.9985230064900001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54002"/>
     </node>
     <node visible="true" id="-54000" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6436547324299999" lon="4.9984819974899999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-54000"/>
     </node>
     <node visible="true" id="-53998" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6444649807600000" lon="4.9996755934900001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53998"/>
     </node>
     <node visible="true" id="-53996" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6442290876200001" lon="4.9996315894899999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53996"/>
     </node>
     <node visible="true" id="-53994" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6441662473000000" lon="4.9996096814900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53994"/>
     </node>
     <node visible="true" id="-53992" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6441104505600002" lon="4.9995645944899998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53992"/>
     </node>
     <node visible="true" id="-53990" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6440912933500000" lon="4.9995059034900002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53990"/>
     </node>
     <node visible="true" id="-53988" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6440812315200000" lon="4.9993972334899999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53988"/>
     </node>
     <node visible="true" id="-53986" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6440750277099999" lon="4.9991993604899996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53986"/>
     </node>
     <node visible="true" id="-53984" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6440242759600000" lon="4.9989803754900004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53984"/>
     </node>
     <node visible="true" id="-53982" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6438554938600000" lon="4.9983936514899998">
-        <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53982"/>
+        <tag k="created_by" v="Merkaartor 0.13"/>
     </node>
     <node visible="true" id="-53980" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.6441668337400001" lon="4.9982624464900001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-53980"/>
     </node>
     <way visible="true" id="-54142" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-54000"/>
@@ -109,15 +85,14 @@
         <nd ref="-54012"/>
         <nd ref="-54014"/>
         <nd ref="-54016"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="highway" v="unclassified"/>
         <tag k="all_weather" v="yes"/>
         <tag k="note" v="2c"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-54142"/>
     </way>
     <way visible="true" id="-54036" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-54018"/>
@@ -125,26 +100,24 @@
         <nd ref="-54022"/>
         <nd ref="-54024"/>
         <nd ref="-54000"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-54036"/>
     </way>
     <way visible="true" id="-54030" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-53982"/>
         <nd ref="-54000"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="highway" v="unclassified"/>
         <tag k="all_weather" v="yes"/>
         <tag k="note" v="2c"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-54030"/>
     </way>
     <way visible="true" id="-54028" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-53982"/>
@@ -156,27 +129,25 @@
         <nd ref="-53994"/>
         <nd ref="-53996"/>
         <nd ref="-53998"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="highway" v="unclassified"/>
         <tag k="all_weather" v="yes"/>
         <tag k="note" v="2a"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-54028"/>
     </way>
     <way visible="true" id="-54026" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-53980"/>
         <nd ref="-53982"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.13"/>
         <tag k="highway" v="unclassified"/>
         <tag k="all_weather" v="yes"/>
         <tag k="note" v="2b"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-54026"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-016/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-016/Expected.osm
@@ -3,54 +3,43 @@
     <bounds minlat="-6.197007752860002" minlon="106.7864763" maxlat="-6.1955524" maxlon="106.7877288"/>
     <node visible="true" id="-144849" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1966581620793493" lon="106.7865276275659596">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144849"/>
     </node>
     <node visible="true" id="-144838" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1969622623099987" lon="106.7865273480000070">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-144838"/>
     </node>
     <node visible="true" id="-144837" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1969908769799993" lon="106.7865669170000018">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-144837"/>
     </node>
     <node visible="true" id="-144836" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1970077528600020" lon="106.7866675939999794">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-144836"/>
     </node>
     <node visible="true" id="-144834" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1969390000000004" lon="106.7865407000000033">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144834"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-144833" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1966834999999989" lon="106.7865287999999850">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144833"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-144832" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1962663999999981" lon="106.7865094999999798">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144832"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-144831" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1958721000000008" lon="106.7864912000000004">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144831"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-144830" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1955524000000004" lon="106.7864763000000039">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144830"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-144829" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1969821999999990" lon="106.7877287999999965">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144829"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-144828" timestamp="1970-01-01T00:00:00Z" version="1" lat="-6.1970029999999996" lon="106.7867337999999933">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-144828"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <way visible="true" id="-144844" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-144828"/>
@@ -58,15 +47,14 @@
         <nd ref="-144837"/>
         <nd ref="-144838"/>
         <nd ref="-144834"/>
-        <tag k="width" v="2.5"/>
-        <tag k="name" v="KEMANGGISAN 3G"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="KEMANGGISAN 3G"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="2"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-144844"/>
     </way>
     <way visible="true" id="-144841" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-144830"/>
@@ -75,29 +63,27 @@
         <nd ref="-144849"/>
         <nd ref="-144833"/>
         <nd ref="-144834"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="name" v="KEMANGGISAN 3G"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="KEMANGGISAN 3G"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-144841"/>
     </way>
     <way visible="true" id="-144826" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-144828"/>
         <nd ref="-144829"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="name" v="KEMANGGISAN 3G"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="KEMANGGISAN 3G"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-144826"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-017/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-017/Expected.osm
@@ -3,331 +3,249 @@
     <bounds minlat="1.29317632789" minlon="5.273732899999999" maxlat="1.29688755074" maxlon="5.27840040167"/>
     <node visible="true" id="-306522" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2939021837159554" lon="5.2772897908224010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306522"/>
     </node>
     <node visible="true" id="-306521" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2942173686298433" lon="5.2772841962230608">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306521"/>
     </node>
     <node visible="true" id="-306520" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2943297230597293" lon="5.2772508412585477">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306520"/>
     </node>
     <node visible="true" id="-306519" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949393956090276" lon="5.2770698460605399">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306519"/>
     </node>
     <node visible="true" id="-306515" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2954937523413077" lon="5.2756561700064610">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306515"/>
     </node>
     <node visible="true" id="-306514" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2950089564512188" lon="5.2755698351127229">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306514"/>
     </node>
     <node visible="true" id="-306510" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2955386895349172" lon="5.2755947446578286">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306510"/>
     </node>
     <node visible="true" id="-306509" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2955560565004580" lon="5.2755096987405521">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306509"/>
     </node>
     <node visible="true" id="-306505" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945859118713576" lon="5.2752830834012343">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306505"/>
     </node>
     <node visible="true" id="-306497" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941851379733504" lon="5.2752701670261040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306497"/>
     </node>
     <node visible="true" id="-306311" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2951920001399999" lon="5.2747859496700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306311"/>
     </node>
     <node visible="true" id="-306310" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2951737094600000" lon="5.2749805286699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306310"/>
     </node>
     <node visible="true" id="-306309" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2951296191699997" lon="5.2751239436699997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306309"/>
     </node>
     <node visible="true" id="-306308" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2950505018399998" lon="5.2754606906699992">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306308"/>
     </node>
     <node visible="true" id="-306307" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2950407364899998" lon="5.2755118966700003">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306307"/>
     </node>
     <node visible="true" id="-306301" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941855441300001" lon="5.2775860996699997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306301"/>
     </node>
     <node visible="true" id="-306300" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941818694000002" lon="5.2777379856700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306300"/>
     </node>
     <node visible="true" id="-306299" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941867184699998" lon="5.2780115176700004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306299"/>
     </node>
     <node visible="true" id="-306298" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2942017660600000" lon="5.2782465826699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306298"/>
     </node>
     <node visible="true" id="-306297" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941989341700000" lon="5.2784004016699999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306297"/>
     </node>
     <node visible="true" id="-306283" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2950327725299999" lon="5.2755536696699998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306283"/>
     </node>
     <node visible="true" id="-306282" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949956266599998" lon="5.2757731556699987">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306282"/>
     </node>
     <node visible="true" id="-306281" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949377554100001" lon="5.2761206256700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306281"/>
     </node>
     <node visible="true" id="-306280" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2948583784700001" lon="5.2765022776699997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306280"/>
     </node>
     <node visible="true" id="-306279" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949135445200000" lon="5.2765503946700001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306279"/>
     </node>
     <node visible="true" id="-306278" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949022670600001" lon="5.2768298036700001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306278"/>
     </node>
     <node visible="true" id="-306255" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2939135710200000" lon="5.2765148466699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306255"/>
     </node>
     <node visible="true" id="-306254" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2938979401599999" lon="5.2767367426699998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306254"/>
     </node>
     <node visible="true" id="-306253" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2938825016400000" lon="5.2769771766700000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306253"/>
     </node>
     <node visible="true" id="-306248" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2942850930499998" lon="5.2767829516700004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306248"/>
     </node>
     <node visible="true" id="-306247" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2943086440800000" lon="5.2769060236699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306247"/>
     </node>
     <node visible="true" id="-306246" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2943045565400000" lon="5.2769794246700004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306246"/>
     </node>
     <node visible="true" id="-306245" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2943238011200000" lon="5.2770403216700004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306245"/>
     </node>
     <node visible="true" id="-306236" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2946396062900001" lon="5.2742322976700002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306236"/>
     </node>
     <node visible="true" id="-306235" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2946752713600000" lon="5.2740638936700002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306235"/>
     </node>
     <node visible="true" id="-306234" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2946924752800000" lon="5.2739058086700004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306234"/>
     </node>
     <node visible="true" id="-306233" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2944091734199998" lon="5.2738635726699998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306233"/>
     </node>
     <node visible="true" id="-306232" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2944160052600000" lon="5.2737587936699999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306232"/>
     </node>
     <node visible="true" id="-306225" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945799398500000" lon="5.2747838406699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306225"/>
     </node>
     <node visible="true" id="-306224" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945499088199999" lon="5.2747446336700001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306224"/>
     </node>
     <node visible="true" id="-306223" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945385594299998" lon="5.2746829366699997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306223"/>
     </node>
     <node visible="true" id="-306222" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945560651400001" lon="5.2746014856699999">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306222"/>
     </node>
     <node visible="true" id="-306215" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2944268480299999" lon="5.2744227326699997">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306215"/>
     </node>
     <node visible="true" id="-306214" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945885199299998" lon="5.2744580586699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306214"/>
     </node>
     <node visible="true" id="-306212" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945975204799998" lon="5.2744619000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306212"/>
     </node>
     <node visible="true" id="-306211" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2946457952899997" lon="5.2740863999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306211"/>
     </node>
     <node visible="true" id="-306210" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2943936599400001" lon="5.2745907000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306210"/>
     </node>
     <node visible="true" id="-306209" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2942703579499997" lon="5.2748856999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306209"/>
     </node>
     <node visible="true" id="-306208" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945384844099999" lon="5.2746604000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306208"/>
     </node>
     <node visible="true" id="-306207" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945278237200000" lon="5.2747355000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306207"/>
     </node>
     <node visible="true" id="-306206" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2946672172299998" lon="5.2748481999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306206"/>
     </node>
     <node visible="true" id="-306205" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2957027104999999" lon="5.2747871000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306205"/>
     </node>
     <node visible="true" id="-306204" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2957294627199998" lon="5.2737328999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306204"/>
     </node>
     <node visible="true" id="-306203" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2966396407099998" lon="5.2747747000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306203"/>
     </node>
     <node visible="true" id="-306202" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2968875507399997" lon="5.2759800999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306202"/>
     </node>
     <node visible="true" id="-306183" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2950187179899999" lon="5.2755731999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306183"/>
     </node>
     <node visible="true" id="-306182" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941469553599998" lon="5.2773051000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306182"/>
     </node>
     <node visible="true" id="-306181" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2939279081299997" lon="5.2752315000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306181"/>
     </node>
     <node visible="true" id="-306180" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2957451519899998" lon="5.2769402999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306180"/>
     </node>
     <node visible="true" id="-306179" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949782878799998" lon="5.2770583000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306179"/>
     </node>
     <node visible="true" id="-306178" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2931763278899999" lon="5.2772943000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306178"/>
     </node>
     <node visible="true" id="-306177" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2943614767099998" lon="5.2765486999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306177"/>
     </node>
     <node visible="true" id="-306176" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2962975950400000" lon="5.2764521000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306176"/>
     </node>
     <node visible="true" id="-306175" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2959721435100000" lon="5.2757500999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306175"/>
     </node>
     <node visible="true" id="-306174" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2953951604099998" lon="5.2769920999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306174"/>
     </node>
     <node visible="true" id="-306173" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2954178897500002" lon="5.2761863000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306173"/>
     </node>
     <node visible="true" id="-306172" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2949308176800001" lon="5.2755428999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306172"/>
     </node>
     <node visible="true" id="-306171" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2940611668999997" lon="5.2758190999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306171"/>
     </node>
     <node visible="true" id="-306170" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2958953063400001" lon="5.2763179999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306170"/>
     </node>
     <node visible="true" id="-306169" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2955654293399999" lon="5.2754637999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306169"/>
     </node>
     <node visible="true" id="-306168" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2941705899299998" lon="5.2753357999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306168"/>
     </node>
     <node visible="true" id="-306167" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2963909259599997" lon="5.2758552999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306167"/>
     </node>
     <node visible="true" id="-306166" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2946672172299998" lon="5.2749340000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306166"/>
     </node>
     <node visible="true" id="-306165" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2945486422299999" lon="5.2754430999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306165"/>
     </node>
     <node visible="true" id="-306164" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2961152577299999" lon="5.2769026999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306164"/>
     </node>
     <node visible="true" id="-306163" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2964638407300000" lon="5.2753040999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306163"/>
     </node>
     <node visible="true" id="-306162" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2939539564499998" lon="5.2763985000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306162"/>
     </node>
     <node visible="true" id="-306161" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2960616527600000" lon="5.2753471000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306161"/>
     </node>
     <node visible="true" id="-306160" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2953822871499998" lon="5.2766492999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306160"/>
     </node>
     <node visible="true" id="-306159" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2958368738799999" lon="5.2757161000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306159"/>
     </node>
     <node visible="true" id="-306158" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2936321237999999" lon="5.2772728999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306158"/>
     </node>
     <node visible="true" id="-306157" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.2959080790099997" lon="5.2769237999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306157"/>
     </node>
     <way visible="true" id="-306601" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306522"/>
@@ -335,15 +253,14 @@
         <nd ref="-306254"/>
         <nd ref="-306255"/>
         <nd ref="-306162"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="KOL. SUTOMO 3"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306601"/>
     </way>
     <way visible="true" id="-306596" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306157"/>
@@ -357,15 +274,14 @@
         <nd ref="-306522"/>
         <nd ref="-306158"/>
         <nd ref="-306178"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="DARUL KHAEROT"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306596"/>
     </way>
     <way visible="true" id="-306593" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306168"/>
@@ -376,14 +292,13 @@
         <nd ref="-306515"/>
         <nd ref="-306159"/>
         <nd ref="-306175"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306593"/>
     </way>
     <way visible="true" id="-306590" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306204"/>
@@ -395,6 +310,7 @@
         <nd ref="-306160"/>
         <nd ref="-306174"/>
         <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="bridge" v="yes"/>
@@ -403,9 +319,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306590"/>
     </way>
     <way visible="true" id="-306588" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306214"/>
@@ -414,15 +328,14 @@
         <nd ref="-306224"/>
         <nd ref="-306225"/>
         <nd ref="-306208"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="KOL. SUTOMO 2"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306588"/>
     </way>
     <way visible="true" id="-306586" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306165"/>
@@ -431,6 +344,7 @@
         <nd ref="-306206"/>
         <nd ref="-306207"/>
         <nd ref="-306208"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="bridge" v="yes"/>
@@ -438,9 +352,7 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306586"/>
     </way>
     <way visible="true" id="-306584" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306168"/>
@@ -448,6 +360,7 @@
         <nd ref="-306209"/>
         <nd ref="-306210"/>
         <nd ref="-306208"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="all_weather" v="yes"/>
         <tag k="bridge" v="yes"/>
@@ -455,49 +368,44 @@
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306584"/>
     </way>
     <way visible="true" id="-306231" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306234"/>
         <nd ref="-306235"/>
         <nd ref="-306236"/>
         <nd ref="-306214"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306231"/>
     </way>
     <way visible="true" id="-306222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306308"/>
         <nd ref="-306309"/>
         <nd ref="-306310"/>
         <nd ref="-306311"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="KOL. SUTOMO 1"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306222"/>
     </way>
     <way visible="true" id="-306221" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306283"/>
         <nd ref="-306307"/>
         <nd ref="-306308"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="road"/>
         <tag k="bridge" v="yes"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306221"/>
     </way>
     <way visible="true" id="-306218" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306297"/>
@@ -506,14 +414,13 @@
         <nd ref="-306300"/>
         <nd ref="-306301"/>
         <nd ref="-306521"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306218"/>
     </way>
     <way visible="true" id="-306215" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306519"/>
@@ -523,15 +430,14 @@
         <nd ref="-306281"/>
         <nd ref="-306282"/>
         <nd ref="-306283"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="KOL. SUTOMO 1"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306215"/>
     </way>
     <way visible="true" id="-306209" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306520"/>
@@ -540,148 +446,134 @@
         <nd ref="-306247"/>
         <nd ref="-306248"/>
         <nd ref="-306177"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="KOL. SUTOMO 2"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306209"/>
     </way>
     <way visible="true" id="-306204" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306232"/>
         <nd ref="-306233"/>
         <nd ref="-306234"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306204"/>
     </way>
     <way visible="true" id="-306202" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306214"/>
         <nd ref="-306215"/>
         <nd ref="-306210"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="KOL. SUTOMO 3"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306202"/>
     </way>
     <way visible="true" id="-306201" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306211"/>
         <nd ref="-306212"/>
         <nd ref="-306208"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306201"/>
     </way>
     <way visible="true" id="-306197" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306167"/>
         <nd ref="-306163"/>
         <nd ref="-306203"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306197"/>
     </way>
     <way visible="true" id="-306196" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306167"/>
         <nd ref="-306202"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306196"/>
     </way>
     <way visible="true" id="-306195" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306177"/>
         <nd ref="-306165"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="KOL. SUTOMO 2"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306195"/>
     </way>
     <way visible="true" id="-306194" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306176"/>
         <nd ref="-306167"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306194"/>
     </way>
     <way visible="true" id="-306193" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306162"/>
         <nd ref="-306171"/>
         <nd ref="-306168"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="KOL. SUTOMO 3"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306193"/>
     </way>
     <way visible="true" id="-306192" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306175"/>
         <nd ref="-306170"/>
         <nd ref="-306157"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="PERINDUSTRIAN 1"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306192"/>
     </way>
     <way visible="true" id="-306189" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306175"/>
         <nd ref="-306167"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306189"/>
     </way>
     <way visible="true" id="-306187" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306161"/>
         <nd ref="-306175"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306187"/>
     </way>
     <way visible="true" id="-306186" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306181"/>
         <nd ref="-306168"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306186"/>
     </way>
     <way visible="true" id="-306185" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306164"/>
         <nd ref="-306157"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306185"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-018/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-018/Expected.osm
@@ -3,47 +3,36 @@
     <bounds minlat="1.30229889329" minlon="5.79580287884" maxlat="1.303086598" maxlon="5.79763887884"/>
     <node visible="true" id="-306997" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3024800394600000" lon="5.7975921969999993">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306997"/>
     </node>
     <node visible="true" id="-306996" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3024062227899997" lon="5.7975219600000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306996"/>
     </node>
     <node visible="true" id="-306995" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3023484995100001" lon="5.7974649810000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306995"/>
     </node>
     <node visible="true" id="-306994" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3022988932899997" lon="5.7974048590000002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306994"/>
     </node>
     <node visible="true" id="-306993" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3024245272299999" lon="5.7969219580000004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-306993"/>
     </node>
     <node visible="true" id="-306982" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3029854240100001" lon="5.7958888788399996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306982"/>
     </node>
     <node visible="true" id="-306981" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3030865979999997" lon="5.7966368788400002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306981"/>
     </node>
     <node visible="true" id="-306980" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3025884717500000" lon="5.7976388788400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306980"/>
     </node>
     <node visible="true" id="-306979" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3027800588399996" lon="5.7965850788399997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306979"/>
     </node>
     <node visible="true" id="-306978" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3025256150700000" lon="5.7965420788399999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306978"/>
     </node>
     <node visible="true" id="-306977" timestamp="1970-01-01T00:00:00Z" version="1" lat="1.3027437528400001" lon="5.7958028788400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-306977"/>
     </node>
     <way visible="true" id="-306981" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306978"/>
@@ -53,83 +42,77 @@
         <nd ref="-306996"/>
         <nd ref="-306997"/>
         <nd ref="-306980"/>
-        <tag k="width" v="5"/>
-        <tag k="alt_name" v="MA 6;MA. 5;MAD 5"/>
-        <tag k="name" v="MADR. 5"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="MADR. 5"/>
+        <tag k="alt_name" v="MA 6;MA. 5;MAD 5"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="2"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-306981"/>
     </way>
     <way visible="true" id="-306976" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306977"/>
         <nd ref="-306982"/>
         <nd ref="-306979"/>
-        <tag k="width" v="2.5"/>
-        <tag k="alt_name" v="M 1;MA. 4"/>
-        <tag k="name" v="MA 4"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="living_street"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="MA 4"/>
+        <tag k="alt_name" v="M 1;MA. 4"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306976"/>
     </way>
     <way visible="true" id="-306975" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306981"/>
         <nd ref="-306979"/>
-        <tag k="width" v="5"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="MADRASAH"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="residential"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="MADRASAH"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306975"/>
     </way>
     <way visible="true" id="-306974" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306979"/>
         <nd ref="-306980"/>
-        <tag k="width" v="2.5"/>
-        <tag k="alt_name" v="MA 4;MA. 3;MAD 3"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="MADRASAH 2"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="living_street"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="MADRASAH 2"/>
+        <tag k="alt_name" v="MA 4;MA. 3;MAD 3"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306974"/>
     </way>
     <way visible="true" id="-306973" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306979"/>
         <nd ref="-306978"/>
         <tag k="source" v="Bing"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306973"/>
     </way>
     <way visible="true" id="-306972" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-306977"/>
         <nd ref="-306978"/>
-        <tag k="width" v="2.5"/>
-        <tag k="alt_name" v="M 4;MA. 6"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="MA 6"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="living_street"/>
-        <tag k="lanes" v="1"/>
+        <tag k="name" v="MA 6"/>
+        <tag k="alt_name" v="M 4;MA. 6"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-306972"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-019/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-019/Expected.osm
@@ -3,119 +3,90 @@
     <bounds minlat="-0.29117506278" minlon="3.864704656449999" maxlat="-0.28617890388" maxlon="3.86750703988"/>
     <node visible="true" id="-359229" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2911717100600000" lon="3.8647160713000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359229"/>
     </node>
     <node visible="true" id="-359228" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2904498219000000" lon="3.8647046564499994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359228"/>
     </node>
     <node visible="true" id="-359227" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2898318517900000" lon="3.8648333564500001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359227"/>
     </node>
     <node visible="true" id="-359226" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2887847345500000" lon="3.8651767564499999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359226"/>
     </node>
     <node visible="true" id="-359225" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2879128593099999" lon="3.8656150564499998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359225"/>
     </node>
     <node visible="true" id="-359224" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2872187401699999" lon="3.8661560564499999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359224"/>
     </node>
     <node visible="true" id="-359223" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2865404155900000" lon="3.8668968564499999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-359223"/>
     </node>
     <node visible="true" id="-325538" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2878618896299999" lon="3.8658294398800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325538"/>
     </node>
     <node visible="true" id="-325537" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2873002566900000" lon="3.8661813398799998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325537"/>
     </node>
     <node visible="true" id="-325536" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2864137972699999" lon="3.8672437398799997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325536"/>
     </node>
     <node visible="true" id="-325535" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2861955023300000" lon="3.8675070398799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325535"/>
     </node>
     <node visible="true" id="-325534" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2872596155300000" lon="3.8657008398800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325534"/>
     </node>
     <node visible="true" id="-325533" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2868536065099999" lon="3.8657414398799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325533"/>
     </node>
     <node visible="true" id="-325532" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2861789038800000" lon="3.8659472398799997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325532"/>
     </node>
     <node visible="true" id="-325530" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2881529169099999" lon="3.8656670398799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325530"/>
     </node>
     <node visible="true" id="-325332" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2911750627800000" lon="3.8647920889799994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325332"/>
     </node>
     <node visible="true" id="-325331" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2911750627800000" lon="3.8648430534499996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325331"/>
     </node>
     <node visible="true" id="-325330" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2909815129600000" lon="3.8648008398799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325330"/>
     </node>
     <node visible="true" id="-325329" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2905957212999999" lon="3.8647873398799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325329"/>
     </node>
     <node visible="true" id="-325328" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2902167705399999" lon="3.8648347398799996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325328"/>
     </node>
     <node visible="true" id="-325327" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2898040193200000" lon="3.8649497398800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325327"/>
     </node>
     <node visible="true" id="-325326" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2894657104200001" lon="3.8651730398800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325326"/>
     </node>
     <node visible="true" id="-325325" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2888769146000000" lon="3.8655317398800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325325"/>
     </node>
     <node visible="true" id="-325324" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2910626952300000" lon="3.8649091398799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325324"/>
     </node>
     <node visible="true" id="-325323" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2906093019700000" lon="3.8653084398799997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325323"/>
     </node>
     <node visible="true" id="-325322" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2901423284299999" lon="3.8655655398800000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325322"/>
     </node>
     <node visible="true" id="-325321" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2896687158500000" lon="3.8656602398799995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325321"/>
     </node>
     <node visible="true" id="-325320" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2890326391100000" lon="3.8656670398799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325320"/>
     </node>
     <node visible="true" id="-325319" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2885656669000000" lon="3.8656670398799999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-325319"/>
     </node>
     <way visible="true" id="-359222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-359223"/>
@@ -126,11 +97,10 @@
         <nd ref="-359228"/>
         <nd ref="-359229"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="motorway_link"/>
         <tag k="lanes" v="3"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-359222"/>
     </way>
     <way visible="true" id="-325529" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-325535"/>
@@ -140,53 +110,49 @@
         <nd ref="-325530"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Gereja"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Gereja"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-325529"/>
     </way>
     <way visible="true" id="-325528" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-325532"/>
         <nd ref="-325533"/>
         <nd ref="-325534"/>
         <nd ref="-325530"/>
-        <tag k="width" v="5"/>
         <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-325528"/>
     </way>
     <way visible="true" id="-325527" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-325530"/>
         <nd ref="-325319"/>
-        <tag k="width" v="5"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Gereja"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="Gereja"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-325527"/>
     </way>
     <way visible="true" id="-325318" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-325332"/>
         <nd ref="-325324"/>
-        <tag k="width" v="5"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="secondary"/>
         <tag k="bridge" v="yes"/>
         <tag k="layer" v="1"/>
-        <tag k="source" v="Bing"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-325318"/>
     </way>
     <way visible="true" id="-325317" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-325319"/>
@@ -197,17 +163,16 @@
         <nd ref="-325329"/>
         <nd ref="-325330"/>
         <nd ref="-325331"/>
-        <tag k="width" v="5"/>
-        <tag k="note" v="Accuracy: Approximate"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="note" v="Accuracy: Approximate"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-325317"/>
     </way>
     <way visible="true" id="-325316" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-325319"/>
@@ -216,16 +181,15 @@
         <nd ref="-325322"/>
         <nd ref="-325323"/>
         <nd ref="-325324"/>
-        <tag k="width" v="5"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="Bing"/>
-        <tag k="name" v="Gereja"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="all_weather" v="yes"/>
         <tag k="highway" v="secondary"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="Gereja"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-325316"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-020/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-020/Expected.osm
@@ -2,106 +2,91 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="-0.2410994805699999" minlon="5.01228789033" maxlat="-0.23831883692" maxlon="5.012791149999999"/>
     <node visible="true" id="-863725" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2383188369200000" lon="5.0127911499999991">
-        <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-863725"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
     </node>
     <node visible="true" id="-863724" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2410994805699999" lon="5.0124886893299996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863724"/>
     </node>
     <node visible="true" id="-863723" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2406254656600000" lon="5.0125346553299996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863723"/>
     </node>
     <node visible="true" id="-863722" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2403391226099999" lon="5.0125624213300002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863722"/>
     </node>
     <node visible="true" id="-863721" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2403061372300000" lon="5.0125656173299999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863721"/>
     </node>
     <node visible="true" id="-863720" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2399198936600000" lon="5.0125892573300002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863720"/>
     </node>
     <node visible="true" id="-863719" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2395664652100000" lon="5.0126197073299998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863719"/>
     </node>
     <node visible="true" id="-863718" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2394186638600000" lon="5.0126409793300004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863718"/>
     </node>
     <node visible="true" id="-863717" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2393830729899999" lon="5.0122878903299997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863717"/>
     </node>
     <node visible="true" id="-863716" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2388975582700000" lon="5.0123426193299991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863716"/>
     </node>
     <node visible="true" id="-863715" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2388258698899999" lon="5.0123476503299988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-863715"/>
     </node>
     <way visible="true" id="-863808" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-863725"/>
         <nd ref="-863718"/>
-        <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="name" v="Kemanggisan Pulo"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="created_by" v="Merkaartor 0.12"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Kemanggisan Pulo"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-863808"/>
     </way>
     <way visible="true" id="-863714" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-863723"/>
         <nd ref="-863724"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="alt_name" v="Kemanggisan Pulo"/>
-        <tag k="name" v="KEMANGGISAN PULO 2"/>
         <tag k="highway" v="secondary"/>
         <tag k="all_weather" v="yes"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="KEMANGGISAN PULO 2"/>
+        <tag k="alt_name" v="Kemanggisan Pulo"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-863714"/>
     </way>
     <way visible="true" id="-863713" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-863722"/>
         <nd ref="-863723"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="alt_name" v="Kemanggisan Pulo"/>
-        <tag k="name" v="KEMANGGISAN PULO 2"/>
         <tag k="highway" v="secondary"/>
         <tag k="all_weather" v="yes"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="KEMANGGISAN PULO 2"/>
+        <tag k="alt_name" v="Kemanggisan Pulo"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-863713"/>
     </way>
     <way visible="true" id="-863712" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-863719"/>
         <nd ref="-863720"/>
         <nd ref="-863721"/>
         <nd ref="-863722"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="alt_name" v="Kemanggisan Pulo"/>
-        <tag k="name" v="KEMANGGISAN PULO 2"/>
         <tag k="highway" v="secondary"/>
         <tag k="all_weather" v="yes"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="KEMANGGISAN PULO 2"/>
+        <tag k="alt_name" v="Kemanggisan Pulo"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-863712"/>
     </way>
     <way visible="true" id="-863711" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-863715"/>
@@ -109,16 +94,15 @@
         <nd ref="-863717"/>
         <nd ref="-863718"/>
         <nd ref="-863719"/>
-        <tag k="width" v="5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="alt_name" v="Kemanggisan Pulo"/>
-        <tag k="name" v="KEMANGGISAN PULO 1"/>
         <tag k="highway" v="secondary"/>
         <tag k="all_weather" v="yes"/>
-        <tag k="lanes" v="2"/>
+        <tag k="name" v="KEMANGGISAN PULO 1"/>
+        <tag k="alt_name" v="Kemanggisan Pulo"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="2"/>
+        <tag k="width" v="5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-863711"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-021/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-021/Expected.osm
@@ -3,33 +3,28 @@
     <bounds minlat="4.15886724908" minlon="4.478056938" maxlat="4.1597321216" maxlon="4.478165724999999"/>
     <node visible="true" id="-1017065" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1588672490800001" lon="4.4780569379999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1017065"/>
     </node>
     <node visible="true" id="-1017064" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1592517771899988" lon="4.4780620590000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1017064"/>
     </node>
     <node visible="true" id="-1017063" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1594942159199997" lon="4.4781095590000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1017063"/>
     </node>
     <node visible="true" id="-1017062" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1597321216000003" lon="4.4781657249999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1017062"/>
     </node>
     <way visible="true" id="-1017051" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1017062"/>
         <nd ref="-1017063"/>
         <nd ref="-1017064"/>
         <nd ref="-1017065"/>
-        <tag k="width" v="2.5"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="highway" v="unclassified"/>
         <tag k="all_weather" v="yes"/>
-        <tag k="lanes" v="1"/>
         <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="3"/>
+        <tag k="lanes" v="1"/>
+        <tag k="width" v="2.5"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-1017051"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-022/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-022/Expected.osm
@@ -3,104 +3,82 @@
     <bounds minlat="4.158025424150001" minlon="4.47661553531" maxlat="4.161093133749999" maxlon="4.47890136433"/>
     <node visible="true" id="-945" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1603488053322426" lon="4.4775877017647865">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-945"/>
     </node>
     <node visible="true" id="-944" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1586002389730368" lon="4.4780463074273289">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-944"/>
     </node>
     <node visible="true" id="-943" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1598848062142446" lon="4.4781112930171645">
         <tag k="hoot:status" v="1"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
-        <tag k="hoot:id" v="-943"/>
     </node>
     <node visible="true" id="-851" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1603868949400011" lon="4.4782974281000003">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-851"/>
     </node>
     <node visible="true" id="-850" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1610931337499988" lon="4.4773470005900000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-850"/>
     </node>
     <node visible="true" id="-849" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1605569237799997" lon="4.4774274617699996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-849"/>
     </node>
     <node visible="true" id="-848" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1580874350499988" lon="4.4789013643300004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-848"/>
     </node>
     <node visible="true" id="-847" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1583245354899994" lon="4.4782320735900001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-847"/>
     </node>
     <node visible="true" id="-845" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1605784030799997" lon="4.4787331273100000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-845"/>
     </node>
     <node visible="true" id="-844" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1601822845700003" lon="4.4781863812099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-844"/>
     </node>
     <node visible="true" id="-836" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1603088809499997" lon="4.4766155353099997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-836"/>
     </node>
     <node visible="true" id="-822" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1580254241500008" lon="4.4774896363199996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-822"/>
     </node>
     <node visible="true" id="-820" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1583974894500004" lon="4.4780382352899997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-820"/>
     </node>
     <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1604667528499997" lon="4.4770379565100002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-59"/>
     </node>
     <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1603487225899984" lon="4.4775880874200000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-57"/>
     </node>
     <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1602498323499990" lon="4.4779974871599988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1588672490800001" lon="4.4780569379999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1592517771899988" lon="4.4780620590000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1594942159200006" lon="4.4781095590000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="4.1598980020899994" lon="4.4781113516000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <way visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-850"/>
         <nd ref="-849"/>
         <nd ref="-945"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-117"/>
     </way>
     <way visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-944"/>
         <nd ref="-847"/>
         <nd ref="-848"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-116"/>
     </way>
     <way visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-836"/>
@@ -116,25 +94,23 @@
         <nd ref="-944"/>
         <nd ref="-820"/>
         <nd ref="-822"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="highway" v="unclassified"/>
         <tag k="all_weather" v="yes"/>
         <tag k="surface" v="paved"/>
         <tag k="lanes" v="1"/>
         <tag k="width" v="2.5"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="10.08"/>
-        <tag k="hoot:id" v="-110"/>
     </way>
     <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-943"/>
         <nd ref="-844"/>
         <nd ref="-851"/>
         <nd ref="-845"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="created_by" v="Merkaartor 0.12"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-27"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-023/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-023/Expected.osm
@@ -3,83 +3,63 @@
     <bounds minlat="-0.29126677493" minlon="3.8655211266" maxlat="-0.28529088888" maxlon="3.867119723170001"/>
     <node visible="true" id="-6586" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2891961361299999" lon="3.8662185009400001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6586"/>
     </node>
     <node visible="true" id="-6575" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2863208443299999" lon="3.8664974506799998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6575"/>
     </node>
     <node visible="true" id="-6574" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2863959452500000" lon="3.8666905697299998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6574"/>
     </node>
     <node visible="true" id="-6573" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2867821785099999" lon="3.8671089943400001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6573"/>
     </node>
     <node visible="true" id="-6572" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2873507996900000" lon="3.8671197231700005">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6572"/>
     </node>
     <node visible="true" id="-6571" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2880052504400001" lon="3.8668193157599995">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6571"/>
     </node>
     <node visible="true" id="-6570" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2886382437500000" lon="3.8665296371899998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6570"/>
     </node>
     <node visible="true" id="-6564" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2861920995800000" lon="3.8663821156900000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6564"/>
     </node>
     <node visible="true" id="-6042" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2852908888800000" lon="3.8664008911599996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6042"/>
     </node>
     <node visible="true" id="-6040" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2859667971600001" lon="3.8664008911599996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6040"/>
     </node>
     <node visible="true" id="-6038" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2863744878400000" lon="3.8662828739599999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6038"/>
     </node>
     <node visible="true" id="-6036" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2865997905800000" lon="3.8658966358600000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6036"/>
     </node>
     <node visible="true" id="-6034" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2871254969600001" lon="3.8656498726300002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6034"/>
     </node>
     <node visible="true" id="-6032" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2876833894200000" lon="3.8655211266000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6032"/>
     </node>
     <node visible="true" id="-6030" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2884558558500001" lon="3.8655318554400000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6030"/>
     </node>
     <node visible="true" id="-6028" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2888850038400000" lon="3.8659502800399999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6028"/>
     </node>
     <node visible="true" id="-6026" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2891961361299999" lon="3.8662185009400001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6026"/>
     </node>
     <node visible="true" id="-6024" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2897540284900000" lon="3.8662292297800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6024"/>
     </node>
     <node visible="true" id="-6022" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2904299364900000" lon="3.8662185009400001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6022"/>
     </node>
     <node visible="true" id="-6021" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.2912667749300000" lon="3.8661970432700001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-6021"/>
     </node>
     <way visible="true" id="-6041" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-6586"/>
@@ -90,9 +70,9 @@
         <nd ref="-6574"/>
         <nd ref="-6575"/>
         <nd ref="-6564"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6041"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6037" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-6021"/>
@@ -109,8 +89,8 @@
         <nd ref="-6564"/>
         <nd ref="-6040"/>
         <nd ref="-6042"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-6037"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-024/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-024/Expected.osm
@@ -3,97 +3,75 @@
     <bounds minlat="38.90118849999999" minlon="-77.02990440000001" maxlat="38.9031" maxlon="-77.02809999999999"/>
     <node visible="true" id="-112286" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025219999999763" lon="-77.0299044000000066">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-112286"/>
     </node>
     <node visible="true" id="-112284" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013257758499904" lon="-77.0296231338400048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112284"/>
     </node>
     <node visible="true" id="-112282" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9016813354200082" lon="-77.0296219290700037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112282"/>
     </node>
     <node visible="true" id="-112280" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9018371865499830" lon="-77.0296226833399942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112280"/>
     </node>
     <node visible="true" id="-112278" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9021763439699981" lon="-77.0296243250499941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112278"/>
     </node>
     <node visible="true" id="-112276" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9024001731499993" lon="-77.0296254916100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112276"/>
     </node>
     <node visible="true" id="-112274" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025223949699992" lon="-77.0296261288900013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112274"/>
     </node>
     <node visible="true" id="-112272" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9026388323000063" lon="-77.0296267356600026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112272"/>
     </node>
     <node visible="true" id="-112270" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9027290058099950" lon="-77.0296272061600007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112270"/>
     </node>
     <node visible="true" id="-112268" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013258125599961" lon="-77.0283844374399820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112268"/>
     </node>
     <node visible="true" id="-112266" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013284759299864" lon="-77.0289114020300048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112266"/>
     </node>
     <node visible="true" id="-112264" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013298097099920" lon="-77.0293427956100061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112264"/>
     </node>
     <node visible="true" id="-112262" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013326499299907" lon="-77.0298658406899932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112262"/>
     </node>
     <node visible="true" id="-112260" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025229377400024" lon="-77.0283647387399952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112260"/>
     </node>
     <node visible="true" id="-112258" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025245713099892" lon="-77.0286843122199940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112258"/>
     </node>
     <node visible="true" id="-112256" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025227247599972" lon="-77.0292288073100053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112256"/>
     </node>
     <node visible="true" id="-112252" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9031000000000020" lon="-77.0296248718899932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112252"/>
     </node>
     <node visible="true" id="-112250" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013310631599865" lon="-77.0280999999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112250"/>
     </node>
     <node visible="true" id="-112248" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025182076199911" lon="-77.0280999999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112248"/>
     </node>
     <node visible="true" id="-112244" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9013326213599839" lon="-77.0299044000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112244"/>
     </node>
     <node visible="true" id="-112242" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9011884999999893" lon="-77.0296235989899856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-112242"/>
     </node>
     <way visible="true" id="-112304" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112274"/>
         <nd ref="-112286"/>
-        <tag k="alt_name" v="K St NW"/>
-        <tag k="name" v="US Hwy 29"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="US Hwy 29"/>
+        <tag k="alt_name" v="K St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112304"/>
     </way>
     <way visible="true" id="-112298" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112284"/>
@@ -102,24 +80,22 @@
         <nd ref="-112278"/>
         <nd ref="-112276"/>
         <nd ref="-112274"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="alt_name" v="13th St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112298"/>
     </way>
     <way visible="true" id="-112296" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112274"/>
         <nd ref="-112272"/>
         <nd ref="-112270"/>
         <nd ref="-112252"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="alt_name" v="13th St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112296"/>
     </way>
     <way visible="true" id="-112294" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112250"/>
@@ -127,12 +103,11 @@
         <nd ref="-112266"/>
         <nd ref="-112264"/>
         <nd ref="-112284"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="I ST NW"/>
+        <tag k="alt_name" v="I St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112294"/>
     </way>
     <way visible="true" id="-112292" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112248"/>
@@ -140,32 +115,29 @@
         <nd ref="-112258"/>
         <nd ref="-112256"/>
         <nd ref="-112274"/>
-        <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="name" v="K ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="K ST NW"/>
+        <tag k="alt_name" v="K St NW;US Hwy 29"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112292"/>
     </way>
     <way visible="true" id="-112288" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112284"/>
         <nd ref="-112262"/>
         <nd ref="-112244"/>
-        <tag k="alt_name" v="I St NW"/>
-        <tag k="name" v="I ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="I ST NW"/>
+        <tag k="alt_name" v="I St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112288"/>
     </way>
     <way visible="true" id="-112286" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-112242"/>
         <nd ref="-112284"/>
-        <tag k="alt_name" v="13th St NW"/>
-        <tag k="name" v="13TH ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="13TH ST NW"/>
+        <tag k="alt_name" v="13th St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-112286"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-025/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-025/Expected.osm
@@ -3,1311 +3,984 @@
     <bounds minlat="38.88897999999999" minlon="-77.0399326" maxlat="38.897714" maxlon="-77.0315925"/>
     <node visible="true" id="-679752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932771902400702" lon="-77.0382197439045342">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679752"/>
     </node>
     <node visible="true" id="-679751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8949632424726275" lon="-77.0377190648163577">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679751"/>
     </node>
     <node visible="true" id="-679740" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8943752880068843" lon="-77.0347339936844122">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679740"/>
     </node>
     <node visible="true" id="-679739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932650470675370" lon="-77.0348668159949170">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679739"/>
     </node>
     <node visible="true" id="-679731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920986737427299" lon="-77.0391229637634041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679731"/>
     </node>
     <node visible="true" id="-679723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954752706619900" lon="-77.0338684265605593">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679723"/>
     </node>
     <node visible="true" id="-679719" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920930505025098" lon="-77.0339249950479967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679719"/>
     </node>
     <node visible="true" id="-679708" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953918442270989" lon="-77.0384010006634554">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679708"/>
     </node>
     <node visible="true" id="-679351" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920889999999986" lon="-77.0317100000000039">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679351"/>
     </node>
     <node visible="true" id="-679303" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8897639999999996" lon="-77.0328999999999837">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679303"/>
     </node>
     <node visible="true" id="-679302" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898489999999981" lon="-77.0329210000000018">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679302"/>
     </node>
     <node visible="true" id="-679301" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8899940000000086" lon="-77.0329710000000034">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679301"/>
     </node>
     <node visible="true" id="-679275" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8964029999999923" lon="-77.0336489999999969">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679275"/>
     </node>
     <node visible="true" id="-679274" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8973450000000014" lon="-77.0336450000000070">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679274"/>
     </node>
     <node visible="true" id="-679272" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8945220000000091" lon="-77.0346550000000008">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679272"/>
     </node>
     <node visible="true" id="-679271" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8946860000000001" lon="-77.0345800000000054">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679271"/>
     </node>
     <node visible="true" id="-679270" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8948109999999971" lon="-77.0345250000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679270"/>
     </node>
     <node visible="true" id="-679269" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8949379999999962" lon="-77.0344549999999941">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679269"/>
     </node>
     <node visible="true" id="-679268" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8950019999999981" lon="-77.0344029999999975">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679268"/>
     </node>
     <node visible="true" id="-679267" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8950459999999936" lon="-77.0343639999999965">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679267"/>
     </node>
     <node visible="true" id="-679266" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951040000000035" lon="-77.0343009999999992">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679266"/>
     </node>
     <node visible="true" id="-679265" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951589999999996" lon="-77.0342339999999979">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679265"/>
     </node>
     <node visible="true" id="-679264" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952110000000104" lon="-77.0341679999999940">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679264"/>
     </node>
     <node visible="true" id="-679263" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952670000000040" lon="-77.0340889999999945">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679263"/>
     </node>
     <node visible="true" id="-679262" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953469999999939" lon="-77.0339680000000016">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679262"/>
     </node>
     <node visible="true" id="-679261" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954129999999978" lon="-77.0338940000000036">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679261"/>
     </node>
     <node visible="true" id="-679250" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8890079999999969" lon="-77.0394900000000007">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679250"/>
     </node>
     <node visible="true" id="-679245" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8961049999999986" lon="-77.0319619999999929">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679245"/>
     </node>
     <node visible="true" id="-679244" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8969589999999954" lon="-77.0319640000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679244"/>
     </node>
     <node visible="true" id="-679243" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8973489999999984" lon="-77.0319630000000046">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679243"/>
     </node>
     <node visible="true" id="-679203" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8959910000000022" lon="-77.0316059999999965">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679203"/>
     </node>
     <node visible="true" id="-679202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8961439999999925" lon="-77.0321720000000028">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679202"/>
     </node>
     <node visible="true" id="-679201" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8962360000000018" lon="-77.0324860000000058">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679201"/>
     </node>
     <node visible="true" id="-679200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8963409999999996" lon="-77.0328640000000036">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679200"/>
     </node>
     <node visible="true" id="-679199" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8963839999999905" lon="-77.0330589999999944">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679199"/>
     </node>
     <node visible="true" id="-679198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8963940000000008" lon="-77.0332009999999912">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679198"/>
     </node>
     <node visible="true" id="-679197" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8963919999999916" lon="-77.0333619999999968">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679197"/>
     </node>
     <node visible="true" id="-679196" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896520000000052" lon="-77.0328820000000007">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679196"/>
     </node>
     <node visible="true" id="-679195" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895979999999923" lon="-77.0328750000000042">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679195"/>
     </node>
     <node visible="true" id="-679194" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895430000000033" lon="-77.0328729999999950">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679194"/>
     </node>
     <node visible="true" id="-679193" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894880000000001" lon="-77.0328710000000001">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679193"/>
     </node>
     <node visible="true" id="-679192" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8894370000000151" lon="-77.0328740000000067">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679192"/>
     </node>
     <node visible="true" id="-679191" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893819999999906" lon="-77.0328760000000017">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679191"/>
     </node>
     <node visible="true" id="-679190" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8893219999999999" lon="-77.0328800000000058">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679190"/>
     </node>
     <node visible="true" id="-679189" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8892369999999943" lon="-77.0328879999999998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679189"/>
     </node>
     <node visible="true" id="-679188" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8890000000000029" lon="-77.0329490000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679188"/>
     </node>
     <node visible="true" id="-679187" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929389999999842" lon="-77.0347110000000015">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679187"/>
     </node>
     <node visible="true" id="-679186" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928169999999938" lon="-77.0346629999999948">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679186"/>
     </node>
     <node visible="true" id="-679185" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927690000000013" lon="-77.0346329999999995">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679185"/>
     </node>
     <node visible="true" id="-679184" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926439999999971" lon="-77.0345509999999933">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679184"/>
     </node>
     <node visible="true" id="-679183" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8925739999999962" lon="-77.0344989999999825">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679183"/>
     </node>
     <node visible="true" id="-679182" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924989999999937" lon="-77.0344269999999938">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679182"/>
     </node>
     <node visible="true" id="-679181" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924220000000034" lon="-77.0343380000000053">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679181"/>
     </node>
     <node visible="true" id="-679180" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8923169999999914" lon="-77.0341889999999978">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679180"/>
     </node>
     <node visible="true" id="-679179" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921430000000043" lon="-77.0339749999999981">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679179"/>
     </node>
     <node visible="true" id="-679152" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931959999999961" lon="-77.0382520000000000">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679152"/>
     </node>
     <node visible="true" id="-679151" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931329999999917" lon="-77.0382850000000019">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679151"/>
     </node>
     <node visible="true" id="-679150" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930139999999938" lon="-77.0383290000000045">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679150"/>
     </node>
     <node visible="true" id="-679149" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929019999999923" lon="-77.0383690000000030">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679149"/>
     </node>
     <node visible="true" id="-679148" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928370000000001" lon="-77.0383960000000059">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679148"/>
     </node>
     <node visible="true" id="-679147" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927690000000013" lon="-77.0384339999999952">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679147"/>
     </node>
     <node visible="true" id="-679146" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926759999999945" lon="-77.0384959999999950">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679146"/>
     </node>
     <node visible="true" id="-679145" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8925210000000021" lon="-77.0386440000000050">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679145"/>
     </node>
     <node visible="true" id="-679144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924549999999982" lon="-77.0387149999999963">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679144"/>
     </node>
     <node visible="true" id="-679143" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924230000000009" lon="-77.0387599999999964">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679143"/>
     </node>
     <node visible="true" id="-679142" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8923580000000086" lon="-77.0388699999999886">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679142"/>
     </node>
     <node visible="true" id="-679141" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8923099999999877" lon="-77.0389480000000049">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679141"/>
     </node>
     <node visible="true" id="-679140" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922799999999995" lon="-77.0390100000000047">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679140"/>
     </node>
     <node visible="true" id="-679139" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922600000000003" lon="-77.0390359999999959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679139"/>
     </node>
     <node visible="true" id="-679138" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922429999999935" lon="-77.0390560000000022">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679138"/>
     </node>
     <node visible="true" id="-679137" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922159999999977" lon="-77.0390790000000010">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679137"/>
     </node>
     <node visible="true" id="-679136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921830000000028" lon="-77.0390989999999789">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679136"/>
     </node>
     <node visible="true" id="-679129" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904249999999934" lon="-77.0316519999999940">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679129"/>
     </node>
     <node visible="true" id="-679128" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904219999999938" lon="-77.0317459999999983">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679128"/>
     </node>
     <node visible="true" id="-679127" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904199999999918" lon="-77.0317859999999968">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679127"/>
     </node>
     <node visible="true" id="-679118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8889799999999966" lon="-77.0329554150900009">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679118"/>
     </node>
     <node visible="true" id="-679117" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904259153799998" lon="-77.0315925000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679117"/>
     </node>
     <node visible="true" id="-679116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920883208099966" lon="-77.0315925000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679116"/>
     </node>
     <node visible="true" id="-679115" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920883208099966" lon="-77.0315925000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679115"/>
     </node>
     <node visible="true" id="-679114" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8889799999999894" lon="-77.0319678693199990">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679114"/>
     </node>
     <node visible="true" id="-679113" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8889799999999894" lon="-77.0394900912099985">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679113"/>
     </node>
     <node visible="true" id="-679112" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8889799999999966" lon="-77.0394960977800025">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679112"/>
     </node>
     <node visible="true" id="-679111" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8959890714299945" lon="-77.0315925000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679111"/>
     </node>
     <node visible="true" id="-679110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8977140000000006" lon="-77.0319599834700028">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679110"/>
     </node>
     <node visible="true" id="-679109" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8889799999999894" lon="-77.0394834228199841">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679109"/>
     </node>
     <node visible="true" id="-679108" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920883208099966" lon="-77.0315925000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679108"/>
     </node>
     <node visible="true" id="-679107" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920999999999921" lon="-77.0399326000000002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679107"/>
     </node>
     <node visible="true" id="-679106" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920999999999921" lon="-77.0399326000000002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679106"/>
     </node>
     <node visible="true" id="-679105" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8955005282499968" lon="-77.0315925000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679105"/>
     </node>
     <node visible="true" id="-679104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8977140000000006" lon="-77.0336446191999897">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679104"/>
     </node>
     <node visible="true" id="-679103" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8977140000000006" lon="-77.0336446191999897">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-679103"/>
     </node>
     <node visible="true" id="-679102" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8901296083099908" lon="-77.0330310174300052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679102"/>
     </node>
     <node visible="true" id="-679100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920895182399988" lon="-77.0336530036900058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679100"/>
     </node>
     <node visible="true" id="-679098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922717306200099" lon="-77.0336411080999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679098"/>
     </node>
     <node visible="true" id="-679096" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922867760099962" lon="-77.0336401260399839">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679096"/>
     </node>
     <node visible="true" id="-679094" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924757728100019" lon="-77.0336360654499970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679094"/>
     </node>
     <node visible="true" id="-679092" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926633271999975" lon="-77.0336356928000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679092"/>
     </node>
     <node visible="true" id="-679090" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928514220599908" lon="-77.0336354356700070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679090"/>
     </node>
     <node visible="true" id="-679088" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930189777600006" lon="-77.0336353993899934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679088"/>
     </node>
     <node visible="true" id="-679086" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931976138400017" lon="-77.0336350225300066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679086"/>
     </node>
     <node visible="true" id="-679084" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8936415434699896" lon="-77.0336448598900034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679084"/>
     </node>
     <node visible="true" id="-679082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8938772015200058" lon="-77.0336479075899945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679082"/>
     </node>
     <node visible="true" id="-679080" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8943144696999994" lon="-77.0336410821900017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679080"/>
     </node>
     <node visible="true" id="-679078" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951428779700024" lon="-77.0336452768799944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679078"/>
     </node>
     <node visible="true" id="-679076" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953234861300032" lon="-77.0336453620599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679076"/>
     </node>
     <node visible="true" id="-679074" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954790622799962" lon="-77.0336454354300031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679074"/>
     </node>
     <node visible="true" id="-679072" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8901561059500054" lon="-77.0330427349599915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679072"/>
     </node>
     <node visible="true" id="-679070" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902236591299868" lon="-77.0330767697599867">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679070"/>
     </node>
     <node visible="true" id="-679068" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902506727700015" lon="-77.0330934512099930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679068"/>
     </node>
     <node visible="true" id="-679066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902918405899953" lon="-77.0331188735499950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679066"/>
     </node>
     <node visible="true" id="-679064" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903640734200025" lon="-77.0331693937500006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679064"/>
     </node>
     <node visible="true" id="-679062" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904355847100049" lon="-77.0332229106400064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679062"/>
     </node>
     <node visible="true" id="-679060" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905010604499992" lon="-77.0332760790300028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679060"/>
     </node>
     <node visible="true" id="-679058" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905804063100007" lon="-77.0333389363999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679058"/>
     </node>
     <node visible="true" id="-679056" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906565991900024" lon="-77.0334017924299985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679056"/>
     </node>
     <node visible="true" id="-679054" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907141515800063" lon="-77.0334406643300014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679054"/>
     </node>
     <node visible="true" id="-679052" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907748567499993" lon="-77.0334799988399936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679052"/>
     </node>
     <node visible="true" id="-679050" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907970071600033" lon="-77.0334939543899964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679050"/>
     </node>
     <node visible="true" id="-679048" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908306985799967" lon="-77.0335151815200021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679048"/>
     </node>
     <node visible="true" id="-679046" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908853712599978" lon="-77.0335435629299923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679046"/>
     </node>
     <node visible="true" id="-679044" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909456283999901" lon="-77.0335744828999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679044"/>
     </node>
     <node visible="true" id="-679042" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909770911499990" lon="-77.0335866598600063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679042"/>
     </node>
     <node visible="true" id="-679040" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910427290100031" lon="-77.0336080714299953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679040"/>
     </node>
     <node visible="true" id="-679038" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8910963239099914" lon="-77.0336251562700056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679038"/>
     </node>
     <node visible="true" id="-679036" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911450561500018" lon="-77.0336357838599923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679036"/>
     </node>
     <node visible="true" id="-679034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911836094600005" lon="-77.0336445631100020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679034"/>
     </node>
     <node visible="true" id="-679032" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912237844099948" lon="-77.0336528806100063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679032"/>
     </node>
     <node visible="true" id="-679030" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912656715099914" lon="-77.0336592400999791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679030"/>
     </node>
     <node visible="true" id="-679028" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913033251799902" lon="-77.0336638685800068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679028"/>
     </node>
     <node visible="true" id="-679026" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913228729799911" lon="-77.0336651457499926">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679026"/>
     </node>
     <node visible="true" id="-679024" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913476458300025" lon="-77.0336657337799977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679024"/>
     </node>
     <node visible="true" id="-679022" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914172807499980" lon="-77.0336650750300009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679022"/>
     </node>
     <node visible="true" id="-679020" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915810534699986" lon="-77.0336633080199960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679020"/>
     </node>
     <node visible="true" id="-679018" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917145576300101" lon="-77.0336630251999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679018"/>
     </node>
     <node visible="true" id="-679016" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918888369399980" lon="-77.0336612026199958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679016"/>
     </node>
     <node visible="true" id="-679014" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919782334799962" lon="-77.0336602678999895">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679014"/>
     </node>
     <node visible="true" id="-679012" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895269012899831" lon="-77.0319624103800038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679012"/>
     </node>
     <node visible="true" id="-679010" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898038184100017" lon="-77.0319636870899984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679010"/>
     </node>
     <node visible="true" id="-679008" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8901013653799907" lon="-77.0319624372099980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679008"/>
     </node>
     <node visible="true" id="-679006" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902976166799945" lon="-77.0319627498999893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679006"/>
     </node>
     <node visible="true" id="-679004" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904126048400016" lon="-77.0319620010299957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679004"/>
     </node>
     <node visible="true" id="-679002" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905120424100019" lon="-77.0319628978299988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679002"/>
     </node>
     <node visible="true" id="-679000" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906276342000012" lon="-77.0319639409100034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-679000"/>
     </node>
     <node visible="true" id="-678998" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909327475999902" lon="-77.0319647692199965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678998"/>
     </node>
     <node visible="true" id="-678996" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8912111964099907" lon="-77.0319647787000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678996"/>
     </node>
     <node visible="true" id="-678994" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915538745599960" lon="-77.0319660849200005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678994"/>
     </node>
     <node visible="true" id="-678992" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918285395799899" lon="-77.0319670148700055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678992"/>
     </node>
     <node visible="true" id="-678990" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919373109599960" lon="-77.0319657099200015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678990"/>
     </node>
     <node visible="true" id="-678988" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920932092299836" lon="-77.0319638389200065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678988"/>
     </node>
     <node visible="true" id="-678986" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954986425399909" lon="-77.0319550570300038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678986"/>
     </node>
     <node visible="true" id="-678984" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920997357700031" lon="-77.0394809573100048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678984"/>
     </node>
     <node visible="true" id="-678982" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920964516199987" lon="-77.0365414627799936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678982"/>
     </node>
     <node visible="true" id="-678980" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922263581300030" lon="-77.0365445400099986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678980"/>
     </node>
     <node visible="true" id="-678978" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922607649799943" lon="-77.0365447478300069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678978"/>
     </node>
     <node visible="true" id="-678976" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924344511199962" lon="-77.0365457993000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678976"/>
     </node>
     <node visible="true" id="-678974" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924598912599961" lon="-77.0365459996500022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678974"/>
     </node>
     <node visible="true" id="-678972" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926095411899908" lon="-77.0365440389099803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678972"/>
     </node>
     <node visible="true" id="-678970" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920927932799927" lon="-77.0338772181600007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678970"/>
     </node>
     <node visible="true" id="-678968" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920930229399957" lon="-77.0338929352199955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678968"/>
     </node>
     <node visible="true" id="-678966" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920930507200069" lon="-77.0339252480599868">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678966"/>
     </node>
     <node visible="true" id="-678964" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920932978499962" lon="-77.0342149375899936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678964"/>
     </node>
     <node visible="true" id="-678962" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920934923299981" lon="-77.0344440373000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678962"/>
     </node>
     <node visible="true" id="-678960" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920931756499968" lon="-77.0355017469599943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678960"/>
     </node>
     <node visible="true" id="-678958" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920951356299938" lon="-77.0358681886099959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678958"/>
     </node>
     <node visible="true" id="-678956" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920962728599875" lon="-77.0362714007199969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678956"/>
     </node>
     <node visible="true" id="-678954" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920963558099970" lon="-77.0363975059500063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678954"/>
     </node>
     <node visible="true" id="-678952" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920965635400009" lon="-77.0367106282599963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678952"/>
     </node>
     <node visible="true" id="-678950" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920965782699923" lon="-77.0367336302299890">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678950"/>
     </node>
     <node visible="true" id="-678948" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920966326300075" lon="-77.0371315394200025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678948"/>
     </node>
     <node visible="true" id="-678946" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920970157499895" lon="-77.0376233931600041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678946"/>
     </node>
     <node visible="true" id="-678944" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920977027999939" lon="-77.0380055108199855">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678944"/>
     </node>
     <node visible="true" id="-678942" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920985361099980" lon="-77.0384868753200038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678942"/>
     </node>
     <node visible="true" id="-678940" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920983958700006" lon="-77.0389102034300066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678940"/>
     </node>
     <node visible="true" id="-678938" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920986738500005" lon="-77.0391230459499923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678938"/>
     </node>
     <node visible="true" id="-678936" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954408575100103" lon="-77.0350237093300052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678936"/>
     </node>
     <node visible="true" id="-678934" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951967225499899" lon="-77.0368441613499897">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678934"/>
     </node>
     <node visible="true" id="-678932" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951960719800027" lon="-77.0368557475099891">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678932"/>
     </node>
     <node visible="true" id="-678930" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951947810299998" lon="-77.0368787418800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678930"/>
     </node>
     <node visible="true" id="-678928" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951831286099932" lon="-77.0369787938199977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678928"/>
     </node>
     <node visible="true" id="-678926" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951528971499982" lon="-77.0371471936200010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678926"/>
     </node>
     <node visible="true" id="-678924" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951346686799937" lon="-77.0372463198300039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678924"/>
     </node>
     <node visible="true" id="-678922" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951177749099983" lon="-77.0373283184100046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678922"/>
     </node>
     <node visible="true" id="-678920" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951081429599981" lon="-77.0373750670800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678920"/>
     </node>
     <node visible="true" id="-678918" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8950504393099976" lon="-77.0375313483099973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678918"/>
     </node>
     <node visible="true" id="-678916" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8949734543000005" lon="-77.0376976479300026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678916"/>
     </node>
     <node visible="true" id="-678914" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8949137784599941" lon="-77.0378228036500019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678914"/>
     </node>
     <node visible="true" id="-678912" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8948599709000007" lon="-77.0379079623400003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678912"/>
     </node>
     <node visible="true" id="-678910" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8948022888200029" lon="-77.0379957701200055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678910"/>
     </node>
     <node visible="true" id="-678908" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8947461441799973" lon="-77.0380666333899882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678908"/>
     </node>
     <node visible="true" id="-678906" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8946771154299995" lon="-77.0381404867700041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678906"/>
     </node>
     <node visible="true" id="-678904" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8946072790400024" lon="-77.0382063857099979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678904"/>
     </node>
     <node visible="true" id="-678902" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8945057277699959" lon="-77.0382887515699935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678902"/>
     </node>
     <node visible="true" id="-678900" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8944097679800009" lon="-77.0383517543399989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678900"/>
     </node>
     <node visible="true" id="-678898" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8943307492999963" lon="-77.0383982820699913">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678898"/>
     </node>
     <node visible="true" id="-678896" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8942156086899971" lon="-77.0384398334999787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678896"/>
     </node>
     <node visible="true" id="-678894" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8941190294000023" lon="-77.0384689453899938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678894"/>
     </node>
     <node visible="true" id="-678892" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8940373186400024" lon="-77.0384836561800057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678892"/>
     </node>
     <node visible="true" id="-678890" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8939365131899990" lon="-77.0384891348600007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678890"/>
     </node>
     <node visible="true" id="-678888" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8938351700099929" lon="-77.0384861983900038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678888"/>
     </node>
     <node visible="true" id="-678886" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8937107739799970" lon="-77.0384571980700059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678886"/>
     </node>
     <node visible="true" id="-678884" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8936400665199997" lon="-77.0384321589699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678884"/>
     </node>
     <node visible="true" id="-678882" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8934653332400018" lon="-77.0383419096500006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678882"/>
     </node>
     <node visible="true" id="-678880" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8933743659599997" lon="-77.0382910261500058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678880"/>
     </node>
     <node visible="true" id="-678878" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8933045671600013" lon="-77.0382419977400019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678878"/>
     </node>
     <node visible="true" id="-678876" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932774631100031" lon="-77.0382199657099989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678876"/>
     </node>
     <node visible="true" id="-678874" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932417054500092" lon="-77.0381908996999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678874"/>
     </node>
     <node visible="true" id="-678872" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931777222399901" lon="-77.0381258130300068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678872"/>
     </node>
     <node visible="true" id="-678870" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931659702199966" lon="-77.0381138582000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678870"/>
     </node>
     <node visible="true" id="-678868" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931006853200003" lon="-77.0380347475600047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678868"/>
     </node>
     <node visible="true" id="-678866" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930084795300033" lon="-77.0379119351700012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678866"/>
     </node>
     <node visible="true" id="-678864" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929603087199922" lon="-77.0378380211400042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678864"/>
     </node>
     <node visible="true" id="-678862" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929141210699925" lon="-77.0377598432500008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678862"/>
     </node>
     <node visible="true" id="-678860" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928727094500033" lon="-77.0376765960899945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678860"/>
     </node>
     <node visible="true" id="-678858" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928253613599964" lon="-77.0375649893900061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678858"/>
     </node>
     <node visible="true" id="-678856" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927763981699925" lon="-77.0374330944299999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678856"/>
     </node>
     <node visible="true" id="-678854" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927129556499906" lon="-77.0372249984900037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678854"/>
     </node>
     <node visible="true" id="-678852" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926919050200013" lon="-77.0371340393800068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678852"/>
     </node>
     <node visible="true" id="-678850" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926645600700027" lon="-77.0370064211600010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678850"/>
     </node>
     <node visible="true" id="-678848" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926601552399873" lon="-77.0369771402800012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678848"/>
     </node>
     <node visible="true" id="-678846" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926544930199967" lon="-77.0369358706600025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678846"/>
     </node>
     <node visible="true" id="-678844" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926118838000008" lon="-77.0366845405499845">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678844"/>
     </node>
     <node visible="true" id="-678842" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920904824699960" lon="-77.0321588226800031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678842"/>
     </node>
     <node visible="true" id="-678840" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920906668099988" lon="-77.0323537450699973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678840"/>
     </node>
     <node visible="true" id="-678838" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920819261899950" lon="-77.0326862918600028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678838"/>
     </node>
     <node visible="true" id="-678836" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920830993999900" lon="-77.0329991335700015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678836"/>
     </node>
     <node visible="true" id="-678834" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920839234000013" lon="-77.0332700164399995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678834"/>
     </node>
     <node visible="true" id="-678832" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920863725499970" lon="-77.0334376383700032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678832"/>
     </node>
     <node visible="true" id="-678830" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926087541900003" lon="-77.0364968563399941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678830"/>
     </node>
     <node visible="true" id="-678828" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926248537999939" lon="-77.0363670143299970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678828"/>
     </node>
     <node visible="true" id="-678826" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926399289999978" lon="-77.0362666052399874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678826"/>
     </node>
     <node visible="true" id="-678824" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926661980500086" lon="-77.0360900241000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678824"/>
     </node>
     <node visible="true" id="-678822" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926807218700006" lon="-77.0360240976699941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678822"/>
     </node>
     <node visible="true" id="-678820" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926856837599928" lon="-77.0360004698000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678820"/>
     </node>
     <node visible="true" id="-678818" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927220348899922" lon="-77.0358463711900043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678818"/>
     </node>
     <node visible="true" id="-678816" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927847017199895" lon="-77.0356547089299966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678816"/>
     </node>
     <node visible="true" id="-678814" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928023730699977" lon="-77.0356057278799824">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678814"/>
     </node>
     <node visible="true" id="-678812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928193233800030" lon="-77.0355578991500067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678812"/>
     </node>
     <node visible="true" id="-678810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928420421700025" lon="-77.0355015432599970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678810"/>
     </node>
     <node visible="true" id="-678808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928505158500002" lon="-77.0354805682700032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678808"/>
     </node>
     <node visible="true" id="-678806" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928670121899955" lon="-77.0354442663000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678806"/>
     </node>
     <node visible="true" id="-678804" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928747644200001" lon="-77.0354276712100017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678804"/>
     </node>
     <node visible="true" id="-678802" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928914402900006" lon="-77.0353952884899940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678802"/>
     </node>
     <node visible="true" id="-678800" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929289366599988" lon="-77.0353222255899936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678800"/>
     </node>
     <node visible="true" id="-678798" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929420071300029" lon="-77.0352946824000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678798"/>
     </node>
     <node visible="true" id="-678796" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930030273400007" lon="-77.0351834764300065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678796"/>
     </node>
     <node visible="true" id="-678794" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930754843800059" lon="-77.0350846098699975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678794"/>
     </node>
     <node visible="true" id="-678792" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931310871799951" lon="-77.0350140914599990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678792"/>
     </node>
     <node visible="true" id="-678790" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931701400899996" lon="-77.0349710699100001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678790"/>
     </node>
     <node visible="true" id="-678788" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932645721500023" lon="-77.0348670408499885">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678788"/>
     </node>
     <node visible="true" id="-678786" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8933540108699987" lon="-77.0348246950200064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678786"/>
     </node>
     <node visible="true" id="-678784" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8933783626100009" lon="-77.0348100292799955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678784"/>
     </node>
     <node visible="true" id="-678782" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8934272620600012" lon="-77.0347805818600051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678782"/>
     </node>
     <node visible="true" id="-678780" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8935442996500029" lon="-77.0347171243199966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678780"/>
     </node>
     <node visible="true" id="-678778" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8936412427400029" lon="-77.0346732529999798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678778"/>
     </node>
     <node visible="true" id="-678776" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8937660190299823" lon="-77.0346382709899871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678776"/>
     </node>
     <node visible="true" id="-678774" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8939032219099943" lon="-77.0346200093499931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678774"/>
     </node>
     <node visible="true" id="-678772" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8940314973700012" lon="-77.0346325210099820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678772"/>
     </node>
     <node visible="true" id="-678770" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8941454466500005" lon="-77.0346547086400051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678770"/>
     </node>
     <node visible="true" id="-678768" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8942889372800025" lon="-77.0346974292399977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678768"/>
     </node>
     <node visible="true" id="-678766" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8943581663199964" lon="-77.0347267436499834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678766"/>
     </node>
     <node visible="true" id="-678764" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8943747998700005" lon="-77.0347337869900031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678764"/>
     </node>
     <node visible="true" id="-678762" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8944050405299961" lon="-77.0347465919600012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678762"/>
     </node>
     <node visible="true" id="-678760" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8945628986900047" lon="-77.0348599088700041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678760"/>
     </node>
     <node visible="true" id="-678758" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8947283595099904" lon="-77.0350192557999804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678758"/>
     </node>
     <node visible="true" id="-678756" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8948446124299991" lon="-77.0351693990999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678756"/>
     </node>
     <node visible="true" id="-678754" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8949433829600011" lon="-77.0353392460500004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678754"/>
     </node>
     <node visible="true" id="-678752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8950314302799995" lon="-77.0355190016900053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678752"/>
     </node>
     <node visible="true" id="-678750" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8950873260699979" lon="-77.0356704995499939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678750"/>
     </node>
     <node visible="true" id="-678748" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8950969353399998" lon="-77.0357344605399987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678748"/>
     </node>
     <node visible="true" id="-678746" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951160942199934" lon="-77.0358619841199896">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678746"/>
     </node>
     <node visible="true" id="-678744" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951589237399915" lon="-77.0360254643499900">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678744"/>
     </node>
     <node visible="true" id="-678742" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951809636900023" lon="-77.0361007365300026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678742"/>
     </node>
     <node visible="true" id="-678740" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951929023700060" lon="-77.0361415092800002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678740"/>
     </node>
     <node visible="true" id="-678738" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954752826999979" lon="-77.0338675945099993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678738"/>
     </node>
     <node visible="true" id="-678736" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954737503599901" lon="-77.0339735044999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678736"/>
     </node>
     <node visible="true" id="-678734" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954742003799936" lon="-77.0340522473699991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678734"/>
     </node>
     <node visible="true" id="-678732" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954751216199952" lon="-77.0342136214800064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678732"/>
     </node>
     <node visible="true" id="-678730" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954702914999970" lon="-77.0344032466300064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678730"/>
     </node>
     <node visible="true" id="-678728" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954656391100002" lon="-77.0346000181399972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678728"/>
     </node>
     <node visible="true" id="-678726" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954625117800035" lon="-77.0348170787000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678726"/>
     </node>
     <node visible="true" id="-678724" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954604072200070" lon="-77.0348509979500022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678724"/>
     </node>
     <node visible="true" id="-678722" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954549081599978" lon="-77.0349396118800058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678722"/>
     </node>
     <node visible="true" id="-678720" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952384217899976" lon="-77.0370362290600070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678720"/>
     </node>
     <node visible="true" id="-678718" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952805284800007" lon="-77.0372013237300024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678718"/>
     </node>
     <node visible="true" id="-678716" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953196195499871" lon="-77.0373483254300027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678716"/>
     </node>
     <node visible="true" id="-678714" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953301950400032" lon="-77.0373880941500033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678714"/>
     </node>
     <node visible="true" id="-678712" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953614633099960" lon="-77.0375296012699948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678712"/>
     </node>
     <node visible="true" id="-678710" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953914388100017" lon="-77.0377091656999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678710"/>
     </node>
     <node visible="true" id="-678708" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953932916899916" lon="-77.0378068041799935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678708"/>
     </node>
     <node visible="true" id="-678706" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953950703199993" lon="-77.0379005232800012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678706"/>
     </node>
     <node visible="true" id="-678704" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953912051100090" lon="-77.0381514737999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678704"/>
     </node>
     <node visible="true" id="-678702" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953918440399988" lon="-77.0384009281400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678702"/>
     </node>
     <node visible="true" id="-678700" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953925628400015" lon="-77.0386796622500043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678700"/>
     </node>
     <node visible="true" id="-678698" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954097714600096" lon="-77.0351619701699803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678698"/>
     </node>
     <node visible="true" id="-678696" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953971713100017" lon="-77.0352170493199964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678696"/>
     </node>
     <node visible="true" id="-678694" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953651290799911" lon="-77.0354238358600014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678694"/>
     </node>
     <node visible="true" id="-678692" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953421397900101" lon="-77.0355533691100050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678692"/>
     </node>
     <node visible="true" id="-678690" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953245218199939" lon="-77.0356526353500044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678690"/>
     </node>
     <node visible="true" id="-678688" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952983706199902" lon="-77.0357408071500060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678688"/>
     </node>
     <node visible="true" id="-678686" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952866758499951" lon="-77.0357783201999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678686"/>
     </node>
     <node visible="true" id="-678684" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952463405999964" lon="-77.0359076982000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678684"/>
     </node>
     <node visible="true" id="-678682" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952156849699975" lon="-77.0359978272000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678682"/>
     </node>
     <node visible="true" id="-678680" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951981557299931" lon="-77.0360984469500067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678680"/>
     </node>
     <node visible="true" id="-678678" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951926728600057" lon="-77.0361299197899996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678678"/>
     </node>
     <node visible="true" id="-678676" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8951987925300031" lon="-77.0364393187799976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678676"/>
     </node>
     <node visible="true" id="-678674" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952009236100054" lon="-77.0365383403999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678674"/>
     </node>
     <node visible="true" id="-678672" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952017845699842" lon="-77.0366656035400013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678672"/>
     </node>
     <node visible="true" id="-678670" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952012130900044" lon="-77.0367641633900035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678670"/>
     </node>
     <node visible="true" id="-678668" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8955040614999987" lon="-77.0325570237800008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678668"/>
     </node>
     <node visible="true" id="-678666" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8955062581200011" lon="-77.0330751844499844">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678666"/>
     </node>
     <node visible="true" id="-678664" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8955055328000086" lon="-77.0334080973599953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678664"/>
     </node>
     <node visible="true" id="-678662" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8954827705000028" lon="-77.0336214600600044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678662"/>
     </node>
     <node visible="true" id="-678660" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904084286999989" lon="-77.0320798007399929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678660"/>
     </node>
     <node visible="true" id="-678658" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903916809899854" lon="-77.0321392368200009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678658"/>
     </node>
     <node visible="true" id="-678656" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903640038099923" lon="-77.0322274031200038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678656"/>
     </node>
     <node visible="true" id="-678654" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903016741999892" lon="-77.0324250904699994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678654"/>
     </node>
     <node visible="true" id="-678652" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902461320899917" lon="-77.0326066094499993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678652"/>
     </node>
     <node visible="true" id="-678650" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902114164500006" lon="-77.0327260092799975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678650"/>
     </node>
     <node visible="true" id="-678648" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902079880399967" lon="-77.0327446808200023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678648"/>
     </node>
     <node visible="true" id="-678646" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8901846382099947" lon="-77.0328433666799981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678646"/>
     </node>
     <node visible="true" id="-678644" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8901710097899951" lon="-77.0329009646199978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678644"/>
     </node>
     <node visible="true" id="-678642" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8946309734200000" lon="-77.0319636503199945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678642"/>
     </node>
     <node visible="true" id="-678640" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8946469164399957" lon="-77.0319640494000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678640"/>
     </node>
     <node visible="true" id="-678638" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8947371643100013" lon="-77.0319586352400023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678638"/>
     </node>
     <node visible="true" id="-678636" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8953191720000007" lon="-77.0319559002700061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678636"/>
     </node>
     <node visible="true" id="-678634" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922846358199976" lon="-77.0319562297299996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678634"/>
     </node>
     <node visible="true" id="-678632" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8936426000200015" lon="-77.0319389118299966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-678632"/>
     </node>
     <way visible="true" id="-679967" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678934"/>
@@ -1407,12 +1080,11 @@
         <nd ref="-678744"/>
         <nd ref="-678742"/>
         <nd ref="-678740"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="ELLIPSE RD NW"/>
         <tag k="alt_name" v="Ellipse Rd NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679967"/>
     </way>
     <way visible="true" id="-679960" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679100"/>
@@ -1437,12 +1109,11 @@
         <nd ref="-679731"/>
         <nd ref="-678938"/>
         <nd ref="-678984"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679960"/>
     </way>
     <way visible="true" id="-679956" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679074"/>
@@ -1469,12 +1140,11 @@
         <nd ref="-678680"/>
         <nd ref="-678678"/>
         <nd ref="-678740"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="E ST NW"/>
         <tag k="alt_name" v="E St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679956"/>
     </way>
     <way visible="true" id="-679952" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678934"/>
@@ -1490,12 +1160,11 @@
         <nd ref="-678702"/>
         <nd ref="-679708"/>
         <nd ref="-678700"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="E ST NW"/>
         <tag k="alt_name" v="E St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679952"/>
     </way>
     <way visible="true" id="-679199" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678986"/>
@@ -1503,51 +1172,46 @@
         <nd ref="-679244"/>
         <nd ref="-679243"/>
         <nd ref="-679110"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="14th St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679199"/>
     </way>
     <way visible="true" id="-679197" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679074"/>
         <nd ref="-679275"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="15th St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679197"/>
     </way>
     <way visible="true" id="-679192" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679107"/>
         <nd ref="-678984"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Constitution Ave NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679192"/>
     </way>
     <way visible="true" id="-679189" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679275"/>
         <nd ref="-679274"/>
         <nd ref="-679103"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Pennsylvania Ave NW"/>
         <tag k="alt_name" v="15th St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679189"/>
     </way>
     <way visible="true" id="-679187" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679115"/>
         <nd ref="-679351"/>
         <nd ref="-678988"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="US Hwy 1"/>
         <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679187"/>
     </way>
     <way visible="true" id="-679184" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679752"/>
@@ -1569,11 +1233,10 @@
         <nd ref="-679137"/>
         <nd ref="-679136"/>
         <nd ref="-679731"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Ellipse Rd NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679184"/>
     </way>
     <way visible="true" id="-679181" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679739"/>
@@ -1587,11 +1250,10 @@
         <nd ref="-679180"/>
         <nd ref="-679179"/>
         <nd ref="-679719"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Ellipse Rd NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679181"/>
     </way>
     <way visible="true" id="-679176" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679740"/>
@@ -1608,20 +1270,18 @@
         <nd ref="-679262"/>
         <nd ref="-679261"/>
         <nd ref="-679723"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Ellipse Rd NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679176"/>
     </way>
     <way visible="true" id="-679175" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679751"/>
         <nd ref="-679708"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Ellipse Rd NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679175"/>
     </way>
     <way visible="true" id="-679174" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679118"/>
@@ -1635,11 +1295,10 @@
         <nd ref="-679195"/>
         <nd ref="-679196"/>
         <nd ref="-679303"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Raoul Wallenberg Pl SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679174"/>
     </way>
     <way visible="true" id="-679173" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679117"/>
@@ -1647,46 +1306,41 @@
         <nd ref="-679128"/>
         <nd ref="-679127"/>
         <nd ref="-679004"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Madison Dr NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679173"/>
     </way>
     <way visible="true" id="-679172" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679116"/>
         <nd ref="-679351"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="US Hwy 50"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679172"/>
     </way>
     <way visible="true" id="-679171" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679114"/>
         <nd ref="-679012"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="US Hwy 1"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679171"/>
     </way>
     <way visible="true" id="-679170" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679250"/>
         <nd ref="-679113"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="unclassified"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679170"/>
     </way>
     <way visible="true" id="-679169" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679250"/>
         <nd ref="-679112"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="17th St SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679169"/>
     </way>
     <way visible="true" id="-679168" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679111"/>
@@ -1699,80 +1353,72 @@
         <nd ref="-679198"/>
         <nd ref="-679197"/>
         <nd ref="-679275"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Pennsylvania Ave NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679168"/>
     </way>
     <way visible="true" id="-679166" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679109"/>
         <nd ref="-679250"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="17th St SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679166"/>
     </way>
     <way visible="true" id="-679165" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679108"/>
         <nd ref="-679351"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Constitution Ave NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679165"/>
     </way>
     <way visible="true" id="-679164" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679106"/>
         <nd ref="-678984"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="US Hwy 50"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679164"/>
     </way>
     <way visible="true" id="-679163" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679105"/>
         <nd ref="-678986"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="E St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679163"/>
     </way>
     <way visible="true" id="-679162" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679274"/>
         <nd ref="-679104"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Pennsylvania Ave NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679162"/>
     </way>
     <way visible="true" id="-679161" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679303"/>
         <nd ref="-679302"/>
         <nd ref="-679301"/>
         <nd ref="-679102"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Raoul Wallenberg Pl SW"/>
         <tag k="alt_name" v="15th St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679161"/>
     </way>
     <way visible="true" id="-679160" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678988"/>
         <nd ref="-678634"/>
         <nd ref="-678632"/>
         <nd ref="-678642"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="alt_name" v="14th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679160"/>
     </way>
     <way visible="true" id="-679158" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678642"/>
@@ -1780,12 +1426,11 @@
         <nd ref="-678638"/>
         <nd ref="-678636"/>
         <nd ref="-678986"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="alt_name" v="14th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679158"/>
     </way>
     <way visible="true" id="-679156" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679004"/>
@@ -1799,12 +1444,11 @@
         <nd ref="-678646"/>
         <nd ref="-678644"/>
         <nd ref="-679102"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="MADISON DR NW"/>
         <tag k="alt_name" v="Madison Dr NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679156"/>
     </way>
     <way visible="true" id="-679154" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678986"/>
@@ -1813,12 +1457,11 @@
         <nd ref="-678664"/>
         <nd ref="-678662"/>
         <nd ref="-679074"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="PENNSYLVANIA AVE NW"/>
         <tag k="alt_name" v="E St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679154"/>
     </way>
     <way visible="true" id="-679152" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678740"/>
@@ -1827,12 +1470,11 @@
         <nd ref="-678672"/>
         <nd ref="-678670"/>
         <nd ref="-678934"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="E ST NW"/>
         <tag k="alt_name" v="E St NW;Ellipse Rd NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679152"/>
     </way>
     <way visible="true" id="-679142" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678988"/>
@@ -1843,12 +1485,11 @@
         <nd ref="-678834"/>
         <nd ref="-678832"/>
         <nd ref="-679100"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="CONSTITUTION AVE NW"/>
         <tag k="alt_name" v="Constitution Ave NW;US Hwy 50"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679142"/>
     </way>
     <way visible="true" id="-679134" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-678982"/>
@@ -1857,12 +1498,11 @@
         <nd ref="-678976"/>
         <nd ref="-678974"/>
         <nd ref="-678972"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="16TH ST NW"/>
         <tag k="alt_name" v="16th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679134"/>
     </way>
     <way visible="true" id="-679132" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679004"/>
@@ -1874,12 +1514,11 @@
         <nd ref="-678992"/>
         <nd ref="-678990"/>
         <nd ref="-678988"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="alt_name" v="14th St NW;US Hwy 1"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679132"/>
     </way>
     <way visible="true" id="-679130" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679012"/>
@@ -1887,12 +1526,11 @@
         <nd ref="-679008"/>
         <nd ref="-679006"/>
         <nd ref="-679004"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="14TH ST NW"/>
         <tag k="alt_name" v="14th St NW;US Hwy 1"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679130"/>
     </way>
     <way visible="true" id="-679128" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679102"/>
@@ -1927,12 +1565,11 @@
         <nd ref="-679016"/>
         <nd ref="-679014"/>
         <nd ref="-679100"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="15TH ST NW"/>
         <tag k="alt_name" v="15th St NW;Raoul Wallenberg Pl SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679128"/>
     </way>
     <way visible="true" id="-679126" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-679100"/>
@@ -1949,11 +1586,10 @@
         <nd ref="-679078"/>
         <nd ref="-679076"/>
         <nd ref="-679074"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="15TH ST NW"/>
         <tag k="alt_name" v="15th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-679126"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-026/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-026/Expected.osm
@@ -3,923 +3,693 @@
     <bounds minlat="38.8845" minlon="-77.036367" maxlat="38.88802260000001" maxlon="-77.033492"/>
     <node visible="true" id="-171320" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850199546185706" lon="-77.0336919789671413">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171320"/>
     </node>
     <node visible="true" id="-171316" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849267531127225" lon="-77.0340790075565565">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171316"/>
     </node>
     <node visible="true" id="-171311" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877379491636503" lon="-77.0340963626714199">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171311"/>
     </node>
     <node visible="true" id="-171308" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878562948873636" lon="-77.0336747586530635">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-171308"/>
     </node>
     <node visible="true" id="-170977" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878530000000140" lon="-77.0337599999999867">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170977"/>
     </node>
     <node visible="true" id="-170976" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878399999999971" lon="-77.0338179999999824">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170976"/>
     </node>
     <node visible="true" id="-170975" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878139999999846" lon="-77.0339010000000002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170975"/>
     </node>
     <node visible="true" id="-170974" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877789999999735" lon="-77.0339809999999829">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170974"/>
     </node>
     <node visible="true" id="-170973" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877399999999795" lon="-77.0340869999999853">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170973"/>
     </node>
     <node visible="true" id="-170911" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849890000000258" lon="-77.0337119999999800">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170911"/>
     </node>
     <node visible="true" id="-170910" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849569999999503" lon="-77.0337349999999645">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170910"/>
     </node>
     <node visible="true" id="-170909" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849269999999834" lon="-77.0337629999999791">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170909"/>
     </node>
     <node visible="true" id="-170908" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848999999999378" lon="-77.0337940000000003">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170908"/>
     </node>
     <node visible="true" id="-170907" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848749999999797" lon="-77.0338279999999855">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170907"/>
     </node>
     <node visible="true" id="-170906" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848629999999531" lon="-77.0338739999999831">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170906"/>
     </node>
     <node visible="true" id="-170905" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848629999999531" lon="-77.0339259999999797">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170905"/>
     </node>
     <node visible="true" id="-170904" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848699999999283" lon="-77.0339649999999807">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170904"/>
     </node>
     <node visible="true" id="-170903" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848810000000285" lon="-77.0340010000000035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170903"/>
     </node>
     <node visible="true" id="-170902" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848959999999551" lon="-77.0340350000000029">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170902"/>
     </node>
     <node visible="true" id="-170869" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8844999999999956" lon="-77.0336523333333218">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170869"/>
     </node>
     <node visible="true" id="-170868" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8844999999999956" lon="-77.0337256804123598">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170868"/>
     </node>
     <node visible="true" id="-170866" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878479898989724" lon="-77.0334919999999954">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170866"/>
     </node>
     <node visible="true" id="-170859" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8868577052293318" lon="-77.0363669999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170859"/>
     </node>
     <node visible="true" id="-170858" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8873929419125517" lon="-77.0363669999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170858"/>
     </node>
     <node visible="true" id="-170857" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876439263739329" lon="-77.0363669999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170857"/>
     </node>
     <node visible="true" id="-170856" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8880226000000064" lon="-77.0336441963078613">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170856"/>
     </node>
     <node visible="true" id="-170855" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877860302210507" lon="-77.0334919999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170855"/>
     </node>
     <node visible="true" id="-170854" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869484478512533" lon="-77.0363669999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170854"/>
     </node>
     <node visible="true" id="-170850" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8844999999999956" lon="-77.0337261161154032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170850"/>
     </node>
     <node visible="true" id="-170847" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845000000000027" lon="-77.0336521967972203">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170847"/>
     </node>
     <node visible="true" id="-170846" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845000000000027" lon="-77.0339047402093513">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170846"/>
     </node>
     <node visible="true" id="-165948" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846779982730055" lon="-77.0337233330781430">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165948"/>
     </node>
     <node visible="true" id="-165947" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847836288390525" lon="-77.0337078974586120">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165947"/>
     </node>
     <node visible="true" id="-165946" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848708954665696" lon="-77.0336936597235962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165946"/>
     </node>
     <node visible="true" id="-165945" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849750811288501" lon="-77.0336925030400721">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165945"/>
     </node>
     <node visible="true" id="-165944" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850203737419875" lon="-77.0336919740722408">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165944"/>
     </node>
     <node visible="true" id="-165943" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8854051731697226" lon="-77.0336874798913840">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165943"/>
     </node>
     <node visible="true" id="-165942" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8859736916408423" lon="-77.0336892466888372">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165942"/>
     </node>
     <node visible="true" id="-165941" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8867044116089460" lon="-77.0337026053468037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165941"/>
     </node>
     <node visible="true" id="-165940" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876947640025534" lon="-77.0337030731647303">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-165940"/>
     </node>
     <node visible="true" id="-136901" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845332403209696" lon="-77.0337271776324428">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136901"/>
     </node>
     <node visible="true" id="-136900" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845484645205488" lon="-77.0337270695719525">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136900"/>
     </node>
     <node visible="true" id="-126504" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8873666097888915" lon="-77.0362555106678712">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126504"/>
     </node>
     <node visible="true" id="-126503" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8873378186994429" lon="-77.0361402352797882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126503"/>
     </node>
     <node visible="true" id="-126502" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8873119912991783" lon="-77.0360540059224803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126502"/>
     </node>
     <node visible="true" id="-126501" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8872725668614478" lon="-77.0359493286738655">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126501"/>
     </node>
     <node visible="true" id="-126500" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8872424115816386" lon="-77.0358752004485581">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126500"/>
     </node>
     <node visible="true" id="-126499" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8872134268138723" lon="-77.0358028017923857">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126499"/>
     </node>
     <node visible="true" id="-126498" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8871620224866703" lon="-77.0356932778631318">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126498"/>
     </node>
     <node visible="true" id="-126497" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870020284692970" lon="-77.0354403794444949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126497"/>
     </node>
     <node visible="true" id="-126496" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869434522691861" lon="-77.0353597484422750">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126496"/>
     </node>
     <node visible="true" id="-126495" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869009840803201" lon="-77.0353016186770105">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126495"/>
     </node>
     <node visible="true" id="-126494" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8868746239333376" lon="-77.0352678652172074">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126494"/>
     </node>
     <node visible="true" id="-126493" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8868380111248015" lon="-77.0352266090125539">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126493"/>
     </node>
     <node visible="true" id="-126492" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8868072554282520" lon="-77.0351947278678608">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126492"/>
     </node>
     <node visible="true" id="-126491" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8867603882442410" lon="-77.0351515922627215">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126491"/>
     </node>
     <node visible="true" id="-126490" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8867149849050975" lon="-77.0351103318579931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126490"/>
     </node>
     <node visible="true" id="-126489" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8866695809881762" lon="-77.0350709459276999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126489"/>
     </node>
     <node visible="true" id="-126488" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8866212476444701" lon="-77.0350296841883022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126488"/>
     </node>
     <node visible="true" id="-126487" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8865714476137398" lon="-77.0349940443240513">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126487"/>
     </node>
     <node visible="true" id="-126486" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8864952817172451" lon="-77.0349433969704194">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126486"/>
     </node>
     <node visible="true" id="-126485" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863947537851331" lon="-77.0348813486865680">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126485"/>
     </node>
     <node visible="true" id="-126484" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863546733092917" lon="-77.0348585076336292">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126484"/>
     </node>
     <node visible="true" id="-126483" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863142322184743" lon="-77.0348365885089521">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126483"/>
     </node>
     <node visible="true" id="-126482" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8862735205627672" lon="-77.0348157066149497">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126482"/>
     </node>
     <node visible="true" id="-126481" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8862325383769303" lon="-77.0347957466902784">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126481"/>
     </node>
     <node visible="true" id="-126480" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8861912856614467" lon="-77.0347767087337587">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126480"/>
     </node>
     <node visible="true" id="-126479" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8861497623825301" lon="-77.0347587080033946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126479"/>
     </node>
     <node visible="true" id="-126478" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8861078784909893" lon="-77.0347416291944285">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126478"/>
     </node>
     <node visible="true" id="-126477" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8860659042044929" lon="-77.0347255876962720">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126477"/>
     </node>
     <node visible="true" id="-126476" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8860236593558071" lon="-77.0347105834194963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126476"/>
     </node>
     <node visible="true" id="-126475" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8858269396307534" lon="-77.0346319963134363">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126475"/>
     </node>
     <node visible="true" id="-126474" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8857724454201730" lon="-77.0346100706623815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126474"/>
     </node>
     <node visible="true" id="-126473" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8857183119156602" lon="-77.0345868773721349">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126473"/>
     </node>
     <node visible="true" id="-126472" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8856644490327028" lon="-77.0345624164017408">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126472"/>
     </node>
     <node visible="true" id="-126471" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8856109468541433" lon="-77.0345366877972424">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126471"/>
     </node>
     <node visible="true" id="-126470" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8855578053452930" lon="-77.0345098068198695">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126470"/>
     </node>
     <node visible="true" id="-126469" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8855050245051430" lon="-77.0344817734716543">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126469"/>
     </node>
     <node visible="true" id="-126468" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8854526944509189" lon="-77.0344524725398543">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126468"/>
     </node>
     <node visible="true" id="-126467" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8854007250297187" lon="-77.0344221344998630">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126467"/>
     </node>
     <node visible="true" id="-126466" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8853492063926325" lon="-77.0343905288805217">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126466"/>
     </node>
     <node visible="true" id="-126465" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8852981385385306" lon="-77.0343576556838343">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126465"/>
     </node>
     <node visible="true" id="-126464" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8852452696419206" lon="-77.0343225917639387">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126464"/>
     </node>
     <node visible="true" id="-126463" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8851929416095032" lon="-77.0342862603178133">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126463"/>
     </node>
     <node visible="true" id="-126462" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8851410642884971" lon="-77.0342488918199422">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126462"/>
     </node>
     <node visible="true" id="-126461" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850896376779218" lon="-77.0342104862719737">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126461"/>
     </node>
     <node visible="true" id="-126460" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850387518607050" lon="-77.0341710437184588">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126460"/>
     </node>
     <node visible="true" id="-126459" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849883167518726" lon="-77.0341305641177314">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126459"/>
     </node>
     <node visible="true" id="-126458" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849385125517060" lon="-77.0340889322996389">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126458"/>
     </node>
     <node visible="true" id="-126457" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849268945981308" lon="-77.0340791298543905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126457"/>
     </node>
     <node visible="true" id="-126456" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848803329934682" lon="-77.0340388827449800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126456"/>
     </node>
     <node visible="true" id="-126455" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848342220621888" lon="-77.0339977138434335">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126455"/>
     </node>
     <node visible="true" id="-126454" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847886518869643" lon="-77.0339556231935916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126454"/>
     </node>
     <node visible="true" id="-126453" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847435323830126" lon="-77.0339126107534042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126453"/>
     </node>
     <node visible="true" id="-126452" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847098503662565" lon="-77.0338804372564567">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126452"/>
     </node>
     <node visible="true" id="-126451" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846766189595314" lon="-77.0338475739011699">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126451"/>
     </node>
     <node visible="true" id="-126450" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846437481124525" lon="-77.0338139032272977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126450"/>
     </node>
     <node visible="true" id="-126449" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846234854232904" lon="-77.0337925710624347">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126449"/>
     </node>
     <node visible="true" id="-126448" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846033128807065" lon="-77.0337710084383218">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126448"/>
     </node>
     <node visible="true" id="-126447" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845834106854227" lon="-77.0337491001831012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126447"/>
     </node>
     <node visible="true" id="-126446" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845636887201564" lon="-77.0337269615113911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126446"/>
     </node>
     <node visible="true" id="-126445" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845308190677770" lon="-77.0336890264399727">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126445"/>
     </node>
     <node visible="true" id="-126427" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8868531210681994" lon="-77.0363473048534786">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126427"/>
     </node>
     <node visible="true" id="-126426" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8868157610058134" lon="-77.0362206201463806">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126426"/>
     </node>
     <node visible="true" id="-126425" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8867740030787417" lon="-77.0360883021480163">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126425"/>
     </node>
     <node visible="true" id="-126424" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8867344372373935" lon="-77.0359785051505384">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126424"/>
     </node>
     <node visible="true" id="-126423" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8866948675329525" lon="-77.0358827815725675">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126423"/>
     </node>
     <node visible="true" id="-126422" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8866355053556561" lon="-77.0357645306244478">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126422"/>
     </node>
     <node visible="true" id="-126421" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8865805347915057" lon="-77.0356716141100719">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126421"/>
     </node>
     <node visible="true" id="-126420" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8865189669606437" lon="-77.0355702509223619">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126420"/>
     </node>
     <node visible="true" id="-126419" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8864661916985099" lon="-77.0354914104962916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126419"/>
     </node>
     <node visible="true" id="-126418" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8864150388974465" lon="-77.0354259620416002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126418"/>
     </node>
     <node visible="true" id="-126417" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863952284302030" lon="-77.0353996729355401">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126417"/>
     </node>
     <node visible="true" id="-126416" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863748772795859" lon="-77.0353739598756846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126416"/>
     </node>
     <node visible="true" id="-126415" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863541655788865" lon="-77.0353489382111576">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126415"/>
     </node>
     <node visible="true" id="-126414" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863328231118075" lon="-77.0353244925480993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126414"/>
     </node>
     <node visible="true" id="-126413" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863111200605047" lon="-77.0353008535400932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126413"/>
     </node>
     <node visible="true" id="-126412" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8862889664113567" lon="-77.0352777906225583">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126412"/>
     </node>
     <node visible="true" id="-126411" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8862663620950926" lon="-77.0352555343148993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126411"/>
     </node>
     <node visible="true" id="-126410" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8862433071465503" lon="-77.0352339700774138">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126410"/>
     </node>
     <node visible="true" id="-126409" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8862198015669662" lon="-77.0352130957487731">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126409"/>
     </node>
     <node visible="true" id="-126408" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8861817957904066" lon="-77.0351812653392329">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126408"/>
     </node>
     <node visible="true" id="-126407" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8861432492247374" lon="-77.0351503567735421">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126407"/>
     </node>
     <node visible="true" id="-126406" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8861042519889608" lon="-77.0351202548358032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126406"/>
     </node>
     <node visible="true" id="-126405" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8860648940983680" lon="-77.0350911900883517">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126405"/>
     </node>
     <node visible="true" id="-126404" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8860250854697966" lon="-77.0350631624857130">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126404"/>
     </node>
     <node visible="true" id="-126403" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8859848261386531" lon="-77.0350360567673533">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126403"/>
     </node>
     <node visible="true" id="-126402" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8859442061893432" lon="-77.0350098729765023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126402"/>
     </node>
     <node visible="true" id="-126401" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8859031349412021" lon="-77.0349847263265985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126401"/>
     </node>
     <node visible="true" id="-126400" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8858617942514400" lon="-77.0349606169054226">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126400"/>
     </node>
     <node visible="true" id="-126399" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8858200022985514" lon="-77.0349374293635094">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126399"/>
     </node>
     <node visible="true" id="-126398" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8856149146209802" lon="-77.0348263348161169">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126398"/>
     </node>
     <node visible="true" id="-126397" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8853800161435217" lon="-77.0346914831901444">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126397"/>
     </node>
     <node visible="true" id="-126396" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8853365137043454" lon="-77.0346643763509888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126396"/>
     </node>
     <node visible="true" id="-126395" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8852932817492700" lon="-77.0346364628689884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126395"/>
     </node>
     <node visible="true" id="-126394" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8852504103954928" lon="-77.0346076282512797">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126394"/>
     </node>
     <node visible="true" id="-126393" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8852078995746027" lon="-77.0345781008540200">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126393"/>
     </node>
     <node visible="true" id="-126392" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8851657493196754" lon="-77.0345477675810741">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126392"/>
     </node>
     <node visible="true" id="-126391" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8851545813130954" lon="-77.0345396933966100">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126391"/>
     </node>
     <node visible="true" id="-126390" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8851193662753403" lon="-77.0345135135278838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126390"/>
     </node>
     <node visible="true" id="-126389" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850845117370625" lon="-77.0344867568497165">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126389"/>
     </node>
     <node visible="true" id="-126388" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850498374962683" lon="-77.0344595392536604">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126388"/>
     </node>
     <node visible="true" id="-126387" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8850154336701479" lon="-77.0344317455258789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126387"/>
     </node>
     <node visible="true" id="-126386" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849847225946945" lon="-77.0344062587590486">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126386"/>
     </node>
     <node visible="true" id="-126385" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849541917829313" lon="-77.0343804263282124">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126385"/>
     </node>
     <node visible="true" id="-126384" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849239313524322" lon="-77.0343541330192778">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126384"/>
     </node>
     <node visible="true" id="-126383" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849003351533753" lon="-77.0343345278762399">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126383"/>
     </node>
     <node visible="true" id="-126382" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848769192203036" lon="-77.0343145770604281">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126382"/>
     </node>
     <node visible="true" id="-126381" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848537736704856" lon="-77.0342941653577356">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126381"/>
     </node>
     <node visible="true" id="-126380" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848308083858640" lon="-77.0342734087029868">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126380"/>
     </node>
     <node visible="true" id="-126379" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8848081134846026" lon="-77.0342521897211157">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126379"/>
     </node>
     <node visible="true" id="-126378" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847806456566332" lon="-77.0342257826027037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126378"/>
     </node>
     <node visible="true" id="-126377" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847535383265424" lon="-77.0341987993909072">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126377"/>
     </node>
     <node visible="true" id="-126376" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847268815778477" lon="-77.0341712401291119">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126376"/>
     </node>
     <node visible="true" id="-126375" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8847004952087261" lon="-77.0341432199884082">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126375"/>
     </node>
     <node visible="true" id="-126374" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846744693701041" lon="-77.0341145084977512">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126374"/>
     </node>
     <node visible="true" id="-126373" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846488039940468" lon="-77.0340853361717279">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126373"/>
     </node>
     <node visible="true" id="-126372" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8846114321487732" lon="-77.0340409443454490">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126372"/>
     </node>
     <node visible="true" id="-126371" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845742405210402" lon="-77.0339963221376109">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126371"/>
     </node>
     <node visible="true" id="-126370" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845374093453202" lon="-77.0339512391199008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-126370"/>
     </node>
     <node visible="true" id="-119100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878305668384101" lon="-77.0336782550725019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119100"/>
     </node>
     <node visible="true" id="-119099" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8879620076064896" lon="-77.0336603923599341">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119099"/>
     </node>
     <node visible="true" id="-119098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8879810379879416" lon="-77.0336578057704742">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119098"/>
     </node>
     <node visible="true" id="-119097" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8880125699310355" lon="-77.0336487149028670">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-119097"/>
     </node>
     <node visible="true" id="-117987" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869518077441612" lon="-77.0363205663445285">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117987"/>
     </node>
     <node visible="true" id="-117986" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869629176769251" lon="-77.0361670308307964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117986"/>
     </node>
     <node visible="true" id="-117985" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869688894792276" lon="-77.0360820865879248">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117985"/>
     </node>
     <node visible="true" id="-117984" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869720519144479" lon="-77.0360513135303506">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117984"/>
     </node>
     <node visible="true" id="-117983" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869804570659454" lon="-77.0359625668838248">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117983"/>
     </node>
     <node visible="true" id="-117982" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8869989732483674" lon="-77.0358030550890049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117982"/>
     </node>
     <node visible="true" id="-117981" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870052976462262" lon="-77.0357425462687644">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117981"/>
     </node>
     <node visible="true" id="-117980" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870263157635989" lon="-77.0355825154940135">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117980"/>
     </node>
     <node visible="true" id="-117979" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870285934098803" lon="-77.0355651712935128">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117979"/>
     </node>
     <node visible="true" id="-117978" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870389127644529" lon="-77.0354921434691704">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117978"/>
     </node>
     <node visible="true" id="-117977" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870490491672527" lon="-77.0354244326674547">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117977"/>
     </node>
     <node visible="true" id="-117976" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870555962494890" lon="-77.0353864855063080">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117976"/>
     </node>
     <node visible="true" id="-117975" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870691731693725" lon="-77.0353077984829184">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117975"/>
     </node>
     <node visible="true" id="-117974" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8870835223819071" lon="-77.0352220513502175">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117974"/>
     </node>
     <node visible="true" id="-117973" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8871005738715780" lon="-77.0351368818192697">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117973"/>
     </node>
     <node visible="true" id="-117972" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8871171741191901" lon="-77.0350542477706171">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117972"/>
     </node>
     <node visible="true" id="-117971" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8871369244105551" lon="-77.0349810666421035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117971"/>
     </node>
     <node visible="true" id="-117970" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8871548715334470" lon="-77.0349127255605168">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117970"/>
     </node>
     <node visible="true" id="-117969" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8871759707577596" lon="-77.0348470369919909">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117969"/>
     </node>
     <node visible="true" id="-117968" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8872022065396621" lon="-77.0347752420418743">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117968"/>
     </node>
     <node visible="true" id="-117967" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8872299792820399" lon="-77.0346846601941877">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117967"/>
     </node>
     <node visible="true" id="-117966" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8872718921715474" lon="-77.0346039976100201">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117966"/>
     </node>
     <node visible="true" id="-117965" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8873493195567477" lon="-77.0344503908684572">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117965"/>
     </node>
     <node visible="true" id="-117964" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8874714431730695" lon="-77.0342460915749854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117964"/>
     </node>
     <node visible="true" id="-117963" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8874893778171398" lon="-77.0342188984170804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117963"/>
     </node>
     <node visible="true" id="-117962" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875036179739766" lon="-77.0341952765891165">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117962"/>
     </node>
     <node visible="true" id="-117961" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875191203104293" lon="-77.0341681975030923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117961"/>
     </node>
     <node visible="true" id="-117960" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875375065343150" lon="-77.0341369703605352">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117960"/>
     </node>
     <node visible="true" id="-117959" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875549031406464" lon="-77.0341012475175262">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117959"/>
     </node>
     <node visible="true" id="-117958" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875728415159685" lon="-77.0340611449652641">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117958"/>
     </node>
     <node visible="true" id="-117957" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875914111352330" lon="-77.0340187374560941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117957"/>
     </node>
     <node visible="true" id="-117956" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876112416438602" lon="-77.0339772526206303">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117956"/>
     </node>
     <node visible="true" id="-117955" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876280999422477" lon="-77.0339338068953765">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117955"/>
     </node>
     <node visible="true" id="-117954" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876353118332929" lon="-77.0339159447219828">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117954"/>
     </node>
     <node visible="true" id="-117953" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876438755134188" lon="-77.0338962389957231">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117953"/>
     </node>
     <node visible="true" id="-117952" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876542154898814" lon="-77.0338650215967533">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117952"/>
     </node>
     <node visible="true" id="-117951" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876784979746191" lon="-77.0337917127856997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-117951"/>
     </node>
     <node visible="true" id="-114557" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876310736262099" lon="-77.0363268776634982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114557"/>
     </node>
     <node visible="true" id="-114556" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875900377527941" lon="-77.0361905012387922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114556"/>
     </node>
     <node visible="true" id="-114555" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875609832176963" lon="-77.0360529791276178">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114555"/>
     </node>
     <node visible="true" id="-114554" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875523528074680" lon="-77.0359958049015177">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114554"/>
     </node>
     <node visible="true" id="-114553" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875456094817622" lon="-77.0359537309374360">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114553"/>
     </node>
     <node visible="true" id="-114552" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875395902479681" lon="-77.0359004769507010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114552"/>
     </node>
     <node visible="true" id="-114551" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875357332128289" lon="-77.0358465324886339">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114551"/>
     </node>
     <node visible="true" id="-114550" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875327749064894" lon="-77.0357993889290782">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114550"/>
     </node>
     <node visible="true" id="-114549" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875313500865900" lon="-77.0357454456961648">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114549"/>
     </node>
     <node visible="true" id="-114548" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875252885749134" lon="-77.0355350899096010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114548"/>
     </node>
     <node visible="true" id="-114547" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875252120882138" lon="-77.0354903683006569">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114547"/>
     </node>
     <node visible="true" id="-114546" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875253198086313" lon="-77.0354322764167989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114546"/>
     </node>
     <node visible="true" id="-114545" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875256957615960" lon="-77.0353807545873082">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114545"/>
     </node>
     <node visible="true" id="-114544" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875262498371157" lon="-77.0353359180288209">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114544"/>
     </node>
     <node visible="true" id="-114543" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875270748781148" lon="-77.0352886611062502">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114543"/>
     </node>
     <node visible="true" id="-114542" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875293422836705" lon="-77.0352379470414377">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114542"/>
     </node>
     <node visible="true" id="-114541" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875315168051401" lon="-77.0351964538707961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114541"/>
     </node>
     <node visible="true" id="-114540" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875361234351331" lon="-77.0351554229432196">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114540"/>
     </node>
     <node visible="true" id="-114539" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875407282140557" lon="-77.0351205008851139">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114539"/>
     </node>
     <node visible="true" id="-114538" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875436178675145" lon="-77.0350991788727555">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114538"/>
     </node>
     <node visible="true" id="-114537" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875530093707127" lon="-77.0350213817608704">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114537"/>
     </node>
     <node visible="true" id="-114536" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875646619586917" lon="-77.0349152313223726">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114536"/>
     </node>
     <node visible="true" id="-114535" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8875842502690858" lon="-77.0347807302995307">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114535"/>
     </node>
     <node visible="true" id="-114534" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876261146419253" lon="-77.0345619835398736">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114534"/>
     </node>
     <node visible="true" id="-114533" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8876937561360592" lon="-77.0342932252009405">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114533"/>
     </node>
     <node visible="true" id="-114532" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877536497985332" lon="-77.0340264221143229">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114532"/>
     </node>
     <node visible="true" id="-114531" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877938735562552" lon="-77.0338609802286243">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114531"/>
     </node>
     <node visible="true" id="-114530" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878035257128829" lon="-77.0338212791326526">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-114530"/>
     </node>
     <node visible="true" id="-83547" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877730175023686" lon="-77.0336875756699868">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-83547"/>
     </node>
     <way visible="true" id="-14171" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-83547"/>
@@ -934,12 +704,11 @@
         <nd ref="-165947"/>
         <nd ref="-165948"/>
         <nd ref="-126446"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="RAOUL WALLENBERG PL SW"/>
         <tag k="alt_name" v="15th St SW;Raoul Wallenberg Pl;Raoul Wallenberg Pl SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-14171"/>
     </way>
     <way visible="true" id="-14169" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-126446"/>
@@ -1004,12 +773,11 @@
         <nd ref="-126503"/>
         <nd ref="-126504"/>
         <nd ref="-170858"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="MAINE AVE SW"/>
         <tag k="alt_name" v="Maine Ave SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-14169"/>
     </way>
     <way visible="true" id="-14167" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-171308"/>
@@ -1019,11 +787,10 @@
         <nd ref="-170974"/>
         <nd ref="-170973"/>
         <nd ref="-171311"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Independence Ave SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-14167"/>
     </way>
     <way visible="true" id="-14165" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170855"/>
@@ -1058,12 +825,11 @@
         <nd ref="-114556"/>
         <nd ref="-114557"/>
         <nd ref="-170857"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-14165"/>
     </way>
     <way visible="true" id="-14163" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170856"/>
@@ -1073,21 +839,19 @@
         <nd ref="-171308"/>
         <nd ref="-119100"/>
         <nd ref="-83547"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="15TH ST SW"/>
         <tag k="alt_name" v="15th St SW;Raoul Wallenberg Pl SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-14163"/>
     </way>
     <way visible="true" id="-13554" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-126446"/>
         <nd ref="-170869"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Maine Ave SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13554"/>
     </way>
     <way visible="true" id="-13548" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-171320"/>
@@ -1102,29 +866,26 @@
         <nd ref="-170903"/>
         <nd ref="-170902"/>
         <nd ref="-171316"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13548"/>
     </way>
     <way visible="true" id="-13547" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170866"/>
         <nd ref="-171308"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Independence Ave SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13547"/>
     </way>
     <way visible="true" id="-13543" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170868"/>
         <nd ref="-126446"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Raoul Wallenberg Pl"/>
         <tag k="alt_name" v="Raoul Wallenberg Pl SW;15th St SW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13543"/>
     </way>
     <way visible="true" id="-13540" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170846"/>
@@ -1187,12 +948,11 @@
         <nd ref="-126426"/>
         <nd ref="-126427"/>
         <nd ref="-170859"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="MAINE AVE SW"/>
         <tag k="alt_name" v="Maine Ave SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13540"/>
     </way>
     <way visible="true" id="-13535" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-83547"/>
@@ -1234,32 +994,29 @@
         <nd ref="-117986"/>
         <nd ref="-117987"/>
         <nd ref="-170854"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="INDEPENDENCE AVE SW"/>
         <tag k="alt_name" v="Independence Ave SW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13535"/>
     </way>
     <way visible="true" id="-13531" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-126446"/>
         <nd ref="-136900"/>
         <nd ref="-136901"/>
         <nd ref="-170850"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="RAOUL WALLENBERG PL SW"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13531"/>
     </way>
     <way visible="true" id="-13528" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170847"/>
         <nd ref="-126445"/>
         <nd ref="-126446"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="MAINE AVE SW"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13528"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-027/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-027/Expected.osm
@@ -3,253 +3,192 @@
     <bounds minlat="38.89021859999999" minlon="-77.03212480000001" maxlat="38.89476852554999" maxlon="-77.02809999999999"/>
     <node visible="true" id="-94118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920905512699946" lon="-77.0321248000000054">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94118"/>
     </node>
     <node visible="true" id="-94117" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8903959111099837" lon="-77.0321248000000054">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94117"/>
     </node>
     <node visible="true" id="-94116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902185999999901" lon="-77.0319625969499953">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94116"/>
     </node>
     <node visible="true" id="-94111" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904080000000008" lon="-77.0320799999999934">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94111"/>
     </node>
     <node visible="true" id="-94101" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918289999999942" lon="-77.0319669999999945">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94101"/>
     </node>
     <node visible="true" id="-94100" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906280000000066" lon="-77.0319640000000021">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94100"/>
     </node>
     <node visible="true" id="-94098" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902980000000085" lon="-77.0319630000000046">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-94098"/>
     </node>
     <node visible="true" id="-94075" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904126048400016" lon="-77.0319620010299957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94075"/>
     </node>
     <node visible="true" id="-94059" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920932092299907" lon="-77.0319638389200065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94059"/>
     </node>
     <node visible="true" id="-94057" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904606771800161" lon="-77.0281865822399965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94057"/>
     </node>
     <node visible="true" id="-94055" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8905943682099959" lon="-77.0281888683500000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94055"/>
     </node>
     <node visible="true" id="-94053" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8906262639199980" lon="-77.0281894140599945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94053"/>
     </node>
     <node visible="true" id="-94051" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8907878743799955" lon="-77.0281884405099930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94051"/>
     </node>
     <node visible="true" id="-94049" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909742575499990" lon="-77.0281887446899987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94049"/>
     </node>
     <node visible="true" id="-94047" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8911421740899854" lon="-77.0281868514800010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94047"/>
     </node>
     <node visible="true" id="-94045" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913385565699983" lon="-77.0281870443400010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94045"/>
     </node>
     <node visible="true" id="-94043" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915325968700003" lon="-77.0281872362700000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94043"/>
     </node>
     <node visible="true" id="-94041" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8916726493399949" lon="-77.0281877735699965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94041"/>
     </node>
     <node visible="true" id="-94039" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917001524399950" lon="-77.0281878788100016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94039"/>
     </node>
     <node visible="true" id="-94037" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919111287999897" lon="-77.0281866942100066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94037"/>
     </node>
     <node visible="true" id="-94035" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920853946799951" lon="-77.0281374134600014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94035"/>
     </node>
     <node visible="true" id="-94033" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8936430017499930" lon="-77.0281297440799904">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94033"/>
     </node>
     <node visible="true" id="-94031" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8937357896599920" lon="-77.0281226323799899">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94031"/>
     </node>
     <node visible="true" id="-94029" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8941890923900004" lon="-77.0281158947200026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94029"/>
     </node>
     <node visible="true" id="-94027" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8946623042100015" lon="-77.0281065135300054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94027"/>
     </node>
     <node visible="true" id="-94025" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920854311799928" lon="-77.0281004185600011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94025"/>
     </node>
     <node visible="true" id="-94023" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920853525300032" lon="-77.0281791552800001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94023"/>
     </node>
     <node visible="true" id="-94021" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920849549700023" lon="-77.0283330394299952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94021"/>
     </node>
     <node visible="true" id="-94019" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920845555199932" lon="-77.0284938397300039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94019"/>
     </node>
     <node visible="true" id="-94017" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920846688699839" lon="-77.0287664513000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94017"/>
     </node>
     <node visible="true" id="-94015" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920864839399982" lon="-77.0290761802300068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94015"/>
     </node>
     <node visible="true" id="-94013" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920862258599840" lon="-77.0293875220900048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94013"/>
     </node>
     <node visible="true" id="-94011" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920859999199919" lon="-77.0296688298599861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94011"/>
     </node>
     <node visible="true" id="-94009" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920859627599924" lon="-77.0297153474299989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94009"/>
     </node>
     <node visible="true" id="-94007" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920874285700009" lon="-77.0299699775899995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94007"/>
     </node>
     <node visible="true" id="-94005" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920877740399931" lon="-77.0300300329599992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94005"/>
     </node>
     <node visible="true" id="-94003" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920886791999934" lon="-77.0303617779599961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94003"/>
     </node>
     <node visible="true" id="-94001" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920886313700009" lon="-77.0304179666100026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-94001"/>
     </node>
     <node visible="true" id="-93999" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920884195700012" lon="-77.0306659731400032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93999"/>
     </node>
     <node visible="true" id="-93997" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920881471899946" lon="-77.0310152385499833">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93997"/>
     </node>
     <node visible="true" id="-93995" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920872433100016" lon="-77.0313640426000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93995"/>
     </node>
     <node visible="true" id="-93993" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920889516200035" lon="-77.0317098508100031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93993"/>
     </node>
     <node visible="true" id="-93991" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920896091899948" lon="-77.0317473128500012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93991"/>
     </node>
     <node visible="true" id="-93989" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904617227300093" lon="-77.0283145551399855">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93989"/>
     </node>
     <node visible="true" id="-93987" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904645459899925" lon="-77.0286322041499858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93987"/>
     </node>
     <node visible="true" id="-93985" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904592197699941" lon="-77.0290427813500003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93985"/>
     </node>
     <node visible="true" id="-93983" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904534397699990" lon="-77.0294609658899958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93983"/>
     </node>
     <node visible="true" id="-93981" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904499456699924" lon="-77.0297408315199874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93981"/>
     </node>
     <node visible="true" id="-93979" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904468576499980" lon="-77.0299692884299958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93979"/>
     </node>
     <node visible="true" id="-93977" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904448953500008" lon="-77.0301144081199993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93977"/>
     </node>
     <node visible="true" id="-93975" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904417558400084" lon="-77.0304102958800030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93975"/>
     </node>
     <node visible="true" id="-93973" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904367282199956" lon="-77.0306894691500048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93973"/>
     </node>
     <node visible="true" id="-93971" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904312116199975" lon="-77.0311112268099976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93971"/>
     </node>
     <node visible="true" id="-93969" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904290645999993" lon="-77.0313918997200062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93969"/>
     </node>
     <node visible="true" id="-93967" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904250306799923" lon="-77.0316521696200027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93967"/>
     </node>
     <node visible="true" id="-93965" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904218427500012" lon="-77.0317458892100007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93965"/>
     </node>
     <node visible="true" id="-93963" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904204902500084" lon="-77.0317856461699932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93963"/>
     </node>
     <node visible="true" id="-93941" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8947685255499920" lon="-77.0280999999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93941"/>
     </node>
     <node visible="true" id="-93939" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920047637499948" lon="-77.0280999999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93939"/>
     </node>
     <node visible="true" id="-93935" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904645246900031" lon="-77.0280999999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-93935"/>
     </node>
     <way visible="true" id="-94105" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94075"/>
         <nd ref="-94111"/>
         <nd ref="-94117"/>
-        <tag k="name" v="Madison Dr NW"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="name" v="Madison Dr NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94105"/>
     </way>
     <way visible="true" id="-94102" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94116"/>
@@ -258,21 +197,19 @@
         <nd ref="-94100"/>
         <nd ref="-94101"/>
         <nd ref="-94059"/>
-        <tag k="alt_name" v="US Hwy 1"/>
-        <tag k="name" v="14th St NW"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="14th St NW"/>
+        <tag k="alt_name" v="US Hwy 1"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94102"/>
     </way>
     <way visible="true" id="-94098" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94059"/>
         <nd ref="-94118"/>
-        <tag k="name" v="Constitution Ave NW"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Constitution Ave NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94098"/>
     </way>
     <way visible="true" id="-94097" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94057"/>
@@ -291,12 +228,11 @@
         <nd ref="-93965"/>
         <nd ref="-93963"/>
         <nd ref="-94075"/>
-        <tag k="alt_name" v="Madison Dr NW"/>
-        <tag k="name" v="MADISON DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="MADISON DR NW"/>
+        <tag k="alt_name" v="Madison Dr NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94097"/>
     </way>
     <way visible="true" id="-94095" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94035"/>
@@ -318,12 +254,11 @@
         <nd ref="-93993"/>
         <nd ref="-93991"/>
         <nd ref="-94059"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 1;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="CONSTITUTION AVE NW"/>
+        <tag k="alt_name" v="Constitution Ave NW;US Hwy 1;US Hwy 50"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94095"/>
     </way>
     <way visible="true" id="-94093" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94057"/>
@@ -338,11 +273,10 @@
         <nd ref="-94039"/>
         <nd ref="-94037"/>
         <nd ref="-94035"/>
-        <tag k="name" v="12TH ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="12TH ST NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94093"/>
     </way>
     <way visible="true" id="-94089" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94035"/>
@@ -351,41 +285,37 @@
         <nd ref="-94029"/>
         <nd ref="-94027"/>
         <nd ref="-93941"/>
-        <tag k="alt_name" v="12th St NW"/>
-        <tag k="name" v="12TH ST NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="12TH ST NW"/>
+        <tag k="alt_name" v="12th St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94089"/>
     </way>
     <way visible="true" id="-94087" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-93939"/>
         <nd ref="-94035"/>
-        <tag k="alt_name" v="12th St NW"/>
-        <tag k="name" v="12TH ST EXPY NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="12TH ST EXPY NW"/>
+        <tag k="alt_name" v="12th St NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94087"/>
     </way>
     <way visible="true" id="-94085" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-94025"/>
         <nd ref="-94035"/>
-        <tag k="alt_name" v="Constitution Ave NW;US Hwy 1;US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="CONSTITUTION AVE NW"/>
+        <tag k="alt_name" v="Constitution Ave NW;US Hwy 1;US Hwy 50"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94085"/>
     </way>
     <way visible="true" id="-94083" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-93935"/>
         <nd ref="-94057"/>
-        <tag k="alt_name" v="Madison Dr NW"/>
-        <tag k="name" v="MADISON DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="MADISON DR NW"/>
+        <tag k="alt_name" v="Madison Dr NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-94083"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-028/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-028/Expected.osm
@@ -3,87 +3,66 @@
     <bounds minlat="38.8913895" minlon="-77.0551" maxlat="38.89231451948048" maxlon="-77.0544829"/>
     <node visible="true" id="-170910" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921502042379501" lon="-77.0546815243074263">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170910"/>
     </node>
     <node visible="true" id="-170907" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915695696683272" lon="-77.0546845212183058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170907"/>
     </node>
     <node visible="true" id="-170865" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919859999999673" lon="-77.0547249999999906">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170865"/>
     </node>
     <node visible="true" id="-170864" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918999999999997" lon="-77.0547469999999919">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170864"/>
     </node>
     <node visible="true" id="-170863" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918600000000438" lon="-77.0547509999999818">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170863"/>
     </node>
     <node visible="true" id="-170862" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918200000000027" lon="-77.0547499999999843">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170862"/>
     </node>
     <node visible="true" id="-170861" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917799999999687" lon="-77.0547459999999660">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170861"/>
     </node>
     <node visible="true" id="-170860" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917399999999702" lon="-77.0547380000000004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170860"/>
     </node>
     <node visible="true" id="-170859" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8923001140350593" lon="-77.0550999999999959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170859"/>
     </node>
     <node visible="true" id="-170858" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8923145194804789" lon="-77.0550999999999959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-170858"/>
     </node>
     <node visible="true" id="-170855" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921170880879785" lon="-77.0544828999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170855"/>
     </node>
     <node visible="true" id="-170854" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8913895000000025" lon="-77.0545554078516943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170854"/>
     </node>
     <node visible="true" id="-170853" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8923092998045803" lon="-77.0550999999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-170853"/>
     </node>
     <node visible="true" id="-153907" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915658981526633" lon="-77.0546824771353158">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153907"/>
     </node>
     <node visible="true" id="-153906" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915459058291404" lon="-77.0546690906903819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153906"/>
     </node>
     <node visible="true" id="-153905" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915042105574287" lon="-77.0546402416848082">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153905"/>
     </node>
     <node visible="true" id="-153904" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914627859062421" lon="-77.0546105867633884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153904"/>
     </node>
     <node visible="true" id="-153903" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8914217219594960" lon="-77.0545801245554713">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-153903"/>
     </node>
     <node visible="true" id="-15036" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922220501690603" lon="-77.0550477874796798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15036"/>
     </node>
     <node visible="true" id="-15035" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921495043437417" lon="-77.0546779563510285">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15035"/>
     </node>
     <node visible="true" id="-15034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921307105815188" lon="-77.0545648707543194">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-15034"/>
     </node>
     <way visible="true" id="-13642" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170855"/>
@@ -91,12 +70,11 @@
         <nd ref="-15035"/>
         <nd ref="-170910"/>
         <nd ref="-15036"/>
-        <tag k="alt_name" v="Rock Crk and Potomac Pkwy NW"/>
-        <tag k="name" v="OHIO DR NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="OHIO DR NW"/>
+        <tag k="alt_name" v="Rock Crk and Potomac Pkwy NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13642"/>
     </way>
     <way visible="true" id="-13640" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170854"/>
@@ -107,12 +85,11 @@
         <nd ref="-153907"/>
         <nd ref="-170907"/>
         <nd ref="-15036"/>
-        <tag k="alt_name" v="Rock Crk and Potomac Pkwy NW"/>
-        <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
+        <tag k="alt_name" v="Rock Crk and Potomac Pkwy NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13640"/>
     </way>
     <way visible="true" id="-13541" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170910"/>
@@ -123,56 +100,50 @@
         <nd ref="-170861"/>
         <nd ref="-170860"/>
         <nd ref="-170907"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13541"/>
     </way>
     <way visible="true" id="-13540" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15036"/>
         <nd ref="-170859"/>
-        <tag k="name" v="Rock Crk and Potomac Pkwy NW"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="name" v="Rock Crk and Potomac Pkwy NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13540"/>
     </way>
     <way visible="true" id="-13539" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15036"/>
         <nd ref="-170858"/>
-        <tag k="name" v="Rock Crk and Potomac Pkwy NW"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="name" v="Rock Crk and Potomac Pkwy NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13539"/>
     </way>
     <way visible="true" id="-13534" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-15036"/>
         <nd ref="-170853"/>
-        <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="ROCK CREEK &amp; POTOMAC PKWY NW"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-13534"/>
     </way>
     <relation visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-13540" role="reviewee"/>
         <member type="way" ref="-13534" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-18"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-13539" role="reviewee"/>
         <member type="way" ref="-13534" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-17"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/highway-029/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-029/Expected.osm
@@ -3,291 +3,219 @@
     <bounds minlat="38.89174512264" minlon="-77.0551" maxlat="38.8932336" maxlon="-77.0527475"/>
     <node visible="true" id="-95441" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8917451226399962" lon="-77.0527474999999953">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95441"/>
     </node>
     <node visible="true" id="-95439" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928163229999910" lon="-77.0550999999999959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95439"/>
     </node>
     <node visible="true" id="-95432" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927019999999928" lon="-77.0548069999999967">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95432"/>
     </node>
     <node visible="true" id="-95431" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926509999999936" lon="-77.0546740000000057">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95431"/>
     </node>
     <node visible="true" id="-95430" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924120000000002" lon="-77.0540699999999958">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95430"/>
     </node>
     <node visible="true" id="-95429" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8922799999999995" lon="-77.0537499999999937">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95429"/>
     </node>
     <node visible="true" id="-95428" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8921439999999947" lon="-77.0534030000000030">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95428"/>
     </node>
     <node visible="true" id="-95427" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8920299999999912" lon="-77.0531209999999902">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95427"/>
     </node>
     <node visible="true" id="-95426" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919999999999959" lon="-77.0530569999999955">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95426"/>
     </node>
     <node visible="true" id="-95425" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919830000000033" lon="-77.0530260000000027">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95425"/>
     </node>
     <node visible="true" id="-95424" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919309999999925" lon="-77.0529360000000025">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95424"/>
     </node>
     <node visible="true" id="-95423" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8919119999999907" lon="-77.0529079999999880">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95423"/>
     </node>
     <node visible="true" id="-95402" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8918489999999935" lon="-77.0528079999999989">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-95402"/>
     </node>
     <node visible="true" id="-95396" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924332856599904" lon="-77.0527866099699850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95396"/>
     </node>
     <node visible="true" id="-95394" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924649749599922" lon="-77.0529468792900047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95394"/>
     </node>
     <node visible="true" id="-95392" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8925094484700082" lon="-77.0531718073599876">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95392"/>
     </node>
     <node visible="true" id="-95390" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8925198376499921" lon="-77.0532243536700037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95390"/>
     </node>
     <node visible="true" id="-95388" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8925327018399969" lon="-77.0532905303400071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95388"/>
     </node>
     <node visible="true" id="-95386" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8925813103999971" lon="-77.0535405850300066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95386"/>
     </node>
     <node visible="true" id="-95384" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926174726399978" lon="-77.0537151093599988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95384"/>
     </node>
     <node visible="true" id="-95382" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8926676890299987" lon="-77.0539574665399982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95382"/>
     </node>
     <node visible="true" id="-95380" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927326578399999" lon="-77.0543064385900038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95380"/>
     </node>
     <node visible="true" id="-95378" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927593878200000" lon="-77.0543599443300025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95378"/>
     </node>
     <node visible="true" id="-95376" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927902150400016" lon="-77.0544602335299942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95376"/>
     </node>
     <node visible="true" id="-95374" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928509661699948" lon="-77.0548253606999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95374"/>
     </node>
     <node visible="true" id="-95372" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928401636599972" lon="-77.0547612815200011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95372"/>
     </node>
     <node visible="true" id="-95370" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927884562899990" lon="-77.0544212902699996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95370"/>
     </node>
     <node visible="true" id="-95368" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927864105899985" lon="-77.0543637688399912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95368"/>
     </node>
     <node visible="true" id="-95366" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927850866499938" lon="-77.0543062479499810">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95366"/>
     </node>
     <node visible="true" id="-95364" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927849726799977" lon="-77.0542934348499955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95364"/>
     </node>
     <node visible="true" id="-95362" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927845729299975" lon="-77.0542486124199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95362"/>
     </node>
     <node visible="true" id="-95360" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927846897099911" lon="-77.0541910926300062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95360"/>
     </node>
     <node visible="true" id="-95358" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927855271399920" lon="-77.0541335733900041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95358"/>
     </node>
     <node visible="true" id="-95356" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927871752799845" lon="-77.0540760547699790">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95356"/>
     </node>
     <node visible="true" id="-95354" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927894539899981" lon="-77.0540185366200063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95354"/>
     </node>
     <node visible="true" id="-95352" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927909933499976" lon="-77.0540013625099931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95352"/>
     </node>
     <node visible="true" id="-95350" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927943406200001" lon="-77.0539707031399956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95350"/>
     </node>
     <node visible="true" id="-95348" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8927983179000023" lon="-77.0539400442499982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95348"/>
     </node>
     <node visible="true" id="-95346" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928031068999900" lon="-77.0539097317700055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95346"/>
     </node>
     <node visible="true" id="-95344" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928085258500005" lon="-77.0538795350399965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95344"/>
     </node>
     <node visible="true" id="-95342" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928146653599995" lon="-77.0538495693899961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95342"/>
     </node>
     <node visible="true" id="-95340" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928215254300014" lon="-77.0538198348200041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95340"/>
     </node>
     <node visible="true" id="-95338" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928290159700012" lon="-77.0537903312599894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95338"/>
     </node>
     <node visible="true" id="-95336" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928357663899931" lon="-77.0537663608299965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95336"/>
     </node>
     <node visible="true" id="-95334" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928461585500003" lon="-77.0537323631800035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95334"/>
     </node>
     <node visible="true" id="-95332" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928556304300059" lon="-77.0537038985199985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95332"/>
     </node>
     <node visible="true" id="-95330" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928659128999925" lon="-77.0536757802800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95330"/>
     </node>
     <node visible="true" id="-95328" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928767356999927" lon="-77.0536480089700007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95328"/>
     </node>
     <node visible="true" id="-95326" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928881888199953" lon="-77.0536208130299940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95326"/>
     </node>
     <node visible="true" id="-95324" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929003624400025" lon="-77.0535939641599867">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95324"/>
     </node>
     <node visible="true" id="-95322" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929130763499984" lon="-77.0535675767700070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95322"/>
     </node>
     <node visible="true" id="-95320" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929264279000009" lon="-77.0535417517899930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95320"/>
     </node>
     <node visible="true" id="-95318" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929388627400030" lon="-77.0535186061499928">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95318"/>
     </node>
     <node visible="true" id="-95316" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929531974499980" lon="-77.0534937184600039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95316"/>
     </node>
     <node visible="true" id="-95314" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929679823099974" lon="-77.0534694074599997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95314"/>
     </node>
     <node visible="true" id="-95312" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929833974899921" lon="-77.0534456732600006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95312"/>
     </node>
     <node visible="true" id="-95310" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8929948278399920" lon="-77.0534287442499988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95310"/>
     </node>
     <node visible="true" id="-95308" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930157584600025" lon="-77.0533999350599998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95308"/>
     </node>
     <node visible="true" id="-95306" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930327942800034" lon="-77.0533780463800042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95306"/>
     </node>
     <node visible="true" id="-95304" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930502802100051" lon="-77.0533568496500010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95304"/>
     </node>
     <node visible="true" id="-95302" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930682162799926" lon="-77.0533362296000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95302"/>
     </node>
     <node visible="true" id="-95300" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8930979825399916" lon="-77.0533046366700063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95300"/>
     </node>
     <node visible="true" id="-95298" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931056188399964" lon="-77.0532971807599978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95298"/>
     </node>
     <node visible="true" id="-95296" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931249952500053" lon="-77.0532787518999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95296"/>
     </node>
     <node visible="true" id="-95294" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931447316699987" lon="-77.0532610149199968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95294"/>
     </node>
     <node visible="true" id="-95292" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931649181400019" lon="-77.0532440851699931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95292"/>
     </node>
     <node visible="true" id="-95290" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8931854645699886" lon="-77.0532279625700056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95290"/>
     </node>
     <node visible="true" id="-95288" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932063270899988" lon="-77.0532125628100033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95288"/>
     </node>
     <node visible="true" id="-95286" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932205186800033" lon="-77.0532026291100038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95286"/>
     </node>
     <node visible="true" id="-95230" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8928783127299909" lon="-77.0550999999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95230"/>
     </node>
     <node visible="true" id="-95222" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8924251240999936" lon="-77.0527474999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95222"/>
     </node>
     <node visible="true" id="-95212" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8932336000000021" lon="-77.0531939932800043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-95212"/>
     </node>
     <way visible="true" id="-95462" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-95441"/>
@@ -303,22 +231,20 @@
         <nd ref="-95431"/>
         <nd ref="-95432"/>
         <nd ref="-95439"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="road"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-95462"/>
     </way>
     <way visible="true" id="-95458" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-95230"/>
         <nd ref="-95374"/>
         <nd ref="-95372"/>
         <nd ref="-95376"/>
-        <tag k="alt_name" v="I- 66;US Hwy 50"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="alt_name" v="I- 66;US Hwy 50"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-95458"/>
     </way>
     <way visible="true" id="-95450" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-95222"/>
@@ -333,12 +259,11 @@
         <nd ref="-95380"/>
         <nd ref="-95378"/>
         <nd ref="-95376"/>
-        <tag k="alt_name" v="US Hwy 50"/>
-        <tag k="name" v="CONSTITUTION AVE NW"/>
-        <tag k="highway" v="road"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="road"/>
+        <tag k="name" v="CONSTITUTION AVE NW"/>
+        <tag k="alt_name" v="US Hwy 50"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-95450"/>
     </way>
     <way visible="true" id="-95444" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-95376"/>
@@ -386,11 +311,10 @@
         <nd ref="-95288"/>
         <nd ref="-95286"/>
         <nd ref="-95212"/>
-        <tag k="alt_name" v="I- 66"/>
-        <tag k="name" v="INTERSTATE 66  BN"/>
-        <tag k="highway" v="motorway"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="motorway"/>
+        <tag k="name" v="INTERSTATE 66  BN"/>
+        <tag k="alt_name" v="I- 66"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-95444"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/highway-030/Expected.osm
+++ b/test-files/cases/network/conflicts/highway-030/Expected.osm
@@ -3,159 +3,120 @@
     <bounds minlat="38.90223879999999" minlon="-77.0551" maxlat="38.90274" maxlon="-77.05133499999999"/>
     <node visible="true" id="-105286" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025804601605429" lon="-77.0514144252534834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105286"/>
     </node>
     <node visible="true" id="-105244" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9027400000000014" lon="-77.0547488009000006">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105244"/>
     </node>
     <node visible="true" id="-105243" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022387999999992" lon="-77.0547485154699956">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105243"/>
     </node>
     <node visible="true" id="-105242" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025804592999975" lon="-77.0513349999999946">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105242"/>
     </node>
     <node visible="true" id="-105238" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9024925138299906" lon="-77.0550999999999959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105238"/>
     </node>
     <node visible="true" id="-105237" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025844559999925" lon="-77.0550999999999959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105237"/>
     </node>
     <node visible="true" id="-105233" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9024959999999993" lon="-77.0539250000000067">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105233"/>
     </node>
     <node visible="true" id="-105228" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025319999999937" lon="-77.0547399999999811">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105228"/>
     </node>
     <node visible="true" id="-105227" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9024840000000012" lon="-77.0547410000000070">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105227"/>
     </node>
     <node visible="true" id="-105226" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022949999999952" lon="-77.0547459999999944">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105226"/>
     </node>
     <node visible="true" id="-105225" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022759999999934" lon="-77.0547480000000036">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105225"/>
     </node>
     <node visible="true" id="-105221" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025730000000038" lon="-77.0547420000000045">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105221"/>
     </node>
     <node visible="true" id="-105218" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022760928699967" lon="-77.0547478698200052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105218"/>
     </node>
     <node visible="true" id="-105216" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022952814200025" lon="-77.0547462705499981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105216"/>
     </node>
     <node visible="true" id="-105214" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022482401199952" lon="-77.0514145964300070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105214"/>
     </node>
     <node visible="true" id="-105212" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9023203903100026" lon="-77.0514145590900057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105212"/>
     </node>
     <node visible="true" id="-105210" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9024040205300068" lon="-77.0514145163299844">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105210"/>
     </node>
     <node visible="true" id="-105208" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9024604607099960" lon="-77.0514144871199989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105208"/>
     </node>
     <node visible="true" id="-105206" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025232123599949" lon="-77.0514144552499971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105206"/>
     </node>
     <node visible="true" id="-105204" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025897801899987" lon="-77.0514144203699942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105204"/>
     </node>
     <node visible="true" id="-105202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9026433320600020" lon="-77.0514143926800017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105202"/>
     </node>
     <node visible="true" id="-105200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9027123771800021" lon="-77.0514143574200006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105200"/>
     </node>
     <node visible="true" id="-105198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9023225500799938" lon="-77.0533076275099802">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105198"/>
     </node>
     <node visible="true" id="-105196" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9023955139499904" lon="-77.0533073491500033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105196"/>
     </node>
     <node visible="true" id="-105194" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025284756599987" lon="-77.0533059865399963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105194"/>
     </node>
     <node visible="true" id="-105192" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9026471263899936" lon="-77.0533047710299996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105192"/>
     </node>
     <node visible="true" id="-105190" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9027221091900017" lon="-77.0533046411700013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105190"/>
     </node>
     <node visible="true" id="-105188" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025297312699934" lon="-77.0547521492199934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105188"/>
     </node>
     <node visible="true" id="-105186" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025235192000096" lon="-77.0516034805999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105186"/>
     </node>
     <node visible="true" id="-105184" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025244213700034" lon="-77.0522087328999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105184"/>
     </node>
     <node visible="true" id="-105182" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025264744799912" lon="-77.0526521244700007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105182"/>
     </node>
     <node visible="true" id="-105180" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025284025699918" lon="-77.0531686073299937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105180"/>
     </node>
     <node visible="true" id="-105178" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025283665099906" lon="-77.0531847423000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105178"/>
     </node>
     <node visible="true" id="-105176" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9025300591699974" lon="-77.0550999999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105176"/>
     </node>
     <node visible="true" id="-105172" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022387999999992" lon="-77.0547484074700009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105172"/>
     </node>
     <node visible="true" id="-105170" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9027400000000014" lon="-77.0533046103400068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105170"/>
     </node>
     <node visible="true" id="-105168" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022387999999850" lon="-77.0514146507699991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105168"/>
     </node>
     <node visible="true" id="-105166" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9027400000000014" lon="-77.0514145757999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105166"/>
     </node>
     <node visible="true" id="-105164" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9022387999999992" lon="-77.0533079467499959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-105164"/>
     </node>
     <way visible="true" id="-105439" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105168"/>
@@ -169,24 +130,22 @@
         <nd ref="-105202"/>
         <nd ref="-105200"/>
         <nd ref="-105166"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="24TH ST NW"/>
         <tag k="alt_name" v="24th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105439"/>
     </way>
     <way visible="true" id="-105244" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105194"/>
         <nd ref="-105233"/>
         <nd ref="-105227"/>
         <nd ref="-105238"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="US Hwy 29"/>
         <tag k="alt_name" v="K St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105244"/>
     </way>
     <way visible="true" id="-105234" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105243"/>
@@ -196,11 +155,10 @@
         <nd ref="-105228"/>
         <nd ref="-105221"/>
         <nd ref="-105244"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="26th St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105234"/>
     </way>
     <way visible="true" id="-105233" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105242"/>
@@ -208,22 +166,20 @@
         <nd ref="-105194"/>
         <nd ref="-105221"/>
         <nd ref="-105237"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="US Hwy 29"/>
         <tag k="alt_name" v="K St NW"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105233"/>
     </way>
     <way visible="true" id="-105230" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105194"/>
         <nd ref="-105188"/>
         <nd ref="-105176"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="K ST NW"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105230"/>
     </way>
     <way visible="true" id="-105228" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105206"/>
@@ -233,65 +189,59 @@
         <nd ref="-105180"/>
         <nd ref="-105178"/>
         <nd ref="-105194"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="K ST NW"/>
         <tag k="alt_name" v="K St NW;US Hwy 29"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105228"/>
     </way>
     <way visible="true" id="-105226" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105172"/>
         <nd ref="-105218"/>
         <nd ref="-105216"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="26TH ST NW"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105226"/>
     </way>
     <way visible="true" id="-105224" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105194"/>
         <nd ref="-105192"/>
         <nd ref="-105190"/>
         <nd ref="-105170"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="25TH ST NW"/>
         <tag k="alt_name" v="25th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105224"/>
     </way>
     <way visible="true" id="-105220" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-105164"/>
         <nd ref="-105198"/>
         <nd ref="-105196"/>
         <nd ref="-105194"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="25TH ST NW"/>
         <tag k="alt_name" v="25th St NW"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="5"/>
-        <tag k="hoot:id" v="-105220"/>
     </way>
     <relation visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-105230" role="reviewee"/>
         <member type="way" ref="-105233" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-30"/>
     </relation>
     <relation visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-105230" role="reviewee"/>
         <member type="way" ref="-105244" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-29"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/pap-001/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-001/Expected.osm
@@ -3,364 +3,282 @@
     <bounds minlat="18.53802799999999" minlon="-72.334763" maxlat="18.541352" maxlon="-72.33079299999999"/>
     <node visible="true" id="2" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5380405999999986" lon="-72.3322969999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="2"/>
     </node>
     <node visible="true" id="3" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5384248000000014" lon="-72.3322038999999819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="3"/>
     </node>
     <node visible="true" id="4" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5384696999999967" lon="-72.3322512999999816">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="4"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5388542999999970" lon="-72.3321755000000053">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{7b6112c7-f655-4989-9130-b8cdb1e7f986}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5389821000000019" lon="-72.3321954000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5386221999999954" lon="-72.3331483000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5384769999999968" lon="-72.3324771999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5381788000000007" lon="-72.3327739000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5383956999999953" lon="-72.3327218000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5406170999999951" lon="-72.3342054000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5407034000000017" lon="-72.3341760999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5408782999999993" lon="-72.3341166999999814">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5411335000000008" lon="-72.3340299000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5400276000000055" lon="-72.3327663999999970">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5bc8056c-8434-4cf8-987f-1b5793cc4cf0}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5402631999999947" lon="-72.3329616000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5402924999999996" lon="-72.3329284000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5403524999999973" lon="-72.3328960000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397199000000015" lon="-72.3331158000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396987000000024" lon="-72.3330236999999840">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5400672999999969" lon="-72.3326043999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5400010999999978" lon="-72.3323307999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5400519999999958" lon="-72.3325253000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397299999999987" lon="-72.3325607999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397618999999949" lon="-72.3325468000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397923999999996" lon="-72.3325307000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5398148999999997" lon="-72.3324925999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5405599000000016" lon="-72.3307939999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5395125000000007" lon="-72.3323503000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396777999999962" lon="-72.3322684999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396306999999965" lon="-72.3321638999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397688999999950" lon="-72.3323900000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396535999999976" lon="-72.3325085999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5394282000000032" lon="-72.3324099000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396461000000023" lon="-72.3325363999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397096999999960" lon="-72.3325827999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397573999999992" lon="-72.3326164000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5398895999999951" lon="-72.3327055000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5399543999999956" lon="-72.3326524999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5398308000000007" lon="-72.3324537999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5398148999999997" lon="-72.3324072999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5398002999999996" lon="-72.3323646999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397500999999920" lon="-72.3322189000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397154999999962" lon="-72.3321284000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5394411999999988" lon="-72.3312590999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5393860000000004" lon="-72.3310848999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5393013999999994" lon="-72.3308253999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5397558999999994" lon="-72.3335782999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396332999999984" lon="-72.3331402999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396109999999972" lon="-72.3330605000000020">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{883514c4-b409-4c86-b953-d37e67b00155}"/>
         <tag k="attribution" v="osm"/>
         <tag k="access" v="no"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5401464999999916" lon="-72.3328287999999873">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5403604000000009" lon="-72.3328338000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5404746999999972" lon="-72.3328290000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5381275000000016" lon="-72.3325470000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5402506000000002" lon="-72.3330042999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5402185999999993" lon="-72.3329518999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5401382999999953" lon="-72.3328937999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5382801999999955" lon="-72.3332230999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5395813999999959" lon="-72.3329569999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5396754999999978" lon="-72.3329355000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5400817999999994" lon="-72.3328508000000028">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Carrefour Tifour"/>
         <tag k="uuid" v="{19a614ad-9f90-4313-96cf-d3042134737b}"/>
         <tag k="alt_name" v="Carrefour Ti Four"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5390820999999981" lon="-72.3339454000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5388195000000024" lon="-72.3330964000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5395548999999988" lon="-72.3315929999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5394669999999984" lon="-72.3315816000000069">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{c256a076-a1b9-4c2b-9a06-ef00be483d3b}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5391365999999991" lon="-72.3314174000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5388301999999925" lon="-72.3312587000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5386306000000012" lon="-72.3311549000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5380280000000006" lon="-72.3322950839699956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5413519999999998" lon="-72.3327863185800055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5380279999999971" lon="-72.3332824745599936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5411188999999936" lon="-72.3310376000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5407940923399970" lon="-72.3347629999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5413519999999963" lon="-72.3324471297399896">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5392908553699982" lon="-72.3307929999999857">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5380279999999935" lon="-72.3316289317699983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5400797021099990" lon="-72.3307929999999857">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5393772076400047" lon="-72.3307929999999857">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5413519999999998" lon="-72.3309501762099956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5412602999999976" lon="-72.3325030999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5406699999999951" lon="-72.3316628999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5404415999999976" lon="-72.3317318000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107" lat="18.5407356000000050" lon="-72.3327463999999907">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <way visible="true" id="1" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="56"/>
@@ -370,15 +288,14 @@
         <nd ref="60"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="survey; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0b5ec539-d84e-4ea9-953c-a01da391e8b2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="asphalt"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="65"/>
@@ -386,14 +303,13 @@
         <nd ref="21"/>
         <nd ref="52"/>
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{52022e28-4a9b-44bf-b5be-956c8d02a88f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="26"/>
@@ -404,15 +320,14 @@
         <nd ref="24"/>
         <nd ref="26"/>
         <tag k="source" v="Bing; survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="area" v="yes"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5b9fafe2-337a-4210-834f-69a9ea4d71f7}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="43"/>
@@ -423,20 +338,20 @@
         <nd ref="39"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="Bing; survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0f0420fb-0a45-4a19-9b76-b2bae7a841d9}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="48"/>
         <nd ref="31"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Borno"/>
@@ -447,9 +362,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="36"/>
@@ -464,15 +377,14 @@
         <nd ref="38"/>
         <nd ref="36"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="area" v="yes"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{35a88255-3ccf-4063-9b4a-fc0dd1d3f660}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="64"/>
@@ -480,34 +392,33 @@
         <nd ref="52"/>
         <nd ref="51"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4df2bacf-abb2-4c48-a67c-6829cbba9933}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="63"/>
         <nd ref="9"/>
         <nd ref="57"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c34bdd5e-db89-4a97-a80c-84140d2a6345}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="68"/>
         <nd ref="67"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Gardère"/>
@@ -518,9 +429,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="73"/>
@@ -529,82 +438,76 @@
         <nd ref="70"/>
         <nd ref="69"/>
         <tag k="source" v="survey; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{61e8bd38-864c-4ef6-a348-910ad7edaa72}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="98"/>
         <nd ref="97"/>
         <nd ref="96"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{cb826794-9c83-4d55-aca9-cce899c295cb}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="8"/>
         <nd ref="7"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{708d4494-1375-4f6d-b0f1-6f6c5bbde945}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="10"/>
         <nd ref="9"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{52d1bdc8-33f0-4bb0-83d9-a2639486459e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="15"/>
         <nd ref="14"/>
         <nd ref="13"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
         <tag k="uuid" v="{86554b91-f538-408a-bdc2-202e4013a0b3};{9924b5db-17ff-43b1-b797-d6362a0536fd}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="16"/>
         <nd ref="15"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4ebfb809-dc25-496a-8300-9a88ffef1657}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="6"/>
@@ -614,36 +517,34 @@
         <nd ref="2"/>
         <nd ref="76"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{67debf55-99b3-40b5-898a-94cbe2ac5dc5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="79"/>
         <nd ref="95"/>
-        <tag k="smoothness" v="intermediate"/>
-        <tag k="source:name" v="CNIGS/OIM/FOCS"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="osm"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Rue Saint Cyr"/>
-        <tag k="uuid" v="{e7638ec1-7a3b-407f-bc30-f94c5c3b799d}"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="operational_status" v="open"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="source:name" v="CNIGS/OIM/FOCS"/>
         <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
+        <tag k="name" v="Rue Saint Cyr"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{e7638ec1-7a3b-407f-bc30-f94c5c3b799d}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="osm"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="highway" v="residential"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="66"/>
@@ -659,6 +560,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Christophe"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -677,9 +580,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="66"/>
@@ -694,6 +594,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Magny"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -712,9 +614,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="88"/>
@@ -731,6 +630,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Route des Dalles"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -749,9 +650,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="89"/>
@@ -774,6 +672,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Lamartinière"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -792,9 +692,6 @@
         <tag k="source" v="GPS; survey; CNIGS/FOCS/OIM;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T14:34:47Z" version="1">
         <nd ref="66"/>
@@ -811,6 +708,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Charles Sumner"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -829,15 +728,13 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="91"/>
         <nd ref="49"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Brisson"/>
@@ -848,15 +745,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="50"/>
         <nd ref="93"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Caméleau"/>
@@ -867,9 +763,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T14:34:47Z" version="1" changeset="107">
         <nd ref="69"/>
@@ -877,6 +771,7 @@
         <nd ref="94"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Jeanty"/>
@@ -887,8 +782,6 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/pap-002/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-002/Expected.osm
@@ -3,1851 +3,1389 @@
     <bounds minlat="18.54912199999999" minlon="-72.333641" maxlat="18.554468" maxlon="-72.323852"/>
     <node visible="true" id="-2169" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5522132395742503" lon="-72.3298581333452262">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-2169"/>
     </node>
     <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5498677000000036" lon="-72.3258945999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-247"/>
     </node>
     <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5497269999999972" lon="-72.3255496999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-246"/>
     </node>
     <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5492114000000043" lon="-72.3245811999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-245"/>
     </node>
     <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5493478000000032" lon="-72.3247594000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-244"/>
     </node>
     <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5522137999999970" lon="-72.3300650999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-243"/>
     </node>
     <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5525112999999990" lon="-72.3308425000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-242"/>
     </node>
     <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5521321999999991" lon="-72.3299257999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-241"/>
     </node>
     <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5521297000000018" lon="-72.3301648999999856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-239"/>
     </node>
     <node visible="true" id="-217" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5533963471444139" lon="-72.3336116297909655">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-217"/>
     </node>
     <node visible="true" id="-137" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5509145668229465" lon="-72.3275192279566994">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-137"/>
     </node>
     <node visible="true" id="-136" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5509331214471445" lon="-72.3275088244698310">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-136"/>
     </node>
     <node visible="true" id="-81" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5531296545069608" lon="-72.3325256440671467">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-81"/>
     </node>
     <node visible="true" id="-50" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5531869940070031" lon="-72.3327226654333657">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-50"/>
     </node>
     <node visible="true" id="-49" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5531946492372199" lon="-72.3327398138614654">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-49"/>
     </node>
     <node visible="true" id="-48" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5532659123048731" lon="-72.3329009592268903">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-48"/>
     </node>
     <node visible="true" id="-47" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5533688660631810" lon="-72.3334489433974426">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-47"/>
     </node>
     <node visible="true" id="-28" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5508060356640705" lon="-72.3275221876192376">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5507390528773257" lon="-72.3272984716015657">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108" lat="18.5507080304422338" lon="-72.3271903271094203">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533970000000004" lon="-72.3279811999999822">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="2" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533622999999963" lon="-72.3278777999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="2"/>
     </node>
     <node visible="true" id="3" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533205999999993" lon="-72.3277432999999803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="3"/>
     </node>
     <node visible="true" id="4" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532898999999993" lon="-72.3275241999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="4"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534083000000045" lon="-72.3272515999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534180000000042" lon="-72.3270954000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534037999999981" lon="-72.3269995999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533780000000021" lon="-72.3268803999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533446999999967" lon="-72.3267282000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531715000000013" lon="-72.3265411000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530074999999997" lon="-72.3263757999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5528882000000017" lon="-72.3262957000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5526221999999983" lon="-72.3259622999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501666000000043" lon="-72.3306527999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501152999999981" lon="-72.3306527999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498952999999958" lon="-72.3307491999999854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497097999999987" lon="-72.3307549999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541889000000033" lon="-72.3269815000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541357000000033" lon="-72.3271756000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498164000000010" lon="-72.3317507999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491862000000012" lon="-72.3284699999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491898000000006" lon="-72.3286326000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492978000000015" lon="-72.3290678000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511143999999994" lon="-72.3287543999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5512866999999986" lon="-72.3296274000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5513193999999970" lon="-72.3299200000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5513288000000003" lon="-72.3301438000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514659000000002" lon="-72.3305670999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5519057000000025" lon="-72.3317035999999831">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502339999999997" lon="-72.3284215999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509968999999977" lon="-72.3282612999999799">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506525999999994" lon="-72.3280031999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5507178999999987" lon="-72.3283203000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5512207999999994" lon="-72.3273377999999809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510089000000029" lon="-72.3274968999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509665000000048" lon="-72.3275241000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538226999999978" lon="-72.3280036000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538862999999985" lon="-72.3282880000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540081000000008" lon="-72.3285723999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542371999999993" lon="-72.3288780000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544456000000046" lon="-72.3290753999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532831000000051" lon="-72.3242184000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529645999999993" lon="-72.3248702000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538267000000019" lon="-72.3313152000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535876000000002" lon="-72.3313823000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534351000000051" lon="-72.3313447000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532366999999994" lon="-72.3312588999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529900999999988" lon="-72.3310630999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502757000000003" lon="-72.3285563000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501284999999996" lon="-72.3286173999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501441999999948" lon="-72.3296397000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510801000000036" lon="-72.3300535999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506117000000010" lon="-72.3297912999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505467000000053" lon="-72.3297577999999817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503029000000019" lon="-72.3300222000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501952000000010" lon="-72.3300325000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502236000000025" lon="-72.3299126999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506039999999999" lon="-72.3306182999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538387000000000" lon="-72.3263723999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505409000000014" lon="-72.3308130000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502247999999987" lon="-72.3312272000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495528999999983" lon="-72.3310746999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495224000000043" lon="-72.3310706999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493990999999951" lon="-72.3310519000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493621999999974" lon="-72.3310545999999874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522393000000001" lon="-72.3293838999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5516074999999994" lon="-72.3287125999999887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5519447999999976" lon="-72.3295004999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5520598999999997" lon="-72.3297694999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522529000000027" lon="-72.3279486999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522601999999992" lon="-72.3283205999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522209999999994" lon="-72.3285287000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522133999999959" lon="-72.3288672999999847">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522437999999994" lon="-72.3290637000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5521220000000007" lon="-72.3291148999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5518447999999978" lon="-72.3292670000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543164999999952" lon="-72.3267647999999923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542306000000039" lon="-72.3267361999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540538999999960" lon="-72.3267505000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5539664000000002" lon="-72.3267716999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538343000000019" lon="-72.3267919000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536591000000008" lon="-72.3269722999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535789999999956" lon="-72.3270619000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535196000000013" lon="-72.3271323999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534140999999977" lon="-72.3263017000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537087999999954" lon="-72.3262431999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535584000000000" lon="-72.3247017999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537475999999977" lon="-72.3246594000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5539251000000007" lon="-72.3245759999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540856000000041" lon="-72.3245528000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537515999999911" lon="-72.3242414999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538896000000015" lon="-72.3241830999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522992999999978" lon="-72.3274013999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544420000000017" lon="-72.3265267999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="101" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541392000000016" lon="-72.3256544000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="101"/>
     </node>
     <node visible="true" id="102" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543860999999950" lon="-72.3303817999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="102"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542945000000010" lon="-72.3303066999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="104" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540835000000044" lon="-72.3303898999999859">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="104"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538850999999951" lon="-72.3303470000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527289000000053" lon="-72.3268364000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529806999999991" lon="-72.3262282000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530899000000034" lon="-72.3261760000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532415999999998" lon="-72.3261027000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533612999999953" lon="-72.3260594999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535946000000003" lon="-72.3259836999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536878999999999" lon="-72.3259488000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538060000000016" lon="-72.3259190999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5539682999999975" lon="-72.3258564000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541866000000013" lon="-72.3257724000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543564999999973" lon="-72.3256398000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536335000000001" lon="-72.3257279999999838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536074999999947" lon="-72.3258663999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535960999999965" lon="-72.3259776999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="120" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535367999999963" lon="-72.3260212999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="120"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535363999999952" lon="-72.3261538000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535053000000012" lon="-72.3263065000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="123" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535400999999993" lon="-72.3264453000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="123"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535727000000001" lon="-72.3265530999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536050999999986" lon="-72.3266672999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536533000000006" lon="-72.3267799000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537571999999997" lon="-72.3268666999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541182999999990" lon="-72.3250641999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538246999999998" lon="-72.3250749999999840">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530784999999980" lon="-72.3238682000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530760999999984" lon="-72.3241596000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530928999999958" lon="-72.3244181999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531014999999968" lon="-72.3246057000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498298000000013" lon="-72.3333745999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500867000000014" lon="-72.3329826999999881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542435999999960" lon="-72.3321554000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536119999999976" lon="-72.3324204999999836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529459000000010" lon="-72.3325899000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5521832999999958" lon="-72.3327050999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530521999999998" lon="-72.3251060999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529454000000023" lon="-72.3251115000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5494118999999991" lon="-72.3250040000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <node visible="true" id="143" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497718999999961" lon="-72.3259137000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="143"/>
     </node>
     <node visible="true" id="144" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5499307999999985" lon="-72.3262083000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="144"/>
     </node>
     <node visible="true" id="145" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502440999999969" lon="-72.3266856999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="145"/>
     </node>
     <node visible="true" id="146" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504323000000042" lon="-72.3269863999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="146"/>
     </node>
     <node visible="true" id="147" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505240999999970" lon="-72.3271114000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="147"/>
     </node>
     <node visible="true" id="148" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505934000000039" lon="-72.3271275000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="148"/>
     </node>
     <node visible="true" id="149" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527706999999999" lon="-72.3287410999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="149"/>
     </node>
     <node visible="true" id="150" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527242000000037" lon="-72.3281744999999887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="150"/>
     </node>
     <node visible="true" id="151" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527404999999987" lon="-72.3279966000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="151"/>
     </node>
     <node visible="true" id="152" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535455999999996" lon="-72.3286817999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="152"/>
     </node>
     <node visible="true" id="153" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500129999999963" lon="-72.3274538000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="153"/>
     </node>
     <node visible="true" id="154" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544079999999987" lon="-72.3293091999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="154"/>
     </node>
     <node visible="true" id="155" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543241000000023" lon="-72.3292582999999922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="155"/>
     </node>
     <node visible="true" id="156" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541765999999981" lon="-72.3291322000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="156"/>
     </node>
     <node visible="true" id="157" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5539655999999979" lon="-72.3289069000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="157"/>
     </node>
     <node visible="true" id="158" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537853000000013" lon="-72.3286324000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="158"/>
     </node>
     <node visible="true" id="159" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536554000000002" lon="-72.3283006999999856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="159"/>
     </node>
     <node visible="true" id="160" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535740000000011" lon="-72.3280673999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="160"/>
     </node>
     <node visible="true" id="161" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500442000000021" lon="-72.3243395999999876">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="161"/>
     </node>
     <node visible="true" id="162" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501791000000011" lon="-72.3246618000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="162"/>
     </node>
     <node visible="true" id="163" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502010000000013" lon="-72.3249153000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="163"/>
     </node>
     <node visible="true" id="164" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502120999999960" lon="-72.3250871999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="164"/>
     </node>
     <node visible="true" id="165" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502374000000039" lon="-72.3252267000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="165"/>
     </node>
     <node visible="true" id="166" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505565000000026" lon="-72.3259639999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="166"/>
     </node>
     <node visible="true" id="167" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506401999999966" lon="-72.3263697000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="167"/>
     </node>
     <node visible="true" id="168" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506804000000045" lon="-72.3269396999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="168"/>
     </node>
     <node visible="true" id="169" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506847999999991" lon="-72.3270545000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="169"/>
     </node>
     <node visible="true" id="170" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543682999999966" lon="-72.3273379000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="170"/>
     </node>
     <node visible="true" id="172" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5539458999999987" lon="-72.3275380000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="172"/>
     </node>
     <node visible="true" id="173" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537990999999991" lon="-72.3276718999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="173"/>
     </node>
     <node visible="true" id="174" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535086999999983" lon="-72.3278652999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="174"/>
     </node>
     <node visible="true" id="175" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533290000000015" lon="-72.3281110000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="175"/>
     </node>
     <node visible="true" id="176" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532410000000034" lon="-72.3282630000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="176"/>
     </node>
     <node visible="true" id="177" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531709999999954" lon="-72.3284539999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="177"/>
     </node>
     <node visible="true" id="178" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531289999999984" lon="-72.3286339999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="178"/>
     </node>
     <node visible="true" id="179" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531265999999988" lon="-72.3286884000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="179"/>
     </node>
     <node visible="true" id="180" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531234999999981" lon="-72.3287229999999823">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="180"/>
     </node>
     <node visible="true" id="181" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531050000000022" lon="-72.3288710000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="181"/>
     </node>
     <node visible="true" id="182" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530620000000006" lon="-72.3290140000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="182"/>
     </node>
     <node visible="true" id="183" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530180000000051" lon="-72.3291099999999858">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="183"/>
     </node>
     <node visible="true" id="184" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529289999999953" lon="-72.3292339999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="184"/>
     </node>
     <node visible="true" id="185" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5528313999999988" lon="-72.3293204000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="185"/>
     </node>
     <node visible="true" id="186" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5526544000000051" lon="-72.3294216000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="186"/>
     </node>
     <node visible="true" id="187" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525516000000046" lon="-72.3295150999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="187"/>
     </node>
     <node visible="true" id="188" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524763999999998" lon="-72.3295717999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="188"/>
     </node>
     <node visible="true" id="189" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5523139999999955" lon="-72.3297740000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="189"/>
     </node>
     <node visible="true" id="190" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525153999999972" lon="-72.3259235999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="190"/>
     </node>
     <node visible="true" id="191" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524163000000044" lon="-72.3259532999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="191"/>
     </node>
     <node visible="true" id="192" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5523454000000037" lon="-72.3260370999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="192"/>
     </node>
     <node visible="true" id="193" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509041000000003" lon="-72.3278822000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="193"/>
     </node>
     <node visible="true" id="194" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505929000000016" lon="-72.3278839999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="194"/>
     </node>
     <node visible="true" id="195" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503770999999951" lon="-72.3278995999999808">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="195"/>
     </node>
     <node visible="true" id="196" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500153999999995" lon="-72.3280074000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="196"/>
     </node>
     <node visible="true" id="197" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496963000000008" lon="-72.3281426000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="197"/>
     </node>
     <node visible="true" id="198" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492360000000076" lon="-72.3301551999999788">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="198"/>
     </node>
     <node visible="true" id="199" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493823999999989" lon="-72.3304423000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="199"/>
     </node>
     <node visible="true" id="200" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495640000000002" lon="-72.3308090000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="200"/>
     </node>
     <node visible="true" id="201" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496110999999999" lon="-72.3310613999999816">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="201"/>
     </node>
     <node visible="true" id="202" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496774000000002" lon="-72.3314172999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="202"/>
     </node>
     <node visible="true" id="203" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496887999999949" lon="-72.3315513999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="203"/>
     </node>
     <node visible="true" id="204" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496758999999969" lon="-72.3317031999999926">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="204"/>
     </node>
     <node visible="true" id="205" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495948000000013" lon="-72.3321949000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="205"/>
     </node>
     <node visible="true" id="206" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495769000000053" lon="-72.3323962999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="206"/>
     </node>
     <node visible="true" id="207" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495756000000007" lon="-72.3325063000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="207"/>
     </node>
     <node visible="true" id="208" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511754999999958" lon="-72.3310312999999923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="208"/>
     </node>
     <node visible="true" id="209" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510896000000010" lon="-72.3305217000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="209"/>
     </node>
     <node visible="true" id="210" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510606000000031" lon="-72.3304298999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="210"/>
     </node>
     <node visible="true" id="211" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509665000000048" lon="-72.3302741999999910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="211"/>
     </node>
     <node visible="true" id="213" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503907000000083" lon="-72.3331663999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="213"/>
     </node>
     <node visible="true" id="214" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502363000000017" lon="-72.3333558000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="214"/>
     </node>
     <node visible="true" id="215" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506421000000010" lon="-72.3305706999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="215"/>
     </node>
     <node visible="true" id="216" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531944000000024" lon="-72.3325164999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="216"/>
     </node>
     <node visible="true" id="217" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531285000000032" lon="-72.3325243000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="217"/>
     </node>
     <node visible="true" id="218" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534929999999960" lon="-72.3334401000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="218"/>
     </node>
     <node visible="true" id="219" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533895999999991" lon="-72.3328625000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="219"/>
     </node>
     <node visible="true" id="220" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533134999999980" lon="-72.3329027999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="220"/>
     </node>
     <node visible="true" id="221" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540593999999999" lon="-72.3255378000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="221"/>
     </node>
     <node visible="true" id="222" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538412000000008" lon="-72.3255766000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="222"/>
     </node>
     <node visible="true" id="223" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5537329000000035" lon="-72.3255221999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="223"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536471000000027" lon="-72.3254979999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533391999999964" lon="-72.3256236999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530229999999996" lon="-72.3257854000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5513605000000013" lon="-72.3240219000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514113999999957" lon="-72.3248586999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="229" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497717000000009" lon="-72.3286935000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="229"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498311999999963" lon="-72.3291756999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500164999999981" lon="-72.3297795999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502764000000013" lon="-72.3306062999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497852999999999" lon="-72.3259386999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491630999999977" lon="-72.3246213999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491424999999985" lon="-72.3246386000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493031999999971" lon="-72.3248030999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492803000000031" lon="-72.3248255000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496808999999949" lon="-72.3255687999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496536000000027" lon="-72.3255800999999821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514529000000010" lon="-72.3289096999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="241" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5513702999999950" lon="-72.3285839999999922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="241"/>
     </node>
     <node visible="true" id="242" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511838000000004" lon="-72.3281194999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="242"/>
     </node>
     <node visible="true" id="243" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534078999999998" lon="-72.3334571999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="243"/>
     </node>
     <node visible="true" id="244" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491649999999986" lon="-72.3300159000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="244"/>
     </node>
     <node visible="true" id="245" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498134000000015" lon="-72.3259232999999853">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="245"/>
     </node>
     <node visible="true" id="246" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524592999999918" lon="-72.3267308000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="246"/>
     </node>
     <node visible="true" id="247" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5523536000000036" lon="-72.3268867000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="247"/>
     </node>
     <node visible="true" id="248" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522223000000004" lon="-72.3270179000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="248"/>
     </node>
     <node visible="true" id="249" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5520080000000043" lon="-72.3272863999999913">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="249"/>
     </node>
     <node visible="true" id="250" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5517922000000048" lon="-72.3275780999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="250"/>
     </node>
     <node visible="true" id="251" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514909000000010" lon="-72.3277413999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="251"/>
     </node>
     <node visible="true" id="252" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5512028999999998" lon="-72.3278873999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="252"/>
     </node>
     <node visible="true" id="253" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5512340000000044" lon="-72.3293253999999877">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="253"/>
     </node>
     <node visible="true" id="254" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511113999999999" lon="-72.3293629000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="254"/>
     </node>
     <node visible="true" id="255" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509510000000013" lon="-72.3293359999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="255"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5508021999999997" lon="-72.3292693000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5507075999999955" lon="-72.3292268000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="258" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505857999999968" lon="-72.3293144999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="258"/>
     </node>
     <node visible="true" id="259" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504889999999989" lon="-72.3294056000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="259"/>
     </node>
     <node visible="true" id="260" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504241999999984" lon="-72.3294771000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="260"/>
     </node>
     <node visible="true" id="261" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502588999999993" lon="-72.3295039000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="261"/>
     </node>
     <node visible="true" id="262" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5499325000000042" lon="-72.3295384999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="262"/>
     </node>
     <node visible="true" id="263" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492021999999963" lon="-72.3283217999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="263"/>
     </node>
     <node visible="true" id="264" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491365999999971" lon="-72.3282410999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="264"/>
     </node>
     <node visible="true" id="265" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533819999999992" lon="-72.3334624000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="265"/>
     </node>
     <node visible="true" id="266" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533511000000004" lon="-72.3332458999999801">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="266"/>
     </node>
     <node visible="true" id="267" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532846000000013" lon="-72.3329157999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="267"/>
     </node>
     <node visible="true" id="268" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5532286999999982" lon="-72.3327891999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="268"/>
     </node>
     <node visible="true" id="269" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530968999999999" lon="-72.3325355999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="269"/>
     </node>
     <node visible="true" id="270" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529469000000020" lon="-72.3322299000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="270"/>
     </node>
     <node visible="true" id="271" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527450000000016" lon="-72.3317430999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="271"/>
     </node>
     <node visible="true" id="272" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527067000000017" lon="-72.3314167999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="272"/>
     </node>
     <node visible="true" id="273" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524273000000015" lon="-72.3306599999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="273"/>
     </node>
     <node visible="true" id="275" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497919999999965" lon="-72.3307539999999847">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="275"/>
     </node>
     <node visible="true" id="276" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496191000000010" lon="-72.3302228999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="276"/>
     </node>
     <node visible="true" id="277" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5495133000000010" lon="-72.3299071999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="277"/>
     </node>
     <node visible="true" id="278" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5494371000000022" lon="-72.3296684999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="278"/>
     </node>
     <node visible="true" id="279" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492966999999958" lon="-72.3292778999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="279"/>
     </node>
     <node visible="true" id="280" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5520121000000024" lon="-72.3300100000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="280"/>
     </node>
     <node visible="true" id="281" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5518381999999953" lon="-72.3300760000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="281"/>
     </node>
     <node visible="true" id="282" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514718999999992" lon="-72.3302264000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="282"/>
     </node>
     <node visible="true" id="283" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500201000000047" lon="-72.3239181000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="283"/>
     </node>
     <node visible="true" id="284" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492509999999946" lon="-72.3238656999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="284"/>
     </node>
     <node visible="true" id="285" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493665999999990" lon="-72.3282612999999799">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="285"/>
     </node>
     <node visible="true" id="286" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5507885000000030" lon="-72.3240327000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="286"/>
     </node>
     <node visible="true" id="287" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541467000000004" lon="-72.3240875999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="287"/>
     </node>
     <node visible="true" id="288" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542882000000020" lon="-72.3244820999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="288"/>
     </node>
     <node visible="true" id="289" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543736000000052" lon="-72.3246927999999798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="289"/>
     </node>
     <node visible="true" id="290" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527769999999954" lon="-72.3307489000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="290"/>
     </node>
     <node visible="true" id="291" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5531132999999997" lon="-72.3306028999999882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="291"/>
     </node>
     <node visible="true" id="292" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5499846999999995" lon="-72.3241998999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="292"/>
     </node>
     <node visible="true" id="293" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498182000000043" lon="-72.3240992000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="293"/>
     </node>
     <node visible="true" id="294" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493833999999964" lon="-72.3241088999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="294"/>
     </node>
     <node visible="true" id="295" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491757999999933" lon="-72.3241385999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="295"/>
     </node>
     <node visible="true" id="296" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5517043999999984" lon="-72.3311597000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="296"/>
     </node>
     <node visible="true" id="297" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530791000000015" lon="-72.3318462999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="297"/>
     </node>
     <node visible="true" id="298" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529213999999989" lon="-72.3318972999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="298"/>
     </node>
     <node visible="true" id="299" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5521321999999991" lon="-72.3299257999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="299"/>
     </node>
     <node visible="true" id="300" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525112999999990" lon="-72.3308425000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="300"/>
     </node>
     <node visible="true" id="301" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5526336000000001" lon="-72.3308080000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="301"/>
     </node>
     <node visible="true" id="302" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5529581999999991" lon="-72.3299437999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="302"/>
     </node>
     <node visible="true" id="303" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5522137999999970" lon="-72.3300650999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="303"/>
     </node>
     <node visible="true" id="304" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5528117000000030" lon="-72.3319376999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="304"/>
     </node>
     <node visible="true" id="305" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527930000000012" lon="-72.3319613000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="305"/>
     </node>
     <node visible="true" id="306" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525996000000006" lon="-72.3320618000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="306"/>
     </node>
     <node visible="true" id="307" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5523468000000022" lon="-72.3321616000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="307"/>
     </node>
     <node visible="true" id="308" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5520818999999975" lon="-72.3322502000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="308"/>
     </node>
     <node visible="true" id="309" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5518893999999968" lon="-72.3241398999999916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="309"/>
     </node>
     <node visible="true" id="310" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5519402999999983" lon="-72.3245047000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="310"/>
     </node>
     <node visible="true" id="311" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5520622999999958" lon="-72.3250732999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="311"/>
     </node>
     <node visible="true" id="312" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5520521999999950" lon="-72.3253952000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="312"/>
     </node>
     <node visible="true" id="313" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5519707999999959" lon="-72.3255668000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="313"/>
     </node>
     <node visible="true" id="314" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5528487999999996" lon="-72.3250739000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="314"/>
     </node>
     <node visible="true" id="317" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506552000000013" lon="-72.3271138000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="317"/>
     </node>
     <node visible="true" id="318" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506597999999983" lon="-72.3271359999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="318"/>
     </node>
     <node visible="true" id="319" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510872000000013" lon="-72.3248964999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="319"/>
     </node>
     <node visible="true" id="320" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511474000000050" lon="-72.3252489000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="320"/>
     </node>
     <node visible="true" id="321" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514730000000014" lon="-72.3259539999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="321"/>
     </node>
     <node visible="true" id="322" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514934000000054" lon="-72.3259960000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="322"/>
     </node>
     <node visible="true" id="323" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5515669000000010" lon="-72.3262354999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="323"/>
     </node>
     <node visible="true" id="324" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5518679999999954" lon="-72.3266126999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="324"/>
     </node>
     <node visible="true" id="325" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509219000000023" lon="-72.3275548000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="325"/>
     </node>
     <node visible="true" id="326" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5508757000000024" lon="-72.3275637999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="326"/>
     </node>
     <node visible="true" id="327" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5508147000000001" lon="-72.3275543000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="327"/>
     </node>
     <node visible="true" id="328" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511310999999957" lon="-72.3279239000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="328"/>
     </node>
     <node visible="true" id="329" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511076999999993" lon="-72.3279356999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="329"/>
     </node>
     <node visible="true" id="330" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509376000000010" lon="-72.3279995000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="330"/>
     </node>
     <node visible="true" id="331" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525239999999947" lon="-72.3246062999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="331"/>
     </node>
     <node visible="true" id="332" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525577999999989" lon="-72.3249667999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="332"/>
     </node>
     <node visible="true" id="333" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5526493000000023" lon="-72.3254120000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="333"/>
     </node>
     <node visible="true" id="334" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527358000000042" lon="-72.3254979000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="334"/>
     </node>
     <node visible="true" id="335" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544521999999965" lon="-72.3283755000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="335"/>
     </node>
     <node visible="true" id="336" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543805999999947" lon="-72.3282518000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="336"/>
     </node>
     <node visible="true" id="337" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5543320000000023" lon="-72.3281410999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="337"/>
     </node>
     <node visible="true" id="338" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542970999999994" lon="-72.3279839000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="338"/>
     </node>
     <node visible="true" id="339" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542919999999967" lon="-72.3278310000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="339"/>
     </node>
     <node visible="true" id="340" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542735999999948" lon="-72.3277356999999910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="340"/>
     </node>
     <node visible="true" id="341" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542437000000042" lon="-72.3276351999999889">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="341"/>
     </node>
     <node visible="true" id="342" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541832999999983" lon="-72.3274973999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="342"/>
     </node>
     <node visible="true" id="343" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541164000000016" lon="-72.3273662999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="343"/>
     </node>
     <node visible="true" id="344" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510193000000001" lon="-72.3254826000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="344"/>
     </node>
     <node visible="true" id="345" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511311999999968" lon="-72.3258687999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="345"/>
     </node>
     <node visible="true" id="346" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506367999999995" lon="-72.3261621999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="346"/>
     </node>
     <node visible="true" id="347" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505178999999991" lon="-72.3302271000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="347"/>
     </node>
     <node visible="true" id="348" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504947000000051" lon="-72.3302589000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="348"/>
     </node>
     <node visible="true" id="349" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504941000000017" lon="-72.3303255999999806">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="349"/>
     </node>
     <node visible="true" id="350" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505197999999965" lon="-72.3304088999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="350"/>
     </node>
     <node visible="true" id="351" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505686999999959" lon="-72.3305423999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="351"/>
     </node>
     <node visible="true" id="352" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503675000000001" lon="-72.3255687999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="352"/>
     </node>
     <node visible="true" id="353" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502655999999959" lon="-72.3256054000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="353"/>
     </node>
     <node visible="true" id="354" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501897999999983" lon="-72.3256324999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="354"/>
     </node>
     <node visible="true" id="355" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501390000000015" lon="-72.3256614999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="355"/>
     </node>
     <node visible="true" id="356" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501207999999984" lon="-72.3256939000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="356"/>
     </node>
     <node visible="true" id="357" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500757000000078" lon="-72.3257255999999842">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="357"/>
     </node>
     <node visible="true" id="358" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500237000000006" lon="-72.3257520999999883">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="358"/>
     </node>
     <node visible="true" id="359" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5499378999999998" lon="-72.3257870999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="359"/>
     </node>
     <node visible="true" id="360" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5494425000000049" lon="-72.3248640999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="360"/>
     </node>
     <node visible="true" id="361" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5494008999999984" lon="-72.3248281000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="361"/>
     </node>
     <node visible="true" id="362" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5493478000000032" lon="-72.3247594000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="362"/>
     </node>
     <node visible="true" id="363" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492114000000043" lon="-72.3245811999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="363"/>
     </node>
     <node visible="true" id="364" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496401999999989" lon="-72.3252954000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="364"/>
     </node>
     <node visible="true" id="365" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496740999999972" lon="-72.3253984999999915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="365"/>
     </node>
     <node visible="true" id="366" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497269999999972" lon="-72.3255496999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="366"/>
     </node>
     <node visible="true" id="367" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497736999999994" lon="-72.3256786999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="367"/>
     </node>
     <node visible="true" id="368" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498344999999958" lon="-72.3258273999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="368"/>
     </node>
     <node visible="true" id="369" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5498677000000036" lon="-72.3258945999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="369"/>
     </node>
     <node visible="true" id="370" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5499942999999980" lon="-72.3260580999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="370"/>
     </node>
     <node visible="true" id="371" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5501910000000052" lon="-72.3262232999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="371"/>
     </node>
     <node visible="true" id="372" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5502505999999983" lon="-72.3262688999999881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="372"/>
     </node>
     <node visible="true" id="373" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503113000000006" lon="-72.3263230999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="373"/>
     </node>
     <node visible="true" id="374" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504141000000011" lon="-72.3264539999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="374"/>
     </node>
     <node visible="true" id="375" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504597999999952" lon="-72.3265497999999809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="375"/>
     </node>
     <node visible="true" id="376" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505074999999948" lon="-72.3266655000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="376"/>
     </node>
     <node visible="true" id="377" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505476000000016" lon="-72.3267124000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="377"/>
     </node>
     <node visible="true" id="378" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5506060999999995" lon="-72.3267249999999819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="378"/>
     </node>
     <node visible="true" id="379" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503605000000000" lon="-72.3295636999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="379"/>
     </node>
     <node visible="true" id="380" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5503288999999967" lon="-72.3295052999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="380"/>
     </node>
     <node visible="true" id="382" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535302000000009" lon="-72.3251171999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="382"/>
     </node>
     <node visible="true" id="383" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534688999999986" lon="-72.3249172999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="383"/>
     </node>
     <node visible="true" id="384" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534407999999971" lon="-72.3247147999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="384"/>
     </node>
     <node visible="true" id="385" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533526000000002" lon="-72.3242949999999922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="385"/>
     </node>
     <node visible="true" id="386" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533348000000018" lon="-72.3241685999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="386"/>
     </node>
     <node visible="true" id="387" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5519901999999988" lon="-72.3319896000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="387"/>
     </node>
     <node visible="true" id="388" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524650000000051" lon="-72.3317566999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="388"/>
     </node>
     <node visible="true" id="389" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5527383999999991" lon="-72.3316868999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="389"/>
     </node>
     <node visible="true" id="390" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5514633000000018" lon="-72.3314754000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="390"/>
     </node>
     <node visible="true" id="391" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5513543000000034" lon="-72.3303341999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="391"/>
     </node>
     <node visible="true" id="392" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5511516999999984" lon="-72.3306101999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="392"/>
     </node>
     <node visible="true" id="393" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509790999999957" lon="-72.3308779999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="393"/>
     </node>
     <node visible="true" id="394" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509516000000012" lon="-72.3309206999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="394"/>
     </node>
     <node visible="true" id="395" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5508793999999995" lon="-72.3310302999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="395"/>
     </node>
     <node visible="true" id="396" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5505437999999998" lon="-72.3315015999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="396"/>
     </node>
     <node visible="true" id="397" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5497548999999999" lon="-72.3326002000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="397"/>
     </node>
     <node visible="true" id="398" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5496036000000046" lon="-72.3327249000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="398"/>
     </node>
     <node visible="true" id="399" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5494458999999985" lon="-72.3327998999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="399"/>
     </node>
     <node visible="true" id="400" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491884999999961" lon="-72.3329465999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="400"/>
     </node>
     <node visible="true" id="403" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544624000000020" lon="-72.3333188000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="403"/>
     </node>
     <node visible="true" id="404" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5542487999999963" lon="-72.3333777999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="404"/>
     </node>
     <node visible="true" id="405" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541975000000008" lon="-72.3333635000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="405"/>
     </node>
     <node visible="true" id="406" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5541699000000051" lon="-72.3333108000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="406"/>
     </node>
     <node visible="true" id="407" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540340999999955" lon="-72.3323024999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="407"/>
     </node>
     <node visible="true" id="408" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533833999999977" lon="-72.3262395999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="408"/>
     </node>
     <node visible="true" id="409" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535318999999994" lon="-72.3262337999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="409"/>
     </node>
     <node visible="true" id="410" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5525203000000012" lon="-72.3276416000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="410"/>
     </node>
     <node visible="true" id="411" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524040999999968" lon="-72.3276484000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="411"/>
     </node>
     <node visible="true" id="412" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524148999999987" lon="-72.3273877000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="412"/>
     </node>
     <node visible="true" id="413" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5536281541400037" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="413"/>
     </node>
     <node visible="true" id="414" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544679999999964" lon="-72.3333169963399882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="414"/>
     </node>
     <node visible="true" id="417" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3329918380999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="417"/>
     </node>
     <node visible="true" id="418" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3244770397700023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="418"/>
     </node>
     <node visible="true" id="419" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3284039917999877">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="419"/>
     </node>
     <node visible="true" id="420" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524533199800032" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="420"/>
     </node>
     <node visible="true" id="421" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5510439094399970" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="421"/>
     </node>
     <node visible="true" id="424" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5528052166099968" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="424"/>
     </node>
     <node visible="true" id="425" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5518595033700002" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="425"/>
     </node>
     <node visible="true" id="426" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491219999999934" lon="-72.3241723468100020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="426"/>
     </node>
     <node visible="true" id="427" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540877639299993" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="427"/>
     </node>
     <node visible="true" id="428" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5507733596600026" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="428"/>
     </node>
     <node visible="true" id="429" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491219999999934" lon="-72.3279090720599953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="429"/>
     </node>
     <node visible="true" id="430" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5492689203300039" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="430"/>
     </node>
     <node visible="true" id="431" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5500808295400041" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="431"/>
     </node>
     <node visible="true" id="432" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5534069568699955" lon="-72.3336410000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="432"/>
     </node>
     <node visible="true" id="433" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3282231818199932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="433"/>
     </node>
     <node visible="true" id="434" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5513581066600004" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="434"/>
     </node>
     <node visible="true" id="435" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5504668051499984" lon="-72.3336410000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="435"/>
     </node>
     <node visible="true" id="437" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3299060897900006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="437"/>
     </node>
     <node visible="true" id="438" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000035" lon="-72.3273539784099881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="438"/>
     </node>
     <node visible="true" id="439" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3293278217600033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="439"/>
     </node>
     <node visible="true" id="440" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3246114749999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="440"/>
     </node>
     <node visible="true" id="441" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3319599967999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="441"/>
     </node>
     <node visible="true" id="442" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5530779133700001" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="442"/>
     </node>
     <node visible="true" id="443" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544679999999964" lon="-72.3251085983099813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="443"/>
     </node>
     <node visible="true" id="444" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3259222472100021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="444"/>
     </node>
     <node visible="true" id="445" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3305841355000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="445"/>
     </node>
     <node visible="true" id="448" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000035" lon="-72.3324209954400033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="448"/>
     </node>
     <node visible="true" id="449" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3302185715999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="449"/>
     </node>
     <node visible="true" id="450" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3310994143899961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="450"/>
     </node>
     <node visible="true" id="451" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533231619100043" lon="-72.3238520000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="451"/>
     </node>
     <node visible="true" id="452" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3249445333299974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="452"/>
     </node>
     <node visible="true" id="453" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544680000000000" lon="-72.3290867606900036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="453"/>
     </node>
     <node visible="true" id="455" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3240650383200006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="455"/>
     </node>
     <node visible="true" id="456" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5524199505100000" lon="-72.3336410000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="456"/>
     </node>
     <node visible="true" id="457" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000041" lon="-72.3282453954600015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="457"/>
     </node>
     <node visible="true" id="458" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5491220000000006" lon="-72.3286336823299933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="458"/>
     </node>
     <node visible="true" id="459" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5544679999999964" lon="-72.3264713622800031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="459"/>
     </node>
     <node visible="true" id="462" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5509473932900022" lon="-72.3336410000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="462"/>
     </node>
     <node visible="true" id="463" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5538129000000005" lon="-72.3271280000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="463"/>
     </node>
     <node visible="true" id="464" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5540690000000019" lon="-72.3274008000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="464"/>
     </node>
     <node visible="true" id="465" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5535640999999991" lon="-72.3238671999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="465"/>
     </node>
     <node visible="true" id="466" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109" lat="18.5533232999999953" lon="-72.3238879999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="466"/>
     </node>
     <way visible="true" id="-4584" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="299"/>
@@ -1881,6 +1419,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Péan"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1898,9 +1438,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4584"/>
     </way>
     <way visible="true" id="-67" timestamp="2017-06-07T14:36:36Z" version="1">
         <nd ref="300"/>
@@ -1910,6 +1447,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1921,9 +1460,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-67"/>
     </way>
     <way visible="true" id="-62" timestamp="2017-06-07T14:36:36Z" version="1">
         <nd ref="269"/>
@@ -1933,6 +1469,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1944,9 +1482,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-62"/>
     </way>
     <way visible="true" id="-61" timestamp="2017-06-07T14:36:36Z" version="1">
         <nd ref="269"/>
@@ -1955,25 +1490,24 @@
         <nd ref="-48"/>
         <nd ref="-47"/>
         <nd ref="-217"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{d061d842-3aec-42a8-a282-1b6d81c2d38f}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-61"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{d061d842-3aec-42a8-a282-1b6d81c2d38f}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-43" timestamp="2017-06-07T14:36:36Z" version="1">
         <nd ref="327"/>
@@ -1986,6 +1520,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1997,80 +1533,74 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-43"/>
     </way>
     <way visible="true" id="-21" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108">
         <nd ref="35"/>
         <nd ref="-137"/>
         <nd ref="-136"/>
         <nd ref="35"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.139Z"/>
-        <tag k="location" v="overground"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{c8711a67-4f55-4d88-879c-3ef775fad316}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-21"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{c8711a67-4f55-4d88-879c-3ef775fad316}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.139Z"/>
+        <tag k="location" v="overground"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-19" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108">
         <nd ref="280"/>
         <nd ref="299"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.140Z"/>
-        <tag k="location" v="overground"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{9af3aa00-e76c-41f5-99f2-86acbd3264c0}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-19"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{9af3aa00-e76c-41f5-99f2-86acbd3264c0}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.140Z"/>
+        <tag k="location" v="overground"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-14" timestamp="2017-06-07T14:36:36Z" version="1" changeset="108">
         <nd ref="-81"/>
         <nd ref="216"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.142Z"/>
-        <tag k="location" v="overground"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{b027a453-7fe5-4884-bc4f-d003ff4a69aa}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{b027a453-7fe5-4884-bc4f-d003ff4a69aa}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.142Z"/>
+        <tag k="location" v="overground"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="13"/>
@@ -2088,15 +1618,14 @@
         <nd ref="1"/>
         <tag k="source:name" v="DMA Topo Map 1994"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Delorme"/>
         <tag k="uuid" v="{d5b9a558-8fe3-4b7b-8c5c-2534169882e5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="200"/>
@@ -2107,27 +1636,25 @@
         <nd ref="14"/>
         <nd ref="232"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{99f038b1-72dc-4877-8537-7c9e772e5b5f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="20"/>
         <nd ref="65"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2232350a-ebde-4a78-83e5-7290f58ca3ee}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="23"/>
@@ -2135,14 +1662,13 @@
         <nd ref="21"/>
         <nd ref="263"/>
         <tag k="source" v="Google 2010-01-17; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{13f1660d-a5c5-4aba-81ad-6eab217fa755}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="31"/>
@@ -2150,27 +1676,25 @@
         <nd ref="30"/>
         <nd ref="53"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b0b75ed1-8e9e-4732-96cd-7303f4d5f51e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="33"/>
         <nd ref="32"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{81277b50-099b-4d81-8e3e-4b1af9761c44}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="35"/>
@@ -2182,6 +1706,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Bergeaud"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2199,9 +1725,6 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="track"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="325"/>
@@ -2213,6 +1736,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Barthélemy"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2228,36 +1753,31 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="229"/>
         <nd ref="54"/>
         <nd ref="53"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{34c4fb35-d250-4d5d-a744-d9059abad3d2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="231"/>
         <nd ref="55"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7ae14b9f-cbd3-4371-aed8-0eedcb52a277}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="61"/>
@@ -2268,34 +1788,33 @@
         <nd ref="56"/>
         <nd ref="211"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{bbccbd18-998b-416e-8bd1-8715a824acbd}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="394"/>
         <nd ref="62"/>
         <nd ref="351"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0a1fb2af-63fd-4f33-a90f-069c6de26135}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="14" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="383"/>
         <nd ref="289"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Decastine"/>
@@ -2306,22 +1825,19 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="63"/>
         <nd ref="86"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1ef3df59-c563-4e02-820b-ab8f6893ba58}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="396"/>
@@ -2329,6 +1845,7 @@
         <nd ref="64"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Saint Félix"/>
@@ -2339,9 +1856,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="70"/>
@@ -2350,28 +1865,26 @@
         <nd ref="67"/>
         <nd ref="201"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{02c14e7d-c83f-44ac-b271-9871bdf50290}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="74"/>
         <nd ref="71"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="service" v="destination"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{8ceeb991-47b3-4207-a419-4b8de46763b4}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="299"/>
@@ -2381,6 +1894,7 @@
         <nd ref="73"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="GPS/Walking Papers;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="2e Ruelle Candio"/>
@@ -2391,9 +1905,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="82"/>
@@ -2404,21 +1916,21 @@
         <nd ref="77"/>
         <nd ref="76"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="service" v="destination"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1118d45e-2b7e-47f7-8849-5ca1b630cee3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="292"/>
         <nd ref="286"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="incline" v="yes"/>
@@ -2430,9 +1942,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="127"/>
@@ -2442,15 +1952,14 @@
         <nd ref="84"/>
         <nd ref="83"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Sureau"/>
         <tag k="uuid" v="{78386e91-cce6-40db-acb0-59c3b94e471a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="5"/>
@@ -2459,21 +1968,21 @@
         <nd ref="88"/>
         <nd ref="127"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Mazaire"/>
         <tag k="uuid" v="{ef90948c-3fe5-4772-84ec-250bec9e08f2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="92"/>
         <nd ref="91"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mariela"/>
@@ -2484,9 +1993,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="288"/>
@@ -2497,6 +2004,7 @@
         <nd ref="384"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Platane"/>
@@ -2507,9 +2015,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="287"/>
@@ -2518,6 +2024,7 @@
         <nd ref="385"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Pouget"/>
@@ -2528,9 +2035,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="27" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="249"/>
@@ -2538,15 +2043,14 @@
         <nd ref="412"/>
         <nd ref="5"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Quisqueya"/>
         <tag k="uuid" v="{4ff0fc75-6418-4f85-afdc-fdf8906eb3ed}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="129"/>
@@ -2560,6 +2064,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Randot"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2577,9 +2083,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="115"/>
@@ -2595,15 +2098,14 @@
         <nd ref="12"/>
         <nd ref="106"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Oreste"/>
         <tag k="uuid" v="{3febf4de-9902-4e92-a2f0-6a6812c45a29}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="127"/>
@@ -2620,40 +2122,37 @@
         <nd ref="117"/>
         <nd ref="224"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ae9974c7-5d7e-4278-b9f8-6dcc90df6711}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="135"/>
         <nd ref="134"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d5bec77-bd49-41e4-affa-0ea5706a70fc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="267"/>
         <nd ref="220"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7a2ef99f-899b-49c5-a3b5-69fbe3768b30}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="139"/>
@@ -2666,6 +2165,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2683,9 +2184,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="314"/>
@@ -2694,6 +2192,7 @@
         <nd ref="383"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Decastine"/>
@@ -2704,9 +2203,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="2"/>
@@ -2718,6 +2215,7 @@
         <nd ref="291"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Barthélemy"/>
@@ -2728,9 +2226,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="158"/>
@@ -2738,6 +2234,7 @@
         <nd ref="179"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Durochér"/>
@@ -2748,14 +2245,13 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="234"/>
         <nd ref="-245"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2763,14 +2259,13 @@
         <tag k="uuid" v="{290423c8-6036-4d21-a5a5-32c689a2ac1a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="236"/>
         <nd ref="-244"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2778,28 +2273,26 @@
         <tag k="uuid" v="{8a61dbf4-99f1-4156-94fc-02e009fd3532}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="318"/>
         <nd ref="153"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Aupont"/>
         <tag k="uuid" v="{698a9aa1-600b-4523-8c89-5c65b3425e6f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <way visible="true" id="40" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="238"/>
         <nd ref="-246"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2807,9 +2300,7 @@
         <tag k="uuid" v="{ad418308-bd52-49ac-97a1-03d64e25f9e5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="40"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="317"/>
@@ -2832,6 +2323,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Ti Chérie"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2849,9 +2342,6 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="324"/>
@@ -2864,6 +2354,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Bergeaud"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2878,9 +2370,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="43" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="285"/>
@@ -2891,6 +2380,7 @@
         <nd ref="193"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Anglade"/>
@@ -2901,22 +2391,19 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="208"/>
         <nd ref="393"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{788c8e7d-89fb-4ef7-8b01-cf61fa71b275}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="44"/>
     </way>
     <way visible="true" id="45" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="211"/>
@@ -2924,33 +2411,32 @@
         <nd ref="209"/>
         <nd ref="392"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5cae3703-1a2f-4861-86fc-b1c2fa49b96d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="45"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="392"/>
         <nd ref="215"/>
         <nd ref="351"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{bbda911c-e77f-4356-9a08-3c837fd88050}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="47" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="304"/>
         <nd ref="298"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2958,14 +2444,13 @@
         <tag k="uuid" v="{aa330091-6313-4759-b909-1852be6e491a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="47"/>
     </way>
     <way visible="true" id="48" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="217"/>
         <nd ref="216"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2974,14 +2459,13 @@
         <tag k="uuid" v="{8c19f6b5-0a0e-4f20-80dd-0c2b051ab13b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="48"/>
     </way>
     <way visible="true" id="49" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="243"/>
         <nd ref="218"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2989,14 +2473,13 @@
         <tag k="uuid" v="{b4e0cca5-5fe3-443b-9ac4-4d9164216888}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="49"/>
     </way>
     <way visible="true" id="50" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="220"/>
         <nd ref="219"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3004,14 +2487,13 @@
         <tag k="uuid" v="{65da41d2-4f9f-41f3-9319-1515681a454d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="50"/>
     </way>
     <way visible="true" id="51" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="-239"/>
         <nd ref="303"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3019,9 +2501,7 @@
         <tag k="uuid" v="{bf30b300-ba5e-489e-9d50-498901ea39fb}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="51"/>
     </way>
     <way visible="true" id="52" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="280"/>
@@ -3029,6 +2509,7 @@
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3038,9 +2519,7 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="52"/>
     </way>
     <way visible="true" id="53" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="13"/>
@@ -3056,6 +2535,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Bergeaud"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3073,9 +2554,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt;heavy_truck_less_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="53"/>
     </way>
     <way visible="true" id="54" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="232"/>
@@ -3085,6 +2563,7 @@
         <nd ref="229"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle F. Doret"/>
@@ -3095,61 +2574,55 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="54"/>
     </way>
     <way visible="true" id="55" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="233"/>
         <nd ref="245"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{8cb761fc-e604-4d48-b3b7-15e273298316}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="55"/>
     </way>
     <way visible="true" id="56" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="235"/>
         <nd ref="234"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0e3c3e54-76e6-4239-ae7e-3e4d9f07952c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="56"/>
     </way>
     <way visible="true" id="57" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="237"/>
         <nd ref="236"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{27276783-dfd2-423f-ac7e-d7992e72a931}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="57"/>
     </way>
     <way visible="true" id="58" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="239"/>
         <nd ref="238"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{14c54b52-99ce-4026-8942-ccb1cec87b91}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="58"/>
     </way>
     <way visible="true" id="59" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="329"/>
@@ -3157,45 +2630,43 @@
         <nd ref="241"/>
         <nd ref="240"/>
         <tag k="source" v="Bing; Yahoo hires;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{60ff6b05-b376-4150-ac1a-a7136dffd4f6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="59"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="265"/>
         <nd ref="243"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{a0d2de4d-dc67-42d5-b8ec-205d8eda4747}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
     <way visible="true" id="61" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="277"/>
         <nd ref="244"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{baeee9fa-8494-4553-84ca-69e7f2d30cde}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="61"/>
     </way>
     <way visible="true" id="62" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="245"/>
         <nd ref="-247"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3203,14 +2674,13 @@
         <tag k="uuid" v="{63737810-dc35-4908-af84-c09964d81021}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="62"/>
     </way>
     <way visible="true" id="63" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="328"/>
         <nd ref="252"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3219,9 +2689,7 @@
         <tag k="uuid" v="{1c05c86f-c201-4acf-b6e9-6ce9ef9dc457}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="63"/>
     </way>
     <way visible="true" id="64" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="252"/>
@@ -3233,6 +2701,7 @@
         <nd ref="246"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Oriol"/>
@@ -3243,9 +2712,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="64"/>
     </way>
     <way visible="true" id="65" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="278"/>
@@ -3262,6 +2729,7 @@
         <nd ref="253"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle A.Innocent"/>
@@ -3272,9 +2740,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="65"/>
     </way>
     <way visible="true" id="66" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="279"/>
@@ -3284,6 +2750,7 @@
         <nd ref="275"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Innocent"/>
@@ -3294,9 +2761,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="66"/>
     </way>
     <way visible="true" id="67" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="391"/>
@@ -3308,6 +2773,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Péan"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3324,9 +2791,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="67"/>
     </way>
     <way visible="true" id="68" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="291"/>
@@ -3337,6 +2801,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Maillart"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3351,9 +2817,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Haiti DMA Topo;osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="68"/>
     </way>
     <way visible="true" id="69" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="300"/>
@@ -3363,6 +2826,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Maillart"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3377,22 +2842,18 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Haiti DMA Topo;osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
     </way>
     <way visible="true" id="70" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="298"/>
         <nd ref="297"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{01be8558-e00d-4e99-808e-87ab4ba25d1d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </way>
     <way visible="true" id="71" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="-243"/>
@@ -3402,6 +2863,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -3415,9 +2878,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="71"/>
     </way>
     <way visible="true" id="72" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="301"/>
@@ -3428,6 +2888,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -3442,15 +2904,13 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="72"/>
     </way>
     <way visible="true" id="73" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="303"/>
         <nd ref="302"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Candio"/>
@@ -3461,9 +2921,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="73"/>
     </way>
     <way visible="true" id="74" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="308"/>
@@ -3472,28 +2930,26 @@
         <nd ref="305"/>
         <nd ref="304"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9e68c530-08c8-4727-a851-d2c55703f730}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="74"/>
     </way>
     <way visible="true" id="75" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="327"/>
         <nd ref="318"/>
         <nd ref="317"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{837e3f8b-d1d7-4d60-89d0-d597a6a65a96}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="75"/>
     </way>
     <way visible="true" id="76" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="327"/>
@@ -3504,6 +2960,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Barthélemy"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3518,38 +2976,33 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Google Aerial;osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="76"/>
     </way>
     <way visible="true" id="77" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="330"/>
         <nd ref="329"/>
         <nd ref="328"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Oriol"/>
         <tag k="uuid" v="{2f0cf7c6-df23-48d7-a38b-d66c689a8f7f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="77"/>
     </way>
     <way visible="true" id="78" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="346"/>
         <nd ref="345"/>
         <nd ref="344"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{d1776f15-958b-4646-a9ae-2689bdcc59f8}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="78"/>
     </way>
     <way visible="true" id="79" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="351"/>
@@ -3558,14 +3011,13 @@
         <nd ref="348"/>
         <nd ref="347"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2fec3dd7-1ed3-4cea-bcde-36da8e5c52e1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="79"/>
     </way>
     <way visible="true" id="80" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="368"/>
@@ -3578,14 +3030,13 @@
         <nd ref="353"/>
         <nd ref="352"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1fae3a50-0b69-49ec-bb3d-c2fe9b5551cf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="80"/>
     </way>
     <way visible="true" id="81" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="378"/>
@@ -3604,27 +3055,25 @@
         <nd ref="365"/>
         <nd ref="364"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9fc89c3f-941c-4c5e-b9e2-14987f90b7be}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="81"/>
     </way>
     <way visible="true" id="82" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="380"/>
         <nd ref="379"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2ea730cc-211a-40f2-9260-b5dd3398ac9f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="82"/>
     </way>
     <way visible="true" id="83" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="386"/>
@@ -3639,6 +3088,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Cheraquit"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3656,94 +3107,85 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="83"/>
     </way>
     <way visible="true" id="84" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="389"/>
         <nd ref="388"/>
         <nd ref="387"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{235997e3-40c8-43f9-aae3-b68caa1ac3fb}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="84"/>
     </way>
     <way visible="true" id="85" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="395"/>
         <nd ref="390"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{50a793d0-8c19-4553-bfc1-7372f9257e23}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="85"/>
     </way>
     <way visible="true" id="86" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="409"/>
         <nd ref="408"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Puceron"/>
         <tag k="uuid" v="{14d3ee62-19f2-4ad9-bb4e-6c7fe1badaa2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="86"/>
     </way>
     <way visible="true" id="87" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="412"/>
         <nd ref="411"/>
         <nd ref="410"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Dartigue"/>
         <tag k="uuid" v="{7623bf4f-b098-45b5-964a-f675a261b30d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="87"/>
     </way>
     <way visible="true" id="88" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="464"/>
         <nd ref="463"/>
         <tag k="source" v="World Bank, 2010/01/21-2010-01/22;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Centrope"/>
         <tag k="uuid" v="{2a89da7e-0ff3-4acd-99df-b09e2423ec30}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="88"/>
     </way>
     <way visible="true" id="89" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="466"/>
         <nd ref="465"/>
         <nd ref="413"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{73186aae-48ce-4c64-95f0-096ce05a2e1a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="FIXME" v="survey; does this path(?) exist (as earlier version implies)?"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="89"/>
     </way>
     <way visible="true" id="90" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="407"/>
@@ -3754,6 +3196,7 @@
         <nd ref="414"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Leonard"/>
@@ -3764,9 +3207,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="90"/>
     </way>
     <way visible="true" id="92" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="417"/>
@@ -3786,6 +3227,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Sans Fil"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3803,9 +3246,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="92"/>
     </way>
     <way visible="true" id="93" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="418"/>
@@ -3814,14 +3254,13 @@
         <nd ref="361"/>
         <nd ref="360"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1a0aa43f-ada4-4abf-8384-069f05eef531}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="93"/>
     </way>
     <way visible="true" id="94" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="343"/>
@@ -3835,6 +3274,7 @@
         <nd ref="335"/>
         <nd ref="419"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse du Travail"/>
@@ -3845,9 +3285,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="94"/>
     </way>
     <way visible="true" id="95" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="334"/>
@@ -3857,6 +3295,7 @@
         <nd ref="420"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Caonabo"/>
@@ -3867,9 +3306,7 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="95"/>
     </way>
     <way visible="true" id="96" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="324"/>
@@ -3885,6 +3322,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Sylvio Cator"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3902,15 +3341,13 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="96"/>
     </way>
     <way visible="true" id="99" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="314"/>
         <nd ref="424"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Decastine"/>
@@ -3921,9 +3358,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="99"/>
     </way>
     <way visible="true" id="100" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="322"/>
@@ -3935,6 +3370,7 @@
         <nd ref="425"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Casimir Prolongée"/>
@@ -3945,9 +3381,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="100"/>
     </way>
     <way visible="true" id="101" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="426"/>
@@ -3960,6 +3394,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Souchet"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3974,9 +3410,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GeoEye;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="101"/>
     </way>
     <way visible="true" id="102" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="289"/>
@@ -3985,6 +3418,7 @@
         <nd ref="427"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Tessier"/>
@@ -3995,15 +3429,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="102"/>
     </way>
     <way visible="true" id="103" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="286"/>
         <nd ref="428"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle A. François"/>
@@ -4014,15 +3447,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="103"/>
     </way>
     <way visible="true" id="104" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="429"/>
         <nd ref="285"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Anglade Prolongée"/>
@@ -4033,29 +3465,27 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="104"/>
     </way>
     <way visible="true" id="105" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="294"/>
         <nd ref="284"/>
         <nd ref="430"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2120b94c-56b2-4c46-b28e-ec5510b8eca7}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="105"/>
     </way>
     <way visible="true" id="106" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="293"/>
         <nd ref="283"/>
         <nd ref="431"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue M. Simon"/>
@@ -4066,9 +3496,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="106"/>
     </way>
     <way visible="true" id="107" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="-2169"/>
@@ -4092,6 +3520,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tokyo"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -4109,9 +3539,6 @@
         <tag k="source" v="GPS/Walkinp Papers;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="107"/>
     </way>
     <way visible="true" id="108" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="433"/>
@@ -4119,14 +3546,13 @@
         <nd ref="263"/>
         <nd ref="285"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5396099a-46e4-4d7b-809b-f584e1da9569}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="108"/>
     </way>
     <way visible="true" id="109" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="321"/>
@@ -4134,29 +3560,27 @@
         <nd ref="227"/>
         <nd ref="434"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{53e20f55-180e-46e3-9988-4d06d58c6bbf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="109"/>
     </way>
     <way visible="true" id="110" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="435"/>
         <nd ref="214"/>
         <nd ref="213"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d44d8ab-5715-4dc9-9a54-231042ce2ea1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="110"/>
     </way>
     <way visible="true" id="112" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="398"/>
@@ -4178,6 +3602,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4195,9 +3621,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="112"/>
     </way>
     <way visible="true" id="114" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="174"/>
@@ -4211,6 +3634,7 @@
         <nd ref="439"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Scylla 1"/>
@@ -4221,9 +3645,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="114"/>
     </way>
     <way visible="true" id="115" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="317"/>
@@ -4245,6 +3667,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Cité Marc"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4262,9 +3686,6 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="115"/>
     </way>
     <way visible="true" id="116" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="216"/>
@@ -4278,6 +3699,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4295,9 +3718,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="116"/>
     </way>
     <way visible="true" id="117" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="133"/>
@@ -4306,14 +3726,13 @@
         <nd ref="130"/>
         <nd ref="442"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{dc1e9e76-0edd-40d1-9b00-0e8accc75398}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="117"/>
     </way>
     <way visible="true" id="118" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="382"/>
@@ -4322,6 +3741,7 @@
         <nd ref="443"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Chanlatte"/>
@@ -4332,9 +3752,7 @@
         <tag k="surface" v="Dirt/Sand;Paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="118"/>
     </way>
     <way visible="true" id="119" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="128"/>
@@ -4342,6 +3760,7 @@
         <nd ref="444"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Oreste"/>
@@ -4352,9 +3771,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="119"/>
     </way>
     <way visible="true" id="120" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="291"/>
@@ -4369,6 +3786,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Maillart"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4386,9 +3805,6 @@
         <tag k="source" v="Mission de Terrain;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="120"/>
     </way>
     <way visible="true" id="123" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="448"/>
@@ -4399,6 +3815,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Bolimann"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -4416,23 +3834,19 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="123"/>
     </way>
     <way visible="true" id="124" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="198"/>
         <nd ref="449"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
         <tag k="uuid" v="{1796747e-b438-4477-a75c-2636745937c6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="124"/>
     </way>
     <way visible="true" id="125" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="290"/>
@@ -4444,6 +3858,7 @@
         <nd ref="450"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Delmas 6"/>
@@ -4454,9 +3869,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="125"/>
     </way>
     <way visible="true" id="126" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="13"/>
@@ -4474,6 +3887,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Saint Lot"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4491,15 +3906,13 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="126"/>
     </way>
     <way visible="true" id="127" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="452"/>
         <nd ref="289"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{70295410-508b-4269-8fb2-98f418cb1d16}"/>
@@ -4509,9 +3922,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="127"/>
     </way>
     <way visible="true" id="128" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="453"/>
@@ -4523,6 +3934,7 @@
         <nd ref="173"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Sans Souci"/>
@@ -4533,9 +3945,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="128"/>
     </way>
     <way visible="true" id="130" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="295"/>
@@ -4545,6 +3955,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -4558,9 +3970,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Google Aerial;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="130"/>
     </way>
     <way visible="true" id="131" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="456"/>
@@ -4586,6 +3995,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Saint Martin"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -4603,35 +4014,30 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="131"/>
     </way>
     <way visible="true" id="132" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="264"/>
         <nd ref="457"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{535b3090-a469-4646-a891-55131f446adc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="132"/>
     </way>
     <way visible="true" id="133" timestamp="2017-06-07T14:36:37Z" version="1" changeset="109">
         <nd ref="458"/>
         <nd ref="22"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{873284c5-b599-4271-9652-7a706d48531f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="133"/>
     </way>
     <way visible="true" id="134" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="343"/>
@@ -4645,6 +4051,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Dartiguenave"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -4659,9 +4067,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="134"/>
     </way>
     <way visible="true" id="137" timestamp="2017-06-07T14:36:37Z" version="1">
         <nd ref="462"/>
@@ -4674,6 +4079,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -4691,50 +4098,43 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="137"/>
     </way>
     <relation visible="true" id="-345" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-62" role="reviewee"/>
         <member type="way" ref="33" role="reviewee"/>
         <member type="way" ref="-14" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-345"/>
     </relation>
     <relation visible="true" id="-344" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-62" role="reviewee"/>
         <member type="way" ref="33" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-344"/>
     </relation>
     <relation visible="true" id="-343" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-62" role="reviewee"/>
         <member type="way" ref="33" role="reviewee"/>
         <member type="way" ref="48" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="3"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-343"/>
     </relation>
     <relation visible="true" id="-342" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-14" role="reviewee"/>
         <member type="way" ref="48" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-342"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/pap-003/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-003/Expected.osm
@@ -3,873 +3,657 @@
     <bounds minlat="18.551137" minlon="-72.337401" maxlat="18.558856" maxlon="-72.3291219"/>
     <node visible="true" id="-688" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5576825857235619" lon="-72.3293464205128771">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-688"/>
     </node>
     <node visible="true" id="-680" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5585906339683433" lon="-72.3335862401604430">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-680"/>
     </node>
     <node visible="true" id="-651" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5527338475482892" lon="-72.3316481106062525">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-651"/>
     </node>
     <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5535839999999972" lon="-72.3344225999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-137"/>
     </node>
     <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5538104000000033" lon="-72.3347009999999813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-136"/>
     </node>
     <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5545940999999992" lon="-72.3351892999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-135"/>
     </node>
     <node visible="true" id="-134" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5587015232021777" lon="-72.3333696873860532">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-134"/>
     </node>
     <node visible="true" id="-123" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5587977654082188" lon="-72.3333618486047953">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-123"/>
     </node>
     <node visible="true" id="-121" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5587977672155695" lon="-72.3369508231099445">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-121"/>
     </node>
     <node visible="true" id="-88" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5564376295564131" lon="-72.3358203985885240">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-88"/>
     </node>
     <node visible="true" id="-87" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5564747074761414" lon="-72.3357205733218080">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-87"/>
     </node>
     <node visible="true" id="-86" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5564946724414028" lon="-72.3355522964580615">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-86"/>
     </node>
     <node visible="true" id="-85" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5564832637466033" lon="-72.3353640545586813">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-85"/>
     </node>
     <node visible="true" id="-84" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5565003766077723" lon="-72.3352670814421828">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-84"/>
     </node>
     <node visible="true" id="-83" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5565060809020288" lon="-72.3352556728428908">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-83"/>
     </node>
     <node visible="true" id="-82" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5565346023545779" lon="-72.3351415868258272">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-82"/>
     </node>
     <node visible="true" id="-80" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5567627742737074" lon="-72.3348221458869602">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5569595725586822" lon="-72.3345540436781675">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5571421101109024" lon="-72.3343201672656733">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5573332041547765" lon="-72.3341690032101639">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5576497928113433" lon="-72.3339636482228059">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5581631798505065" lon="-72.3336641721872695">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-73" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5562950221012173" lon="-72.3360086405742209">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-69" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5562237183585097" lon="-72.3360628314656680">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-33" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5565009534553091" lon="-72.3362749402979262">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5567840381538609" lon="-72.3364706528824968">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5568725749320222" lon="-72.3365265707537759">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5570356689690072" lon="-72.3365801586740815">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5571218758007603" lon="-72.3365836534945714">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5571789587066505" lon="-72.3365754987653702">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5571929381866525" lon="-72.3365754987575258">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5572535159596086" lon="-72.3365615192483489">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5573909808720536" lon="-72.3364869619367568">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5575121363856717" lon="-72.3364147345434958">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5576193124186837" lon="-72.3363611464717167">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5576705705187095" lon="-72.3363413421797361">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5577462927345955" lon="-72.3363331874400899">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5578872525498966" lon="-72.3363238677042659">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5579548200728297" lon="-72.3363296924444086">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5580818004415704" lon="-72.3363867752637617">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5582833381242516" lon="-72.3365708383279866">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5585081749686616" lon="-72.3367782005111764">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5585769074738813" lon="-72.3368282936155538">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110" lat="18.5586456399650004" lon="-72.3368702320227186">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5567433000000044" lon="-72.3350202999999965">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{592902bb-4d4c-4e7c-807f-5773c86b1489}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5524206000000049" lon="-72.3352054000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5526596999999960" lon="-72.3356480000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5528860000000009" lon="-72.3362086000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5529761999999963" lon="-72.3366256999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5514659000000002" lon="-72.3305670999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5519056999999989" lon="-72.3317035999999831">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5524972999999953" lon="-72.3339469000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5541547999999956" lon="-72.3371996000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5577508999999949" lon="-72.3303444000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5572492000000011" lon="-72.3304756999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5569339000000006" lon="-72.3305775999999838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5565168999999983" lon="-72.3306474000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5560926999999971" lon="-72.3307465999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5559899000000037" lon="-72.3307420000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5558931000000022" lon="-72.3306134000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5556071999999972" lon="-72.3307685999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5554634999999983" lon="-72.3308470999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5551379999999959" lon="-72.3310417000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546581999999987" lon="-72.3310871999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5545361000000000" lon="-72.3310764999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5538267000000019" lon="-72.3313152000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5535875999999966" lon="-72.3313823000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5534351000000015" lon="-72.3313447000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5532366999999994" lon="-72.3312588999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5529900999999953" lon="-72.3310630999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5547312000000026" lon="-72.3312387000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5543857000000010" lon="-72.3353975999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542391000000038" lon="-72.3355329999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5534885000000003" lon="-72.3359152000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5524941999999982" lon="-72.3340859000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5517492999999973" lon="-72.3343993000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5545067000000010" lon="-72.3324668000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5549491999999958" lon="-72.3327919999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5555593000000023" lon="-72.3330408000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5558741999999981" lon="-72.3331658999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5559358000000003" lon="-72.3331936999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5560113000000015" lon="-72.3332388000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5562168999999990" lon="-72.3333618000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5562769000000038" lon="-72.3334823999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5563259000000009" lon="-72.3336105000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5563886999999994" lon="-72.3341283999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5564362000000003" lon="-72.3345699999999852">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5565254999999958" lon="-72.3347370999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552022999999977" lon="-72.3343461000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5555379999999985" lon="-72.3343171000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5560212999999976" lon="-72.3343095999999832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="221" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5575254000000029" lon="-72.3307333999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="221"/>
     </node>
     <node visible="true" id="222" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5573353999999995" lon="-72.3307810999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="222"/>
     </node>
     <node visible="true" id="223" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5572477999999990" lon="-72.3307858999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="223"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5571033000000014" lon="-72.3308353000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5565083000000008" lon="-72.3309478999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5561243000000005" lon="-72.3309292999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5558605000000014" lon="-72.3311360000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5553893999999957" lon="-72.3313502999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="229" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5547451999999993" lon="-72.3314261000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="229"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5545368999999987" lon="-72.3319000000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542435999999960" lon="-72.3321554000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5536120000000011" lon="-72.3324204999999836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5554150000000000" lon="-72.3367101999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5557856999999977" lon="-72.3364665000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5561219000000008" lon="-72.3362685000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5529458999999939" lon="-72.3325899000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5521832999999958" lon="-72.3327050999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546403999999967" lon="-72.3349738000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5545958999999989" lon="-72.3339313000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546399999999920" lon="-72.3332187999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="241" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546721999999953" lon="-72.3329171999999829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="241"/>
     </node>
     <node visible="true" id="242" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546769000000005" lon="-72.3325454000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="242"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552703999999977" lon="-72.3351786000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552565999999999" lon="-72.3352655000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="273" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552959999999985" lon="-72.3309581000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="273"/>
     </node>
     <node visible="true" id="317" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5516518999999960" lon="-72.3335189999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="317"/>
     </node>
     <node visible="true" id="318" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5515690999999947" lon="-72.3337029000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="318"/>
     </node>
     <node visible="true" id="319" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5514808000000038" lon="-72.3338398000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="319"/>
     </node>
     <node visible="true" id="320" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5513298999999989" lon="-72.3339670999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="320"/>
     </node>
     <node visible="true" id="321" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5518555999999997" lon="-72.3336656999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="321"/>
     </node>
     <node visible="true" id="322" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5520746000000010" lon="-72.3342004999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="322"/>
     </node>
     <node visible="true" id="323" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5538770000000000" lon="-72.3346410000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="323"/>
     </node>
     <node visible="true" id="324" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5536740000000009" lon="-72.3343595000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="324"/>
     </node>
     <node visible="true" id="325" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5531943999999989" lon="-72.3325164999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="325"/>
     </node>
     <node visible="true" id="326" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5531284999999997" lon="-72.3325243000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="326"/>
     </node>
     <node visible="true" id="327" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546250999999991" lon="-72.3351052000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="327"/>
     </node>
     <node visible="true" id="328" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5534929999999996" lon="-72.3334401000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="328"/>
     </node>
     <node visible="true" id="329" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5533895999999956" lon="-72.3328625000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="329"/>
     </node>
     <node visible="true" id="330" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5533135000000016" lon="-72.3329027999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="330"/>
     </node>
     <node visible="true" id="345" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5534079000000034" lon="-72.3334571999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="345"/>
     </node>
     <node visible="true" id="346" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5536767999999981" lon="-72.3362728999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="346"/>
     </node>
     <node visible="true" id="347" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5545038999999967" lon="-72.3357941999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="347"/>
     </node>
     <node visible="true" id="348" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552607999999957" lon="-72.3329326000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="348"/>
     </node>
     <node visible="true" id="349" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5551909999999971" lon="-72.3331426999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="349"/>
     </node>
     <node visible="true" id="350" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5550941999999957" lon="-72.3334365000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="350"/>
     </node>
     <node visible="true" id="351" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5548102999999998" lon="-72.3342281000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="351"/>
     </node>
     <node visible="true" id="352" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5550156999999984" lon="-72.3349343000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="352"/>
     </node>
     <node visible="true" id="353" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552226999999981" lon="-72.3349292999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="353"/>
     </node>
     <node visible="true" id="354" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5552549000000049" lon="-72.3349284999999895">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="354"/>
     </node>
     <node visible="true" id="355" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5555702999999994" lon="-72.3348912999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="355"/>
     </node>
     <node visible="true" id="356" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5556349000000012" lon="-72.3348912999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="356"/>
     </node>
     <node visible="true" id="357" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5558726000000007" lon="-72.3349407999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="357"/>
     </node>
     <node visible="true" id="358" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5561666999999986" lon="-72.3348392999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="358"/>
     </node>
     <node visible="true" id="371" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5562734000000020" lon="-72.3361723999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="371"/>
     </node>
     <node visible="true" id="372" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5556710000000074" lon="-72.3357862000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="372"/>
     </node>
     <node visible="true" id="373" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5551417000000001" lon="-72.3354140999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="373"/>
     </node>
     <node visible="true" id="374" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5545940999999992" lon="-72.3351892999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="374"/>
     </node>
     <node visible="true" id="375" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5543479000000033" lon="-72.3351024999999908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="375"/>
     </node>
     <node visible="true" id="376" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542967999999959" lon="-72.3350874000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="376"/>
     </node>
     <node visible="true" id="377" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5541854000000015" lon="-72.3350413999999802">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="377"/>
     </node>
     <node visible="true" id="378" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5540306000000008" lon="-72.3349347999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="378"/>
     </node>
     <node visible="true" id="379" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5538104000000033" lon="-72.3347009999999813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="379"/>
     </node>
     <node visible="true" id="380" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5537630999999976" lon="-72.3346465000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="380"/>
     </node>
     <node visible="true" id="381" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5535839999999972" lon="-72.3344225999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="381"/>
     </node>
     <node visible="true" id="382" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5535495000000026" lon="-72.3343299999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="382"/>
     </node>
     <node visible="true" id="383" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5535241000000006" lon="-72.3342362000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="383"/>
     </node>
     <node visible="true" id="384" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5533819999999992" lon="-72.3334624000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="384"/>
     </node>
     <node visible="true" id="385" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5533511000000004" lon="-72.3332458999999801">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="385"/>
     </node>
     <node visible="true" id="386" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5532845999999978" lon="-72.3329157999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="386"/>
     </node>
     <node visible="true" id="387" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5532286999999982" lon="-72.3327891999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="387"/>
     </node>
     <node visible="true" id="388" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5530968999999999" lon="-72.3325355999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="388"/>
     </node>
     <node visible="true" id="389" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5529468999999949" lon="-72.3322299000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="389"/>
     </node>
     <node visible="true" id="390" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5527449999999980" lon="-72.3317430999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="390"/>
     </node>
     <node visible="true" id="391" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5527066999999981" lon="-72.3314167999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="391"/>
     </node>
     <node visible="true" id="392" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5524273000000015" lon="-72.3306599999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="392"/>
     </node>
     <node visible="true" id="403" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5534733000000003" lon="-72.3339164000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="403"/>
     </node>
     <node visible="true" id="404" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5540005999999984" lon="-72.3337783999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="404"/>
     </node>
     <node visible="true" id="405" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5549768999999962" lon="-72.3337647999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="405"/>
     </node>
     <node visible="true" id="410" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5527769999999954" lon="-72.3307489000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="410"/>
     </node>
     <node visible="true" id="412" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5517043999999984" lon="-72.3311597000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="412"/>
     </node>
     <node visible="true" id="413" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5530790999999979" lon="-72.3318462999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="413"/>
     </node>
     <node visible="true" id="414" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5529213999999989" lon="-72.3318972999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="414"/>
     </node>
     <node visible="true" id="416" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5525112999999955" lon="-72.3308425000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="416"/>
     </node>
     <node visible="true" id="420" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5528116999999995" lon="-72.3319376999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="420"/>
     </node>
     <node visible="true" id="421" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5527930000000012" lon="-72.3319613000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="421"/>
     </node>
     <node visible="true" id="422" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5525996000000006" lon="-72.3320618000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="422"/>
     </node>
     <node visible="true" id="423" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5523468000000022" lon="-72.3321616000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="423"/>
     </node>
     <node visible="true" id="424" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5520818999999975" lon="-72.3322502000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="424"/>
     </node>
     <node visible="true" id="462" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5519901999999952" lon="-72.3319896000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="462"/>
     </node>
     <node visible="true" id="464" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5527383999999991" lon="-72.3316868999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="464"/>
     </node>
     <node visible="true" id="465" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5536537999999922" lon="-72.3345151000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="465"/>
     </node>
     <node visible="true" id="466" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5526087000000039" lon="-72.3343595000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="466"/>
     </node>
     <node visible="true" id="467" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5525145999999985" lon="-72.3341851999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="467"/>
     </node>
     <node visible="true" id="468" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5530333000000027" lon="-72.3340483999999861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="468"/>
     </node>
     <node visible="true" id="469" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5534466000000009" lon="-72.3339246999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="469"/>
     </node>
     <node visible="true" id="470" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5537065999999982" lon="-72.3338494999999853">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="470"/>
     </node>
     <node visible="true" id="471" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5537298999999969" lon="-72.3339881999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="471"/>
     </node>
     <node visible="true" id="472" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5537668000000018" lon="-72.3341472000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="472"/>
     </node>
     <node visible="true" id="473" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5538414999999972" lon="-72.3342422999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="473"/>
     </node>
     <node visible="true" id="474" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5541187999999977" lon="-72.3346037000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="474"/>
     </node>
     <node visible="true" id="475" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546174999999955" lon="-72.3346089999999862">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="475"/>
     </node>
     <node visible="true" id="476" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542914000000003" lon="-72.3350187000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="476"/>
     </node>
     <node visible="true" id="477" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5543118000000007" lon="-72.3349055999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="477"/>
     </node>
     <node visible="true" id="478" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5543103999999950" lon="-72.3346056000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="478"/>
     </node>
     <node visible="true" id="479" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5543219999999955" lon="-72.3337920000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="479"/>
     </node>
     <node visible="true" id="483" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5546371999999984" lon="-72.3332625000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="483"/>
     </node>
     <node visible="true" id="484" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5544623999999985" lon="-72.3333188000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="484"/>
     </node>
     <node visible="true" id="485" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542487999999963" lon="-72.3333777999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="485"/>
     </node>
     <node visible="true" id="486" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5541975000000008" lon="-72.3333635000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="486"/>
     </node>
     <node visible="true" id="487" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5541699000000015" lon="-72.3333108000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="487"/>
     </node>
     <node visible="true" id="488" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5540340999999955" lon="-72.3323024999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="488"/>
     </node>
     <node visible="true" id="498" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5588559999999987" lon="-72.3342078276999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="498"/>
     </node>
     <node visible="true" id="522" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542832892199989" lon="-72.3374009999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="522"/>
     </node>
     <node visible="true" id="533" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5542745805200013" lon="-72.3374009999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="533"/>
     </node>
     <node visible="true" id="537" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5511369999999971" lon="-72.3338026461800041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="537"/>
     </node>
     <node visible="true" id="539" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5531623291800010" lon="-72.3374009999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="539"/>
     </node>
     <node visible="true" id="553" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5576442999999998" lon="-72.3291219000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="553"/>
     </node>
     <node visible="true" id="554" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5577135999999996" lon="-72.3295283000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="554"/>
     </node>
     <node visible="true" id="555" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5578798000000020" lon="-72.3303255000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="555"/>
     </node>
     <node visible="true" id="556" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5578858999999987" lon="-72.3305653000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="556"/>
     </node>
     <node visible="true" id="557" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5579947999999995" lon="-72.3309428000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="557"/>
     </node>
     <node visible="true" id="558" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5580661999999990" lon="-72.3312915000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="558"/>
     </node>
     <node visible="true" id="559" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5582361999999961" lon="-72.3321236000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="559"/>
     </node>
     <node visible="true" id="560" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5584502000000029" lon="-72.3330897000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="560"/>
     </node>
     <node visible="true" id="561" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111" lat="18.5585801999999980" lon="-72.3335617999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="561"/>
     </node>
     <way visible="true" id="-1178" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="498"/>
@@ -891,6 +675,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Autoroute de Delmas"/>
         <tag k="ref" v="101"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
@@ -909,9 +695,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1178"/>
     </way>
     <way visible="true" id="-50" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="392"/>
@@ -948,6 +731,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tokyo"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -965,9 +750,6 @@
         <tag k="source" v="GPS/Walkinp Papers;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-50"/>
     </way>
     <way visible="true" id="-42" timestamp="2017-06-07T14:39:33Z" version="1">
         <nd ref="371"/>
@@ -992,25 +774,24 @@
         <nd ref="-15"/>
         <nd ref="-14"/>
         <nd ref="-121"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{d061d842-3aec-42a8-a282-1b6d81c2d38f}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-42"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{d061d842-3aec-42a8-a282-1b6d81c2d38f}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-41" timestamp="2017-06-07T14:39:33Z" version="1">
         <nd ref="371"/>
@@ -1020,6 +801,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1031,9 +814,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-41"/>
     </way>
     <way visible="true" id="-6" timestamp="2017-06-07T14:39:33Z" version="1">
         <nd ref="-73"/>
@@ -1052,72 +832,69 @@
         <nd ref="-76"/>
         <nd ref="-75"/>
         <nd ref="-680"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="median" v="no"/>
-        <tag k="location" v="surface"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{5e4c9bb2-896f-4fc5-b586-406f641fd3a3}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
         <tag k="seasonal" v="no"/>
-        <tag k="lanes" v="2"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-6"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{5e4c9bb2-896f-4fc5-b586-406f641fd3a3}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-5" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110">
         <nd ref="-680"/>
         <nd ref="-134"/>
         <nd ref="-123"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.147Z"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{7fcaa5a2-4843-42f0-86e6-537a7e437fed}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{7fcaa5a2-4843-42f0-86e6-537a7e437fed}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.147Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-4" timestamp="2017-06-07T14:39:33Z" version="1" changeset="110">
         <nd ref="-69"/>
         <nd ref="-73"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
-        <tag k="location" v="overground"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{15289545-7f8c-406b-a1b1-7b9fbb31708d}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{15289545-7f8c-406b-a1b1-7b9fbb31708d}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.144Z"/>
+        <tag k="location" v="overground"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="410"/>
@@ -1143,6 +920,7 @@
         <nd ref="555"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Delmas 6"/>
@@ -1153,15 +931,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="81"/>
         <nd ref="229"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="OIM/GIS/DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Delmas 6"/>
@@ -1172,9 +949,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="84"/>
@@ -1183,15 +958,14 @@
         <nd ref="374"/>
         <tag k="source:name" v="from COSMHA note on market place by the road"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Charlemagne Peralte"/>
         <tag k="uuid" v="{48f92b1b-1c70-49bc-80bc-92236944b032}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="87"/>
@@ -1199,15 +973,14 @@
         <nd ref="86"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Mariela"/>
         <tag k="uuid" v="{3d857258-4d8f-4ae1-8843-d02ab5b8ef05}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="14" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="14"/>
@@ -1232,6 +1005,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Bolimann"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -1249,23 +1024,19 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="240"/>
         <nd ref="349"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0877a4e9-03ae-402e-a2d1-fab5f21af366}"/>
         <tag k="practicability" v="non_motorized"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="126"/>
@@ -1273,27 +1044,25 @@
         <nd ref="124"/>
         <nd ref="353"/>
         <tag k="source" v="Bing; GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{adb81a08-3db9-4ac9-bb27-45f220b0eddf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="386"/>
         <nd ref="330"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7a2ef99f-899b-49c5-a3b5-69fbe3768b30}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="325"/>
@@ -1317,6 +1086,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1334,9 +1105,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="43" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="237"/>
@@ -1349,6 +1117,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1366,9 +1136,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="242"/>
@@ -1380,6 +1147,7 @@
         <nd ref="238"/>
         <nd ref="327"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Charlemagne Peralte"/>
@@ -1390,36 +1158,32 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="44"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="257"/>
         <nd ref="256"/>
         <nd ref="354"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{fa4093b1-1128-49bf-b15f-e4ed543d3b0d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="47" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="324"/>
         <nd ref="473"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ca88bf77-f9ce-4caa-a5b8-ccd80e67b44f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="47"/>
     </way>
     <way visible="true" id="56" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="320"/>
@@ -1427,32 +1191,31 @@
         <nd ref="318"/>
         <nd ref="317"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b84f8b92-b866-440a-94ac-11428d5f8c4d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="56"/>
     </way>
     <way visible="true" id="57" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="322"/>
         <nd ref="321"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f1a4bd96-604a-4a86-aff2-1c032fa617c3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="57"/>
     </way>
     <way visible="true" id="58" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="420"/>
         <nd ref="414"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -1460,14 +1223,13 @@
         <tag k="uuid" v="{aa330091-6313-4759-b909-1852be6e491a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="58"/>
     </way>
     <way visible="true" id="59" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="-136"/>
         <nd ref="323"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -1475,14 +1237,13 @@
         <tag k="uuid" v="{0d886e20-086d-4912-99aa-b02d6b9fe4f2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="59"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="-137"/>
         <nd ref="324"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -1490,9 +1251,7 @@
         <tag k="uuid" v="{72ecd9b6-c468-4b32-8027-f418c1aeacb5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
     <way visible="true" id="61" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="326"/>
@@ -1503,6 +1262,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -1518,14 +1279,12 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GeoEye;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="61"/>
     </way>
     <way visible="true" id="62" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="-135"/>
         <nd ref="327"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -1533,14 +1292,13 @@
         <tag k="uuid" v="{d26f93e0-d7d9-46f1-9761-28267373a9ae}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="62"/>
     </way>
     <way visible="true" id="63" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="345"/>
         <nd ref="328"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -1548,14 +1306,13 @@
         <tag k="uuid" v="{b4e0cca5-5fe3-443b-9ac4-4d9164216888}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="63"/>
     </way>
     <way visible="true" id="64" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="330"/>
         <nd ref="329"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -1563,22 +1320,19 @@
         <tag k="uuid" v="{65da41d2-4f9f-41f3-9319-1515681a454d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="64"/>
     </way>
     <way visible="true" id="68" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="384"/>
         <nd ref="345"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{a0d2de4d-dc67-42d5-b8ec-205d8eda4747}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="68"/>
     </way>
     <way visible="true" id="69" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="373"/>
@@ -1586,6 +1340,7 @@
         <nd ref="346"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="GPS/Walkinp Papers;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Corridor Chéry"/>
@@ -1596,9 +1351,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
     </way>
     <way visible="true" id="70" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="358"/>
@@ -1615,6 +1368,7 @@
         <nd ref="348"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Lakou Citadelle"/>
@@ -1625,9 +1379,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </way>
     <way visible="true" id="76" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="405"/>
@@ -1637,27 +1389,25 @@
         <nd ref="403"/>
         <nd ref="469"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{514678d8-6f9a-46af-95d2-0786ee91f711}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="76"/>
     </way>
     <way visible="true" id="79" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="414"/>
         <nd ref="413"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{01be8558-e00d-4e99-808e-87ab4ba25d1d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="79"/>
     </way>
     <way visible="true" id="83" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="424"/>
@@ -1666,27 +1416,25 @@
         <nd ref="421"/>
         <nd ref="420"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9e68c530-08c8-4727-a851-d2c55703f730}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="83"/>
     </way>
     <way visible="true" id="88" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="466"/>
         <nd ref="465"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{105ef982-8e71-42be-9597-443097c67821}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="88"/>
     </way>
     <way visible="true" id="89" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="469"/>
@@ -1694,6 +1442,7 @@
         <nd ref="467"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Mariella"/>
@@ -1704,9 +1453,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="89"/>
     </way>
     <way visible="true" id="90" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="475"/>
@@ -1717,14 +1464,13 @@
         <nd ref="471"/>
         <nd ref="470"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ef653cac-8797-4979-91bf-c67b6ea663e4}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="90"/>
     </way>
     <way visible="true" id="91" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="479"/>
@@ -1733,6 +1479,7 @@
         <nd ref="476"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Charlemagne Péralte"/>
@@ -1743,9 +1490,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="91"/>
     </way>
     <way visible="true" id="92" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="488"/>
@@ -1756,6 +1501,7 @@
         <nd ref="483"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Leonard"/>
@@ -1766,9 +1512,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="92"/>
     </way>
     <way visible="true" id="121" timestamp="2017-06-07T14:39:34Z" version="1" changeset="111">
         <nd ref="371"/>
@@ -1781,6 +1525,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1796,9 +1542,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="121"/>
     </way>
     <way visible="true" id="127" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="533"/>
@@ -1821,6 +1564,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Saint Martin"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -1838,9 +1583,6 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="127"/>
     </way>
     <way visible="true" id="129" timestamp="2017-06-07T14:39:34Z" version="1">
         <nd ref="539"/>
@@ -1853,6 +1595,7 @@
         <nd ref="537"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Tiremasse"/>
@@ -1863,8 +1606,6 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="129"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/pap-004/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-004/Expected.osm
@@ -3,232 +3,180 @@
     <bounds minlat="18.546063" minlon="-72.323514" maxlat="18.553024" maxlon="-72.3164799"/>
     <node visible="true" id="-514" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5486976693356986" lon="-72.3207641242250503">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-514"/>
     </node>
     <node visible="true" id="-75" timestamp="2017-06-07T14:42:49Z" version="1" changeset="112" lat="18.5490267214600024" lon="-72.3208411239100002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="2017-06-07T14:42:49Z" version="1" changeset="112" lat="18.5489967123499966" lon="-72.3208337394700038">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471511999999983" lon="-72.3224088000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470563999999953" lon="-72.3222843000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469493999999955" lon="-72.3221556000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5468626000000008" lon="-72.3220081999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5467492999999983" lon="-72.3219299999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5466526999999992" lon="-72.3218683000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5461620000000025" lon="-72.3216027999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480941000000001" lon="-72.3167818000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479109999999991" lon="-72.3168354000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476871999999950" lon="-72.3169158999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5475015999999968" lon="-72.3169936999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5472411000000008" lon="-72.3170695000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5528477999999950" lon="-72.3220472000000001">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="hole"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{389d4bac-9bbc-48b7-8bb6-cf8350c3f2fd}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5493874000000041" lon="-72.3164799000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507210999999970" lon="-72.3165750000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506801000000010" lon="-72.3164823000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479776999999970" lon="-72.3193993999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476646999999986" lon="-72.3193284000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5475790999999965" lon="-72.3193143000000020">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e2a156dc-63c5-4c3f-8963-5153863145dd}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470197000000034" lon="-72.3191355999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5468952999999956" lon="-72.3190814000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5467198000000018" lon="-72.3189526999999828">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5465875999999987" lon="-72.3188667999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5498152999999988" lon="-72.3200034000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5497707999999939" lon="-72.3200073999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5497358999999982" lon="-72.3199986999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5495993000000041" lon="-72.3199536999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5495409000000002" lon="-72.3198316999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490763999999970" lon="-72.3188856999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506017999999990" lon="-72.3183973999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5501648999999951" lon="-72.3188150999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5501539999999956" lon="-72.3188379000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5500723000000001" lon="-72.3192370000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="187" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522871000000009" lon="-72.3195853000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="187"/>
     </node>
     <node visible="true" id="188" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523480000000021" lon="-72.3197660000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="188"/>
     </node>
     <node visible="true" id="189" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523862000000008" lon="-72.3198373999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="189"/>
     </node>
     <node visible="true" id="190" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524292999999965" lon="-72.3198938000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="190"/>
     </node>
     <node visible="true" id="191" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524753000000011" lon="-72.3199446999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="191"/>
     </node>
     <node visible="true" id="192" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5525413999999991" lon="-72.3199821999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="192"/>
     </node>
     <node visible="true" id="193" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5526226999999970" lon="-72.3200090999999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="193"/>
     </node>
     <node visible="true" id="194" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5526885999999962" lon="-72.3200260999999927">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="194"/>
     </node>
     <node visible="true" id="195" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527371999999957" lon="-72.3200331999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="195"/>
     </node>
     <node visible="true" id="196" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527828999999969" lon="-72.3200386000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="196"/>
     </node>
     <node visible="true" id="197" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5528389000000011" lon="-72.3200386000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="197"/>
     </node>
     <node visible="true" id="198" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5529100999999947" lon="-72.3200197999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="198"/>
     </node>
     <node visible="true" id="199" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5529913999999998" lon="-72.3199769000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="199"/>
     </node>
     <node visible="true" id="200" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5500493000000013" lon="-72.3192820999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="200"/>
     </node>
     <node visible="true" id="201" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5497955000000019" lon="-72.3194131999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="201"/>
     </node>
     <node visible="true" id="202" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5498956999999969" lon="-72.3197224000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="202"/>
     </node>
     <node visible="true" id="203" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5499566999999992" lon="-72.3199690999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="203"/>
     </node>
     <node visible="true" id="204" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5499787000000005" lon="-72.3200917000000061">
         <tag k="addr:country" v="HT"/>
         <tag k="maxspeed" v="10"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="proximity" v="100"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="obstacle"/>
@@ -236,658 +184,496 @@
         <tag k="uuid" v="{fe1f5a70-05a1-4868-bfb2-1e18ae6037cd}"/>
         <tag k="description" v="Hindernis, Obstacle, Obstáculo"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="204"/>
     </node>
     <node visible="true" id="205" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5500071000000020" lon="-72.3204508999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="205"/>
     </node>
     <node visible="true" id="206" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490664000000010" lon="-72.3188245000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="206"/>
     </node>
     <node visible="true" id="207" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490785999999979" lon="-72.3187601999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="207"/>
     </node>
     <node visible="true" id="208" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491020000000013" lon="-72.3187037999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="208"/>
     </node>
     <node visible="true" id="209" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491890999999995" lon="-72.3185971999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="209"/>
     </node>
     <node visible="true" id="210" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5493754999999965" lon="-72.3184509000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="210"/>
     </node>
     <node visible="true" id="211" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5498099999999972" lon="-72.3182560000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="211"/>
     </node>
     <node visible="true" id="212" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505950000000048" lon="-72.3179970000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="212"/>
     </node>
     <node visible="true" id="213" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502357000000018" lon="-72.3192413999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="213"/>
     </node>
     <node visible="true" id="214" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5504153999999986" lon="-72.3191491000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="214"/>
     </node>
     <node visible="true" id="215" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5504852999999983" lon="-72.3191222999999894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="215"/>
     </node>
     <node visible="true" id="216" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505311999999982" lon="-72.3191242999999844">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="216"/>
     </node>
     <node visible="true" id="217" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505920999999994" lon="-72.3191558000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="217"/>
     </node>
     <node visible="true" id="218" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507421999999984" lon="-72.3193030000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="218"/>
     </node>
     <node visible="true" id="219" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5509126999999943" lon="-72.3196342999999899">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="219"/>
     </node>
     <node visible="true" id="220" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510250999999968" lon="-72.3198114999999859">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="220"/>
     </node>
     <node visible="true" id="221" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486039999999974" lon="-72.3171640000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="221"/>
     </node>
     <node visible="true" id="222" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484879999999954" lon="-72.3172220000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="222"/>
     </node>
     <node visible="true" id="223" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477939999999961" lon="-72.3173089999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="223"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473531999999999" lon="-72.3173258000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530116000000014" lon="-72.3178433000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5529100999999947" lon="-72.3177926999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5528409999999973" lon="-72.3177242999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527846999999966" lon="-72.3176157999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473284000000049" lon="-72.3222226000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473130000000026" lon="-72.3221016999999904">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473402000000007" lon="-72.3213022999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473116000000005" lon="-72.3210942999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5472423999999982" lon="-72.3208915000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471335000000010" lon="-72.3206679000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5468677000000035" lon="-72.3207584000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5467273000000006" lon="-72.3173280000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5467312999999976" lon="-72.3200238000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469591999999999" lon="-72.3196530999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484405000000017" lon="-72.3182110000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="241" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484624999999994" lon="-72.3182197000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="241"/>
     </node>
     <node visible="true" id="242" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484783999999969" lon="-72.3182355000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="242"/>
     </node>
     <node visible="true" id="243" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5485627999999956" lon="-72.3184818000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="243"/>
     </node>
     <node visible="true" id="244" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5485969999999973" lon="-72.3186687999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="244"/>
     </node>
     <node visible="true" id="245" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486226999999957" lon="-72.3188236000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="245"/>
     </node>
     <node visible="true" id="246" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487240999999976" lon="-72.3194490000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="246"/>
     </node>
     <node visible="true" id="247" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487620000000035" lon="-72.3195934999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="247"/>
     </node>
     <node visible="true" id="248" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487783999999998" lon="-72.3197219999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="248"/>
     </node>
     <node visible="true" id="249" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487800000000007" lon="-72.3198342999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="249"/>
     </node>
     <node visible="true" id="250" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487823000000027" lon="-72.3200091999999870">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="250"/>
     </node>
     <node visible="true" id="251" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487783999999998" lon="-72.3200834999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="251"/>
     </node>
     <node visible="true" id="252" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487564999999996" lon="-72.3201825999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="252"/>
     </node>
     <node visible="true" id="253" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487189999999984" lon="-72.3202799999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="253"/>
     </node>
     <node visible="true" id="254" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486986000000016" lon="-72.3203872999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="254"/>
     </node>
     <node visible="true" id="255" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5487054999999970" lon="-72.3205109000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="255"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486974999999994" lon="-72.3207696000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5485097999999979" lon="-72.3213207999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="258" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5503177000000008" lon="-72.3202026000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="258"/>
     </node>
     <node visible="true" id="259" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5529086999999997" lon="-72.3202997000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="259"/>
     </node>
     <node visible="true" id="260" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527714000000010" lon="-72.3202729000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="260"/>
     </node>
     <node visible="true" id="261" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523518000000003" lon="-72.3200985999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="261"/>
     </node>
     <node visible="true" id="262" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522120000000008" lon="-72.3200101000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="262"/>
     </node>
     <node visible="true" id="272" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5529900000000012" lon="-72.3182374000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="272"/>
     </node>
     <node visible="true" id="273" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527925999999965" lon="-72.3182805999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="273"/>
     </node>
     <node visible="true" id="274" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5525289999999998" lon="-72.3181995000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="274"/>
     </node>
     <node visible="true" id="275" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510061999999927" lon="-72.3208451999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="275"/>
     </node>
     <node visible="true" id="276" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5503940999999948" lon="-72.3207488999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="276"/>
     </node>
     <node visible="true" id="277" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5499993999999937" lon="-72.3207134999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="277"/>
     </node>
     <node visible="true" id="278" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5496027999999988" lon="-72.3207306000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="278"/>
     </node>
     <node visible="true" id="279" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5492938000000009" lon="-72.3208324000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="279"/>
     </node>
     <node visible="true" id="280" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491336999999987" lon="-72.3208247999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="280"/>
     </node>
     <node visible="true" id="281" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524178999999982" lon="-72.3206430999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="281"/>
     </node>
     <node visible="true" id="282" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524455000000010" lon="-72.3205121000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="282"/>
     </node>
     <node visible="true" id="283" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524586000000014" lon="-72.3204498999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="283"/>
     </node>
     <node visible="true" id="284" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524713000000006" lon="-72.3203426999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="284"/>
     </node>
     <node visible="true" id="285" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524674999999988" lon="-72.3201492999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="285"/>
     </node>
     <node visible="true" id="286" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5516821000000007" lon="-72.3208731000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="286"/>
     </node>
     <node visible="true" id="300" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522773999999977" lon="-72.3209971999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="300"/>
     </node>
     <node visible="true" id="301" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522773999999977" lon="-72.3210320999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="301"/>
     </node>
     <node visible="true" id="305" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524486000000053" lon="-72.3175387000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="305"/>
     </node>
     <node visible="true" id="306" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5525731000000071" lon="-72.3174987999999814">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="306"/>
     </node>
     <node visible="true" id="307" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527379999999980" lon="-72.3174901000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="307"/>
     </node>
     <node visible="true" id="308" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5528745999999920" lon="-72.3174829000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="308"/>
     </node>
     <node visible="true" id="314" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483363999999966" lon="-72.3206463000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="314"/>
     </node>
     <node visible="true" id="315" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482940999999961" lon="-72.3203764000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="315"/>
     </node>
     <node visible="true" id="316" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483273000000004" lon="-72.3201380999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="316"/>
     </node>
     <node visible="true" id="317" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482958999999958" lon="-72.3198881000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="317"/>
     </node>
     <node visible="true" id="318" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482191999999948" lon="-72.3194679000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="318"/>
     </node>
     <node visible="true" id="319" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481561000000035" lon="-72.3189044999999879">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="319"/>
     </node>
     <node visible="true" id="320" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480746999999973" lon="-72.3187006999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="320"/>
     </node>
     <node visible="true" id="321" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480453999999959" lon="-72.3186622999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="321"/>
     </node>
     <node visible="true" id="322" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480047999999975" lon="-72.3186219999999906">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="322"/>
     </node>
     <node visible="true" id="323" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479501000000049" lon="-72.3185964999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="323"/>
     </node>
     <node visible="true" id="324" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478915999999998" lon="-72.3185845000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="324"/>
     </node>
     <node visible="true" id="325" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478420000000028" lon="-72.3185897999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="325"/>
     </node>
     <node visible="true" id="326" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477594000000074" lon="-72.3186005999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="326"/>
     </node>
     <node visible="true" id="327" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510658999999976" lon="-72.3191671999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="327"/>
     </node>
     <node visible="true" id="328" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5511237999999956" lon="-72.3198660999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="328"/>
     </node>
     <node visible="true" id="329" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513809000000052" lon="-72.3227451000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="329"/>
     </node>
     <node visible="true" id="330" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474628999999993" lon="-72.3232703999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="330"/>
     </node>
     <node visible="true" id="331" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470757999999911" lon="-72.3230216000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="331"/>
     </node>
     <node visible="true" id="332" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5463595000000012" lon="-72.3222671000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="332"/>
     </node>
     <node visible="true" id="333" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5462373999999954" lon="-72.3221490999999901">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="333"/>
     </node>
     <node visible="true" id="334" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460898999999984" lon="-72.3220526000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="334"/>
     </node>
     <node visible="true" id="335" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477315999999952" lon="-72.3229658000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="335"/>
     </node>
     <node visible="true" id="336" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474503000000013" lon="-72.3230874000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="336"/>
     </node>
     <node visible="true" id="337" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5472210000000004" lon="-72.3231458000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="337"/>
     </node>
     <node visible="true" id="338" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470314000000052" lon="-72.3234980000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="338"/>
     </node>
     <node visible="true" id="339" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476874999999950" lon="-72.3223892000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="339"/>
     </node>
     <node visible="true" id="340" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474873999999978" lon="-72.3223421000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="340"/>
     </node>
     <node visible="true" id="341" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473875999999969" lon="-72.3223136000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="341"/>
     </node>
     <node visible="true" id="342" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5472633999999950" lon="-72.3223533000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="342"/>
     </node>
     <node visible="true" id="343" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5515459000000043" lon="-72.3168516000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="343"/>
     </node>
     <node visible="true" id="344" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513839999999988" lon="-72.3167681999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="344"/>
     </node>
     <node visible="true" id="345" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5512303999999979" lon="-72.3166082999999844">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="345"/>
     </node>
     <node visible="true" id="349" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505106999999967" lon="-72.3216967999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="349"/>
     </node>
     <node visible="true" id="350" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502039000000032" lon="-72.3217812999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="350"/>
     </node>
     <node visible="true" id="351" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5516584000000009" lon="-72.3215024000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="351"/>
     </node>
     <node visible="true" id="352" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507124999999995" lon="-72.3212127000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="352"/>
     </node>
     <node visible="true" id="353" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5504479999999958" lon="-72.3211268999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="353"/>
     </node>
     <node visible="true" id="354" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502241999999988" lon="-72.3211053999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="354"/>
     </node>
     <node visible="true" id="355" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5504727000000038" lon="-72.3233847000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="355"/>
     </node>
     <node visible="true" id="360" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507718000000033" lon="-72.3220727000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="360"/>
     </node>
     <node visible="true" id="361" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506310999999968" lon="-72.3221247000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="361"/>
     </node>
     <node visible="true" id="362" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5504650000000026" lon="-72.3221604999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="362"/>
     </node>
     <node visible="true" id="363" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502141000000016" lon="-72.3222533999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="363"/>
     </node>
     <node visible="true" id="364" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5500310000000006" lon="-72.3223284999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="364"/>
     </node>
     <node visible="true" id="365" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5498580999999980" lon="-72.3225967000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="365"/>
     </node>
     <node visible="true" id="366" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5496545999999967" lon="-72.3227040000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="366"/>
     </node>
     <node visible="true" id="367" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5494682000000033" lon="-72.3228470999999900">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="367"/>
     </node>
     <node visible="true" id="368" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491562000000023" lon="-72.3232512000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="368"/>
     </node>
     <node visible="true" id="370" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5465329999999966" lon="-72.3200396000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="370"/>
     </node>
     <node visible="true" id="371" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5463615999999973" lon="-72.3196402999999890">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="371"/>
     </node>
     <node visible="true" id="378" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5526655999999974" lon="-72.3183063000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="378"/>
     </node>
     <node visible="true" id="379" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5521625999999955" lon="-72.3192938999999910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="379"/>
     </node>
     <node visible="true" id="380" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5520594000000010" lon="-72.3194522000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="380"/>
     </node>
     <node visible="true" id="381" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519907000000011" lon="-72.3196453000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="381"/>
     </node>
     <node visible="true" id="382" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519500000000015" lon="-72.3198088999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="382"/>
     </node>
     <node visible="true" id="383" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519347000000003" lon="-72.3199268999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="383"/>
     </node>
     <node visible="true" id="384" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519736999999978" lon="-72.3202437000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="384"/>
     </node>
     <node visible="true" id="385" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519907000000011" lon="-72.3204472999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="385"/>
     </node>
     <node visible="true" id="386" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519974999999953" lon="-72.3206109000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="386"/>
     </node>
     <node visible="true" id="387" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519965999999954" lon="-72.3207771000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="387"/>
     </node>
     <node visible="true" id="388" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519961999999978" lon="-72.3208494999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="388"/>
     </node>
     <node visible="true" id="389" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519515999999989" lon="-72.3212515000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="389"/>
     </node>
     <node visible="true" id="390" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5518916000000011" lon="-72.3216462000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="390"/>
     </node>
     <node visible="true" id="391" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5518321999999998" lon="-72.3219126000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="391"/>
     </node>
     <node visible="true" id="394" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527763999999955" lon="-72.3230441000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="394"/>
     </node>
     <node visible="true" id="395" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5493220000000036" lon="-72.3168208000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="395"/>
     </node>
     <node visible="true" id="396" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490896999999997" lon="-72.3168718000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="396"/>
     </node>
     <node visible="true" id="397" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5488010000000045" lon="-72.3170204999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="397"/>
     </node>
     <node visible="true" id="398" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469529000000044" lon="-72.3186503000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="398"/>
     </node>
     <node visible="true" id="399" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469150999999997" lon="-72.3186125999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="399"/>
     </node>
     <node visible="true" id="400" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5468770999999961" lon="-72.3185596000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="400"/>
     </node>
     <node visible="true" id="401" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5468063000000001" lon="-72.3184162000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="401"/>
     </node>
     <node visible="true" id="402" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5466765999999978" lon="-72.3181668000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="402"/>
     </node>
     <node visible="true" id="403" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5465446999999983" lon="-72.3179080999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="403"/>
     </node>
     <node visible="true" id="404" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5464494000000002" lon="-72.3177503000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="404"/>
     </node>
     <node visible="true" id="405" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5463698999999984" lon="-72.3176712000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="405"/>
     </node>
     <node visible="true" id="406" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5462847000000011" lon="-72.3176849999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="406"/>
     </node>
     <node visible="true" id="407" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5462686000000012" lon="-72.3177223999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="407"/>
     </node>
     <node visible="true" id="408" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5511558000000001" lon="-72.3172407999999791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="408"/>
     </node>
     <node visible="true" id="409" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5512435999999958" lon="-72.3174087000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="409"/>
     </node>
     <node visible="true" id="410" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513690999999952" lon="-72.3175542000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="410"/>
     </node>
     <node visible="true" id="411" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5517570999999997" lon="-72.3179482000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="411"/>
     </node>
     <node visible="true" id="412" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5515770999999958" lon="-72.3181272000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="412"/>
     </node>
     <node visible="true" id="413" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5515020000000028" lon="-72.3183413000000002">
         <tag k="addr:country" v="HT"/>
         <tag k="maxspeed" v="10"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="proximity" v="100"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="obstacle"/>
@@ -895,298 +681,229 @@
         <tag k="uuid" v="{526a7464-c72d-4cb2-9277-30be8c310207}"/>
         <tag k="description" v="Hindernis, Obstacle, Obstáculo"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="413"/>
     </node>
     <node visible="true" id="414" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5515496999999989" lon="-72.3188379000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="414"/>
     </node>
     <node visible="true" id="415" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513990000000000" lon="-72.3194321999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="415"/>
     </node>
     <node visible="true" id="416" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5512036000000045" lon="-72.3199481000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="416"/>
     </node>
     <node visible="true" id="417" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5512841999999978" lon="-72.3203735999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="417"/>
     </node>
     <node visible="true" id="418" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5514118999999980" lon="-72.3208589000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="418"/>
     </node>
     <node visible="true" id="419" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5514447999999987" lon="-72.3210889000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="419"/>
     </node>
     <node visible="true" id="420" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513496999999994" lon="-72.3214054000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="420"/>
     </node>
     <node visible="true" id="421" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513432999999957" lon="-72.3214633999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="421"/>
     </node>
     <node visible="true" id="422" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513308000000023" lon="-72.3215966000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="422"/>
     </node>
     <node visible="true" id="423" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513077999999965" lon="-72.3218428999999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="423"/>
     </node>
     <node visible="true" id="424" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5512980000000027" lon="-72.3219110000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="424"/>
     </node>
     <node visible="true" id="425" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510938000000003" lon="-72.3226990000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="425"/>
     </node>
     <node visible="true" id="426" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510212999999986" lon="-72.3230975000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="426"/>
     </node>
     <node visible="true" id="427" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5512381999999967" lon="-72.3223595999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="427"/>
     </node>
     <node visible="true" id="428" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5514520999999988" lon="-72.3222927999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="428"/>
     </node>
     <node visible="true" id="429" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5517634999999963" lon="-72.3221699999999856">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="bump"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b402e2e2-e330-4977-8dfa-4ebacb8414a3}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="429"/>
     </node>
     <node visible="true" id="430" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5517812999999947" lon="-72.3221630000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="430"/>
     </node>
     <node visible="true" id="431" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5518037000000042" lon="-72.3221616000000012">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="bump"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2856cc6b-f4f5-4f0c-90c0-f42f88e0050e}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="431"/>
     </node>
     <node visible="true" id="432" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523130000000052" lon="-72.3221302999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="432"/>
     </node>
     <node visible="true" id="433" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523384000000000" lon="-72.3227365000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="433"/>
     </node>
     <node visible="true" id="434" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523813000000040" lon="-72.3230833999999874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="434"/>
     </node>
     <node visible="true" id="435" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507712999999974" lon="-72.3208029999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="435"/>
     </node>
     <node visible="true" id="436" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507792999999985" lon="-72.3207285000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="436"/>
     </node>
     <node visible="true" id="437" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507340999999961" lon="-72.3205542000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="437"/>
     </node>
     <node visible="true" id="438" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506675999999970" lon="-72.3202285999999788">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="438"/>
     </node>
     <node visible="true" id="439" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505605000000031" lon="-72.3199197999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="439"/>
     </node>
     <node visible="true" id="440" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5504202999999954" lon="-72.3197093999999794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="440"/>
     </node>
     <node visible="true" id="441" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502776999999988" lon="-72.3194342000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="441"/>
     </node>
     <node visible="true" id="442" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502110999999950" lon="-72.3193114999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="442"/>
     </node>
     <node visible="true" id="443" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5501521999999959" lon="-72.3192784999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="443"/>
     </node>
     <node visible="true" id="444" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5500095999999921" lon="-72.3203522999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="444"/>
     </node>
     <node visible="true" id="445" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5497610000000002" lon="-72.3203850999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="445"/>
     </node>
     <node visible="true" id="446" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5495090000000005" lon="-72.3204467000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="446"/>
     </node>
     <node visible="true" id="447" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5493006999999963" lon="-72.3204968999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="447"/>
     </node>
     <node visible="true" id="448" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491254999999988" lon="-72.3205473999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="448"/>
     </node>
     <node visible="true" id="449" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490544999999969" lon="-72.3203474999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="449"/>
     </node>
     <node visible="true" id="450" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490490000000001" lon="-72.3200927999999834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="450"/>
     </node>
     <node visible="true" id="462" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5497977999999968" lon="-72.3177258000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="462"/>
     </node>
     <node visible="true" id="463" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5502165999999988" lon="-72.3176737000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="463"/>
     </node>
     <node visible="true" id="464" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506549999999955" lon="-72.3176789000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="464"/>
     </node>
     <node visible="true" id="465" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507654000000031" lon="-72.3173462999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="465"/>
     </node>
     <node visible="true" id="466" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506229000000005" lon="-72.3173531999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="466"/>
     </node>
     <node visible="true" id="467" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5501932999999966" lon="-72.3173764000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="467"/>
     </node>
     <node visible="true" id="468" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477784999999962" lon="-72.3234709999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="468"/>
     </node>
     <node visible="true" id="469" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479781999999993" lon="-72.3233015999999793">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="469"/>
     </node>
     <node visible="true" id="470" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481249999999953" lon="-72.3232279000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="470"/>
     </node>
     <node visible="true" id="471" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483429999999991" lon="-72.3231468000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="471"/>
     </node>
     <node visible="true" id="472" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470600999999995" lon="-72.3225055999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="472"/>
     </node>
     <node visible="true" id="473" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476020999999953" lon="-72.3223692999999912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="473"/>
     </node>
     <node visible="true" id="474" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476606999999980" lon="-72.3224835000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="474"/>
     </node>
     <node visible="true" id="475" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477367000000015" lon="-72.3227370999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="475"/>
     </node>
     <node visible="true" id="488" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469968999999963" lon="-72.3165110000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="488"/>
     </node>
     <node visible="true" id="494" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5466728999999937" lon="-72.3204351999999915">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="494"/>
     </node>
     <node visible="true" id="495" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469201999999989" lon="-72.3204101000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="495"/>
     </node>
     <node visible="true" id="496" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471809000000043" lon="-72.3204061999999794">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="496"/>
     </node>
     <node visible="true" id="497" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478284000000002" lon="-72.3205049999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="497"/>
     </node>
     <node visible="true" id="498" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479143999999962" lon="-72.3206863999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="498"/>
     </node>
     <node visible="true" id="499" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479849999999971" lon="-72.3209274000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="499"/>
     </node>
     <node visible="true" id="500" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480615999999969" lon="-72.3213357000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="500"/>
     </node>
     <node visible="true" id="501" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481173000000013" lon="-72.3215244999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="501"/>
     </node>
     <node visible="true" id="508" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527854999999953" lon="-72.3220594000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="508"/>
     </node>
     <node visible="true" id="509" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5526950999999976" lon="-72.3214369999999889">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="509"/>
     </node>
     <node visible="true" id="510" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5526544000000015" lon="-72.3210828999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="510"/>
     </node>
     <node visible="true" id="511" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471233999999967" lon="-72.3233788000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="511"/>
     </node>
     <node visible="true" id="513" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5511743999999972" lon="-72.3177821000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="513"/>
     </node>
     <node visible="true" id="519" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505630000000039" lon="-72.3169948999999832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="519"/>
     </node>
     <node visible="true" id="520" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506621000000074" lon="-72.3173517999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="520"/>
     </node>
     <node visible="true" id="522" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478787999999994" lon="-72.3165809000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="522"/>
     </node>
     <node visible="true" id="523" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478808999999956" lon="-72.3167354999999930">
         <tag k="addr:country" v="HT"/>
         <tag k="maxspeed" v="10"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="proximity" v="100"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="obstacle"/>
@@ -1194,256 +911,195 @@
         <tag k="uuid" v="{629c473e-9cf0-4d39-8f20-5203f3ed0630}"/>
         <tag k="description" v="Hindernis, Obstacle, Obstáculo"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="523"/>
     </node>
     <node visible="true" id="524" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479187999999979" lon="-72.3168612000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="524"/>
     </node>
     <node visible="true" id="525" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479809999999965" lon="-72.3169728999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="525"/>
     </node>
     <node visible="true" id="526" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481894000000018" lon="-72.3172681000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="526"/>
     </node>
     <node visible="true" id="539" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5511649000000034" lon="-72.3182862000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="539"/>
     </node>
     <node visible="true" id="540" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510972999999986" lon="-72.3184660999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="540"/>
     </node>
     <node visible="true" id="541" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5509083000000032" lon="-72.3182874999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="541"/>
     </node>
     <node visible="true" id="542" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5508874000000006" lon="-72.3178999000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="542"/>
     </node>
     <node visible="true" id="552" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480832000000007" lon="-72.3228742000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="552"/>
     </node>
     <node visible="true" id="553" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484268000000014" lon="-72.3227815999999848">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="553"/>
     </node>
     <node visible="true" id="554" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481506000000032" lon="-72.3228565999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="554"/>
     </node>
     <node visible="true" id="555" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471399000000012" lon="-72.3183267000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="555"/>
     </node>
     <node visible="true" id="556" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470361999999973" lon="-72.3180545000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="556"/>
     </node>
     <node visible="true" id="557" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5472332999999949" lon="-72.3200030999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="557"/>
     </node>
     <node visible="true" id="558" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473635999999971" lon="-72.3204130000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="558"/>
     </node>
     <node visible="true" id="559" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471052999999948" lon="-72.3173266999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="559"/>
     </node>
     <node visible="true" id="560" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5471563999999951" lon="-72.3174084999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="560"/>
     </node>
     <node visible="true" id="561" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473094000000032" lon="-72.3175463999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="561"/>
     </node>
     <node visible="true" id="562" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474794000000003" lon="-72.3176485000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="562"/>
     </node>
     <node visible="true" id="563" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479252999999957" lon="-72.3177892000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="563"/>
     </node>
     <node visible="true" id="564" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481094000000013" lon="-72.3178383000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="564"/>
     </node>
     <node visible="true" id="565" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482034999999996" lon="-72.3178785000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="565"/>
     </node>
     <node visible="true" id="566" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484095000000018" lon="-72.3178785000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="566"/>
     </node>
     <node visible="true" id="567" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486536000000051" lon="-72.3178302999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="567"/>
     </node>
     <node visible="true" id="568" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510260999999979" lon="-72.3234223000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="568"/>
     </node>
     <node visible="true" id="569" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513515999999967" lon="-72.3233900999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="569"/>
     </node>
     <node visible="true" id="570" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5518043000000006" lon="-72.3233204000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="570"/>
     </node>
     <node visible="true" id="571" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476964000000031" lon="-72.3177132999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="571"/>
     </node>
     <node visible="true" id="572" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476402000000000" lon="-72.3180057000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="572"/>
     </node>
     <node visible="true" id="573" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5499846999999960" lon="-72.3173945000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="573"/>
     </node>
     <node visible="true" id="574" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5488591999999954" lon="-72.3169831000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="574"/>
     </node>
     <node visible="true" id="575" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491011999999991" lon="-72.3170915999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="575"/>
     </node>
     <node visible="true" id="576" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491583999999960" lon="-72.3171640000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="576"/>
     </node>
     <node visible="true" id="577" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491877999999950" lon="-72.3172399000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="577"/>
     </node>
     <node visible="true" id="578" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491290000000006" lon="-72.3175777999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="578"/>
     </node>
     <node visible="true" id="579" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491452999999993" lon="-72.3176260999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="579"/>
     </node>
     <node visible="true" id="580" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5489949999999979" lon="-72.3180071000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="580"/>
     </node>
     <node visible="true" id="581" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5495478999999968" lon="-72.3175228000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="581"/>
     </node>
     <node visible="true" id="582" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5495637999999978" lon="-72.3176744000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="582"/>
     </node>
     <node visible="true" id="583" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5495425000000012" lon="-72.3177658000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="583"/>
     </node>
     <node visible="true" id="584" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5492336000000009" lon="-72.3179554000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="584"/>
     </node>
     <node visible="true" id="587" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5493875000000052" lon="-72.3188434000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="587"/>
     </node>
     <node visible="true" id="588" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5496935000000036" lon="-72.3186972000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="588"/>
     </node>
     <node visible="true" id="589" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5501356999999949" lon="-72.3185205999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="589"/>
     </node>
     <node visible="true" id="590" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5499816999999965" lon="-72.3189212000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="590"/>
     </node>
     <node visible="true" id="591" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5496063000000042" lon="-72.3190661000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="591"/>
     </node>
     <node visible="true" id="592" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5492525000000015" lon="-72.3193145999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="592"/>
     </node>
     <node visible="true" id="593" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478118999999957" lon="-72.3212055000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="593"/>
     </node>
     <node visible="true" id="594" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477853999999986" lon="-72.3213130999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="594"/>
     </node>
     <node visible="true" id="595" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480131999999962" lon="-72.3211026000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="595"/>
     </node>
     <node visible="true" id="596" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483311999999998" lon="-72.3209540999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="596"/>
     </node>
     <node visible="true" id="597" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479121999999990" lon="-72.3224009999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="597"/>
     </node>
     <node visible="true" id="598" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482577999999982" lon="-72.3228273000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="598"/>
     </node>
     <node visible="true" id="599" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481134999999995" lon="-72.3223715000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="599"/>
     </node>
     <node visible="true" id="600" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480154999999982" lon="-72.3223877999999871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="600"/>
     </node>
     <node visible="true" id="604" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510327999999980" lon="-72.3229206000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="604"/>
     </node>
     <node visible="true" id="605" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5508665999999991" lon="-72.3230008000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="605"/>
     </node>
     <node visible="true" id="606" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507186999999973" lon="-72.3231181000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="606"/>
     </node>
     <node visible="true" id="608" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5490582593699997" lon="-72.3176067390599968">
-        <tag k="hoot" v="PortAuPrince_OSM_Rds"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="hoot" v="PortAuPrince_OSM_Rds"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="608"/>
     </node>
     <node visible="true" id="610" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513781999999949" lon="-72.3228055999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="610"/>
     </node>
     <node visible="true" id="611" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5517643999999997" lon="-72.3227512999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="611"/>
     </node>
     <node visible="true" id="612" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5463048000000015" lon="-72.3209647000000047">
         <tag k="addr:country" v="HT"/>
         <tag k="maxspeed" v="10"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="proximity" v="100"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="obstacle"/>
@@ -1451,481 +1107,361 @@
         <tag k="uuid" v="{450750bc-6120-4d6c-bc00-77a341af772a}"/>
         <tag k="description" v="Hindernis, Obstacle, Obstáculo"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="612"/>
     </node>
     <node visible="true" id="613" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5464589999999987" lon="-72.3209753000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="613"/>
     </node>
     <node visible="true" id="614" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5465866999999989" lon="-72.3209339999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="614"/>
     </node>
     <node visible="true" id="615" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5467951999999983" lon="-72.3207735000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="615"/>
     </node>
     <node visible="true" id="616" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5462428999999993" lon="-72.3177819000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="616"/>
     </node>
     <node visible="true" id="617" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5462807000000005" lon="-72.3182064999999881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="617"/>
     </node>
     <node visible="true" id="618" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5463780000000007" lon="-72.3187457999999879">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="618"/>
     </node>
     <node visible="true" id="619" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5475105999999990" lon="-72.3193495999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="619"/>
     </node>
     <node visible="true" id="620" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5475851999999968" lon="-72.3194467999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="620"/>
     </node>
     <node visible="true" id="621" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476665999999994" lon="-72.3195910999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="621"/>
     </node>
     <node visible="true" id="622" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477082999999965" lon="-72.3197290999999893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="622"/>
     </node>
     <node visible="true" id="623" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477294999999955" lon="-72.3199342000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="623"/>
     </node>
     <node visible="true" id="624" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477406000000009" lon="-72.3204250999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="624"/>
     </node>
     <node visible="true" id="625" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474190999999990" lon="-72.3192878999999920">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="625"/>
     </node>
     <node visible="true" id="626" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473330999999959" lon="-72.3191252999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="626"/>
     </node>
     <node visible="true" id="627" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470752999999959" lon="-72.3187441000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="627"/>
     </node>
     <node visible="true" id="628" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486964999999948" lon="-72.3193088999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="628"/>
     </node>
     <node visible="true" id="629" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5491798999999951" lon="-72.3191407999999853">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="629"/>
     </node>
     <node visible="true" id="632" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519588000000013" lon="-72.3166468000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="632"/>
     </node>
     <node visible="true" id="633" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5519606000000010" lon="-72.3168015999999909">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="633"/>
     </node>
     <node visible="true" id="634" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5520334999999967" lon="-72.3169910999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="634"/>
     </node>
     <node visible="true" id="635" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522449999999957" lon="-72.3173149999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="635"/>
     </node>
     <node visible="true" id="636" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523411999999936" lon="-72.3174970999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="636"/>
     </node>
     <node visible="true" id="637" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5523429000000029" lon="-72.3175724999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="637"/>
     </node>
     <node visible="true" id="638" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522916999999978" lon="-72.3176371999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="638"/>
     </node>
     <node visible="true" id="639" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5522400000000047" lon="-72.3176578000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="639"/>
     </node>
     <node visible="true" id="640" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5521294999999924" lon="-72.3176689999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="640"/>
     </node>
     <node visible="true" id="641" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5520463999999947" lon="-72.3176519000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="641"/>
     </node>
     <node visible="true" id="642" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5518779999999950" lon="-72.3175389999999823">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="642"/>
     </node>
     <node visible="true" id="643" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5516049999999986" lon="-72.3173819999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="643"/>
     </node>
     <node visible="true" id="644" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513219999999990" lon="-72.3171779999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="644"/>
     </node>
     <node visible="true" id="645" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510955999999965" lon="-72.3169591999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="645"/>
     </node>
     <node visible="true" id="646" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510480000000015" lon="-72.3169079999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="646"/>
     </node>
     <node visible="true" id="647" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5509200000000014" lon="-72.3167959999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="647"/>
     </node>
     <node visible="true" id="648" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5508009999999963" lon="-72.3167320000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="648"/>
     </node>
     <node visible="true" id="649" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507553999999963" lon="-72.3167205999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="649"/>
     </node>
     <node visible="true" id="650" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5506929999999990" lon="-72.3167049999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="650"/>
     </node>
     <node visible="true" id="651" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5505088999999970" lon="-72.3166886000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="651"/>
     </node>
     <node visible="true" id="652" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5498646000000029" lon="-72.3167669999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="652"/>
     </node>
     <node visible="true" id="653" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5494574000000014" lon="-72.3167995000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="653"/>
     </node>
     <node visible="true" id="677" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460630000000002" lon="-72.3209359011700030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="677"/>
     </node>
     <node visible="true" id="682" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5472511430900013" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="682"/>
     </node>
     <node visible="true" id="683" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3210116752200065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="683"/>
     </node>
     <node visible="true" id="685" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5524216484299984" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="685"/>
     </node>
     <node visible="true" id="686" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3220125496300028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="686"/>
     </node>
     <node visible="true" id="687" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5510299006200015" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="687"/>
     </node>
     <node visible="true" id="688" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5527931606500012" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="688"/>
     </node>
     <node visible="true" id="690" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5518244041600049" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="690"/>
     </node>
     <node visible="true" id="691" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460630000000002" lon="-72.3190821595500068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="691"/>
     </node>
     <node visible="true" id="692" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3213734140200017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="692"/>
     </node>
     <node visible="true" id="693" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5507274206600030" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="693"/>
     </node>
     <node visible="true" id="695" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5503706257499985" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="695"/>
     </node>
     <node visible="true" id="696" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5470172332200001" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="696"/>
     </node>
     <node visible="true" id="699" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3226627748200031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="699"/>
     </node>
     <node visible="true" id="700" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478287892499978" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="700"/>
     </node>
     <node visible="true" id="701" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460629999999966" lon="-72.3220427719400050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="701"/>
     </node>
     <node visible="true" id="702" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5513533453500052" lon="-72.3235140000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="702"/>
     </node>
     <node visible="true" id="704" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3174210406500038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="704"/>
     </node>
     <node visible="true" id="708" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000042" lon="-72.3182413759799942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="708"/>
     </node>
     <node visible="true" id="709" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3203075621899956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="709"/>
     </node>
     <node visible="true" id="710" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3230207177399933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="710"/>
     </node>
     <node visible="true" id="712" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530240000000006" lon="-72.3178467341100060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="712"/>
     </node>
     <node visible="true" id="713" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460629999999966" lon="-72.3172936131300048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="713"/>
     </node>
     <node visible="true" id="714" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5530239999999971" lon="-72.3199530788200065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="714"/>
     </node>
     <node visible="true" id="717" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460630000000002" lon="-72.3211967495399932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="717"/>
     </node>
     <node visible="true" id="718" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460629999999966" lon="-72.3217973594699970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="718"/>
     </node>
     <node visible="true" id="720" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5460629999999966" lon="-72.3186873689100054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="720"/>
     </node>
     <node visible="true" id="731" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483586000000003" lon="-72.3180930999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="731"/>
     </node>
     <node visible="true" id="732" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483103000000007" lon="-72.3179563000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="732"/>
     </node>
     <node visible="true" id="733" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483027000000007" lon="-72.3178785000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="733"/>
     </node>
     <node visible="true" id="734" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483027000000007" lon="-72.3177873000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="734"/>
     </node>
     <node visible="true" id="735" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482975999999979" lon="-72.3176854000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="735"/>
     </node>
     <node visible="true" id="736" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482900000000015" lon="-72.3175915000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="736"/>
     </node>
     <node visible="true" id="737" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482951000000007" lon="-72.3174654999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="737"/>
     </node>
     <node visible="true" id="738" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483434000000003" lon="-72.3173287000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="738"/>
     </node>
     <node visible="true" id="739" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483556000000007" lon="-72.3172423999999836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="739"/>
     </node>
     <node visible="true" id="740" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481968000000030" lon="-72.3192049999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="740"/>
     </node>
     <node visible="true" id="741" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482152999999990" lon="-72.3190847999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="741"/>
     </node>
     <node visible="true" id="742" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482262999999961" lon="-72.3190228999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="742"/>
     </node>
     <node visible="true" id="743" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482278999999970" lon="-72.3189346000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="743"/>
     </node>
     <node visible="true" id="744" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482362999999992" lon="-72.3188686999999817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="744"/>
     </node>
     <node visible="true" id="745" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482509999999969" lon="-72.3187991000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="745"/>
     </node>
     <node visible="true" id="746" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482692999999976" lon="-72.3186919999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="746"/>
     </node>
     <node visible="true" id="747" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482596000000051" lon="-72.3185205000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="747"/>
     </node>
     <node visible="true" id="748" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482522000000003" lon="-72.3184186000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="748"/>
     </node>
     <node visible="true" id="749" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482376000000002" lon="-72.3183116000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="749"/>
     </node>
     <node visible="true" id="750" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482438000000016" lon="-72.3182786999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="750"/>
     </node>
     <node visible="true" id="751" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482692999999976" lon="-72.3182445000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="751"/>
     </node>
     <node visible="true" id="752" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5483719999999970" lon="-72.3182161000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="752"/>
     </node>
     <node visible="true" id="753" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484094000000006" lon="-72.3182132999999823">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="753"/>
     </node>
     <node visible="true" id="754" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5468748999999988" lon="-72.3232978000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="754"/>
     </node>
     <node visible="true" id="755" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5467807999999970" lon="-72.3231691000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="755"/>
     </node>
     <node visible="true" id="756" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5469994999999948" lon="-72.3229434999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="756"/>
     </node>
     <node visible="true" id="758" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5485240000000005" lon="-72.3211811999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="758"/>
     </node>
     <node visible="true" id="759" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486639000000011" lon="-72.3211842999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="759"/>
     </node>
     <node visible="true" id="760" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486432000000008" lon="-72.3213178999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="760"/>
     </node>
     <node visible="true" id="761" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486293999999994" lon="-72.3215952999999843">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="761"/>
     </node>
     <node visible="true" id="762" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5485973000000008" lon="-72.3216445000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="762"/>
     </node>
     <node visible="true" id="763" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484453999999950" lon="-72.3216386000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="763"/>
     </node>
     <node visible="true" id="764" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482596999999991" lon="-72.3216161999999798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="764"/>
     </node>
     <node visible="true" id="765" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481423999999961" lon="-72.3216194000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="765"/>
     </node>
     <node visible="true" id="766" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5480037999999965" lon="-72.3216206000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="766"/>
     </node>
     <node visible="true" id="767" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478276999999991" lon="-72.3216220999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="767"/>
     </node>
     <node visible="true" id="768" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477218000000015" lon="-72.3216302000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="768"/>
     </node>
     <node visible="true" id="769" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5475288999999997" lon="-72.3216594999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="769"/>
     </node>
     <node visible="true" id="770" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474629000000029" lon="-72.3216696000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="770"/>
     </node>
     <node visible="true" id="771" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473265999999981" lon="-72.3216864999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="771"/>
     </node>
     <node visible="true" id="772" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5473302999999987" lon="-72.3219773000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="772"/>
     </node>
     <node visible="true" id="773" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5474099000000017" lon="-72.3219775999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="773"/>
     </node>
     <node visible="true" id="774" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5475124999999963" lon="-72.3219833999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="774"/>
     </node>
     <node visible="true" id="775" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5476202999999948" lon="-72.3219839000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="775"/>
     </node>
     <node visible="true" id="776" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5477023000000010" lon="-72.3219614000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="776"/>
     </node>
     <node visible="true" id="777" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5478217000000036" lon="-72.3219370000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="777"/>
     </node>
     <node visible="true" id="778" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5479012999999995" lon="-72.3219224999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="778"/>
     </node>
     <node visible="true" id="779" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5481102000000000" lon="-72.3218940999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="779"/>
     </node>
     <node visible="true" id="780" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5482718999999960" lon="-72.3218806999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="780"/>
     </node>
     <node visible="true" id="781" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5484098000000017" lon="-72.3218949000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="781"/>
     </node>
     <node visible="true" id="782" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5485544000000004" lon="-72.3219098000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="782"/>
     </node>
     <node visible="true" id="783" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113" lat="18.5486755999999993" lon="-72.3219205999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="783"/>
     </node>
     <way visible="true" id="-963" timestamp="2017-06-07T14:42:49Z" version="1">
         <nd ref="280"/>
@@ -1937,6 +1473,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1948,9 +1486,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-963"/>
     </way>
     <way visible="true" id="-953" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="763"/>
@@ -1981,6 +1516,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Coquillo"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -1995,9 +1532,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Google Aerial;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-953"/>
     </way>
     <way visible="true" id="-44" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="574"/>
@@ -2006,6 +1540,7 @@
         <nd ref="653"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Route de Nazon"/>
@@ -2015,9 +1550,7 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-44"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="34"/>
@@ -2026,20 +1559,20 @@
         <nd ref="31"/>
         <nd ref="30"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5b73dd8c-ea53-408c-a577-83000da239c3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="653"/>
         <nd ref="83"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Logand"/>
@@ -2050,9 +1583,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="85"/>
@@ -2060,6 +1591,7 @@
         <nd ref="649"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="living_street"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Armand"/>
@@ -2068,9 +1600,7 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="dirt"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="206"/>
@@ -2084,15 +1614,14 @@
         <nd ref="127"/>
         <nd ref="203"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{845c73d5-ebb1-401d-abba-5594a4d86272}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="443"/>
@@ -2104,6 +1633,7 @@
         <nd ref="133"/>
         <nd ref="212"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="IIème Ruelle Jean Price Mars"/>
@@ -2114,9 +1644,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="488"/>
@@ -2124,6 +1652,7 @@
         <nd ref="224"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Docteur Jean Bartholy"/>
@@ -2132,9 +1661,7 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="paved"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="277"/>
@@ -2147,15 +1674,14 @@
         <nd ref="200"/>
         <nd ref="443"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f9e68fc9-2f12-4da3-9395-254388d21e6e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="410"/>
@@ -2170,6 +1696,7 @@
         <nd ref="206"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Jean Price Mars"/>
@@ -2180,9 +1707,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <way visible="true" id="40" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="328"/>
@@ -2196,6 +1721,7 @@
         <nd ref="213"/>
         <nd ref="443"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Trichet"/>
@@ -2206,14 +1732,13 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="40"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="416"/>
         <nd ref="328"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Trichet"/>
@@ -2221,9 +1746,7 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="615"/>
@@ -2243,6 +1766,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Impasse Caiman"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -2260,9 +1785,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="43" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="237"/>
@@ -2270,14 +1792,13 @@
         <nd ref="402"/>
         <tag k="source" v="osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4f01f0de-e4e2-484f-8356-59127ca7f480}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="622"/>
@@ -2286,6 +1807,7 @@
         <nd ref="370"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Ducasse"/>
@@ -2296,14 +1818,13 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="44"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="258"/>
         <nd ref="276"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Venia"/>
@@ -2314,9 +1835,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="47" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="448"/>
@@ -2334,6 +1853,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Impasse Médilien"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2351,9 +1872,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="47"/>
     </way>
     <way visible="true" id="48" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="285"/>
@@ -2362,27 +1880,25 @@
         <nd ref="282"/>
         <nd ref="281"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{223ea449-7098-4a58-aaa5-478015b2bf4c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="48"/>
     </way>
     <way visible="true" id="49" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="286"/>
         <nd ref="387"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{8475cc65-2abb-45d9-83bb-0e01dec2ed31}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="49"/>
     </way>
     <way visible="true" id="53" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="432"/>
@@ -2390,6 +1906,7 @@
         <nd ref="300"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Caonabo"/>
@@ -2400,9 +1917,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="53"/>
     </way>
     <way visible="true" id="56" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="323"/>
@@ -2417,15 +1932,14 @@
         <nd ref="315"/>
         <nd ref="314"/>
         <tag k="source" v="geoeye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Saint Rémy"/>
         <tag k="uuid" v="{6a546adb-ab0f-4530-bc19-2ec613ec9ac1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="56"/>
     </way>
     <way visible="true" id="57" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="627"/>
@@ -2434,14 +1948,13 @@
         <nd ref="324"/>
         <nd ref="323"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{cfd447fe-44bf-4261-91f2-3655c104a2b2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="57"/>
     </way>
     <way visible="true" id="58" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="328"/>
@@ -2449,6 +1962,7 @@
         <nd ref="540"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Camep"/>
@@ -2459,9 +1973,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="58"/>
     </way>
     <way visible="true" id="59" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="23"/>
@@ -2472,14 +1984,13 @@
         <nd ref="339"/>
         <nd ref="597"/>
         <tag k="source" v="Google Aerial; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c24aab7d-6057-4c3e-98ee-63e856c26289}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="59"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="345"/>
@@ -2488,6 +1999,7 @@
         <nd ref="633"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mathon"/>
@@ -2498,9 +2010,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
     <way visible="true" id="61" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="350"/>
@@ -2508,6 +2018,7 @@
         <nd ref="422"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Nou Se Fanmi"/>
@@ -2518,9 +2029,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="61"/>
     </way>
     <way visible="true" id="62" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="354"/>
@@ -2530,6 +2039,7 @@
         <nd ref="351"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Célestin"/>
@@ -2540,9 +2050,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="62"/>
     </way>
     <way visible="true" id="64" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="368"/>
@@ -2557,6 +2065,7 @@
         <nd ref="424"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Exumé"/>
@@ -2567,9 +2076,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="64"/>
     </way>
     <way visible="true" id="69" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="616"/>
@@ -2586,6 +2093,7 @@
         <nd ref="627"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Saint Rémy"/>
@@ -2596,9 +2104,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
     </way>
     <way visible="true" id="70" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="443"/>
@@ -2612,6 +2118,7 @@
         <nd ref="435"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="2e Impasse Médilien"/>
@@ -2622,9 +2129,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </way>
     <way visible="true" id="71" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="450"/>
@@ -2636,6 +2141,7 @@
         <nd ref="444"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="2e Ruelle Jésus-Christ"/>
@@ -2646,9 +2152,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="71"/>
     </way>
     <way visible="true" id="74" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="466"/>
@@ -2656,6 +2160,7 @@
         <nd ref="463"/>
         <nd ref="462"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Val"/>
@@ -2666,9 +2171,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="74"/>
     </way>
     <way visible="true" id="75" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="573"/>
@@ -2677,14 +2180,13 @@
         <nd ref="520"/>
         <nd ref="465"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{16beb9f3-9ab1-416e-8de0-ad5da8daac13}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="75"/>
     </way>
     <way visible="true" id="76" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="471"/>
@@ -2692,41 +2194,38 @@
         <nd ref="469"/>
         <nd ref="468"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{edff258d-94be-4fc7-b989-e2fd4344be6a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="76"/>
     </way>
     <way visible="true" id="77" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="472"/>
         <nd ref="23"/>
         <tag k="source" v="Google Aerial; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{bb477a52-5f89-4c52-9978-65d986705547}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="77"/>
     </way>
     <way visible="true" id="78" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="475"/>
         <nd ref="474"/>
         <nd ref="473"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{76f9852c-1f65-4d50-8c34-d9fe2c973825}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="78"/>
     </way>
     <way visible="true" id="82" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="624"/>
@@ -2736,6 +2235,7 @@
         <nd ref="494"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="2e Impasse Ducasse"/>
@@ -2746,9 +2246,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="82"/>
     </way>
     <way visible="true" id="83" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="765"/>
@@ -2760,28 +2258,26 @@
         <nd ref="497"/>
         <nd ref="624"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{abce1451-babd-4a72-a704-6c5e4079b450}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="83"/>
     </way>
     <way visible="true" id="85" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="539"/>
         <nd ref="513"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{967168ce-fb46-481b-bf38-40ac06eac804}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="85"/>
     </way>
     <way visible="true" id="87" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="520"/>
@@ -2789,6 +2285,7 @@
         <nd ref="651"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="Mission de Terrain;Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
@@ -2800,9 +2297,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="87"/>
     </way>
     <way visible="true" id="88" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="526"/>
@@ -2813,6 +2308,7 @@
         <nd ref="522"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Jean Jacck"/>
@@ -2821,28 +2317,26 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="paved"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="88"/>
     </way>
     <way visible="true" id="91" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="540"/>
         <nd ref="539"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0c3f7dc3-11be-48d4-8472-418d92caa779}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="91"/>
     </way>
     <way visible="true" id="92" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="542"/>
         <nd ref="541"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Métélus"/>
@@ -2853,14 +2347,13 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="92"/>
     </way>
     <way visible="true" id="98" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="552"/>
         <nd ref="554"/>
         <tag k="source" v="Yahoo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2869,51 +2362,46 @@
         <tag k="uuid" v="{771e1296-4451-425a-8a12-76d2f25becde}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="98"/>
     </way>
     <way visible="true" id="99" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="554"/>
         <nd ref="598"/>
         <nd ref="553"/>
         <tag k="source" v="Yahoo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Anne"/>
         <tag k="uuid" v="{1865bf01-54fc-4fb1-ba49-07b665096286}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="99"/>
     </way>
     <way visible="true" id="100" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="556"/>
         <nd ref="555"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b769e9d5-d562-46db-9054-f957e764ed7e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="100"/>
     </way>
     <way visible="true" id="101" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="558"/>
         <nd ref="557"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
         <tag k="uuid" v="{5e0660ec-22eb-4a71-b364-834250b74c8f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="101"/>
     </way>
     <way visible="true" id="102" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="567"/>
@@ -2928,6 +2416,7 @@
         <nd ref="560"/>
         <nd ref="559"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Charmeau"/>
@@ -2938,9 +2427,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="102"/>
     </way>
     <way visible="true" id="103" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="570"/>
@@ -2948,6 +2435,7 @@
         <nd ref="568"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Pidou"/>
@@ -2958,28 +2446,26 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="103"/>
     </way>
     <way visible="true" id="104" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="572"/>
         <nd ref="571"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f2ee90d6-9d2d-40a9-95ff-f99e075ddd20}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="104"/>
     </way>
     <way visible="true" id="105" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="652"/>
         <nd ref="573"/>
         <nd ref="581"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Charlemagne B"/>
@@ -2990,9 +2476,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="105"/>
     </way>
     <way visible="true" id="106" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="580"/>
@@ -3003,14 +2487,13 @@
         <nd ref="575"/>
         <nd ref="574"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{024a00cf-be7c-4146-adbf-7a9bd4bc9297}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="106"/>
     </way>
     <way visible="true" id="107" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="584"/>
@@ -3018,20 +2501,20 @@
         <nd ref="582"/>
         <nd ref="581"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{fd8e50de-c4f3-4597-9c8e-03c19e836771}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="107"/>
     </way>
     <way visible="true" id="108" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="589"/>
         <nd ref="588"/>
         <nd ref="587"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="2e Impasse Jean Price Mars"/>
@@ -3042,15 +2525,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="108"/>
     </way>
     <way visible="true" id="109" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="592"/>
         <nd ref="591"/>
         <nd ref="590"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="3e Impasse Jean Price Mars"/>
@@ -3061,41 +2543,38 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="109"/>
     </way>
     <way visible="true" id="110" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="767"/>
         <nd ref="594"/>
         <nd ref="593"/>
         <tag k="source" v="Google 2010-01-17; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{8edd9170-0eeb-42e4-a5b8-211d79814efc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="110"/>
     </way>
     <way visible="true" id="111" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="596"/>
         <nd ref="595"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2cdd2e17-ad89-4b98-b330-cdfcf8356882}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="111"/>
     </way>
     <way visible="true" id="112" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="597"/>
         <nd ref="600"/>
         <tag k="source" v="Google Aerial; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3103,29 +2582,27 @@
         <tag k="uuid" v="{d3f0a216-0b74-4f78-873d-62e1c6784554}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="112"/>
     </way>
     <way visible="true" id="113" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="600"/>
         <nd ref="599"/>
         <nd ref="598"/>
         <tag k="source" v="Google Aerial; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{cd4fe70f-ddb9-4da5-9dbc-055d279b0807}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="113"/>
     </way>
     <way visible="true" id="117" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="606"/>
         <nd ref="605"/>
         <nd ref="604"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue M. Simon"/>
@@ -3136,29 +2613,27 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="117"/>
     </way>
     <way visible="true" id="120" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="611"/>
         <nd ref="610"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Damier"/>
         <tag k="uuid" v="{a0120502-a4cf-4234-8c35-9095ee62cac0}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="120"/>
     </way>
     <way visible="true" id="121" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="618"/>
         <nd ref="617"/>
         <nd ref="616"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Saint Rémy"/>
@@ -3169,9 +2644,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="121"/>
     </way>
     <way visible="true" id="122" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="624"/>
@@ -3183,42 +2656,39 @@
         <nd ref="625"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse G. Carver"/>
         <tag k="uuid" v="{c2b944ab-e3bb-4c67-a6d9-8d30196a08d3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="122"/>
     </way>
     <way visible="true" id="123" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="627"/>
         <nd ref="626"/>
         <nd ref="625"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{be70fcd1-ae38-47d6-9db8-388952443728}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="123"/>
     </way>
     <way visible="true" id="124" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="629"/>
         <nd ref="628"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{854a431c-71ac-4ca8-855c-13390e080990}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="124"/>
     </way>
     <way visible="true" id="125" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="653"/>
@@ -3245,6 +2715,7 @@
         <nd ref="632"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Route de Nazon"/>
@@ -3254,9 +2725,7 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="125"/>
     </way>
     <way visible="true" id="130" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="739"/>
@@ -3270,15 +2739,14 @@
         <nd ref="731"/>
         <nd ref="753"/>
         <tag k="source" v="Google;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse J. Charles"/>
         <tag k="uuid" v="{e2bf1c28-4d8a-4014-96f8-c410dde85dfa}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="130"/>
     </way>
     <way visible="true" id="131" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="753"/>
@@ -3297,29 +2765,27 @@
         <nd ref="740"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Célimène"/>
         <tag k="uuid" v="{d8d0ec79-db50-4764-9415-b1f807b21ee4}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="131"/>
     </way>
     <way visible="true" id="132" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="756"/>
         <nd ref="755"/>
         <nd ref="754"/>
         <tag k="source" v="NOAA; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{66dac7d6-214b-44e7-8afd-9503baf45454}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="132"/>
     </way>
     <way visible="true" id="133" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="771"/>
@@ -3342,6 +2808,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="1re Impasse Caiman"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3359,9 +2827,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="133"/>
     </way>
     <way visible="true" id="134" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="783"/>
@@ -3377,15 +2842,14 @@
         <nd ref="773"/>
         <nd ref="772"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="2e Impasse Caiman"/>
         <tag k="uuid" v="{d549121b-1a2d-452a-a023-41e76d917e87}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="134"/>
     </way>
     <way visible="true" id="141" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="29"/>
@@ -3396,15 +2860,14 @@
         <nd ref="24"/>
         <nd ref="23"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="3e Impasse Caiman"/>
         <tag k="uuid" v="{34f1c24b-d7b0-49ec-b932-fdcd97cbeca9}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="141"/>
     </way>
     <way visible="true" id="146" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="615"/>
@@ -3414,6 +2877,7 @@
         <nd ref="677"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Docteur Brun Ricot"/>
@@ -3425,23 +2889,20 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="146"/>
     </way>
     <way visible="true" id="151" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="511"/>
         <nd ref="682"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Josaphat"/>
         <tag k="uuid" v="{4e9d8f38-1686-48ba-b3be-2a398b2de904}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="151"/>
     </way>
     <way visible="true" id="152" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="683"/>
@@ -3450,6 +2911,7 @@
         <nd ref="508"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Milscent"/>
@@ -3460,9 +2922,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="152"/>
     </way>
     <way visible="true" id="154" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="685"/>
@@ -3471,6 +2931,7 @@
         <nd ref="432"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Caonabo"/>
@@ -3481,9 +2942,7 @@
         <tag k="surface" v="paving_stones"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="154"/>
     </way>
     <way visible="true" id="155" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="686"/>
@@ -3501,6 +2960,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 24"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3519,9 +2980,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="155"/>
     </way>
     <way visible="true" id="156" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="687"/>
@@ -3554,6 +3012,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Sylvio Cator"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3571,15 +3031,13 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="156"/>
     </way>
     <way visible="true" id="157" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="688"/>
         <nd ref="394"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Decastine"/>
@@ -3590,9 +3048,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="157"/>
     </way>
     <way visible="true" id="159" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="690"/>
@@ -3615,6 +3071,7 @@
         <nd ref="378"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Casimir Prolongée"/>
@@ -3625,9 +3082,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="159"/>
     </way>
     <way visible="true" id="160" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="691"/>
@@ -3640,6 +3095,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -3653,15 +3110,13 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="bing;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="160"/>
     </way>
     <way visible="true" id="161" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="692"/>
         <nd ref="509"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Merlet"/>
@@ -3672,15 +3127,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="161"/>
     </way>
     <way visible="true" id="162" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="693"/>
         <nd ref="606"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle A. François"/>
@@ -3691,15 +3145,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="162"/>
     </way>
     <way visible="true" id="164" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="695"/>
         <nd ref="355"/>
         <nd ref="606"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue M. Simon"/>
@@ -3710,9 +3163,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="164"/>
     </way>
     <way visible="true" id="165" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="696"/>
@@ -3723,15 +3174,14 @@
         <nd ref="335"/>
         <nd ref="552"/>
         <tag k="source" v="Yahoo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Anne"/>
         <tag k="uuid" v="{f48ef1e8-9e7d-47f9-9e1d-e30f47900cd7}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="165"/>
     </way>
     <way visible="true" id="167" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="699"/>
@@ -3739,6 +3189,7 @@
         <nd ref="611"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Damier"/>
@@ -3749,9 +3200,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="167"/>
     </way>
     <way visible="true" id="168" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="701"/>
@@ -3766,6 +3215,7 @@
         <nd ref="700"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Caravelle"/>
@@ -3776,9 +3226,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="168"/>
     </way>
     <way visible="true" id="169" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="702"/>
@@ -3787,15 +3235,14 @@
         <nd ref="329"/>
         <nd ref="428"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{53e20f55-180e-46e3-9988-4d06d58c6bbf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="gravel"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="169"/>
     </way>
     <way visible="true" id="171" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="704"/>
@@ -3806,6 +3253,7 @@
         <nd ref="637"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Delmas 28-B"/>
@@ -3816,9 +3264,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="171"/>
     </way>
     <way visible="true" id="174" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="411"/>
@@ -3827,10 +3273,9 @@
         <nd ref="273"/>
         <nd ref="272"/>
         <nd ref="708"/>
-        <tag k="source:datetime" v="2017-06-07T14:42:50Z"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="source:datetime" v="2017-06-07T14:42:50Z"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="174"/>
     </way>
     <way visible="true" id="175" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="383"/>
@@ -3841,6 +3286,7 @@
         <nd ref="259"/>
         <nd ref="709"/>
         <tag k="source" v="surve; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Bethesda"/>
@@ -3852,9 +3298,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="175"/>
     </way>
     <way visible="true" id="176" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="434"/>
@@ -3862,6 +3306,7 @@
         <nd ref="710"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Platons"/>
@@ -3872,9 +3317,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="176"/>
     </way>
     <way visible="true" id="178" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="307"/>
@@ -3884,14 +3327,13 @@
         <nd ref="225"/>
         <nd ref="712"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{dc103805-a865-4d82-8eea-9594fbbcb3cf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="178"/>
     </way>
     <way visible="true" id="179" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="713"/>
@@ -3907,6 +3349,7 @@
         <nd ref="574"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Route de Nazon"/>
@@ -3916,9 +3359,7 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="179"/>
     </way>
     <way visible="true" id="180" timestamp="2017-06-07T14:42:50Z" version="1" changeset="113">
         <nd ref="714"/>
@@ -3938,6 +3379,7 @@
         <nd ref="379"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Héreaux"/>
@@ -3948,23 +3390,20 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="180"/>
     </way>
     <way visible="true" id="183" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="718"/>
         <nd ref="29"/>
         <nd ref="717"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e527d243-7383-4c4f-9b87-3a601f0140dc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="183"/>
     </way>
     <way visible="true" id="185" timestamp="2017-06-07T14:42:50Z" version="1">
         <nd ref="720"/>
@@ -3980,6 +3419,7 @@
         <nd ref="318"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Saint Remi Rouzier"/>
@@ -3990,8 +3430,6 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="Confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="185"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/pap-005/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-005/Expected.osm
@@ -3,1452 +3,1099 @@
     <bounds minlat="18.546516" minlon="-72.33502" maxlat="18.551705" maxlon="-72.32552"/>
     <node visible="true" id="-56" timestamp="2017-06-07T14:55:59Z" version="1" changeset="114" lat="18.5509176740614343" lon="-72.3275139002104055">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-56"/>
     </node>
     <node visible="true" id="-55" timestamp="2017-06-07T14:55:59Z" version="1" changeset="114" lat="18.5509361940436364" lon="-72.3275035004483158">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-55"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480164000000052" lon="-72.3264460000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="2" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501666000000043" lon="-72.3306527999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="2"/>
     </node>
     <node visible="true" id="3" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501153000000016" lon="-72.3306527999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="3"/>
     </node>
     <node visible="true" id="4" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498952999999958" lon="-72.3307491999999854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="4"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497097999999987" lon="-72.3307549999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498164000000045" lon="-72.3317507999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490143999999972" lon="-72.3286353999999818">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489134000000000" lon="-72.3286989000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488911999999999" lon="-72.3286989000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487007999999989" lon="-72.3287969999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490081999999958" lon="-72.3284306999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483958000000015" lon="-72.3273559999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487317999999988" lon="-72.3283775000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488761999999987" lon="-72.3283176999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489449000000022" lon="-72.3282974999999908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491862000000047" lon="-72.3284699999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491898000000006" lon="-72.3286326000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492978000000015" lon="-72.3290678000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511143999999994" lon="-72.3287543999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5512866999999950" lon="-72.3296274000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5513194000000041" lon="-72.3299200000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5513288000000003" lon="-72.3301438000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5514659000000002" lon="-72.3305670999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502339999999997" lon="-72.3284215999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509968999999977" lon="-72.3282612999999799">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506525999999994" lon="-72.3280031999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5507178999999987" lon="-72.3283203000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5512208000000030" lon="-72.3273377999999809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5510089000000029" lon="-72.3274968999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509665000000012" lon="-72.3275241000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489946000000003" lon="-72.3262608000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490803000000000" lon="-72.3268790000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491053999999984" lon="-72.3270602999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5475008999999993" lon="-72.3282383999999894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480723000000012" lon="-72.3310785000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492455000000014" lon="-72.3270277000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492251000000010" lon="-72.3268563999999827">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491522999999994" lon="-72.3262459999999834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491310000000027" lon="-72.3259216999999808">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5472488000000020" lon="-72.3301976000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473288999999966" lon="-72.3304909000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473493000000040" lon="-72.3306733000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473493000000040" lon="-72.3309201000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473334000000030" lon="-72.3310163000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5475547999999968" lon="-72.3313538999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5478344999999969" lon="-72.3319953999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5478806999999968" lon="-72.3322801000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480017000000004" lon="-72.3326350999999903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5481474999999989" lon="-72.3329506999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484150999999962" lon="-72.3335715000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485432999999986" lon="-72.3339693000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486137999999983" lon="-72.3342352999999889">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486459000000039" lon="-72.3344100000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486584000000008" lon="-72.3346188000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486176999999977" lon="-72.3347956000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485423999999952" lon="-72.3350025999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480435999999997" lon="-72.3277432000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502756999999967" lon="-72.3285563000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501285000000031" lon="-72.3286173999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501441999999983" lon="-72.3296397000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484301000000009" lon="-72.3296026999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483049999999992" lon="-72.3296657999999866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484164999999983" lon="-72.3303607999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485942000000001" lon="-72.3303641999999911">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487146999999979" lon="-72.3303913000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488209999999967" lon="-72.3303922999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488785999999948" lon="-72.3303707999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489742999999976" lon="-72.3303118999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491035999999987" lon="-72.3302287999999862">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5481721000000057" lon="-72.3286518999999828">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5482739999999993" lon="-72.3288177999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479097000000053" lon="-72.3285199999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480787000000014" lon="-72.3284742000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483094000000008" lon="-72.3284041000000002">
         <tag k="addr:country" v="HT"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{b7095931-fc88-4bea-b1cf-098c7934f1ec}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485943000000013" lon="-72.3282705000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483082000000010" lon="-72.3333113999999853">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5481885999999960" lon="-72.3333322000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480852999999968" lon="-72.3332470000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480079000000018" lon="-72.3331732999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5478981999999988" lon="-72.3330787999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5477914000000013" lon="-72.3329882999999825">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5476344999999974" lon="-72.3329190000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5474893999999964" lon="-72.3328876000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473881999999968" lon="-72.3328474999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473174999999983" lon="-72.3328249999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5472141999999991" lon="-72.3327933999999857">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5469670000000022" lon="-72.3326794000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5468247999999996" lon="-72.3326428999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5467280000000017" lon="-72.3326002999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5466470000000001" lon="-72.3325310999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5478044999999980" lon="-72.3317303999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5474929000000017" lon="-72.3318557999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5510801000000036" lon="-72.3300535999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506117000000010" lon="-72.3297912999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505467000000088" lon="-72.3297577999999817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503028999999984" lon="-72.3300222000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501951999999974" lon="-72.3300325000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502235999999989" lon="-72.3299126999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506039999999999" lon="-72.3306182999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505409000000014" lon="-72.3308130000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502248000000023" lon="-72.3312272000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491358999999925" lon="-72.3310062999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490913999999982" lon="-72.3309633999999875">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490633999999979" lon="-72.3309432999999871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489692999999960" lon="-72.3309098000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488624999999985" lon="-72.3309741000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495529000000019" lon="-72.3310746999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495224000000007" lon="-72.3310706999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493990999999951" lon="-72.3310519000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493622000000009" lon="-72.3310545999999874">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479726999999990" lon="-72.3325498999999894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480830999999995" lon="-72.3325379000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483819000000061" lon="-72.3324936000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485218000000032" lon="-72.3324936000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498855999999996" lon="-72.3349369999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5500348000000024" lon="-72.3348512999999826">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5469487999999991" lon="-72.3266229000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5469640999999967" lon="-72.3267342000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5470046000000011" lon="-72.3268999999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5471139000000029" lon="-72.3273532999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5471940999999987" lon="-72.3275620000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5472563000000008" lon="-72.3276166999999788">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473661999999990" lon="-72.3276036000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5475132999999950" lon="-72.3275358000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5476025000000000" lon="-72.3275052000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480498999999988" lon="-72.3273341999999815">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480571999999952" lon="-72.3271830999999850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5478546999999985" lon="-72.3264656000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480926999999980" lon="-72.3328319999999820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484316000000007" lon="-72.3327684999999860">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <node visible="true" id="143" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486372999999993" lon="-72.3327653999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="143"/>
     </node>
     <node visible="true" id="144" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498174999999961" lon="-72.3347359999999924">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="144"/>
     </node>
     <node visible="true" id="145" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496867999999999" lon="-72.3346240000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="145"/>
     </node>
     <node visible="true" id="146" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5494708999999993" lon="-72.3345670000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="146"/>
     </node>
     <node visible="true" id="147" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493272000000005" lon="-72.3345276000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="147"/>
     </node>
     <node visible="true" id="148" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490767000000005" lon="-72.3344476000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="148"/>
     </node>
     <node visible="true" id="149" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498298000000048" lon="-72.3333745999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="149"/>
     </node>
     <node visible="true" id="150" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5500867000000014" lon="-72.3329826999999881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="150"/>
     </node>
     <node visible="true" id="151" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497718999999996" lon="-72.3259137000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="151"/>
     </node>
     <node visible="true" id="152" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5499307999999949" lon="-72.3262083000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="152"/>
     </node>
     <node visible="true" id="153" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502441000000005" lon="-72.3266856999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="153"/>
     </node>
     <node visible="true" id="154" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5504323000000007" lon="-72.3269863999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="154"/>
     </node>
     <node visible="true" id="155" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505241000000041" lon="-72.3271114000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="155"/>
     </node>
     <node visible="true" id="156" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505934000000003" lon="-72.3271275000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="156"/>
     </node>
     <node visible="true" id="157" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5500129999999999" lon="-72.3274538000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="157"/>
     </node>
     <node visible="true" id="158" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505565000000026" lon="-72.3259639999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="158"/>
     </node>
     <node visible="true" id="159" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506402000000037" lon="-72.3263697000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="159"/>
     </node>
     <node visible="true" id="160" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506804000000010" lon="-72.3269396999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="160"/>
     </node>
     <node visible="true" id="161" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506847999999991" lon="-72.3270545000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="161"/>
     </node>
     <node visible="true" id="162" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5476150000000004" lon="-72.3299514999999928">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="162"/>
     </node>
     <node visible="true" id="163" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479568999999991" lon="-72.3300161999999887">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="163"/>
     </node>
     <node visible="true" id="164" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480680000000042" lon="-72.3305746999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="164"/>
     </node>
     <node visible="true" id="165" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480450999999960" lon="-72.3307984000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="165"/>
     </node>
     <node visible="true" id="166" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480272999999976" lon="-72.3309717000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="166"/>
     </node>
     <node visible="true" id="167" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479622999999982" lon="-72.3311523999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="167"/>
     </node>
     <node visible="true" id="168" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479153999999973" lon="-72.3312827999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="168"/>
     </node>
     <node visible="true" id="169" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5477776999999975" lon="-72.3314940000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="169"/>
     </node>
     <node visible="true" id="170" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5466273999999984" lon="-72.3284687999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="170"/>
     </node>
     <node visible="true" id="171" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5468997999999985" lon="-72.3289146000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="171"/>
     </node>
     <node visible="true" id="172" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5471535000000003" lon="-72.3293634999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="172"/>
     </node>
     <node visible="true" id="173" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5475366000000008" lon="-72.3298934999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="173"/>
     </node>
     <node visible="true" id="174" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509041000000039" lon="-72.3278822000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="174"/>
     </node>
     <node visible="true" id="175" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505929000000016" lon="-72.3278839999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="175"/>
     </node>
     <node visible="true" id="176" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503770999999986" lon="-72.3278995999999808">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="176"/>
     </node>
     <node visible="true" id="177" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5500153999999995" lon="-72.3280074000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="177"/>
     </node>
     <node visible="true" id="178" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496963000000008" lon="-72.3281426000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="178"/>
     </node>
     <node visible="true" id="179" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5475424000000011" lon="-72.3262172999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="179"/>
     </node>
     <node visible="true" id="180" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5476892999999983" lon="-72.3267667999999873">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="180"/>
     </node>
     <node visible="true" id="181" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5478350999999968" lon="-72.3274377000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="181"/>
     </node>
     <node visible="true" id="182" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479063000000011" lon="-72.3276629000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="182"/>
     </node>
     <node visible="true" id="183" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480334999999954" lon="-72.3279444000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="183"/>
     </node>
     <node visible="true" id="184" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480878000000047" lon="-72.3280643999999882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="184"/>
     </node>
     <node visible="true" id="185" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5482705999999986" lon="-72.3284222999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="185"/>
     </node>
     <node visible="true" id="186" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488135000000050" lon="-72.3291871999999927">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="186"/>
     </node>
     <node visible="true" id="187" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492359999999969" lon="-72.3301551999999788">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="187"/>
     </node>
     <node visible="true" id="188" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493824000000025" lon="-72.3304423000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="188"/>
     </node>
     <node visible="true" id="189" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495640000000002" lon="-72.3308090000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="189"/>
     </node>
     <node visible="true" id="190" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496110999999999" lon="-72.3310613999999816">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="190"/>
     </node>
     <node visible="true" id="191" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496774000000002" lon="-72.3314172999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="191"/>
     </node>
     <node visible="true" id="192" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496887999999949" lon="-72.3315513999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="192"/>
     </node>
     <node visible="true" id="193" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496759000000004" lon="-72.3317031999999926">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="193"/>
     </node>
     <node visible="true" id="194" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495948000000013" lon="-72.3321949000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="194"/>
     </node>
     <node visible="true" id="195" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495769000000017" lon="-72.3323962999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="195"/>
     </node>
     <node visible="true" id="196" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495756000000043" lon="-72.3325063000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="196"/>
     </node>
     <node visible="true" id="197" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511754999999958" lon="-72.3310312999999923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="197"/>
     </node>
     <node visible="true" id="198" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5510896000000010" lon="-72.3305217000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="198"/>
     </node>
     <node visible="true" id="199" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5510605999999996" lon="-72.3304298999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="199"/>
     </node>
     <node visible="true" id="200" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509664999999977" lon="-72.3302741999999910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="200"/>
     </node>
     <node visible="true" id="201" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5516518999999995" lon="-72.3335189999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="201"/>
     </node>
     <node visible="true" id="202" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5515691000000018" lon="-72.3337029000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="202"/>
     </node>
     <node visible="true" id="203" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5514808000000002" lon="-72.3338398000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="203"/>
     </node>
     <node visible="true" id="204" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5513298999999954" lon="-72.3339670999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="204"/>
     </node>
     <node visible="true" id="205" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503907000000012" lon="-72.3331663999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="205"/>
     </node>
     <node visible="true" id="206" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502362999999981" lon="-72.3333558000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="206"/>
     </node>
     <node visible="true" id="207" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505409999999991" lon="-72.3337328000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="207"/>
     </node>
     <node visible="true" id="208" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506421000000010" lon="-72.3305706999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="208"/>
     </node>
     <node visible="true" id="209" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5476951999999962" lon="-72.3268776999999830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="209"/>
     </node>
     <node visible="true" id="210" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497717000000044" lon="-72.3286935000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="210"/>
     </node>
     <node visible="true" id="211" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498311999999963" lon="-72.3291756999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="211"/>
     </node>
     <node visible="true" id="212" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5500165000000017" lon="-72.3297795999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="212"/>
     </node>
     <node visible="true" id="213" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502764000000049" lon="-72.3306062999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="213"/>
     </node>
     <node visible="true" id="214" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497852999999999" lon="-72.3259386999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="214"/>
     </node>
     <node visible="true" id="215" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496808999999985" lon="-72.3255687999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="215"/>
     </node>
     <node visible="true" id="216" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496535999999992" lon="-72.3255800999999821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="216"/>
     </node>
     <node visible="true" id="217" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5514529000000010" lon="-72.3289096999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="217"/>
     </node>
     <node visible="true" id="218" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5513702999999950" lon="-72.3285839999999922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="218"/>
     </node>
     <node visible="true" id="219" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511838000000004" lon="-72.3281194999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="219"/>
     </node>
     <node visible="true" id="220" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491649999999986" lon="-72.3300159000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="220"/>
     </node>
     <node visible="true" id="221" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498134000000015" lon="-72.3259232999999853">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="221"/>
     </node>
     <node visible="true" id="222" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5514909000000010" lon="-72.3277413999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="222"/>
     </node>
     <node visible="true" id="223" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5512028999999963" lon="-72.3278873999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="223"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5512340000000044" lon="-72.3293253999999877">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511113999999999" lon="-72.3293629000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509510000000049" lon="-72.3293359999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5508021999999961" lon="-72.3292693000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5507075999999955" lon="-72.3292268000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="229" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505857999999968" lon="-72.3293144999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="229"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5504890000000024" lon="-72.3294056000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5504241999999948" lon="-72.3294771000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502588999999958" lon="-72.3295039000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5499325000000006" lon="-72.3295384999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505697000000005" lon="-72.3347325999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492021999999963" lon="-72.3283217999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491365999999971" lon="-72.3282410999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490090000000016" lon="-72.3280844999999886">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488581000000003" lon="-72.3279998999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487196999999995" lon="-72.3279428999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485675000000043" lon="-72.3276975999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="241" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484649999999966" lon="-72.3276362999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="241"/>
     </node>
     <node visible="true" id="242" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483857000000008" lon="-72.3275497000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="242"/>
     </node>
     <node visible="true" id="243" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497920000000036" lon="-72.3307539999999847">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="243"/>
     </node>
     <node visible="true" id="244" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496191000000010" lon="-72.3302228999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="244"/>
     </node>
     <node visible="true" id="245" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495133000000010" lon="-72.3299071999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="245"/>
     </node>
     <node visible="true" id="246" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5494370999999987" lon="-72.3296684999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="246"/>
     </node>
     <node visible="true" id="247" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492967000000029" lon="-72.3292778999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="247"/>
     </node>
     <node visible="true" id="248" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5514718999999992" lon="-72.3302264000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="248"/>
     </node>
     <node visible="true" id="249" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493666000000026" lon="-72.3282612999999799">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="249"/>
     </node>
     <node visible="true" id="250" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491181999999952" lon="-72.3279035999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="250"/>
     </node>
     <node visible="true" id="251" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489916000000044" lon="-72.3276191000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="251"/>
     </node>
     <node visible="true" id="252" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488968999999990" lon="-72.3274358999999833">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="252"/>
     </node>
     <node visible="true" id="253" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488338999999982" lon="-72.3273324999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="253"/>
     </node>
     <node visible="true" id="254" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488014999999997" lon="-72.3272130999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="254"/>
     </node>
     <node visible="true" id="255" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487461999999965" lon="-72.3270093000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="255"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486980999999993" lon="-72.3267280999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486372999999993" lon="-72.3263156999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="258" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517043999999984" lon="-72.3311597000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="258"/>
     </node>
     <node visible="true" id="259" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493899000000013" lon="-72.3272518999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="259"/>
     </node>
     <node visible="true" id="260" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489299000000045" lon="-72.3274758999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="260"/>
     </node>
     <node visible="true" id="261" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5494021999999994" lon="-72.3275538999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="261"/>
     </node>
     <node visible="true" id="262" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490232000000006" lon="-72.3277451999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="262"/>
     </node>
     <node visible="true" id="264" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506598000000018" lon="-72.3271359999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="264"/>
     </node>
     <node visible="true" id="268" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509218999999987" lon="-72.3275548000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="268"/>
     </node>
     <node visible="true" id="269" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5508757000000060" lon="-72.3275637999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="269"/>
     </node>
     <node visible="true" id="270" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5508147000000037" lon="-72.3275543000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="270"/>
     </node>
     <node visible="true" id="271" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486798000000022" lon="-72.3307056999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="271"/>
     </node>
     <node visible="true" id="272" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484073000000045" lon="-72.3308368999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="272"/>
     </node>
     <node visible="true" id="273" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5481944999999975" lon="-72.3309612999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="273"/>
     </node>
     <node visible="true" id="274" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5481210999999959" lon="-72.3310192000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="274"/>
     </node>
     <node visible="true" id="275" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511310999999957" lon="-72.3279239000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="275"/>
     </node>
     <node visible="true" id="276" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511076999999993" lon="-72.3279356999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="276"/>
     </node>
     <node visible="true" id="277" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509376000000046" lon="-72.3279995000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="277"/>
     </node>
     <node visible="true" id="278" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489377000000033" lon="-72.3259086999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="278"/>
     </node>
     <node visible="true" id="279" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487389000000000" lon="-72.3259622000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="279"/>
     </node>
     <node visible="true" id="280" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485125999999987" lon="-72.3259637000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="280"/>
     </node>
     <node visible="true" id="285" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506367999999995" lon="-72.3261621999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="285"/>
     </node>
     <node visible="true" id="286" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505178999999956" lon="-72.3302271000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="286"/>
     </node>
     <node visible="true" id="287" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5504947000000016" lon="-72.3302589000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="287"/>
     </node>
     <node visible="true" id="288" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5504941000000052" lon="-72.3303255999999806">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="288"/>
     </node>
     <node visible="true" id="289" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505198000000000" lon="-72.3304088999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="289"/>
     </node>
     <node visible="true" id="290" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505686999999959" lon="-72.3305423999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="290"/>
     </node>
     <node visible="true" id="291" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503674999999966" lon="-72.3255687999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="291"/>
     </node>
     <node visible="true" id="299" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497270000000007" lon="-72.3255496999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="299"/>
     </node>
     <node visible="true" id="302" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5498677000000001" lon="-72.3258945999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="302"/>
     </node>
     <node visible="true" id="311" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5506060999999995" lon="-72.3267249999999819">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="311"/>
     </node>
     <node visible="true" id="312" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503604999999965" lon="-72.3295636999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="312"/>
     </node>
     <node visible="true" id="313" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503289000000002" lon="-72.3295052999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="313"/>
     </node>
     <node visible="true" id="314" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5474269000000014" lon="-72.3269473999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="314"/>
     </node>
     <node visible="true" id="315" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5472241000000011" lon="-72.3270044000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="315"/>
     </node>
     <node visible="true" id="316" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5470733000000045" lon="-72.3270931999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="316"/>
     </node>
     <node visible="true" id="317" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5468669000000013" lon="-72.3270813999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="317"/>
     </node>
     <node visible="true" id="318" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5467146999999954" lon="-72.3270315000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="318"/>
     </node>
     <node visible="true" id="319" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465505999999998" lon="-72.3270071999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="319"/>
     </node>
     <node visible="true" id="323" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484465999999983" lon="-72.3263520000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="323"/>
     </node>
     <node visible="true" id="324" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5484034000000015" lon="-72.3262031000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="324"/>
     </node>
     <node visible="true" id="325" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5483332000000019" lon="-72.3260116999999809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="325"/>
     </node>
     <node visible="true" id="326" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5482413999999984" lon="-72.3297349999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="326"/>
     </node>
     <node visible="true" id="327" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5482799000000007" lon="-72.3298939999999817">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="327"/>
     </node>
     <node visible="true" id="328" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5482679999999931" lon="-72.3299193000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="328"/>
     </node>
     <node visible="true" id="329" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5479640000000039" lon="-72.3300516999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="329"/>
     </node>
     <node visible="true" id="330" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5514633000000018" lon="-72.3314754000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="330"/>
     </node>
     <node visible="true" id="331" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5513543000000034" lon="-72.3303341999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="331"/>
     </node>
     <node visible="true" id="332" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5511516999999984" lon="-72.3306101999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="332"/>
     </node>
     <node visible="true" id="333" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509790999999957" lon="-72.3308779999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="333"/>
     </node>
     <node visible="true" id="334" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5509516000000012" lon="-72.3309206999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="334"/>
     </node>
     <node visible="true" id="335" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5508793999999959" lon="-72.3310302999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="335"/>
     </node>
     <node visible="true" id="336" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5505437999999998" lon="-72.3315015999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="336"/>
     </node>
     <node visible="true" id="337" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497549000000035" lon="-72.3326002000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="337"/>
     </node>
     <node visible="true" id="338" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496036000000046" lon="-72.3327249000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="338"/>
     </node>
     <node visible="true" id="339" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5494458999999985" lon="-72.3327998999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="339"/>
     </node>
     <node visible="true" id="340" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5491884999999996" lon="-72.3329465999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="340"/>
     </node>
     <node visible="true" id="341" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490708999999967" lon="-72.3330265999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="341"/>
     </node>
     <node visible="true" id="342" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489452999999997" lon="-72.3332309000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="342"/>
     </node>
     <node visible="true" id="343" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488609999999987" lon="-72.3334797999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="343"/>
     </node>
     <node visible="true" id="344" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488570000000017" lon="-72.3337570000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="344"/>
     </node>
     <node visible="true" id="345" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488609999999987" lon="-72.3340120000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="345"/>
     </node>
     <node visible="true" id="346" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488830000000071" lon="-72.3342860000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="346"/>
     </node>
     <node visible="true" id="347" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488848999999973" lon="-72.3344215999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="347"/>
     </node>
     <node visible="true" id="348" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488869999999970" lon="-72.3345889999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="348"/>
     </node>
     <node visible="true" id="349" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488539999999986" lon="-72.3348170000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="349"/>
     </node>
     <node visible="true" id="350" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5502901000000016" lon="-72.3348613999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="350"/>
     </node>
     <node visible="true" id="351" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501946000000011" lon="-72.3348124999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="351"/>
     </node>
     <node visible="true" id="352" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5501064999999947" lon="-72.3346126999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="352"/>
     </node>
     <node visible="true" id="353" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5499863000000005" lon="-72.3344155999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="353"/>
     </node>
     <node visible="true" id="354" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497446000000004" lon="-72.3342197999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="354"/>
     </node>
     <node visible="true" id="355" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496291000000006" lon="-72.3340137999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="355"/>
     </node>
     <node visible="true" id="356" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5495228999999995" lon="-72.3338229999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="356"/>
     </node>
     <node visible="true" id="357" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5494382999999985" lon="-72.3336953999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="357"/>
     </node>
     <node visible="true" id="358" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5493549999999949" lon="-72.3336175000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="358"/>
     </node>
     <node visible="true" id="359" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5492430000000006" lon="-72.3335588000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="359"/>
     </node>
     <node visible="true" id="360" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5490648000000000" lon="-72.3335472999999922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="360"/>
     </node>
     <node visible="true" id="361" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5488578000000004" lon="-72.3335533999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="361"/>
     </node>
     <node visible="true" id="362" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5474551000000041" lon="-72.3257579999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="362"/>
     </node>
     <node visible="true" id="363" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465865000000036" lon="-72.3264901000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="363"/>
     </node>
     <node visible="true" id="364" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5469334000000003" lon="-72.3265083999999803">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="364"/>
     </node>
     <node visible="true" id="365" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5476285999999995" lon="-72.3265099000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="365"/>
     </node>
     <node visible="true" id="368" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465159999999969" lon="-72.3264735647200041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="368"/>
     </node>
     <node visible="true" id="369" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465159999999969" lon="-72.3262964925999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="369"/>
     </node>
     <node visible="true" id="370" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480246161699966" lon="-72.3255199999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="370"/>
     </node>
     <node visible="true" id="371" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5487874705900033" lon="-72.3350200000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="371"/>
     </node>
     <node visible="true" id="372" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5480962017400017" lon="-72.3255199999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="372"/>
     </node>
     <node visible="true" id="375" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465159999999969" lon="-72.3270071999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="375"/>
     </node>
     <node visible="true" id="383" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517049999999983" lon="-72.3311594641299820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="383"/>
     </node>
     <node visible="true" id="384" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517049999999983" lon="-72.3301306909099964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="384"/>
     </node>
     <node visible="true" id="385" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5508132957800029" lon="-72.3350200000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="385"/>
     </node>
     <node visible="true" id="386" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517050000000019" lon="-72.3276253610700053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="386"/>
     </node>
     <node visible="true" id="388" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5473958136999997" lon="-72.3255199999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="388"/>
     </node>
     <node visible="true" id="389" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465159999999969" lon="-72.3282524970099985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="389"/>
     </node>
     <node visible="true" id="390" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503489414500038" lon="-72.3255199999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="390"/>
     </node>
     <node visible="true" id="391" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5496283853299992" lon="-72.3255199999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="391"/>
     </node>
     <node visible="true" id="393" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5497868636699970" lon="-72.3350200000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="393"/>
     </node>
     <node visible="true" id="396" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5465159999999969" lon="-72.3323051250000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="396"/>
     </node>
     <node visible="true" id="397" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485319430199986" lon="-72.3350200000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="397"/>
     </node>
     <node visible="true" id="398" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5503245832499992" lon="-72.3350200000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="398"/>
     </node>
     <node visible="true" id="399" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517049999999983" lon="-72.3267953194399809">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="399"/>
     </node>
     <node visible="true" id="400" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517049999999983" lon="-72.3311613211599962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="400"/>
     </node>
     <node visible="true" id="401" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5517049999999983" lon="-72.3343536479700049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="401"/>
     </node>
     <node visible="true" id="404" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5489220999999951" lon="-72.3293955999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="404"/>
     </node>
     <node visible="true" id="405" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5486897999999911" lon="-72.3294893000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="405"/>
     </node>
     <node visible="true" id="406" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115" lat="18.5485419000000000" lon="-72.3295490000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="406"/>
     </node>
     <way visible="true" id="-11" timestamp="2017-06-07T14:55:59Z" version="1" changeset="114">
         <nd ref="29"/>
         <nd ref="-56"/>
         <nd ref="-55"/>
         <nd ref="29"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.139Z"/>
-        <tag k="location" v="overground"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{c8711a67-4f55-4d88-879c-3ef775fad316}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-11"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{c8711a67-4f55-4d88-879c-3ef775fad316}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.139Z"/>
+        <tag k="location" v="overground"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="32"/>
         <nd ref="37"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7a66ade3-92df-4425-b7ce-3387d0f181db}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="38"/>
@@ -1464,6 +1111,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Anglade"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -1481,9 +1130,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="189"/>
@@ -1494,27 +1140,25 @@
         <nd ref="2"/>
         <nd ref="213"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{99f038b1-72dc-4877-8537-7c9e772e5b5f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="6"/>
         <nd ref="106"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2232350a-ebde-4a78-83e5-7290f58ca3ee}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="10"/>
@@ -1523,40 +1167,37 @@
         <nd ref="7"/>
         <nd ref="17"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{873284c5-b599-4271-9652-7a706d48531f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="11"/>
         <nd ref="15"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{66b654a1-50ba-4d45-ba9d-9bee4c06359b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="12"/>
         <nd ref="254"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ccd85899-ab07-4d01-83b1-a324c7e0b599}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="236"/>
@@ -1564,14 +1205,13 @@
         <nd ref="14"/>
         <nd ref="13"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{535b3090-a469-4646-a891-55131f446adc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="18"/>
@@ -1579,14 +1219,13 @@
         <nd ref="16"/>
         <nd ref="235"/>
         <tag k="source" v="Google 2010-01-17; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{13f1660d-a5c5-4aba-81ad-6eab217fa755}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="25"/>
@@ -1594,27 +1233,25 @@
         <nd ref="24"/>
         <nd ref="58"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b0b75ed1-8e9e-4732-96cd-7303f4d5f51e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="27"/>
         <nd ref="26"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{81277b50-099b-4d81-8e3e-4b1af9761c44}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="268"/>
@@ -1626,6 +1263,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Barthélemy"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -1641,9 +1280,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="36"/>
@@ -1652,6 +1288,7 @@
         <nd ref="31"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Pierre Adrien"/>
@@ -1662,15 +1299,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="14" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="183"/>
         <nd ref="34"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Ficaire"/>
@@ -1681,23 +1317,20 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="167"/>
         <nd ref="35"/>
         <nd ref="274"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{672e07b9-91fd-40cf-87b3-78a459a4c674}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="39"/>
@@ -1706,6 +1339,7 @@
         <nd ref="36"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Dupont"/>
@@ -1716,77 +1350,70 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="242"/>
         <nd ref="57"/>
         <tag k="source" v="Google 2010-01-17: Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5aa92e42-f8e6-4486-b5cd-b49c4a62792b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="210"/>
         <nd ref="59"/>
         <nd ref="58"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{34c4fb35-d250-4d5d-a744-d9059abad3d2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="212"/>
         <nd ref="60"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7ae14b9f-cbd3-4371-aed8-0eedcb52a277}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="61"/>
         <nd ref="406"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
         <tag k="uuid" v="{e8409b8e-32df-41bd-83a1-7a78c164a986}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="326"/>
         <nd ref="62"/>
         <nd ref="61"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e016e699-00d6-44a3-8f5c-e23dc14930b4}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="187"/>
@@ -1798,29 +1425,27 @@
         <nd ref="64"/>
         <nd ref="63"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
         <tag k="uuid" v="{1796747e-b438-4477-a75c-2636745937c6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="71"/>
         <nd ref="70"/>
         <nd ref="73"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{a3e66672-9033-4030-b914-5fd3c752fcb3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="75"/>
@@ -1829,27 +1454,25 @@
         <nd ref="73"/>
         <nd ref="72"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1b819851-c590-4ebe-adc4-aee6a578c1a7}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="92"/>
         <nd ref="91"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f5e4df1b-6284-4da1-99ac-042b58677325}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="98"/>
@@ -1860,28 +1483,26 @@
         <nd ref="93"/>
         <nd ref="200"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{bbccbd18-998b-416e-8bd1-8715a824acbd}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="27" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="334"/>
         <nd ref="99"/>
         <nd ref="290"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0a1fb2af-63fd-4f33-a90f-069c6de26135}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="336"/>
@@ -1889,6 +1510,7 @@
         <nd ref="105"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Saint Félix"/>
@@ -1899,9 +1521,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="111"/>
@@ -1910,14 +1530,13 @@
         <nd ref="108"/>
         <nd ref="107"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6f068f65-ac69-4383-b41a-325c245ef465}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="115"/>
@@ -1926,14 +1545,13 @@
         <nd ref="112"/>
         <nd ref="190"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{02c14e7d-c83f-44ac-b271-9871bdf50290}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="119"/>
@@ -1941,15 +1559,14 @@
         <nd ref="117"/>
         <nd ref="116"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{616cf63f-1248-4509-af7f-3ec6e5a96ae7}"/>
         <tag k="note" v="with steps?"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="140"/>
@@ -1969,6 +1586,7 @@
         <nd ref="364"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Narcisse"/>
@@ -1979,24 +1597,21 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="143"/>
         <nd ref="142"/>
         <nd ref="141"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{15fdc7a0-fcd4-4a83-a563-8c8bbcfa8f7e}"/>
         <tag k="note" v="with steps?"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="347"/>
@@ -2006,46 +1621,44 @@
         <nd ref="145"/>
         <nd ref="144"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f952aa56-cf2a-4ade-9da2-f52ef1e37139}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="150"/>
         <nd ref="149"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d5bec77-bd49-41e4-affa-0ea5706a70fc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="264"/>
         <nd ref="157"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Aupont"/>
         <tag k="uuid" v="{698a9aa1-600b-4523-8c89-5c65b3425e6f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="215"/>
         <nd ref="299"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2053,9 +1666,7 @@
         <tag k="uuid" v="{ad418308-bd52-49ac-97a1-03d64e25f9e5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="169"/>
@@ -2070,6 +1681,7 @@
         <nd ref="173"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Dumarsais Estime"/>
@@ -2080,9 +1692,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="249"/>
@@ -2093,6 +1703,7 @@
         <nd ref="174"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Anglade"/>
@@ -2103,22 +1714,19 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <way visible="true" id="40" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="197"/>
         <nd ref="333"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{788c8e7d-89fb-4ef7-8b01-cf61fa71b275}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="40"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="200"/>
@@ -2126,14 +1734,13 @@
         <nd ref="198"/>
         <nd ref="332"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5cae3703-1a2f-4861-86fc-b1c2fa49b96d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="204"/>
@@ -2141,48 +1748,46 @@
         <nd ref="202"/>
         <nd ref="201"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b84f8b92-b866-440a-94ac-11428d5f8c4d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="43" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="207"/>
         <nd ref="206"/>
         <nd ref="205"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d44d8ab-5715-4dc9-9a54-231042ce2ea1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="332"/>
         <nd ref="208"/>
         <nd ref="290"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{bbda911c-e77f-4356-9a08-3c837fd88050}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="44"/>
     </way>
     <way visible="true" id="45" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="314"/>
         <nd ref="209"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Boisson"/>
@@ -2193,9 +1798,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="45"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="213"/>
@@ -2205,6 +1808,7 @@
         <nd ref="210"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle F. Doret"/>
@@ -2215,35 +1819,31 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="47" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="214"/>
         <nd ref="221"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{8cb761fc-e604-4d48-b3b7-15e273298316}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="47"/>
     </way>
     <way visible="true" id="48" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="216"/>
         <nd ref="215"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{14c54b52-99ce-4026-8942-ccb1cec87b91}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="48"/>
     </way>
     <way visible="true" id="49" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="276"/>
@@ -2251,32 +1851,31 @@
         <nd ref="218"/>
         <nd ref="217"/>
         <tag k="source" v="Bing; Yahoo hires;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{60ff6b05-b376-4150-ac1a-a7136dffd4f6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="49"/>
     </way>
     <way visible="true" id="50" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="245"/>
         <nd ref="220"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{baeee9fa-8494-4553-84ca-69e7f2d30cde}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="50"/>
     </way>
     <way visible="true" id="51" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="221"/>
         <nd ref="302"/>
         <tag k="source" v="Google Aerial;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2284,14 +1883,13 @@
         <tag k="uuid" v="{63737810-dc35-4908-af84-c09964d81021}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="51"/>
     </way>
     <way visible="true" id="52" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="275"/>
         <nd ref="223"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2300,9 +1898,7 @@
         <tag k="uuid" v="{1c05c86f-c201-4acf-b6e9-6ce9ef9dc457}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="52"/>
     </way>
     <way visible="true" id="53" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="246"/>
@@ -2319,6 +1915,7 @@
         <nd ref="224"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle A.Innocent"/>
@@ -2329,9 +1926,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="53"/>
     </way>
     <way visible="true" id="54" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="242"/>
@@ -2344,14 +1939,13 @@
         <nd ref="235"/>
         <nd ref="249"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5396099a-46e4-4d7b-809b-f584e1da9569}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="54"/>
     </way>
     <way visible="true" id="55" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="247"/>
@@ -2361,6 +1955,7 @@
         <nd ref="243"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Innocent"/>
@@ -2371,9 +1966,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="55"/>
     </way>
     <way visible="true" id="56" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="257"/>
@@ -2389,6 +1982,7 @@
         <nd ref="249"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Anglade Prolongée"/>
@@ -2399,15 +1993,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="56"/>
     </way>
     <way visible="true" id="57" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="260"/>
         <nd ref="259"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Lily"/>
@@ -2418,15 +2011,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="57"/>
     </way>
     <way visible="true" id="58" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="262"/>
         <nd ref="261"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Eben-Ezer"/>
@@ -2437,9 +2029,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="58"/>
     </way>
     <way visible="true" id="59" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="270"/>
@@ -2449,6 +2039,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -2462,9 +2054,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Google Aerial;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="59"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="270"/>
@@ -2475,6 +2064,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Barthélemy"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2489,9 +2080,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="Google Aerial;osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
     <way visible="true" id="61" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="274"/>
@@ -2500,6 +2088,7 @@
         <nd ref="271"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue St Charles"/>
@@ -2510,24 +2099,21 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="61"/>
     </way>
     <way visible="true" id="62" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="277"/>
         <nd ref="276"/>
         <nd ref="275"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Oriol"/>
         <tag k="uuid" v="{2f0cf7c6-df23-48d7-a38b-d66c689a8f7f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="62"/>
     </way>
     <way visible="true" id="63" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="325"/>
@@ -2535,14 +2121,13 @@
         <nd ref="279"/>
         <nd ref="278"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f7915e79-6bad-4742-a9e0-6c03c17cb771}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="63"/>
     </way>
     <way visible="true" id="64" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="290"/>
@@ -2551,27 +2136,25 @@
         <nd ref="287"/>
         <nd ref="286"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2fec3dd7-1ed3-4cea-bcde-36da8e5c52e1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="64"/>
     </way>
     <way visible="true" id="66" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="313"/>
         <nd ref="312"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2ea730cc-211a-40f2-9260-b5dd3398ac9f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="66"/>
     </way>
     <way visible="true" id="67" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="329"/>
@@ -2580,6 +2163,7 @@
         <nd ref="326"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Corridor St. Michel"/>
@@ -2590,22 +2174,19 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="67"/>
     </way>
     <way visible="true" id="68" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="335"/>
         <nd ref="330"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{50a793d0-8c19-4553-bfc1-7372f9257e23}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="68"/>
     </way>
     <way visible="true" id="69" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="361"/>
@@ -2626,6 +2207,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Impasse Dorcé"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -2643,23 +2226,19 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
     </way>
     <way visible="true" id="70" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="406"/>
         <nd ref="405"/>
         <nd ref="404"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9c7eb54d-7c89-4917-90b3-a7ebde73b2c3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </way>
     <way visible="true" id="73" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="365"/>
@@ -2672,6 +2251,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Sylvia"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -2689,9 +2270,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="73"/>
     </way>
     <way visible="true" id="74" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="370"/>
@@ -2699,6 +2277,7 @@
         <nd ref="369"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Dejean"/>
@@ -2709,9 +2288,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="74"/>
     </way>
     <way visible="true" id="75" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="371"/>
@@ -2741,6 +2318,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Sans Fil"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2758,9 +2337,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="75"/>
     </way>
     <way visible="true" id="76" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="372"/>
@@ -2769,6 +2345,7 @@
         <nd ref="323"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Suchet"/>
@@ -2779,9 +2356,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="76"/>
     </way>
     <way visible="true" id="78" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="375"/>
@@ -2793,6 +2368,7 @@
         <nd ref="314"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Boisson"/>
@@ -2803,23 +2379,20 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="78"/>
     </way>
     <way visible="true" id="84" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="383"/>
         <nd ref="258"/>
         <tag k="source" v="Haiti DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Maillart"/>
         <tag k="uuid" v="{da70f6e6-db75-4966-8eb8-2265a92571a2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="84"/>
     </way>
     <way visible="true" id="85" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="331"/>
@@ -2830,6 +2403,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Péan"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2846,9 +2421,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="85"/>
     </way>
     <way visible="true" id="86" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="385"/>
@@ -2856,6 +2428,7 @@
         <nd ref="350"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Macajoux"/>
@@ -2866,9 +2439,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="86"/>
     </way>
     <way visible="true" id="87" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="223"/>
@@ -2876,6 +2447,7 @@
         <nd ref="386"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Oriol"/>
@@ -2886,9 +2458,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="87"/>
     </way>
     <way visible="true" id="89" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="338"/>
@@ -2922,6 +2492,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2939,9 +2511,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="89"/>
     </way>
     <way visible="true" id="90" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="173"/>
@@ -2955,6 +2524,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Dumarsais Estimé"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2972,9 +2543,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="90"/>
     </way>
     <way visible="true" id="91" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="264"/>
@@ -2992,6 +2560,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Ti Chérie"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3009,9 +2579,6 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="91"/>
     </way>
     <way visible="true" id="92" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="264"/>
@@ -3030,6 +2597,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Cité Marc"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3047,9 +2616,6 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="92"/>
     </way>
     <way visible="true" id="94" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="350"/>
@@ -3058,6 +2624,7 @@
         <nd ref="393"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Macajoux"/>
@@ -3065,9 +2632,7 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="94"/>
     </way>
     <way visible="true" id="97" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="396"/>
@@ -3088,6 +2653,7 @@
         <nd ref="76"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse du Terasse"/>
@@ -3098,9 +2664,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="97"/>
     </way>
     <way visible="true" id="98" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="397"/>
@@ -3133,6 +2697,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Fort National"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3150,9 +2716,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="98"/>
     </way>
     <way visible="true" id="99" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="350"/>
@@ -3163,6 +2726,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Césars"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3180,9 +2745,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="99"/>
     </way>
     <way visible="true" id="100" timestamp="2017-06-07T14:56:00Z" version="1" changeset="115">
         <nd ref="29"/>
@@ -3194,6 +2756,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Bergeaud"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3211,9 +2775,6 @@
         <tag k="source" v="osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="track"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="100"/>
     </way>
     <way visible="true" id="101" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="400"/>
@@ -3235,6 +2796,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Saint Martin"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3252,9 +2815,6 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="101"/>
     </way>
     <way visible="true" id="102" timestamp="2017-06-07T14:56:00Z" version="1">
         <nd ref="401"/>
@@ -3268,6 +2828,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3285,8 +2847,5 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="102"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/pap-006/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-006/Expected.osm
@@ -3,599 +3,455 @@
     <bounds minlat="18.544216" minlon="-72.3495523" maxlat="18.549036" maxlon="-72.340941"/>
     <node visible="true" id="-36" timestamp="2017-06-07T15:16:55Z" version="1" changeset="116" lat="18.5442327236992028" lon="-72.3479671644483773">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-16" timestamp="2017-06-07T15:16:55Z" version="1" changeset="116" lat="18.5444159010916145" lon="-72.3479061053931645">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463604999999880" lon="-72.3472852000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="2" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460960999999998" lon="-72.3473560000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="2"/>
     </node>
     <node visible="true" id="3" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5450757999999958" lon="-72.3476198999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="3"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463306999999951" lon="-72.3468486999999811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463741999999989" lon="-72.3469943000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486996999999931" lon="-72.3468201000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473485999999994" lon="-72.3471519000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5453608999999950" lon="-72.3495522999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5452998999999963" lon="-72.3490373000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5453150999999963" lon="-72.3489567999999821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5452845999999951" lon="-72.3486886000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466423999999961" lon="-72.3473252000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466267000000009" lon="-72.3472605999999843">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466064999999993" lon="-72.3472294999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465656999999986" lon="-72.3471934999999888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465194999999952" lon="-72.3471851000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464517999999963" lon="-72.3471875999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464157999999948" lon="-72.3472036000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463824999999964" lon="-72.3472366000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463569999999969" lon="-72.3473331999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463771999999949" lon="-72.3473943000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464067999999962" lon="-72.3474285999999864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464469999999935" lon="-72.3474513000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465071999999971" lon="-72.3474671000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466037999999962" lon="-72.3474214999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488974999999989" lon="-72.3487492999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485582999999998" lon="-72.3486496000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483136000000002" lon="-72.3485107999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5467543999999975" lon="-72.3474721000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466247999999965" lon="-72.3473883000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488980999999988" lon="-72.3480011000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490354999999987" lon="-72.3477780000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490145999999960" lon="-72.3478599000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490172999999956" lon="-72.3479245999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487392999999976" lon="-72.3478243999999791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487493000000008" lon="-72.3478123999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487417000000043" lon="-72.3477318999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486882999999949" lon="-72.3476540999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485676999999960" lon="-72.3477299000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488967999999979" lon="-72.3475440999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487977000000015" lon="-72.3475494999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487263999999961" lon="-72.3475468000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486222000000041" lon="-72.3476540999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485204999999951" lon="-72.3475011999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486285999999936" lon="-72.3475236999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486769000000038" lon="-72.3475559000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490087000000017" lon="-72.3484480000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489628999999958" lon="-72.3484159000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489248000000018" lon="-72.3484050999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488916999999951" lon="-72.3484050999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488382999999999" lon="-72.3483649000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487696999999940" lon="-72.3483300000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487010000000012" lon="-72.3483085999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486746999999994" lon="-72.3481852999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488499000000004" lon="-72.3481440000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489234999999972" lon="-72.3481244999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483119999999957" lon="-72.3469141999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5476449999999957" lon="-72.3437440999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488587000000003" lon="-72.3478295999999830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487091999999976" lon="-72.3478702000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486083999999956" lon="-72.3478893999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5461508999999971" lon="-72.3474597999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460811999999962" lon="-72.3483207999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463805999999956" lon="-72.3483935000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466134999999959" lon="-72.3485043000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471076000000004" lon="-72.3487724999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5472447999999979" lon="-72.3488854000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473764999999986" lon="-72.3490165000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5474521999999986" lon="-72.3491154999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5475540000000017" lon="-72.3492241999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5476506999999948" lon="-72.3493176999999861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5477011999999988" lon="-72.3493753999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471021999999977" lon="-72.3412442999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5459917999999959" lon="-72.3429339000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473763999999939" lon="-72.3425907000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5481617999999990" lon="-72.3460184000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5462543999999987" lon="-72.3464747000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5443711999999969" lon="-72.3469414000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471399000000012" lon="-72.3414185000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451784999999951" lon="-72.3416548999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5454871999999966" lon="-72.3430367999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5457570999999959" lon="-72.3441762000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5445850000000014" lon="-72.3478640999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5482358000000040" lon="-72.3411717999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484754999999950" lon="-72.3423156000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487228999999978" lon="-72.3434648000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489697000000007" lon="-72.3446454999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471023999999964" lon="-72.3477086000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5472575999999947" lon="-72.3476361000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484690999999984" lon="-72.3473520000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487508000000005" lon="-72.3472802999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484420000000014" lon="-72.3473618000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484700999999959" lon="-72.3474982000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485251999999967" lon="-72.3477656999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485524999999960" lon="-72.3478984999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486138999999959" lon="-72.3481967000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486349999999973" lon="-72.3482991000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487046999999947" lon="-72.3487044000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460012999999968" lon="-72.3454937999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="101" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5479269999999943" lon="-72.3450419999999923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="101"/>
     </node>
     <node visible="true" id="102" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490224999999960" lon="-72.3447800999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="102"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465459999999958" lon="-72.3474619999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="104" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5470576999999963" lon="-72.3478314999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="104"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5482264999999948" lon="-72.3486065999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485025999999955" lon="-72.3487513000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486416999999975" lon="-72.3488001999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486936000000000" lon="-72.3488177999999920">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488603999999988" lon="-72.3488607999999829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451003000000014" lon="-72.3477426000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3466479838299961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3488785603699966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3459388062899933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3447770649799793">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3472163173999832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5481833481800003" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3448408807699934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5450276523399928" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3409679649199973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="120" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3458156529400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="120"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999987" lon="-72.3469670106999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442160000000023" lon="-72.3433536260800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="123" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3421889451300046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="123"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3418932164200044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3484123481800054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3476930497400019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3477771650599806">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3479855952899982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3486075393099952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442160000000023" lon="-72.3445897743199993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3487509983399946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3479753262299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442160000000023" lon="-72.3462816993999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5470361288099994" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000045" lon="-72.3467378757499944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3446083533700062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3433872431200058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3478569061299908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486804999999997" lon="-72.3467308000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483079999999987" lon="-72.3468175999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473270999999968" lon="-72.3470496999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465999000000004" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <way visible="true" id="-14" timestamp="2017-06-07T15:16:55Z" version="1">
         <nd ref="-36"/>
         <nd ref="-16"/>
         <nd ref="84"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="yes"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
         <tag k="seasonal" v="no"/>
-        <tag k="lanes" v="4"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="18"/>
@@ -610,6 +466,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Casernes"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -628,35 +486,30 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="139"/>
         <nd ref="7"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{19d7e8e8-2ddf-4aaf-ba23-d79480c07ed0}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="141"/>
         <nd ref="8"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{80416c3c-d608-4d6a-a59a-346ada5f1e6d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="110"/>
@@ -665,27 +518,25 @@
         <nd ref="10"/>
         <nd ref="9"/>
         <tag k="source" v="geoeye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c7acd2eb-accb-4b34-ae66-4463e5c8f664}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="89"/>
         <nd ref="104"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4aa747a3-768b-43c2-a7c2-188ce187a200}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="31"/>
@@ -708,28 +559,26 @@
         <nd ref="13"/>
         <nd ref="31"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d02aaea-648c-4b09-8acf-8cf0b4fd4124}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
         <tag k="junction" v="roundabout"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="32"/>
         <nd ref="35"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{83dbfc5a-f894-4fe3-9d14-63fdb4425af6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="95"/>
@@ -741,14 +590,13 @@
         <nd ref="36"/>
         <nd ref="61"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1b094678-4e70-4726-9c60-efc6c19f6588}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="47"/>
@@ -756,14 +604,13 @@
         <nd ref="45"/>
         <nd ref="94"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9095d65f-b9d2-425b-a4e0-fb8b61eada23}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="57"/>
@@ -771,14 +618,13 @@
         <nd ref="55"/>
         <nd ref="97"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{83455e56-898e-4fa5-8e16-7b62ddefa087}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="74"/>
@@ -795,6 +641,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Pavée"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -815,9 +663,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="96"/>
@@ -825,14 +670,13 @@
         <nd ref="61"/>
         <nd ref="60"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{fd518d81-26c8-4bbf-8604-3538476bea30}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="73"/>
@@ -847,14 +691,13 @@
         <nd ref="64"/>
         <nd ref="63"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4007d710-d32a-4585-8483-8c2e146ebfdf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="108"/>
@@ -866,28 +709,26 @@
         <nd ref="94"/>
         <nd ref="93"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Antonio Macéo"/>
         <tag k="uuid" v="{3d5251db-486f-4dde-b1ab-46bab5cdeecc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="3"/>
         <nd ref="110"/>
         <tag k="source" v="geoeye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{cdea7081-4c1c-4220-9bc9-50b3cf92b5d9}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="142"/>
@@ -900,6 +741,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Marie Jeanne"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="4"/>
@@ -915,9 +758,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="112"/>
@@ -934,6 +774,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Harry Truman"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="4"/>
@@ -949,9 +791,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GRU/COSMHA;osm;mgcp"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="114"/>
@@ -961,6 +800,7 @@
         <nd ref="113"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/GIS /DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Magasin de l'État"/>
@@ -971,9 +811,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="115"/>
@@ -983,15 +821,14 @@
         <nd ref="90"/>
         <nd ref="89"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Pie XII"/>
         <tag k="uuid" v="{dc81339f-b308-4492-80e5-c71e2c93ea82}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="117"/>
@@ -1004,6 +841,7 @@
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue des Miracles"/>
@@ -1014,9 +852,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="100"/>
@@ -1032,6 +868,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Casernes"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1050,9 +888,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="119"/>
@@ -1060,6 +895,7 @@
         <nd ref="80"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Peuple"/>
@@ -1070,9 +906,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="121"/>
@@ -1082,6 +916,7 @@
         <nd ref="120"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/GIS /DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Quai"/>
@@ -1092,9 +927,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="123"/>
@@ -1105,6 +938,7 @@
         <nd ref="122"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
         <tag k="history" v="Retrieved from v20"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Centre"/>
@@ -1116,9 +950,7 @@
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="surface_condition" v="Smooth_greater_than_40kph"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="124"/>
@@ -1130,6 +962,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Enterrement"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -1147,9 +981,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="27" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="98"/>
@@ -1162,14 +993,13 @@
         <nd ref="48"/>
         <nd ref="125"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{67d71af3-7f1a-447a-b664-c4a747b7277b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="44"/>
@@ -1179,14 +1009,13 @@
         <nd ref="41"/>
         <nd ref="126"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6a07b25b-60a7-4944-8e1d-361936b2eb89}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="128"/>
@@ -1196,6 +1025,7 @@
         <nd ref="127"/>
         <tag k="foot" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="cycleway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bicycle" v="no"/>
@@ -1206,9 +1036,7 @@
         <tag k="attribution" v="osm"/>
         <tag k="access" v="no"/>
         <tag k="motor_vehicle" v="permissive"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="129"/>
@@ -1219,14 +1047,13 @@
         <nd ref="42"/>
         <nd ref="92"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0c8279b7-71f3-4f70-be9d-1b40a954cd69}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="130"/>
@@ -1239,6 +1066,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
         <tag k="ref" v="RN 2"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
@@ -1257,9 +1086,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="31"/>
@@ -1272,6 +1098,7 @@
         <nd ref="131"/>
         <tag k="source" v="GRU/COSMHA;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Boulevard Harry Truman"/>
@@ -1279,9 +1106,7 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
         <tag k="loc_name" v="Bicentenaire"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="22"/>
@@ -1295,6 +1120,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Harry Truman"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1313,9 +1140,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="84"/>
@@ -1327,6 +1151,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue du Champ de Mars"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1344,9 +1170,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="134"/>
@@ -1358,6 +1181,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Pavée"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1380,9 +1205,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="135"/>
@@ -1392,29 +1214,27 @@
         <nd ref="13"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Marie Jeanne"/>
         <tag k="uuid" v="{b211a83c-4c16-49e1-82db-f9c74b3aef73}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="136"/>
         <nd ref="88"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Courbe"/>
         <tag k="uuid" v="{3ba8056c-2b4e-4105-a2ad-5809a6047816}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="59"/>
@@ -1427,6 +1247,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
         <tag k="ref" v="RN 1"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
@@ -1445,9 +1267,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="138"/>
@@ -1458,6 +1277,7 @@
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/GIS /DTM;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Boulevard Harry Truman"/>
@@ -1468,38 +1288,33 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <relation visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="33" role="reviewee"/>
         <member type="way" ref="-14" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-111"/>
     </relation>
     <relation visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-14" role="reviewee"/>
         <member type="way" ref="39" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-110"/>
     </relation>
     <relation visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="140" role="reviewee"/>
         <member type="way" ref="11" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-109"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/pap-007/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-007/Expected.osm
@@ -3,2014 +3,1516 @@
     <bounds minlat="18.54724071879813" minlon="-72.34827818244368" maxlat="18.5559549597128" maxlon="-72.332367"/>
     <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5535840000000043" lon="-72.3344225999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-214"/>
     </node>
     <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5538104000000033" lon="-72.3347009999999813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-213"/>
     </node>
     <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5545940999999992" lon="-72.3351892999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-212"/>
     </node>
     <node visible="true" id="-209" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5528078103602958" lon="-72.3473612512200788">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-209"/>
     </node>
     <node visible="true" id="-208" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5532981102122285" lon="-72.3479442297817457">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-208"/>
     </node>
     <node visible="true" id="-207" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5535970735394748" lon="-72.3482730894808128">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-207"/>
     </node>
     <node visible="true" id="-206" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5512391140720645" lon="-72.3482266605280557">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-206"/>
     </node>
     <node visible="true" id="-205" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5516761166975535" lon="-72.3479514709215294">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-205"/>
     </node>
     <node visible="true" id="-204" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5517947702771338" lon="-72.3478412425723860">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-204"/>
     </node>
     <node visible="true" id="-203" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5519130605317741" lon="-72.3477313777396347">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-203"/>
     </node>
     <node visible="true" id="-202" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5524924922238164" lon="-72.3472255599250644">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-202"/>
     </node>
     <node visible="true" id="-201" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5525585928193415" lon="-72.3471700680864558">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-201"/>
     </node>
     <node visible="true" id="-200" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5526100060636416" lon="-72.3471269063553137">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-200"/>
     </node>
     <node visible="true" id="-199" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5527235164731295" lon="-72.3470316136948668">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-199"/>
     </node>
     <node visible="true" id="-198" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5528775326430697" lon="-72.3469317884392211">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-198"/>
     </node>
     <node visible="true" id="-197" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5531142611838753" lon="-72.3468234067333924">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-197"/>
     </node>
     <node visible="true" id="-196" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5538643769240359" lon="-72.3466209041013286">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-196"/>
     </node>
     <node visible="true" id="-195" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5542032519353626" lon="-72.3465071028472266">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-195"/>
     </node>
     <node visible="true" id="-194" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5542590634700026" lon="-72.3464736369000008">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-194"/>
     </node>
     <node visible="true" id="-193" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5544501575899972" lon="-72.3463852202200002">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-193"/>
     </node>
     <node visible="true" id="-192" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5547154076399998" lon="-72.3462369083599981">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-192"/>
     </node>
     <node visible="true" id="-190" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5550034748900003" lon="-72.3460315534899934">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-190"/>
     </node>
     <node visible="true" id="-189" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5511446428339575" lon="-72.3482781824436785">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-189"/>
     </node>
     <node visible="true" id="-188" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5552788326467279" lon="-72.3457255949631559">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-188"/>
     </node>
     <node visible="true" id="-187" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5559549597127962" lon="-72.3449531046146035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-187"/>
     </node>
     <node visible="true" id="-186" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5555562042630520" lon="-72.3453558848035811">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-186"/>
     </node>
     <node visible="true" id="-185" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5557472983392877" lon="-72.3451362691145761">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-185"/>
     </node>
     <node visible="true" id="-184" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5558699408048504" lon="-72.3450136265780657">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-184"/>
     </node>
     <node visible="true" id="-168" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5472407187981325" lon="-72.3471777049857536">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-168"/>
     </node>
     <node visible="true" id="-164" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5535990814892919" lon="-72.3482749202608915">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-164"/>
     </node>
     <node visible="true" id="-132" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118" lat="18.5477387272806773" lon="-72.3470515475541305">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-132"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5524206000000014" lon="-72.3352054000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5526596999999995" lon="-72.3356480000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5528860000000009" lon="-72.3362086000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5529761999999998" lon="-72.3366256999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5531715000000013" lon="-72.3374392000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542428000000008" lon="-72.3421292000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5524972999999953" lon="-72.3339469000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5541547999999992" lon="-72.3371996000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5553691000000036" lon="-72.3394533000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5516887000000033" lon="-72.3481100000000055">
         <tag k="addr:country" v="HT"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{eccd0017-8d52-4d59-9d70-8177cdd22e7c}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5517515000000017" lon="-72.3482101000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492947999999984" lon="-72.3466746000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496812000000020" lon="-72.3465774999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486997000000002" lon="-72.3468201000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5473486000000030" lon="-72.3471519000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493950000000005" lon="-72.3361170000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490622000000016" lon="-72.3380915999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491835999999992" lon="-72.3382228999999910">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492434000000017" lon="-72.3383395999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493451000000000" lon="-72.3385461000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495434000000010" lon="-72.3390583999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5556450999999996" lon="-72.3411564000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5556408000000026" lon="-72.3409733000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5552759000000016" lon="-72.3400757999999797">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5553574999999995" lon="-72.3413386000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5553038000000043" lon="-72.3412412999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510149000000055" lon="-72.3476406000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510021999999957" lon="-72.3475334000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510301999999996" lon="-72.3474288000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510784999999991" lon="-72.3473616999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5511343999999987" lon="-72.3473321999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512157999999978" lon="-72.3473134000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5513531000000000" lon="-72.3473482999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514089999999996" lon="-72.3474099999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514472000000019" lon="-72.3474903999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514776999999960" lon="-72.3476110999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515208999999963" lon="-72.3478176999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514140999999952" lon="-72.3478874000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512031000000057" lon="-72.3479597999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512818999999993" lon="-72.3473106999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510607000000007" lon="-72.3458435999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510657999999964" lon="-72.3459133000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510555999999980" lon="-72.3459804000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510098000000028" lon="-72.3460527999999954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509656000000014" lon="-72.3460891000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5508622999999986" lon="-72.3461144999999846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5508111000000042" lon="-72.3461109999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5507491999999985" lon="-72.3460802000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5506944999999988" lon="-72.3460151999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510504999999988" lon="-72.3457738000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5506428000000092" lon="-72.3458799999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509888000000025" lon="-72.3469419999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5511936999999918" lon="-72.3469029999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5508572999999970" lon="-72.3458255999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509148000000010" lon="-72.3461051999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510759000000007" lon="-72.3463586000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5508753999999989" lon="-72.3464114999999879">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515046999999988" lon="-72.3472103000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514394999999972" lon="-72.3468548999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5513149999999989" lon="-72.3462942000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5511928999999967" lon="-72.3457405999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510927999999993" lon="-72.3453595999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510734000000035" lon="-72.3479652000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509717000000016" lon="-72.3479169000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5507707999999987" lon="-72.3470049999999816">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5506446999999994" lon="-72.3464588999999876">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5505254000000050" lon="-72.3459095000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5504373000000022" lon="-72.3455038000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5554306000000011" lon="-72.3441045999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488980999999988" lon="-72.3480011000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493841999999987" lon="-72.3480763999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494389999999996" lon="-72.3480144999999908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494668000000047" lon="-72.3479509000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="101" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494628000000006" lon="-72.3477989000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="101"/>
     </node>
     <node visible="true" id="102" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494230000000009" lon="-72.3477254999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="102"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493854999999961" lon="-72.3476876000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="104" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492506999999982" lon="-72.3476375000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="104"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491281000000008" lon="-72.3476708999999829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490354999999987" lon="-72.3477780000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490146000000031" lon="-72.3478599000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490173000000027" lon="-72.3479245999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490363999999985" lon="-72.3479868999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490831999999983" lon="-72.3480557999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491302000000040" lon="-72.3480933000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492060000000016" lon="-72.3481220000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493175000000008" lon="-72.3481132000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487392999999976" lon="-72.3478243999999791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487493000000043" lon="-72.3478123999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487417000000008" lon="-72.3477318999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486882999999985" lon="-72.3476540999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485676999999995" lon="-72.3477299000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5543857000000045" lon="-72.3353975999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="120" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542391000000002" lon="-72.3355329999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="120"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5534885000000003" lon="-72.3359152000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546979999999984" lon="-72.3442780999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="123" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5531824999999984" lon="-72.3375362999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="123"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509966000000013" lon="-72.3380752000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498790000000007" lon="-72.3383453000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490667000000009" lon="-72.3477259000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488968000000014" lon="-72.3475440999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487977000000015" lon="-72.3475494999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487263999999961" lon="-72.3475468000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486222000000076" lon="-72.3476540999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485205000000022" lon="-72.3475011999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486286000000042" lon="-72.3475236999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486768999999967" lon="-72.3475559000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491711000000024" lon="-72.3476502000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5557987000000004" lon="-72.3432727000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545274000000013" lon="-72.3435311000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491557000000000" lon="-72.3481065999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486746999999994" lon="-72.3481852999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488499000000004" lon="-72.3481440000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489235000000008" lon="-72.3481244999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5523279999999993" lon="-72.3361500999999834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5524941999999982" lon="-72.3340859000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <node visible="true" id="143" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5517493000000009" lon="-72.3343993000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="143"/>
     </node>
     <node visible="true" id="149" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493277999999968" lon="-72.3476535999999868">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="149"/>
     </node>
     <node visible="true" id="150" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494786000000005" lon="-72.3473780000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="150"/>
     </node>
     <node visible="true" id="151" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494242000000042" lon="-72.3480358999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="151"/>
     </node>
     <node visible="true" id="152" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5483119999999992" lon="-72.3469141999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="152"/>
     </node>
     <node visible="true" id="153" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5476449999999993" lon="-72.3437440999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="153"/>
     </node>
     <node visible="true" id="154" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488586999999967" lon="-72.3478295999999830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="154"/>
     </node>
     <node visible="true" id="155" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487092000000011" lon="-72.3478702000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="155"/>
     </node>
     <node visible="true" id="156" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486084000000062" lon="-72.3478893999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="156"/>
     </node>
     <node visible="true" id="157" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494738000000012" lon="-72.3478616000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="157"/>
     </node>
     <node visible="true" id="158" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495801000000000" lon="-72.3478535999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="158"/>
     </node>
     <node visible="true" id="159" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493031000000066" lon="-72.3481177000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="159"/>
     </node>
     <node visible="true" id="164" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487623000000070" lon="-72.3356196999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="164"/>
     </node>
     <node visible="true" id="165" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491400999999989" lon="-72.3355061999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="165"/>
     </node>
     <node visible="true" id="166" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495114000000036" lon="-72.3353189999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="166"/>
     </node>
     <node visible="true" id="167" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5497506999999970" lon="-72.3350504000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="167"/>
     </node>
     <node visible="true" id="168" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498855999999961" lon="-72.3349369999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="168"/>
     </node>
     <node visible="true" id="169" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5500347999999988" lon="-72.3348512999999826">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="169"/>
     </node>
     <node visible="true" id="172" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493325999999996" lon="-72.3397953000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="172"/>
     </node>
     <node visible="true" id="173" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5497906999999991" lon="-72.3406690999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="173"/>
     </node>
     <node visible="true" id="174" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496149999999957" lon="-72.3407124999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="174"/>
     </node>
     <node visible="true" id="175" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495401999999991" lon="-72.3407433999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="175"/>
     </node>
     <node visible="true" id="176" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495969999999986" lon="-72.3397262000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="176"/>
     </node>
     <node visible="true" id="177" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494291999999987" lon="-72.3397748000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="177"/>
     </node>
     <node visible="true" id="178" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5547132999999960" lon="-72.3382720999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="178"/>
     </node>
     <node visible="true" id="179" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542882999999996" lon="-72.3384520000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="179"/>
     </node>
     <node visible="true" id="180" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5539561999999982" lon="-72.3385571999999826">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="180"/>
     </node>
     <node visible="true" id="181" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5534409000000018" lon="-72.3387017000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="181"/>
     </node>
     <node visible="true" id="182" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492209000000017" lon="-72.3398360999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="182"/>
     </node>
     <node visible="true" id="183" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491733000000032" lon="-72.3398629999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="183"/>
     </node>
     <node visible="true" id="184" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493774999999950" lon="-72.3408036999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="184"/>
     </node>
     <node visible="true" id="185" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494495000000050" lon="-72.3407789000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="185"/>
     </node>
     <node visible="true" id="186" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5480789000000001" lon="-72.3353673999999955">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{426ab858-4552-4be2-a900-e155a4584bca}"/>
         <tag k="attribution" v="osm"/>
         <tag k="hazard" v="hole"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="186"/>
     </node>
     <node visible="true" id="190" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498175000000032" lon="-72.3347359999999924">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="190"/>
     </node>
     <node visible="true" id="191" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496867999999999" lon="-72.3346240000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="191"/>
     </node>
     <node visible="true" id="192" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494708999999993" lon="-72.3345670000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="192"/>
     </node>
     <node visible="true" id="193" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493272000000005" lon="-72.3345276000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="193"/>
     </node>
     <node visible="true" id="194" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490767000000005" lon="-72.3344476000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="194"/>
     </node>
     <node visible="true" id="195" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498297999999977" lon="-72.3333745999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="195"/>
     </node>
     <node visible="true" id="196" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5500867000000014" lon="-72.3329826999999881">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="196"/>
     </node>
     <node visible="true" id="197" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5536120000000011" lon="-72.3324204999999836">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="197"/>
     </node>
     <node visible="true" id="198" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542768999999943" lon="-72.3374048999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="198"/>
     </node>
     <node visible="true" id="199" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5554150000000000" lon="-72.3367101999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="199"/>
     </node>
     <node visible="true" id="200" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5557857000000013" lon="-72.3364665000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="200"/>
     </node>
     <node visible="true" id="201" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5529459000000010" lon="-72.3325899000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="201"/>
     </node>
     <node visible="true" id="202" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5521832999999958" lon="-72.3327050999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="202"/>
     </node>
     <node visible="true" id="203" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546403999999967" lon="-72.3349738000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="203"/>
     </node>
     <node visible="true" id="204" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545958999999989" lon="-72.3339313000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="204"/>
     </node>
     <node visible="true" id="205" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546399999999956" lon="-72.3332187999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="205"/>
     </node>
     <node visible="true" id="206" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546721999999953" lon="-72.3329171999999829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="206"/>
     </node>
     <node visible="true" id="207" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546769000000040" lon="-72.3325454000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="207"/>
     </node>
     <node visible="true" id="211" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515964000000082" lon="-72.3479573000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="211"/>
     </node>
     <node visible="true" id="213" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5529974999999965" lon="-72.3468371999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="213"/>
     </node>
     <node visible="true" id="220" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5551530999999983" lon="-72.3458873000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="220"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496279000000008" lon="-72.3371882999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5507410999999998" lon="-72.3369356999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495769000000017" lon="-72.3323962999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495756000000007" lon="-72.3325063000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5507222000000027" lon="-72.3467945000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="229" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509465999999996" lon="-72.3467449000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="229"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5513905999999977" lon="-72.3466328999999888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5511471000000014" lon="-72.3466875999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5516518999999960" lon="-72.3335189999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515690999999983" lon="-72.3337029000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514808000000002" lon="-72.3338398000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5513298999999989" lon="-72.3339670999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5503907000000012" lon="-72.3331663999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5502363000000052" lon="-72.3333558000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5505409999999991" lon="-72.3337328000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5518556000000032" lon="-72.3336656999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5520746000000045" lon="-72.3342004999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="241" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5473764000000045" lon="-72.3425907000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="241"/>
     </node>
     <node visible="true" id="242" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5539479878100018" lon="-72.3409685962299989">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7b5127dd-7b09-4160-804b-7ac03d17ed6a}"/>
         <tag k="attribution" v="osm"/>
         <tag k="hoot" v="PortAuPrince_OSM_Roads;Merged_PortAuPrince__5ae"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="242"/>
     </node>
     <node visible="true" id="243" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545265000000050" lon="-72.3408630999999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="243"/>
     </node>
     <node visible="true" id="244" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5550685000000044" lon="-72.3406910999999866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="244"/>
     </node>
     <node visible="true" id="245" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5554993999999951" lon="-72.3405041000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="245"/>
     </node>
     <node visible="true" id="246" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5558799999999984" lon="-72.3403418000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="246"/>
     </node>
     <node visible="true" id="247" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5544528000000000" lon="-72.3431927999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="247"/>
     </node>
     <node visible="true" id="248" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495760999999995" lon="-72.3420669000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="248"/>
     </node>
     <node visible="true" id="249" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498237999999986" lon="-72.3431920999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="249"/>
     </node>
     <node visible="true" id="250" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5499949000000051" lon="-72.3440710999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="250"/>
     </node>
     <node visible="true" id="251" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5528386000000012" lon="-72.3388257000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="251"/>
     </node>
     <node visible="true" id="252" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512513000000041" lon="-72.3392307999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="252"/>
     </node>
     <node visible="true" id="253" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5501526000000005" lon="-72.3395076999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="253"/>
     </node>
     <node visible="true" id="254" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496891999999995" lon="-72.3396371000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="254"/>
     </node>
     <node visible="true" id="255" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5484952000000050" lon="-72.3398906999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="255"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5525054000000011" lon="-72.3447522000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5521993000000016" lon="-72.3433820999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="258" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5520279000000023" lon="-72.3426692999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="258"/>
     </node>
     <node visible="true" id="259" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5517432000000007" lon="-72.3415040000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="259"/>
     </node>
     <node visible="true" id="260" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5521757000000029" lon="-72.3432970000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="260"/>
     </node>
     <node visible="true" id="261" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496266000000034" lon="-72.3455132999999790">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="261"/>
     </node>
     <node visible="true" id="262" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496637000000035" lon="-72.3456494999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="262"/>
     </node>
     <node visible="true" id="263" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5481617999999990" lon="-72.3460184000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="263"/>
     </node>
     <node visible="true" id="264" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5513940999999996" lon="-72.3449860999999856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="264"/>
     </node>
     <node visible="true" id="265" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510519999999985" lon="-72.3436006000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="265"/>
     </node>
     <node visible="true" id="266" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5508612999999976" lon="-72.3429174999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="266"/>
     </node>
     <node visible="true" id="267" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5506551999999978" lon="-72.3417910000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="267"/>
     </node>
     <node visible="true" id="268" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5503977999999989" lon="-72.3406432999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="268"/>
     </node>
     <node visible="true" id="269" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515111000000026" lon="-72.3403706000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="269"/>
     </node>
     <node visible="true" id="270" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5537248999999989" lon="-72.3398796000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="270"/>
     </node>
     <node visible="true" id="271" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542149000000016" lon="-72.3397396999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="271"/>
     </node>
     <node visible="true" id="272" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5503067000000037" lon="-72.3453547000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="272"/>
     </node>
     <node visible="true" id="273" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5503452999999965" lon="-72.3455866000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="273"/>
     </node>
     <node visible="true" id="274" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5504265000000039" lon="-72.3459347999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="274"/>
     </node>
     <node visible="true" id="275" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5505214000000009" lon="-72.3463603000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="275"/>
     </node>
     <node visible="true" id="276" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5505533000000042" lon="-72.3464780999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="276"/>
     </node>
     <node visible="true" id="277" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5507029999999986" lon="-72.3471200999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="277"/>
     </node>
     <node visible="true" id="278" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5508163000000010" lon="-72.3476059999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="278"/>
     </node>
     <node visible="true" id="279" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5538770000000000" lon="-72.3346410000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="279"/>
     </node>
     <node visible="true" id="280" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5536740000000044" lon="-72.3343595000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="280"/>
     </node>
     <node visible="true" id="281" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5531943999999989" lon="-72.3325164999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="281"/>
     </node>
     <node visible="true" id="282" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5531284999999997" lon="-72.3325243000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="282"/>
     </node>
     <node visible="true" id="283" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546250999999991" lon="-72.3351052000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="283"/>
     </node>
     <node visible="true" id="284" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5534929999999960" lon="-72.3334401000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="284"/>
     </node>
     <node visible="true" id="285" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5533895999999991" lon="-72.3328625000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="285"/>
     </node>
     <node visible="true" id="286" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5533135000000051" lon="-72.3329027999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="286"/>
     </node>
     <node visible="true" id="287" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495650999999988" lon="-72.3369232000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="287"/>
     </node>
     <node visible="true" id="288" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5501149000000041" lon="-72.3477524000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="288"/>
     </node>
     <node visible="true" id="289" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5534078999999998" lon="-72.3334571999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="289"/>
     </node>
     <node visible="true" id="290" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5536768000000052" lon="-72.3362728999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="290"/>
     </node>
     <node visible="true" id="291" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545039000000038" lon="-72.3357941999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="291"/>
     </node>
     <node visible="true" id="302" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542322999999989" lon="-72.3398027000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="302"/>
     </node>
     <node visible="true" id="303" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545785999999957" lon="-72.3396960999999834">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="303"/>
     </node>
     <node visible="true" id="304" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546680000000030" lon="-72.3397781999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="304"/>
     </node>
     <node visible="true" id="305" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5547348999999997" lon="-72.3399158999999798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="305"/>
     </node>
     <node visible="true" id="306" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5549285999999967" lon="-72.3407353999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="306"/>
     </node>
     <node visible="true" id="307" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5523851999999962" lon="-72.3365739999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="307"/>
     </node>
     <node visible="true" id="308" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5526157000000005" lon="-72.3376784000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="308"/>
     </node>
     <node visible="true" id="309" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5505697000000005" lon="-72.3347325999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="309"/>
     </node>
     <node visible="true" id="310" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510112999999990" lon="-72.3352306000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="310"/>
     </node>
     <node visible="true" id="311" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512444999999992" lon="-72.3353522000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="311"/>
     </node>
     <node visible="true" id="312" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514082000000009" lon="-72.3355339999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="312"/>
     </node>
     <node visible="true" id="313" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515375999999996" lon="-72.3356698999999850">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="313"/>
     </node>
     <node visible="true" id="314" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545065999999963" lon="-72.3434701999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="314"/>
     </node>
     <node visible="true" id="315" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5473293000000083" lon="-72.3371898999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="315"/>
     </node>
     <node visible="true" id="316" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5473590000000002" lon="-72.3372985999999827">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="316"/>
     </node>
     <node visible="true" id="317" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5473880999999992" lon="-72.3374527999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="317"/>
     </node>
     <node visible="true" id="318" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5474907000000009" lon="-72.3378574999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="318"/>
     </node>
     <node visible="true" id="319" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5479737000000000" lon="-72.3400184999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="319"/>
     </node>
     <node visible="true" id="320" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5482358000000040" lon="-72.3411717999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="320"/>
     </node>
     <node visible="true" id="321" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5484755000000021" lon="-72.3423156000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="321"/>
     </node>
     <node visible="true" id="322" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487229000000013" lon="-72.3434648000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="322"/>
     </node>
     <node visible="true" id="323" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489697000000007" lon="-72.3446454999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="323"/>
     </node>
     <node visible="true" id="324" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492418999999948" lon="-72.3457678999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="324"/>
     </node>
     <node visible="true" id="325" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494310000000020" lon="-72.3466410000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="325"/>
     </node>
     <node visible="true" id="326" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5556710000000002" lon="-72.3357862000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="326"/>
     </node>
     <node visible="true" id="327" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5551417000000001" lon="-72.3354140999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="327"/>
     </node>
     <node visible="true" id="328" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5545940999999992" lon="-72.3351892999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="328"/>
     </node>
     <node visible="true" id="329" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5543479000000033" lon="-72.3351024999999908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="329"/>
     </node>
     <node visible="true" id="330" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542968000000030" lon="-72.3350874000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="330"/>
     </node>
     <node visible="true" id="331" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5541853999999979" lon="-72.3350413999999802">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="331"/>
     </node>
     <node visible="true" id="332" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5540305999999973" lon="-72.3349347999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="332"/>
     </node>
     <node visible="true" id="333" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5538104000000033" lon="-72.3347009999999813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="333"/>
     </node>
     <node visible="true" id="334" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5537630999999976" lon="-72.3346465000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="334"/>
     </node>
     <node visible="true" id="335" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5535840000000043" lon="-72.3344225999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="335"/>
     </node>
     <node visible="true" id="336" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5535494999999990" lon="-72.3343299999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="336"/>
     </node>
     <node visible="true" id="337" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5535241000000042" lon="-72.3342362000000065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="337"/>
     </node>
     <node visible="true" id="338" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5533819999999992" lon="-72.3334624000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="338"/>
     </node>
     <node visible="true" id="339" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5533511000000075" lon="-72.3332458999999801">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="339"/>
     </node>
     <node visible="true" id="340" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5532846000000049" lon="-72.3329157999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="340"/>
     </node>
     <node visible="true" id="341" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5532286999999947" lon="-72.3327891999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="341"/>
     </node>
     <node visible="true" id="342" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5530969000000034" lon="-72.3325355999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="342"/>
     </node>
     <node visible="true" id="343" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5484690999999984" lon="-72.3473520000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="343"/>
     </node>
     <node visible="true" id="344" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487508000000005" lon="-72.3472802999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="344"/>
     </node>
     <node visible="true" id="345" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490704000000015" lon="-72.3472086000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="345"/>
     </node>
     <node visible="true" id="346" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494288999999988" lon="-72.3471337999999946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="346"/>
     </node>
     <node visible="true" id="347" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5499779999999994" lon="-72.3470068999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="347"/>
     </node>
     <node visible="true" id="348" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5506435000000067" lon="-72.3468356000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="348"/>
     </node>
     <node visible="true" id="349" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5534733000000003" lon="-72.3339164000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="349"/>
     </node>
     <node visible="true" id="350" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5540005999999984" lon="-72.3337783999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="350"/>
     </node>
     <node visible="true" id="351" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5549769000000033" lon="-72.3337647999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="351"/>
     </node>
     <node visible="true" id="352" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5484420000000014" lon="-72.3473618000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="352"/>
     </node>
     <node visible="true" id="353" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5484700999999994" lon="-72.3474982000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="353"/>
     </node>
     <node visible="true" id="354" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485252000000038" lon="-72.3477656999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="354"/>
     </node>
     <node visible="true" id="355" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485524999999960" lon="-72.3478984999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="355"/>
     </node>
     <node visible="true" id="356" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486139000000030" lon="-72.3481967000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="356"/>
     </node>
     <node visible="true" id="357" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5548759999999930" lon="-72.3419440999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="357"/>
     </node>
     <node visible="true" id="358" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5517744000000029" lon="-72.3478285999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="358"/>
     </node>
     <node visible="true" id="359" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515067000000009" lon="-72.3468278999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="359"/>
     </node>
     <node visible="true" id="360" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514009000000044" lon="-72.3462995999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="360"/>
     </node>
     <node visible="true" id="361" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512559999999986" lon="-72.3457245999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="361"/>
     </node>
     <node visible="true" id="362" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5510950000000037" lon="-72.3450679999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="362"/>
     </node>
     <node visible="true" id="372" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5553169000000118" lon="-72.3437413000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="372"/>
     </node>
     <node visible="true" id="373" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5552153000000004" lon="-72.3433758000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="373"/>
     </node>
     <node visible="true" id="374" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5479270000000049" lon="-72.3450419999999923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="374"/>
     </node>
     <node visible="true" id="375" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490224999999960" lon="-72.3447800999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="375"/>
     </node>
     <node visible="true" id="376" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494036999999992" lon="-72.3446943999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="376"/>
     </node>
     <node visible="true" id="377" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5500921000000041" lon="-72.3444724000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="377"/>
     </node>
     <node visible="true" id="378" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512021000000047" lon="-72.3442390000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="378"/>
     </node>
     <node visible="true" id="379" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5523041000000006" lon="-72.3439616999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="379"/>
     </node>
     <node visible="true" id="380" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5539243999999961" lon="-72.3435881000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="380"/>
     </node>
     <node visible="true" id="381" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5474785000000040" lon="-72.3347138000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="381"/>
     </node>
     <node visible="true" id="382" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5480939000000014" lon="-72.3353628999999927">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="382"/>
     </node>
     <node visible="true" id="383" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5482042999999983" lon="-72.3354798999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="383"/>
     </node>
     <node visible="true" id="384" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5482807000000030" lon="-72.3355841000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="384"/>
     </node>
     <node visible="true" id="385" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485007999999993" lon="-72.3363097000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="385"/>
     </node>
     <node visible="true" id="386" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486864000000011" lon="-72.3371655999999916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="386"/>
     </node>
     <node visible="true" id="387" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490552999999991" lon="-72.3397614000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="387"/>
     </node>
     <node visible="true" id="388" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495872999999953" lon="-72.3396675000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="388"/>
     </node>
     <node visible="true" id="389" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496304999999992" lon="-72.3396572000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="389"/>
     </node>
     <node visible="true" id="390" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498566000000018" lon="-72.3407703000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="390"/>
     </node>
     <node visible="true" id="391" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493087000000010" lon="-72.3408984999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="391"/>
     </node>
     <node visible="true" id="392" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485787999999978" lon="-72.3356366999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="392"/>
     </node>
     <node visible="true" id="393" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486994000000038" lon="-72.3362668999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="393"/>
     </node>
     <node visible="true" id="394" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487095999999987" lon="-72.3363530000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="394"/>
     </node>
     <node visible="true" id="395" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487604000000026" lon="-72.3365916999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="395"/>
     </node>
     <node visible="true" id="396" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488112999999970" lon="-72.3367688000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="396"/>
     </node>
     <node visible="true" id="397" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489159999999984" lon="-72.3371015999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="397"/>
     </node>
     <node visible="true" id="398" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5536537999999958" lon="-72.3345151000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="398"/>
     </node>
     <node visible="true" id="399" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5526087000000004" lon="-72.3343595000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="399"/>
     </node>
     <node visible="true" id="400" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5525145999999985" lon="-72.3341851999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="400"/>
     </node>
     <node visible="true" id="401" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5530333000000027" lon="-72.3340483999999861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="401"/>
     </node>
     <node visible="true" id="402" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5534466000000009" lon="-72.3339246999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="402"/>
     </node>
     <node visible="true" id="403" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5537065999999982" lon="-72.3338494999999853">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="403"/>
     </node>
     <node visible="true" id="404" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5537298999999969" lon="-72.3339881999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="404"/>
     </node>
     <node visible="true" id="405" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5537668000000018" lon="-72.3341472000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="405"/>
     </node>
     <node visible="true" id="406" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5538415000000008" lon="-72.3342422999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="406"/>
     </node>
     <node visible="true" id="407" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5541187999999977" lon="-72.3346037000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="407"/>
     </node>
     <node visible="true" id="408" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546174999999955" lon="-72.3346089999999862">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="408"/>
     </node>
     <node visible="true" id="409" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5542914000000003" lon="-72.3350187000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="409"/>
     </node>
     <node visible="true" id="410" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5543118000000007" lon="-72.3349055999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="410"/>
     </node>
     <node visible="true" id="411" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5543103999999985" lon="-72.3346056000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="411"/>
     </node>
     <node visible="true" id="412" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5543219999999955" lon="-72.3337920000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="412"/>
     </node>
     <node visible="true" id="413" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488321999999997" lon="-72.3362381000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="413"/>
     </node>
     <node visible="true" id="414" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489307999999973" lon="-72.3365864000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="414"/>
     </node>
     <node visible="true" id="415" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490173000000027" lon="-72.3368464999999787">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="415"/>
     </node>
     <node visible="true" id="416" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491038000000046" lon="-72.3370467999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="416"/>
     </node>
     <node visible="true" id="417" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489230999999997" lon="-72.3356009000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="417"/>
     </node>
     <node visible="true" id="418" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489442000000011" lon="-72.3358850999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="418"/>
     </node>
     <node visible="true" id="419" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489949999999979" lon="-72.3360272000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="419"/>
     </node>
     <node visible="true" id="420" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490205000000010" lon="-72.3361988999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="420"/>
     </node>
     <node visible="true" id="421" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491272999999985" lon="-72.3363758999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="421"/>
     </node>
     <node visible="true" id="422" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492449999999991" lon="-72.3364677999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="422"/>
     </node>
     <node visible="true" id="423" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492803999999971" lon="-72.3366831999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="423"/>
     </node>
     <node visible="true" id="424" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493828000000001" lon="-72.3369672000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="424"/>
     </node>
     <node visible="true" id="427" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5497548999999964" lon="-72.3326002000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="427"/>
     </node>
     <node visible="true" id="428" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496036000000011" lon="-72.3327249000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="428"/>
     </node>
     <node visible="true" id="429" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494458999999985" lon="-72.3327998999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="429"/>
     </node>
     <node visible="true" id="430" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491884999999961" lon="-72.3329465999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="430"/>
     </node>
     <node visible="true" id="431" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490708999999967" lon="-72.3330265999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="431"/>
     </node>
     <node visible="true" id="432" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489453000000033" lon="-72.3332309000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="432"/>
     </node>
     <node visible="true" id="433" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488610000000058" lon="-72.3334797999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="433"/>
     </node>
     <node visible="true" id="434" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488570000000017" lon="-72.3337570000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="434"/>
     </node>
     <node visible="true" id="435" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488609999999987" lon="-72.3340120000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="435"/>
     </node>
     <node visible="true" id="436" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488830000000000" lon="-72.3342860000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="436"/>
     </node>
     <node visible="true" id="437" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488849000000009" lon="-72.3344215999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="437"/>
     </node>
     <node visible="true" id="438" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488870000000041" lon="-72.3345889999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="438"/>
     </node>
     <node visible="true" id="439" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488539999999986" lon="-72.3348170000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="439"/>
     </node>
     <node visible="true" id="440" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487760000000037" lon="-72.3350549999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="440"/>
     </node>
     <node visible="true" id="441" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486313999999979" lon="-72.3353141000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="441"/>
     </node>
     <node visible="true" id="442" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5483303000000035" lon="-72.3356847999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="442"/>
     </node>
     <node visible="true" id="443" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5502901000000016" lon="-72.3348613999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="443"/>
     </node>
     <node visible="true" id="444" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5501946000000011" lon="-72.3348124999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="444"/>
     </node>
     <node visible="true" id="445" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5501065000000018" lon="-72.3346126999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="445"/>
     </node>
     <node visible="true" id="446" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5499863000000005" lon="-72.3344155999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="446"/>
     </node>
     <node visible="true" id="447" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5497445999999968" lon="-72.3342197999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="447"/>
     </node>
     <node visible="true" id="448" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496291000000006" lon="-72.3340137999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="448"/>
     </node>
     <node visible="true" id="449" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495228999999995" lon="-72.3338229999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="449"/>
     </node>
     <node visible="true" id="450" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494383000000020" lon="-72.3336953999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="450"/>
     </node>
     <node visible="true" id="451" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493549999999985" lon="-72.3336175000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="451"/>
     </node>
     <node visible="true" id="452" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492429999999970" lon="-72.3335588000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="452"/>
     </node>
     <node visible="true" id="453" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490647999999929" lon="-72.3335472999999922">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="453"/>
     </node>
     <node visible="true" id="454" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488578000000039" lon="-72.3335533999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="454"/>
     </node>
     <node visible="true" id="455" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5546371999999984" lon="-72.3332625000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="455"/>
     </node>
     <node visible="true" id="462" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3470643710400054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="462"/>
     </node>
     <node visible="true" id="463" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3389871039899930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="463"/>
     </node>
     <node visible="true" id="464" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5516013999999991" lon="-72.3357316999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="464"/>
     </node>
     <node visible="true" id="466" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5518290000000015" lon="-72.3366919999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="466"/>
     </node>
     <node visible="true" id="468" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5520788000000003" lon="-72.3378100999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="468"/>
     </node>
     <node visible="true" id="470" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5523248999999986" lon="-72.3389530000000036">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="470"/>
     </node>
     <node visible="true" id="471" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5499223599300009" lon="-72.3323670000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="471"/>
     </node>
     <node visible="true" id="472" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5526093000000003" lon="-72.3401156999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="472"/>
     </node>
     <node visible="true" id="474" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5528968000000027" lon="-72.3412442000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="474"/>
     </node>
     <node visible="true" id="475" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3345305933799949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="475"/>
     </node>
     <node visible="true" id="476" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5531492000000000" lon="-72.3423837999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="476"/>
     </node>
     <node visible="true" id="477" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3451973157799983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="477"/>
     </node>
     <node visible="true" id="478" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5533086000000011" lon="-72.3432889000000046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="478"/>
     </node>
     <node visible="true" id="480" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5533774999999999" lon="-72.3436952999999789">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="480"/>
     </node>
     <node visible="true" id="482" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5535701999999993" lon="-72.3444791000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="482"/>
     </node>
     <node visible="true" id="484" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5540037999999967" lon="-72.3465685999999835">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="484"/>
     </node>
     <node visible="true" id="485" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5559420000000017" lon="-72.3414419347100051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="485"/>
     </node>
     <node visible="true" id="486" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509434000000013" lon="-72.3351734999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="486"/>
     </node>
     <node visible="true" id="487" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486261190400015" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="487"/>
     </node>
     <node visible="true" id="488" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5511190000000070" lon="-72.3359503999999873">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="488"/>
     </node>
     <node visible="true" id="489" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3476343861999851">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="489"/>
     </node>
     <node visible="true" id="490" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5513011999999975" lon="-72.3368157999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="490"/>
     </node>
     <node visible="true" id="491" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5559420000000017" lon="-72.3359599387100047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="491"/>
     </node>
     <node visible="true" id="492" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5515481000000051" lon="-72.3379345999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="492"/>
     </node>
     <node visible="true" id="493" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5530141718400046" lon="-72.3323670000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="493"/>
     </node>
     <node visible="true" id="494" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3368852252500005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="494"/>
     </node>
     <node visible="true" id="496" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5502332964699974" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="496"/>
     </node>
     <node visible="true" id="497" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999959" lon="-72.3374792567399822">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="497"/>
     </node>
     <node visible="true" id="498" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5509957180000029" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="498"/>
     </node>
     <node visible="true" id="499" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3413903385200001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="499"/>
     </node>
     <node visible="true" id="500" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3462329380299991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="500"/>
     </node>
     <node visible="true" id="501" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3401815232199965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="501"/>
     </node>
     <node visible="true" id="502" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3426183126499893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="502"/>
     </node>
     <node visible="true" id="503" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5495795041200005" lon="-72.3323670000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="503"/>
     </node>
     <node visible="true" id="506" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3365572965399934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="506"/>
     </node>
     <node visible="true" id="507" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5559420000000017" lon="-72.3363744494299965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="507"/>
     </node>
     <node visible="true" id="508" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5538033758499985" lon="-72.3323670000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="508"/>
     </node>
     <node visible="true" id="509" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5477333000000044" lon="-72.3388652999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="509"/>
     </node>
     <node visible="true" id="510" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3356101443999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="510"/>
     </node>
     <node visible="true" id="511" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5482107999999961" lon="-72.3387579000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="511"/>
     </node>
     <node visible="true" id="513" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485937000000014" lon="-72.3386031000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="513"/>
     </node>
     <node visible="true" id="514" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493314481100064" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="514"/>
     </node>
     <node visible="true" id="515" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486859000000024" lon="-72.3385549999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="515"/>
     </node>
     <node visible="true" id="516" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3420385516700009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="516"/>
     </node>
     <node visible="true" id="517" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486622999999966" lon="-72.3383920999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="517"/>
     </node>
     <node visible="true" id="518" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496379517600012" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="518"/>
     </node>
     <node visible="true" id="519" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486985000000040" lon="-72.3382514000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="519"/>
     </node>
     <node visible="true" id="521" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487290000000016" lon="-72.3381428999999798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="521"/>
     </node>
     <node visible="true" id="523" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486013000000014" lon="-72.3375963000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="523"/>
     </node>
     <node visible="true" id="524" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491159177900009" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="524"/>
     </node>
     <node visible="true" id="525" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485194000000000" lon="-72.3372365999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="525"/>
     </node>
     <node visible="true" id="526" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5559420000000017" lon="-72.3432463141400035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="526"/>
     </node>
     <node visible="true" id="527" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496703646899981" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="527"/>
     </node>
     <node visible="true" id="528" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489581330799957" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="528"/>
     </node>
     <node visible="true" id="529" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5559419999999982" lon="-72.3439523292099977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="529"/>
     </node>
     <node visible="true" id="530" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472650000000066" lon="-72.3438310738900014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="530"/>
     </node>
     <node visible="true" id="535" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5472649999999994" lon="-72.3471724152600046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="535"/>
     </node>
     <node visible="true" id="536" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5516772042400007" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="536"/>
     </node>
     <node visible="true" id="537" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5517789321000031" lon="-72.3482559999999921">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="537"/>
     </node>
     <node visible="true" id="538" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5521079354399987" lon="-72.3323670000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="538"/>
     </node>
     <node visible="true" id="539" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5559420000000017" lon="-72.3404459718999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="539"/>
     </node>
     <node visible="true" id="549" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5498620999999986" lon="-72.3465098000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="549"/>
     </node>
     <node visible="true" id="550" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494153999999973" lon="-72.3465596000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="550"/>
     </node>
     <node visible="true" id="551" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486804999999997" lon="-72.3467308000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="551"/>
     </node>
     <node visible="true" id="552" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5483079999999951" lon="-72.3468175999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="552"/>
     </node>
     <node visible="true" id="553" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5473271000000004" lon="-72.3470496999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="553"/>
     </node>
     <node visible="true" id="556" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5486615999999991" lon="-72.3384135000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="556"/>
     </node>
     <node visible="true" id="557" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485900999999949" lon="-72.3383529999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="557"/>
     </node>
     <node visible="true" id="558" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5485120000000023" lon="-72.3382399999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="558"/>
     </node>
     <node visible="true" id="559" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5483702000000044" lon="-72.3378699000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="559"/>
     </node>
     <node visible="true" id="560" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5483237000000010" lon="-72.3376623999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="560"/>
     </node>
     <node visible="true" id="561" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5496386999999991" lon="-72.3395814999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="561"/>
     </node>
     <node visible="true" id="562" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489616999999996" lon="-72.3397446999999829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="562"/>
     </node>
     <node visible="true" id="563" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5487958999999982" lon="-72.3391383999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="563"/>
     </node>
     <node visible="true" id="564" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5488368000000037" lon="-72.3391292999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="564"/>
     </node>
     <node visible="true" id="565" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5489373000000022" lon="-72.3391067999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="565"/>
     </node>
     <node visible="true" id="566" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5490169000000016" lon="-72.3391273000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="566"/>
     </node>
     <node visible="true" id="567" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491084999999991" lon="-72.3391299999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="567"/>
     </node>
     <node visible="true" id="568" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5491874999999986" lon="-72.3391168999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="568"/>
     </node>
     <node visible="true" id="569" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5492586999999993" lon="-72.3390820999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="569"/>
     </node>
     <node visible="true" id="570" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5493195000000028" lon="-72.3390200000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="570"/>
     </node>
     <node visible="true" id="571" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5494875999999991" lon="-72.3389882000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="571"/>
     </node>
     <node visible="true" id="586" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5514715000000017" lon="-72.3428080999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="586"/>
     </node>
     <node visible="true" id="587" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5512003999999955" lon="-72.3416548000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="587"/>
     </node>
     <node visible="true" id="588" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5519269999999956" lon="-72.3448687000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="588"/>
     </node>
     <node visible="true" id="589" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5517574999999972" lon="-72.3440913000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="589"/>
     </node>
     <node visible="true" id="590" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119" lat="18.5516157000000028" lon="-72.3434306000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="590"/>
     </node>
     <way visible="true" id="-226" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="159"/>
@@ -2039,6 +1541,7 @@
         <nd ref="159"/>
         <tag k="foot" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="cycleway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bicycle" v="no"/>
@@ -2049,9 +1552,7 @@
         <tag k="attribution" v="osm"/>
         <tag k="access" v="no"/>
         <tag k="motor_vehicle" v="permissive"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-226"/>
     </way>
     <way visible="true" id="-108" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="398"/>
@@ -2071,6 +1572,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tokyo"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -2088,9 +1591,6 @@
         <tag k="source" v="GPS/Walkinp Papers;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-108"/>
     </way>
     <way visible="true" id="-14" timestamp="2017-06-07T15:18:19Z" version="1">
         <nd ref="-189"/>
@@ -2117,49 +1617,47 @@
         <nd ref="-185"/>
         <nd ref="-184"/>
         <nd ref="-187"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="15"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.132Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{6ba1536c-3242-4379-b468-7cb8c7d04902}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="6"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="6"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{6ba1536c-3242-4379-b468-7cb8c7d04902}}"/>
+        <tag k="width:minimum_traveled_way" v="15"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.132Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-3" timestamp="2017-06-07T15:18:19Z" version="1">
         <nd ref="-168"/>
         <nd ref="-132"/>
         <nd ref="552"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.132Z"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="yes"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{4c6565c4-9ac3-4175-a398-7633e498309d}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="4"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{4c6565c4-9ac3-4175-a398-7633e498309d}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.132Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-1" timestamp="2017-06-07T15:18:19Z" version="1" changeset="118">
         <nd ref="-200"/>
@@ -2172,6 +1670,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -2183,9 +1683,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="180"/>
@@ -2196,6 +1693,7 @@
         <nd ref="373"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue des Remparts"/>
@@ -2206,9 +1704,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="247"/>
@@ -2233,6 +1729,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -2250,15 +1748,13 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="15"/>
         <nd ref="12"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Monseigneur Guilloux"/>
@@ -2269,9 +1765,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="153"/>
@@ -2290,6 +1784,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
         <tag k="ref" v="RN 1"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
@@ -2308,24 +1804,20 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="265"/>
         <nd ref="250"/>
         <nd ref="323"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Courbe"/>
         <tag k="uuid" v="{3ba8056c-2b4e-4105-a2ad-5809a6047816}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="549"/>
@@ -2335,6 +1827,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Marie Jeanne"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="4"/>
@@ -2349,56 +1843,50 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="551"/>
         <nd ref="21"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{19d7e8e8-2ddf-4aaf-ba23-d79480c07ed0}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="553"/>
         <nd ref="22"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{80416c3c-d608-4d6a-a59a-346ada5f1e6d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="253"/>
         <nd ref="268"/>
-        <tag k="smoothness" v="bad"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="survey; CNIGS/OIM/ FOCS;osm"/>
-        <tag k="highway" v="living_street"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Rue des Fronts-Forts"/>
-        <tag k="uuid" v="{ea240122-2dcb-43d1-a573-379e958b7061}"/>
-        <tag k="note" v="(at least) this block totally blocked by the market (during day/afternoon)"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="operational_status" v="open"/>
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="attribution" v="osm"/>
         <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
+        <tag k="name" v="Rue des Fronts-Forts"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="smoothness" v="bad"/>
+        <tag k="uuid" v="{ea240122-2dcb-43d1-a573-379e958b7061}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="note" v="(at least) this block totally blocked by the market (during day/afternoon)"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="survey; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="highway" v="living_street"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="165"/>
@@ -2410,6 +1898,7 @@
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue des Fronts-Forts"/>
@@ -2420,9 +1909,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="269"/>
@@ -2433,6 +1920,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Césars"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2451,9 +1940,6 @@
         <tag k="source" v="survey; CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="living_street"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="443"/>
@@ -2467,6 +1953,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Césars"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2484,9 +1972,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="254"/>
@@ -2503,6 +1988,8 @@
         <tag k="type" v="roadblock"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Saint Laurent"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -2520,9 +2007,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="14" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="57"/>
@@ -2531,14 +2015,13 @@
         <nd ref="84"/>
         <nd ref="74"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{3ad3c519-f3bc-413b-8421-ad9f809e1fee}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="41"/>
@@ -2547,6 +2030,7 @@
         <nd ref="39"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Porcelaine"/>
@@ -2557,9 +2041,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="244"/>
@@ -2567,6 +2049,7 @@
         <nd ref="52"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle A. Césaire"/>
@@ -2577,9 +2060,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="90"/>
@@ -2599,15 +2080,14 @@
         <nd ref="54"/>
         <nd ref="90"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="area" v="yes"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{8b8f35c3-244c-4ac3-9599-773051fab4d9}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="67"/>
@@ -2616,14 +2096,13 @@
         <nd ref="83"/>
         <nd ref="71"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{99c199cf-feb0-47ed-b692-74ef54bef7c8}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="78"/>
@@ -2639,14 +2118,13 @@
         <nd ref="68"/>
         <nd ref="77"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5e8a9b03-5282-4ca8-b863-b02212ffb4b1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="274"/>
@@ -2657,14 +2135,13 @@
         <nd ref="88"/>
         <nd ref="361"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6f66ecd5-5cc6-461a-be85-dc6c4e20db0a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="359"/>
@@ -2674,27 +2151,25 @@
         <nd ref="92"/>
         <nd ref="277"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{3ac29fff-820c-462d-986a-b3369fa74209}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="82"/>
         <nd ref="81"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2a730249-bf84-44ea-ab51-c33d6438d1af}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="276"/>
@@ -2704,14 +2179,13 @@
         <nd ref="87"/>
         <nd ref="360"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{3e87be57-4b83-4716-9587-6863a8da0996}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="95"/>
@@ -2722,14 +2196,13 @@
         <nd ref="86"/>
         <nd ref="85"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e29636b1-5133-49ab-92e5-3dae1d6bba00}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="95"/>
@@ -2740,27 +2213,25 @@
         <nd ref="91"/>
         <nd ref="90"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{fa87d52d-7977-4434-b478-f4da3c7bc81c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="97"/>
         <nd ref="108"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{83dbfc5a-f894-4fe3-9d14-63fdb4425af6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="354"/>
@@ -2772,14 +2243,13 @@
         <nd ref="114"/>
         <nd ref="155"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1b094678-4e70-4726-9c60-efc6c19f6588}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="121"/>
@@ -2788,15 +2258,14 @@
         <nd ref="328"/>
         <tag k="source:name" v="from COSMHA note on market place by the road"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Charlemagne Peralte"/>
         <tag k="uuid" v="{48f92b1b-1c70-49bc-80bc-92236944b032}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="220"/>
@@ -2809,6 +2278,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2823,9 +2294,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="256"/>
@@ -2835,6 +2303,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Césars"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2850,9 +2320,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="261"/>
@@ -2862,15 +2329,14 @@
         <nd ref="588"/>
         <nd ref="256"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Quai"/>
         <tag k="uuid" v="{0c729d3e-0f58-4f94-bd0b-d69777d909bc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="125"/>
@@ -2881,6 +2347,7 @@
         <nd ref="123"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Monseigneur Guilloux"/>
@@ -2891,9 +2358,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="130"/>
@@ -2903,14 +2368,13 @@
         <nd ref="127"/>
         <nd ref="126"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6a07b25b-60a7-4944-8e1d-361936b2eb89}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="133"/>
@@ -2918,27 +2382,25 @@
         <nd ref="131"/>
         <nd ref="353"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9095d65f-b9d2-425b-a4e0-fb8b61eada23}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="345"/>
         <nd ref="134"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5bb3c8ee-d11e-47b3-a3b2-dcbd394af8e2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="140"/>
@@ -2946,20 +2408,20 @@
         <nd ref="138"/>
         <nd ref="356"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{83455e56-898e-4fa5-8e16-7b62ddefa087}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="307"/>
         <nd ref="141"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Saint Come"/>
@@ -2969,9 +2431,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="143"/>
@@ -2979,28 +2439,26 @@
         <nd ref="142"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Mariela"/>
         <tag k="uuid" v="{3d857258-4d8f-4ae1-8843-d02ab5b8ef05}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <way visible="true" id="40" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="150"/>
         <nd ref="149"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{afcfc1f6-cbee-4533-92a8-3292fe365540}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="40"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="355"/>
@@ -3008,27 +2466,25 @@
         <nd ref="155"/>
         <nd ref="154"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{fd518d81-26c8-4bbf-8604-3538476bea30}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="158"/>
         <nd ref="157"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{728ec24f-f7bb-4a25-a2f4-1a4284ba9255}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="45" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="443"/>
@@ -3043,6 +2499,7 @@
         <nd ref="442"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Macajoux"/>
@@ -3050,15 +2507,14 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="45"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="318"/>
         <nd ref="560"/>
         <nd ref="523"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Pétion"/>
@@ -3067,23 +2523,20 @@
         <tag k="operational_status" v="open"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="47" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="511"/>
         <nd ref="255"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Courte"/>
         <tag k="uuid" v="{f1a4f2ae-da62-4211-8fc6-54d94aa5eb0c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="47"/>
     </way>
     <way visible="true" id="48" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="176"/>
@@ -3095,41 +2548,38 @@
         <nd ref="185"/>
         <nd ref="182"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{d71553c2-0da4-46bd-af2e-76717f6d561d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="48"/>
     </way>
     <way visible="true" id="49" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="175"/>
         <nd ref="174"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{85b01764-dc00-45f7-adbc-8f8ed95cb071}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="49"/>
     </way>
     <way visible="true" id="50" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="177"/>
         <nd ref="176"/>
         <nd ref="388"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{a6c936cc-e2ad-49d5-9dad-8fe5537675f8}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="50"/>
     </way>
     <way visible="true" id="51" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="251"/>
@@ -3143,6 +2593,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Docteur Aubry"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3160,9 +2612,6 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="51"/>
     </way>
     <way visible="true" id="52" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="185"/>
@@ -3170,14 +2619,13 @@
         <nd ref="183"/>
         <nd ref="182"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5c16a7b5-4c3c-466c-9d1d-b656f9fe15ac}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="52"/>
     </way>
     <way visible="true" id="54" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="437"/>
@@ -3187,40 +2635,37 @@
         <nd ref="191"/>
         <nd ref="190"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f952aa56-cf2a-4ade-9da2-f52ef1e37139}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="54"/>
     </way>
     <way visible="true" id="55" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="196"/>
         <nd ref="195"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d5bec77-bd49-41e4-affa-0ea5706a70fc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="55"/>
     </way>
     <way visible="true" id="56" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="340"/>
         <nd ref="286"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7a2ef99f-899b-49c5-a3b5-69fbe3768b30}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="56"/>
     </way>
     <way visible="true" id="57" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="202"/>
@@ -3233,6 +2678,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3250,9 +2697,6 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="57"/>
     </way>
     <way visible="true" id="58" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="207"/>
@@ -3264,6 +2708,7 @@
         <nd ref="203"/>
         <nd ref="283"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Charlemagne Peralte"/>
@@ -3274,22 +2719,19 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="58"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="280"/>
         <nd ref="406"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ca88bf77-f9ce-4caa-a5b8-ccd80e67b44f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
     <way visible="true" id="61" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="307"/>
@@ -3299,6 +2741,7 @@
         <nd ref="224"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue des Pucelles"/>
@@ -3310,35 +2753,31 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="61"/>
     </way>
     <way visible="true" id="63" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="229"/>
         <nd ref="228"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{12d3c041-0914-4842-86d2-8b3efc754fb8}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="63"/>
     </way>
     <way visible="true" id="64" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="231"/>
         <nd ref="230"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2d0548ba-6f74-451d-8ab0-4f383516a7ec}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="64"/>
     </way>
     <way visible="true" id="65" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="235"/>
@@ -3346,70 +2785,65 @@
         <nd ref="233"/>
         <nd ref="232"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b84f8b92-b866-440a-94ac-11428d5f8c4d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="65"/>
     </way>
     <way visible="true" id="66" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="238"/>
         <nd ref="237"/>
         <nd ref="236"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d44d8ab-5715-4dc9-9a54-231042ce2ea1}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="66"/>
     </way>
     <way visible="true" id="67" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="240"/>
         <nd ref="239"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f1a4bd96-604a-4a86-aff2-1c032fa617c3}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="67"/>
     </way>
     <way visible="true" id="68" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="288"/>
         <nd ref="278"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Vilaire"/>
         <tag k="uuid" v="{bba6d815-d212-4122-ba7f-26db2338c7a2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="68"/>
     </way>
     <way visible="true" id="69" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="247"/>
         <nd ref="478"/>
         <nd ref="257"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Courbe"/>
         <tag k="uuid" v="{8d385c3e-c35c-4e76-bdf6-5ae115f44386}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
     </way>
     <way visible="true" id="70" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="272"/>
@@ -3424,6 +2858,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Bonne Foi"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3438,9 +2874,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </way>
     <way visible="true" id="71" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="259"/>
@@ -3455,6 +2888,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue des Césars"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3472,15 +2907,13 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="71"/>
     </way>
     <way visible="true" id="72" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="260"/>
         <nd ref="590"/>
         <nd ref="265"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Courbe"/>
@@ -3488,9 +2921,7 @@
         <tag k="uuid" v="{bc982527-8810-4e94-926a-f851be70cf0e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="72"/>
     </way>
     <way visible="true" id="73" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="549"/>
@@ -3498,15 +2929,14 @@
         <nd ref="261"/>
         <nd ref="376"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Eden"/>
         <tag k="uuid" v="{f9c8e358-6c46-40c1-a1a3-72a40f9b282b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="73"/>
     </way>
     <way visible="true" id="74" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="268"/>
@@ -3518,6 +2948,7 @@
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue des Fronts-Forts"/>
@@ -3528,14 +2959,13 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="74"/>
     </way>
     <way visible="true" id="75" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="-213"/>
         <nd ref="279"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3543,14 +2973,13 @@
         <tag k="uuid" v="{0d886e20-086d-4912-99aa-b02d6b9fe4f2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="75"/>
     </way>
     <way visible="true" id="76" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="-214"/>
         <nd ref="280"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3558,9 +2987,7 @@
         <tag k="uuid" v="{72ecd9b6-c468-4b32-8027-f418c1aeacb5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="76"/>
     </way>
     <way visible="true" id="77" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="282"/>
@@ -3571,6 +2998,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3586,14 +3015,12 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GeoEye;osm;mgcp"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="77"/>
     </way>
     <way visible="true" id="78" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="-212"/>
         <nd ref="283"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3601,14 +3028,13 @@
         <tag k="uuid" v="{d26f93e0-d7d9-46f1-9761-28267373a9ae}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="78"/>
     </way>
     <way visible="true" id="79" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="289"/>
         <nd ref="284"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3616,14 +3042,13 @@
         <tag k="uuid" v="{b4e0cca5-5fe3-443b-9ac4-4d9164216888}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="79"/>
     </way>
     <way visible="true" id="80" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="286"/>
         <nd ref="285"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -3631,22 +3056,19 @@
         <tag k="uuid" v="{65da41d2-4f9f-41f3-9319-1515681a454d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="80"/>
     </way>
     <way visible="true" id="81" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="338"/>
         <nd ref="289"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{a0d2de4d-dc67-42d5-b8ec-205d8eda4747}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="81"/>
     </way>
     <way visible="true" id="82" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="327"/>
@@ -3654,6 +3076,7 @@
         <nd ref="290"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="GPS/Walkinp Papers;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Corridor Chéry"/>
@@ -3664,9 +3087,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="82"/>
     </way>
     <way visible="true" id="83" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="306"/>
@@ -3676,6 +3097,7 @@
         <nd ref="302"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Caillard"/>
@@ -3686,15 +3108,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="83"/>
     </way>
     <way visible="true" id="84" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="308"/>
         <nd ref="307"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Saint Come"/>
@@ -3704,9 +3125,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="84"/>
     </way>
     <way visible="true" id="85" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="464"/>
@@ -3719,6 +3138,7 @@
         <nd ref="443"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Macajoux"/>
@@ -3729,14 +3149,13 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="85"/>
     </way>
     <way visible="true" id="86" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="314"/>
         <nd ref="380"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
@@ -3744,9 +3163,7 @@
         <tag k="uuid" v="{f99df6be-98c3-437f-9872-cc4dcd127b64}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="86"/>
     </way>
     <way visible="true" id="87" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="351"/>
@@ -3756,14 +3173,13 @@
         <nd ref="349"/>
         <nd ref="402"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{514678d8-6f9a-46af-95d2-0786ee91f711}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="87"/>
     </way>
     <way visible="true" id="88" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="362"/>
@@ -3772,20 +3188,20 @@
         <nd ref="359"/>
         <nd ref="358"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue de la Marine"/>
         <tag k="uuid" v="{f39575e7-eda6-4f56-972a-e29f452f5d1c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="88"/>
     </way>
     <way visible="true" id="89" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="373"/>
         <nd ref="372"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
@@ -3793,9 +3209,7 @@
         <tag k="uuid" v="{ca96defa-9e53-4135-b5b9-e0a40d9827e0}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="89"/>
     </way>
     <way visible="true" id="90" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="391"/>
@@ -3805,15 +3219,14 @@
         <nd ref="387"/>
         <nd ref="391"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="area" v="yes"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9c350906-aefe-4469-ad56-8240e424f131}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="90"/>
     </way>
     <way visible="true" id="91" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="397"/>
@@ -3824,28 +3237,26 @@
         <nd ref="392"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Morisseau"/>
         <tag k="uuid" v="{6134892f-dd46-409a-a4a5-cb37bbde92cd}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="91"/>
     </way>
     <way visible="true" id="92" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="399"/>
         <nd ref="398"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{105ef982-8e71-42be-9597-443097c67821}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="92"/>
     </way>
     <way visible="true" id="93" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="402"/>
@@ -3853,6 +3264,7 @@
         <nd ref="400"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Mariella"/>
@@ -3863,9 +3275,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="93"/>
     </way>
     <way visible="true" id="94" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="408"/>
@@ -3876,14 +3286,13 @@
         <nd ref="404"/>
         <nd ref="403"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ef653cac-8797-4979-91bf-c67b6ea663e4}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="94"/>
     </way>
     <way visible="true" id="95" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="412"/>
@@ -3892,6 +3301,7 @@
         <nd ref="409"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Charlemagne Péralte"/>
@@ -3902,9 +3312,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="95"/>
     </way>
     <way visible="true" id="96" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="416"/>
@@ -3913,15 +3321,14 @@
         <nd ref="413"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Rimbaud"/>
         <tag k="uuid" v="{4b6183bd-1a7c-4f29-8e6b-e46448c08a40}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="96"/>
     </way>
     <way visible="true" id="97" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="424"/>
@@ -3934,15 +3341,14 @@
         <nd ref="417"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Franklin"/>
         <tag k="uuid" v="{673dfdb2-b81d-4433-a62c-62935c9a1a87}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="97"/>
     </way>
     <way visible="true" id="99" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="454"/>
@@ -3963,6 +3369,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Impasse Dorcé"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -3980,9 +3388,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="99"/>
     </way>
     <way visible="true" id="101" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="484"/>
@@ -3998,6 +3403,7 @@
         <nd ref="464"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Macajoux"/>
@@ -4008,9 +3414,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="101"/>
     </way>
     <way visible="true" id="102" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="492"/>
@@ -4018,15 +3422,14 @@
         <nd ref="488"/>
         <nd ref="486"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Houille"/>
         <tag k="uuid" v="{9712942b-f9ab-4ac5-ae10-38d69f8ad217}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="102"/>
     </way>
     <way visible="true" id="107" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="560"/>
@@ -4035,6 +3438,7 @@
         <nd ref="557"/>
         <nd ref="556"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Pétion 1re"/>
@@ -4044,9 +3448,7 @@
         <tag k="operational_status" v="open"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="107"/>
     </way>
     <way visible="true" id="108" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="571"/>
@@ -4062,21 +3464,21 @@
         <nd ref="561"/>
         <nd ref="571"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="area" v="yes"/>
         <tag k="highway" v="pedestrian"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b33c3252-16d5-4953-b9de-07139bbe1d4b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="108"/>
     </way>
     <way visible="true" id="111" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="587"/>
         <nd ref="586"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Traversière"/>
@@ -4087,24 +3489,21 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="111"/>
     </way>
     <way visible="true" id="112" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="590"/>
         <nd ref="589"/>
         <nd ref="588"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
         <tag k="uuid" v="{89ac31fa-afff-4e00-8d77-1179eb8a8126}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="112"/>
     </way>
     <way visible="true" id="114" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="462"/>
@@ -4118,6 +3517,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Marie Jeanne"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="4"/>
@@ -4133,9 +3534,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="114"/>
     </way>
     <way visible="true" id="115" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="525"/>
@@ -4156,6 +3554,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Monseigneur Guilloux"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4173,9 +3573,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary;road"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="115"/>
     </way>
     <way visible="true" id="118" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="442"/>
@@ -4202,6 +3599,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Sans Fil"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4219,9 +3618,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="118"/>
     </way>
     <way visible="true" id="120" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="386"/>
@@ -4239,6 +3635,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Borgella"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="smoothness" v="bad"/>
@@ -4255,9 +3653,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified;road"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="120"/>
     </way>
     <way visible="true" id="121" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="380"/>
@@ -4272,6 +3667,7 @@
         <nd ref="477"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/GIS /DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Magasin de l'État"/>
@@ -4282,9 +3678,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="121"/>
     </way>
     <way visible="true" id="124" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="357"/>
@@ -4295,6 +3689,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
         <tag k="ref" v="RN 1"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
@@ -4313,9 +3709,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="124"/>
     </way>
     <way visible="true" id="125" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="487"/>
@@ -4325,15 +3718,14 @@
         <nd ref="353"/>
         <nd ref="352"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Antonio Macéo"/>
         <tag k="uuid" v="{3d5251db-486f-4dde-b1ab-46bab5cdeecc}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="125"/>
     </way>
     <way visible="true" id="126" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="348"/>
@@ -4345,15 +3737,14 @@
         <nd ref="352"/>
         <nd ref="489"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Pie XII"/>
         <tag k="uuid" v="{dc81339f-b308-4492-80e5-c71e2c93ea82}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="126"/>
     </way>
     <way visible="true" id="127" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="493"/>
@@ -4373,6 +3764,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tokyo"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -4390,9 +3783,6 @@
         <tag k="source" v="GPS/Walkinp Papers;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="127"/>
     </way>
     <way visible="true" id="128" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="325"/>
@@ -4413,6 +3803,7 @@
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue des Miracles"/>
@@ -4423,9 +3814,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="128"/>
     </way>
     <way visible="true" id="130" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="496"/>
@@ -4433,15 +3822,14 @@
         <nd ref="347"/>
         <nd ref="549"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse French"/>
         <tag k="uuid" v="{96235e2c-40c3-4f14-bc3f-2a1c9bf15641}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="130"/>
     </way>
     <way visible="true" id="131" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="497"/>
@@ -4459,6 +3847,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Montalais"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="smoothness" v="bad"/>
@@ -4475,9 +3865,6 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="unclassified;road"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="131"/>
     </way>
     <way visible="true" id="132" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="498"/>
@@ -4494,6 +3881,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Bonne Foi"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -4508,9 +3897,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="132"/>
     </way>
     <way visible="true" id="133" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="271"/>
@@ -4524,6 +3910,7 @@
         <nd ref="499"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Peuple"/>
@@ -4534,9 +3921,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="133"/>
     </way>
     <way visible="true" id="134" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="500"/>
@@ -4545,6 +3930,7 @@
         <nd ref="262"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/GIS /DTM;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Quai"/>
@@ -4555,9 +3941,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="134"/>
     </way>
     <way visible="true" id="135" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="501"/>
@@ -4577,6 +3961,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Docteur Aubry"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -4594,9 +3980,6 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="135"/>
     </way>
     <way visible="true" id="136" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="246"/>
@@ -4615,6 +3998,7 @@
         <nd ref="502"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
         <tag k="history" v="Retrieved from v20"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Centre"/>
@@ -4626,9 +4010,7 @@
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="surface_condition" v="Smooth_greater_than_40kph"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="136"/>
     </way>
     <way visible="true" id="137" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="428"/>
@@ -4641,6 +4023,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Tiremasse"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4658,30 +4042,26 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="137"/>
     </way>
     <way visible="true" id="139" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="506"/>
         <nd ref="385"/>
-        <tag k="smoothness" v="intermediate"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Rue Geffrard"/>
-        <tag k="uuid" v="{8bfc5da0-f937-42a1-ae3c-baf70d589caa}"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="operational_status" v="open"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="attribution" v="osm"/>
         <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="139"/>
+        <tag k="name" v="Rue Geffrard"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{8bfc5da0-f937-42a1-ae3c-baf70d589caa}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="140" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="507"/>
@@ -4693,6 +4073,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -4708,9 +4090,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="140"/>
     </way>
     <way visible="true" id="141" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="281"/>
@@ -4722,6 +4101,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Delmas 4"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4739,15 +4120,13 @@
         <tag k="source" v="OIM/GIS/DTM;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="residential"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="141"/>
     </way>
     <way visible="true" id="142" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="510"/>
         <nd ref="186"/>
         <nd ref="382"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Lamarre"/>
@@ -4757,22 +4136,19 @@
         <tag k="operational_status" v="open"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="142"/>
     </way>
     <way visible="true" id="144" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="159"/>
         <nd ref="514"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{74e03987-e7de-4ff0-8052-128f8db00464}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="144"/>
     </way>
     <way visible="true" id="145" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="516"/>
@@ -4788,6 +4164,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Pavée"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -4808,35 +4186,30 @@
         <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="145"/>
     </way>
     <way visible="true" id="146" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="151"/>
         <nd ref="518"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0e32ea3c-d73c-40e8-ab04-9e42bef466c0}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="146"/>
     </way>
     <way visible="true" id="148" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="524"/>
         <nd ref="137"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{67d71af3-7f1a-447a-b664-c4a747b7277b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="148"/>
     </way>
     <way visible="true" id="149" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="136"/>
@@ -4844,15 +4217,14 @@
         <nd ref="135"/>
         <nd ref="526"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Magasin de l'État"/>
         <tag k="uuid" v="{0a8ad9a4-e9b0-4082-97bc-f9bf71f3bdf5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="149"/>
     </way>
     <way visible="true" id="150" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="346"/>
@@ -4861,15 +4233,14 @@
         <nd ref="527"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Simon Bolivar"/>
         <tag k="uuid" v="{929fb2cf-7312-4e91-9cb7-c3e0c4fc574c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="150"/>
     </way>
     <way visible="true" id="151" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="528"/>
@@ -4879,14 +4250,13 @@
         <nd ref="128"/>
         <nd ref="344"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{0c8279b7-71f3-4f70-be9d-1b40a954cd69}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="151"/>
     </way>
     <way visible="true" id="152" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="256"/>
@@ -4895,15 +4265,14 @@
         <nd ref="96"/>
         <nd ref="529"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Quai"/>
         <tag k="uuid" v="{0205b03a-add0-478a-b499-63481de3287d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="152"/>
     </way>
     <way visible="true" id="153" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="530"/>
@@ -4915,6 +4284,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
         <tag k="ref" v="RN 2"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
@@ -4933,9 +4304,6 @@
         <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
         <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="153"/>
     </way>
     <way visible="true" id="157" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="549"/>
@@ -4948,28 +4316,26 @@
         <nd ref="535"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Marie Jeanne"/>
         <tag k="uuid" v="{b211a83c-4c16-49e1-82db-f9c74b3aef73}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="157"/>
     </way>
     <way visible="true" id="158" timestamp="2017-06-07T15:18:21Z" version="1" changeset="119">
         <nd ref="18"/>
         <nd ref="536"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6262d1c7-cf8e-4473-8b18-3f72dead5f4d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="158"/>
     </way>
     <way visible="true" id="159" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="211"/>
@@ -4977,14 +4343,13 @@
         <nd ref="18"/>
         <nd ref="537"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{d1212963-6663-413f-bf29-859f83f4a8b0}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="159"/>
     </way>
     <way visible="true" id="160" timestamp="2017-06-07T15:18:21Z" version="1">
         <nd ref="539"/>
@@ -5007,6 +4372,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Saint Martin"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -5024,48 +4391,41 @@
         <tag k="source" v="hot_iom_cosmha;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="160"/>
     </way>
     <relation visible="true" id="-310" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-3" role="reviewee"/>
         <member type="way" ref="114" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-310"/>
     </relation>
     <relation visible="true" id="-309" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="157" role="reviewee"/>
         <member type="way" ref="-3" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-309"/>
     </relation>
     <relation visible="true" id="-308" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-3" role="reviewee"/>
         <member type="way" ref="157" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-308"/>
     </relation>
     <relation visible="true" id="-307" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="114" role="reviewee"/>
         <member type="way" ref="-3" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="type" v="review"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-307"/>
     </relation>
 </osm>

--- a/test-files/cases/network/conflicts/pap-008/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-008/Expected.osm
@@ -3,1763 +3,1348 @@
     <bounds minlat="18.53259194475" minlon="-72.32887100000001" maxlat="18.540399" maxlon="-72.314108"/>
     <node visible="true" id="-5285" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5366241268752354" lon="-72.3148384687989960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-5285"/>
     </node>
     <node visible="true" id="-128" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5325919447500027" lon="-72.3149362179299970">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-128"/>
     </node>
     <node visible="true" id="-119" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5367381214500000" lon="-72.3148341462100035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-118" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5368436510400016" lon="-72.3147343209199960">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-118"/>
     </node>
     <node visible="true" id="-117" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5369691456900014" lon="-72.3145546354100048">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-117"/>
     </node>
     <node visible="true" id="-116" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5370375973100003" lon="-72.3144405493699907">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-116"/>
     </node>
     <node visible="true" id="-115" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5371117532400014" lon="-72.3143892106500061">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-115"/>
     </node>
     <node visible="true" id="-114" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5380985974899950" lon="-72.3141096998499933">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-114"/>
     </node>
     <node visible="true" id="-113" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5329833537500051" lon="-72.3143340616399968">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-113"/>
     </node>
     <node visible="true" id="-112" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5331415590100015" lon="-72.3143678195200010">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-112"/>
     </node>
     <node visible="true" id="-111" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5333640267900037" lon="-72.3144191582399998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-111"/>
     </node>
     <node visible="true" id="-110" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5335180429400026" lon="-72.3144362711399964">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-110"/>
     </node>
     <node visible="true" id="-109" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5336492418900001" lon="-72.3144419754400047">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-109"/>
     </node>
     <node visible="true" id="-108" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5337433628699984" lon="-72.3144248625399939">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-108"/>
     </node>
     <node visible="true" id="-107" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5338317795599963" lon="-72.3143934888800004">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-107"/>
     </node>
     <node visible="true" id="-106" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5339287526899987" lon="-72.3143307415499947">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-106"/>
     </node>
     <node visible="true" id="-105" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5340342822800004" lon="-72.3142138033600048">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-105"/>
     </node>
     <node visible="true" id="-104" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5341027338999993" lon="-72.3141082737699890">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-104"/>
     </node>
     <node visible="true" id="-103" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5326654280400049" lon="-72.3146275880900049">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-103"/>
     </node>
     <node visible="true" id="-102" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5327139146100031" lon="-72.3143794509499998">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-102"/>
     </node>
     <node visible="true" id="-101" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5327237334899984" lon="-72.3142878080600013">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-101"/>
     </node>
     <node visible="true" id="-100" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5327310275200006" lon="-72.3142197304899952">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-100"/>
     </node>
     <node visible="true" id="-99" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5403469837999992" lon="-72.3257702291100060">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-99"/>
     </node>
     <node visible="true" id="-98" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5402414542100011" lon="-72.3254393795899944">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-98"/>
     </node>
     <node visible="true" id="-97" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5401245160199970" lon="-72.3251399037299905">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-97"/>
     </node>
     <node visible="true" id="-96" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5399476826499985" lon="-72.3247035246299959">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-96"/>
     </node>
     <node visible="true" id="-33" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5349614096199993" lon="-72.3193200895599944">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-33"/>
     </node>
     <node visible="true" id="-32" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5348359149800004" lon="-72.3192031513700044">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5346505251600036" lon="-72.3191090303899955">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5345079176100000" lon="-72.3190519873700026">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5343196756399955" lon="-72.3190006486499897">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5341542508800075" lon="-72.3189493099300051">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5340772427999951" lon="-72.3188808583099956">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-26" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5339574524600081" lon="-72.3187040249400042">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-26"/>
     </node>
     <node visible="true" id="-25" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5337635061899988" lon="-72.3183218366999796">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-25"/>
     </node>
     <node visible="true" id="-24" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5335752642199942" lon="-72.3179824307299981">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-24"/>
     </node>
     <node visible="true" id="-23" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5333527964399991" lon="-72.3175688688299800">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-23"/>
     </node>
     <node visible="true" id="-22" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5332558233100002" lon="-72.3173806268699906">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-22"/>
     </node>
     <node visible="true" id="-21" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5332187453400010" lon="-72.3172266107099944">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-21"/>
     </node>
     <node visible="true" id="-20" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5331816673799992" lon="-72.3170069950800070">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-20"/>
     </node>
     <node visible="true" id="-19" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5331417372699967" lon="-72.3167303364299983">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-19"/>
     </node>
     <node visible="true" id="-18" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5331103636099961" lon="-72.3165249815599935">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-18"/>
     </node>
     <node visible="true" id="-17" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5330761377900011" lon="-72.3164194519700061">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-17"/>
     </node>
     <node visible="true" id="-16" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5330219469199982" lon="-72.3163310352900055">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="-15" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5328650786199987" lon="-72.3161456454700016">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-15"/>
     </node>
     <node visible="true" id="-14" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5327595490300006" lon="-72.3159830728600070">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-14"/>
     </node>
     <node visible="true" id="-13" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5326739845000077" lon="-72.3157748658399981">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13"/>
     </node>
     <node visible="true" id="-12" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5326169414800042" lon="-72.3155010593399936">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-12"/>
     </node>
     <node visible="true" id="-11" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5326226457799983" lon="-72.3152529222000027">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-11"/>
     </node>
     <node visible="true" id="-10" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5326568715899995" lon="-72.3149876721499965">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-10"/>
     </node>
     <node visible="true" id="-9" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5327624011800012" lon="-72.3145256236900025">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-9"/>
     </node>
     <node visible="true" id="-8" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5328251484999988" lon="-72.3143003037600067">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-8"/>
     </node>
     <node visible="true" id="-6" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5341028660700040" lon="-72.3141080000000045">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-6"/>
     </node>
     <node visible="true" id="-5" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5381057131399949" lon="-72.3141080000000045">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-5"/>
     </node>
     <node visible="true" id="-3" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5327334047600019" lon="-72.3141080000000045">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-3"/>
     </node>
     <node visible="true" id="-2" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120" lat="18.5403990000000007" lon="-72.3259500565499991">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399483999999930" lon="-72.3268829999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="2" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398336999999991" lon="-72.3264584000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="2"/>
     </node>
     <node visible="true" id="3" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400682000000003" lon="-72.3261049999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="3"/>
     </node>
     <node visible="true" id="4" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399798000000011" lon="-72.3258457000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="4"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402321999999984" lon="-72.3275768000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5383838999999995" lon="-72.3281900000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5382496000000003" lon="-72.3282308999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381982999999977" lon="-72.3282880000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5380624999999988" lon="-72.3282796999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5375614000000013" lon="-72.3255101000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376194000000076" lon="-72.3259211000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5385057999999994" lon="-72.3285924000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391600000000061" lon="-72.3283523000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392561999999970" lon="-72.3282951000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395551999999988" lon="-72.3264601999999854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5378700999999992" lon="-72.3270320000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393308999999995" lon="-72.3265360999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394823000000031" lon="-72.3270164000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392167000000008" lon="-72.3233917999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393503000000024" lon="-72.3234451000000007">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395141999999993" lon="-72.3233864999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5390839999999990" lon="-72.3227957999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392028999999958" lon="-72.3228196000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393190000000025" lon="-72.3228538999999984">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5377873000000015" lon="-72.3269602999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5377034000000052" lon="-72.3269734000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5362793000000003" lon="-72.3268828000000070">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5388678999999996" lon="-72.3181138000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393676999999961" lon="-72.3179496999999856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395059999999994" lon="-72.3226535999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393343000000037" lon="-72.3225841999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392134000000013" lon="-72.3225077000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400251000000011" lon="-72.3232651000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400445000000005" lon="-72.3230741999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401713000000008" lon="-72.3229658999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394595999999972" lon="-72.3232277000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391903000000013" lon="-72.3233120000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389267000000046" lon="-72.3233943999999838">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5380430999999994" lon="-72.3196563999999995">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{3c99c92c-e8fd-43a8-807e-77b47ef3d20f}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5382889000000013" lon="-72.3278765000000021">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{af0b1c36-eaea-477c-8d73-df2c8f83d81a}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365904000000015" lon="-72.3234551999999979">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5222d046-2242-41a7-bc54-932aa215d72a}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402105000000006" lon="-72.3184166000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395493000000009" lon="-72.3147512000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5372910000000033" lon="-72.3143939999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373087999999981" lon="-72.3160572999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5371000000000059" lon="-72.3153242000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5368275000000047" lon="-72.3148953999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391927999999986" lon="-72.3151634999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5390352000000043" lon="-72.3152366999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5385776999999976" lon="-72.3145362000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376184999999971" lon="-72.3198404999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373998000000064" lon="-72.3199503999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5372209000000012" lon="-72.3201205999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370686000000013" lon="-72.3142765000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370713000000009" lon="-72.3141090000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386071000000001" lon="-72.3203345000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386910000000000" lon="-72.3203211000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389495999999987" lon="-72.3204460999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5390094999999988" lon="-72.3204683000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5390718999999997" lon="-72.3204817999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393590999999951" lon="-72.3204166000000015">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="bump"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e7fdbbb4-2899-4b9f-b356-316dd3f20419}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397175999999995" lon="-72.3202717000000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399439999999984" lon="-72.3201779000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391917000000035" lon="-72.3217523000000000">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{2a85e3fa-0aeb-49da-8d88-c4c445570282}"/>
         <tag k="attribution" v="osm"/>
         <tag k="access" v="private"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397148999999963" lon="-72.3215457000000015">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{d10de03c-c044-4282-a1c2-eaf26d3ad164}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401157000000048" lon="-72.3213860999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386993000000082" lon="-72.3192781999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384309999999992" lon="-72.3193667000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5379259999999952" lon="-72.3187276000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5380889999999958" lon="-72.3186575999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5382534999999997" lon="-72.3185160999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384685000000005" lon="-72.3184353999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386387000000035" lon="-72.3184064999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391180000000020" lon="-72.3183114999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403525999999985" lon="-72.3215292000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402766999999997" lon="-72.3215603999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402281999999978" lon="-72.3217150999999916">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401881000000017" lon="-72.3217831000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400811999999959" lon="-72.3218403000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399919999999980" lon="-72.3218520000000069">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399098999999978" lon="-72.3216661000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398378000000008" lon="-72.3216613999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397896000000024" lon="-72.3215167000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403061999999998" lon="-72.3234015000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401541999999999" lon="-72.3234053999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381746999999990" lon="-72.3226824000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5383557000000003" lon="-72.3226271000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367493000000003" lon="-72.3252860999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367050999999954" lon="-72.3251513999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366916000000046" lon="-72.3243001000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366959000000016" lon="-72.3241114000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398563000000003" lon="-72.3197583000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400436999999982" lon="-72.3201217000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395528999999968" lon="-72.3150044999999864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396385000000024" lon="-72.3193993000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394050000000021" lon="-72.3216680999999966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="101" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394146999999982" lon="-72.3217034000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="101"/>
     </node>
     <node visible="true" id="102" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394566000000012" lon="-72.3218307999999865">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="102"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396893000000027" lon="-72.3217499999999802">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="104" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396447000000038" lon="-72.3216065000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="104"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396317000000010" lon="-72.3215785999999952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370774999999952" lon="-72.3202464000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369022000000001" lon="-72.3191362999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370090999999952" lon="-72.3181440999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373348000000000" lon="-72.3189579000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402580000000050" lon="-72.3179279999999807">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402178000000077" lon="-72.3178092999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366855000000008" lon="-72.3148426000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403790999999991" lon="-72.3246024999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401051999999993" lon="-72.3212175000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398558999999992" lon="-72.3213145999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396074000000013" lon="-72.3214171999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393383000000043" lon="-72.3215320000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391364000000003" lon="-72.3216034999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5380526000000003" lon="-72.3272733000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="120" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5363688999999994" lon="-72.3235796000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="120"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5363758999999959" lon="-72.3236205999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365467999999964" lon="-72.3236640999999878">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="123" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365671000000063" lon="-72.3236670999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="123"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366152999999976" lon="-72.3236667000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5374996000000003" lon="-72.3167766999999913">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395116999999949" lon="-72.3151703999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395262000000010" lon="-72.3150121000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395585000000018" lon="-72.3148278999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5378590000000010" lon="-72.3164806999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5377583000000037" lon="-72.3142208999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366277000000039" lon="-72.3148213000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365267000000031" lon="-72.3153065999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5364991999999980" lon="-72.3156218999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365256999999950" lon="-72.3158897999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365797999999948" lon="-72.3161405999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366603999999988" lon="-72.3164096000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367582999999989" lon="-72.3166322999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369338000000035" lon="-72.3169412000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370959999999947" lon="-72.3172543000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5371806999999968" lon="-72.3174522999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376988000000011" lon="-72.3188097999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5378936999999979" lon="-72.3192822999999976">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c99fa486-f443-4cd7-9751-9733f95bffcf}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <node visible="true" id="143" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5379956000000021" lon="-72.3195355999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="143"/>
     </node>
     <node visible="true" id="144" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395390999999989" lon="-72.3153697999999849">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="144"/>
     </node>
     <node visible="true" id="145" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400349999999996" lon="-72.3162212000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="145"/>
     </node>
     <node visible="true" id="146" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397569999999980" lon="-72.3159313000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="146"/>
     </node>
     <node visible="true" id="147" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396877999999994" lon="-72.3158217000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="147"/>
     </node>
     <node visible="true" id="148" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396199000000053" lon="-72.3156862999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="148"/>
     </node>
     <node visible="true" id="149" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395882000000007" lon="-72.3155828000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="149"/>
     </node>
     <node visible="true" id="150" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395560000000046" lon="-72.3154494000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="150"/>
     </node>
     <node visible="true" id="151" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5388008000000006" lon="-72.3208908999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="151"/>
     </node>
     <node visible="true" id="152" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5359037999999998" lon="-72.3149248000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="152"/>
     </node>
     <node visible="true" id="153" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366435000000003" lon="-72.3147435000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="153"/>
     </node>
     <node visible="true" id="154" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5374493999999999" lon="-72.3181497999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="154"/>
     </node>
     <node visible="true" id="155" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5382362999999977" lon="-72.3177358999999882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="155"/>
     </node>
     <node visible="true" id="156" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384078000000017" lon="-72.3176770000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="156"/>
     </node>
     <node visible="true" id="157" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5385609000000038" lon="-72.3177083000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="157"/>
     </node>
     <node visible="true" id="158" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5387531999999950" lon="-72.3177601999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="158"/>
     </node>
     <node visible="true" id="159" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389280999999961" lon="-72.3176955999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="159"/>
     </node>
     <node visible="true" id="160" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5375748999999956" lon="-72.3157426999999871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="160"/>
     </node>
     <node visible="true" id="161" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381491999999994" lon="-72.3199129000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="161"/>
     </node>
     <node visible="true" id="162" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5383715000000002" lon="-72.3204417000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="162"/>
     </node>
     <node visible="true" id="163" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384801999999951" lon="-72.3206744000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="163"/>
     </node>
     <node visible="true" id="164" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386187000000042" lon="-72.3209973999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="164"/>
     </node>
     <node visible="true" id="165" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389320999999967" lon="-72.3217041000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="165"/>
     </node>
     <node visible="true" id="166" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389829000000077" lon="-72.3218327000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="166"/>
     </node>
     <node visible="true" id="167" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389976999999995" lon="-72.3218731000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="167"/>
     </node>
     <node visible="true" id="168" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392671999999976" lon="-72.3226671999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="168"/>
     </node>
     <node visible="true" id="169" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395280000000007" lon="-72.3234264999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="169"/>
     </node>
     <node visible="true" id="170" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399561999999953" lon="-72.3247231999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="170"/>
     </node>
     <node visible="true" id="171" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399871999999988" lon="-72.3248071999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="171"/>
     </node>
     <node visible="true" id="172" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398391999999994" lon="-72.3160256999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="172"/>
     </node>
     <node visible="true" id="173" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398840000000007" lon="-72.3161686999999915">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{75deeb1f-df89-4d9d-a512-45450e61c640}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="173"/>
     </node>
     <node visible="true" id="174" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399748999999971" lon="-72.3163772000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="174"/>
     </node>
     <node visible="true" id="175" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400427000000008" lon="-72.3166236999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="175"/>
     </node>
     <node visible="true" id="176" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400671999999958" lon="-72.3169448000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="176"/>
     </node>
     <node visible="true" id="177" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401047000000005" lon="-72.3171806999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="177"/>
     </node>
     <node visible="true" id="178" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401163000000047" lon="-72.3173678999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="178"/>
     </node>
     <node visible="true" id="179" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5401004000000000" lon="-72.3174698999999919">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="179"/>
     </node>
     <node visible="true" id="180" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400369000000005" lon="-72.3175367999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="180"/>
     </node>
     <node visible="true" id="181" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399613000000052" lon="-72.3175807999999876">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="181"/>
     </node>
     <node visible="true" id="182" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397815000000001" lon="-72.3177330999999839">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="182"/>
     </node>
     <node visible="true" id="183" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396934999999985" lon="-72.3178198999999893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="183"/>
     </node>
     <node visible="true" id="184" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396151000000025" lon="-72.3178575000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="184"/>
     </node>
     <node visible="true" id="185" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393833000000008" lon="-72.3179439000000031">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6601d06e-773e-4bee-966b-3e6de5be59c4}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="185"/>
     </node>
     <node visible="true" id="186" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398151999999996" lon="-72.3173167000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="186"/>
     </node>
     <node visible="true" id="187" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398858999999980" lon="-72.3176184000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="187"/>
     </node>
     <node visible="true" id="188" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391859000000032" lon="-72.3175642999999866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="188"/>
     </node>
     <node visible="true" id="189" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5388452000000008" lon="-72.3167865000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="189"/>
     </node>
     <node visible="true" id="190" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5388769999999994" lon="-72.3166896999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="190"/>
     </node>
     <node visible="true" id="191" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391340000000007" lon="-72.3165137999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="191"/>
     </node>
     <node visible="true" id="192" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393472999999958" lon="-72.3164186999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="192"/>
     </node>
     <node visible="true" id="193" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394237000000004" lon="-72.3164088999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="193"/>
     </node>
     <node visible="true" id="194" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370157000000013" lon="-72.3150782000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="194"/>
     </node>
     <node visible="true" id="195" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5372231999999997" lon="-72.3149679999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="195"/>
     </node>
     <node visible="true" id="196" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373449000000043" lon="-72.3149207000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="196"/>
     </node>
     <node visible="true" id="197" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5379341000000011" lon="-72.3146521999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="197"/>
     </node>
     <node visible="true" id="198" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398557000000039" lon="-72.3283210000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="198"/>
     </node>
     <node visible="true" id="199" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397992999999914" lon="-72.3284026000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="199"/>
     </node>
     <node visible="true" id="200" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397865000000017" lon="-72.3284984999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="200"/>
     </node>
     <node visible="true" id="201" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393445999999962" lon="-72.3229209999999796">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="201"/>
     </node>
     <node visible="true" id="202" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393946000000014" lon="-72.3227521000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="202"/>
     </node>
     <node visible="true" id="203" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392267000000075" lon="-72.3225467000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="203"/>
     </node>
     <node visible="true" id="204" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391665000000003" lon="-72.3226563999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="204"/>
     </node>
     <node visible="true" id="205" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366879000000040" lon="-72.3239430999999939">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="205"/>
     </node>
     <node visible="true" id="206" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5368438000000069" lon="-72.3236066000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="206"/>
     </node>
     <node visible="true" id="207" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369974999999982" lon="-72.3233672000000070">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ccb42781-ea17-4d67-a3d9-692fe208947e}"/>
         <tag k="attribution" v="osm"/>
         <tag k="hazard" v="hole"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="207"/>
     </node>
     <node visible="true" id="208" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394925000000015" lon="-72.3284428999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="208"/>
     </node>
     <node visible="true" id="209" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393551000000016" lon="-72.3279674999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="209"/>
     </node>
     <node visible="true" id="210" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5388478999999968" lon="-72.3211998000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="210"/>
     </node>
     <node visible="true" id="211" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392243000000008" lon="-72.3210468999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="211"/>
     </node>
     <node visible="true" id="212" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394150000000053" lon="-72.3210227999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="212"/>
     </node>
     <node visible="true" id="213" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395701000000024" lon="-72.3210281000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="213"/>
     </node>
     <node visible="true" id="214" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398777999999993" lon="-72.3209154999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="214"/>
     </node>
     <node visible="true" id="215" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400456999999967" lon="-72.3207759999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="215"/>
     </node>
     <node visible="true" id="216" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5389727999999998" lon="-72.3201767999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="216"/>
     </node>
     <node visible="true" id="217" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5387918000000056" lon="-72.3202557000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="217"/>
     </node>
     <node visible="true" id="218" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5387738000000013" lon="-72.3203381999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="218"/>
     </node>
     <node visible="true" id="219" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5371318000000045" lon="-72.3261044999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="219"/>
     </node>
     <node visible="true" id="220" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381103999999972" lon="-72.3258186000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="220"/>
     </node>
     <node visible="true" id="221" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369500999999985" lon="-72.3165498999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="221"/>
     </node>
     <node visible="true" id="222" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373711000000014" lon="-72.3163870000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="222"/>
     </node>
     <node visible="true" id="223" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376606000000024" lon="-72.3162769000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="223"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5390623999999988" lon="-72.3254687000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5387549000000007" lon="-72.3255970999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391868000000031" lon="-72.3249789000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395592999999970" lon="-72.3186816000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395537000000026" lon="-72.3186663999999979">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{93649268-e796-4815-8370-fd043dfacf87}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="229" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394410000000036" lon="-72.3183575999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="229"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394424999999998" lon="-72.3182189999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394402999999990" lon="-72.3181223999999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395754999999980" lon="-72.3147806000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396383000000000" lon="-72.3146090000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5385458000000050" lon="-72.3287241000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5374811000000008" lon="-72.3285955999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365317999999988" lon="-72.3278451999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356775999999961" lon="-72.3278832000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386929999999985" lon="-72.3256913000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5386714999999960" lon="-72.3256319000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5385171000000000" lon="-72.3252052999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="241" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384701999999990" lon="-72.3250759000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="241"/>
     </node>
     <node visible="true" id="242" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393561000000027" lon="-72.3199364999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="242"/>
     </node>
     <node visible="true" id="243" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394277000000010" lon="-72.3199996000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="243"/>
     </node>
     <node visible="true" id="244" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394593000000043" lon="-72.3200331999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="244"/>
     </node>
     <node visible="true" id="245" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394858000000013" lon="-72.3200984000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="245"/>
     </node>
     <node visible="true" id="246" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395758000000015" lon="-72.3203290000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="246"/>
     </node>
     <node visible="true" id="247" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5402212000000048" lon="-72.3150404999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="247"/>
     </node>
     <node visible="true" id="248" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5399734999999950" lon="-72.3150430999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="248"/>
     </node>
     <node visible="true" id="249" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5374273999999950" lon="-72.3240816999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="249"/>
     </node>
     <node visible="true" id="250" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370190999999984" lon="-72.3240614999999849">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="250"/>
     </node>
     <node visible="true" id="251" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370508999999970" lon="-72.3241957000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="251"/>
     </node>
     <node visible="true" id="252" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369489999999999" lon="-72.3242230000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="252"/>
     </node>
     <node visible="true" id="253" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367737000000012" lon="-72.3242666999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="253"/>
     </node>
     <node visible="true" id="254" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367498000000026" lon="-72.3242908000000000">
         <tag k="entrance" v="main"/>
         <tag k="foot" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="bicycle" v="yes"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{58410890-9963-4815-85e5-545cf188257b}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="254"/>
     </node>
     <node visible="true" id="255" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366910000000011" lon="-72.3243109000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="255"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5380752000000015" lon="-72.3150578000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381488999999995" lon="-72.3163681000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="258" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367515000000012" lon="-72.3148213000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="258"/>
     </node>
     <node visible="true" id="259" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5368293000000008" lon="-72.3147565000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="259"/>
     </node>
     <node visible="true" id="260" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369331000000059" lon="-72.3146208999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="260"/>
     </node>
     <node visible="true" id="261" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370257999999986" lon="-72.3144716999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="261"/>
     </node>
     <node visible="true" id="262" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370559999999998" lon="-72.3144075000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="262"/>
     </node>
     <node visible="true" id="263" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394670999999960" lon="-72.3226662000000005">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="263"/>
     </node>
     <node visible="true" id="264" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5393829000000032" lon="-72.3226946999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="264"/>
     </node>
     <node visible="true" id="265" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5395727999999984" lon="-72.3274698999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="265"/>
     </node>
     <node visible="true" id="266" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381637000000019" lon="-72.3168598999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="266"/>
     </node>
     <node visible="true" id="267" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381636000000007" lon="-72.3172830999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="267"/>
     </node>
     <node visible="true" id="268" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373133000000045" lon="-72.3177869999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="268"/>
     </node>
     <node visible="true" id="269" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384352999999997" lon="-72.3273611999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="269"/>
     </node>
     <node visible="true" id="270" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381305999999988" lon="-72.3274354999999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="270"/>
     </node>
     <node visible="true" id="271" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365268000000007" lon="-72.3232871999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="271"/>
     </node>
     <node visible="true" id="272" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5364879000000009" lon="-72.3231480000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="272"/>
     </node>
     <node visible="true" id="273" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5364220999999958" lon="-72.3230068000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="273"/>
     </node>
     <node visible="true" id="274" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5363139999999973" lon="-72.3228659999999905">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="274"/>
     </node>
     <node visible="true" id="275" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5360660999999993" lon="-72.3226067999999884">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="275"/>
     </node>
     <node visible="true" id="276" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5359949999999998" lon="-72.3224905999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="276"/>
     </node>
     <node visible="true" id="277" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5359370000000006" lon="-72.3223193999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="277"/>
     </node>
     <node visible="true" id="278" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5358753999999983" lon="-72.3220632000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="278"/>
     </node>
     <node visible="true" id="279" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5357343999999991" lon="-72.3214921000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="279"/>
     </node>
     <node visible="true" id="280" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356656000000015" lon="-72.3212245999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="280"/>
     </node>
     <node visible="true" id="281" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356193999999981" lon="-72.3209963999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="281"/>
     </node>
     <node visible="true" id="282" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356113000000029" lon="-72.3208869000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="282"/>
     </node>
     <node visible="true" id="283" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356301000000023" lon="-72.3208034999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="283"/>
     </node>
     <node visible="true" id="284" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356193999999981" lon="-72.3207196999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="284"/>
     </node>
     <node visible="true" id="285" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5355625000000011" lon="-72.3205784999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="285"/>
     </node>
     <node visible="true" id="286" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5352722000000050" lon="-72.3199611000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="286"/>
     </node>
     <node visible="true" id="287" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5350968999999992" lon="-72.3195537000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="287"/>
     </node>
     <node visible="true" id="288" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376438000000086" lon="-72.3285922999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="288"/>
     </node>
     <node visible="true" id="289" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381089999999986" lon="-72.3216093999999856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="289"/>
     </node>
     <node visible="true" id="290" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5387442000000000" lon="-72.3212635000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="290"/>
     </node>
     <node visible="true" id="291" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5371908999999988" lon="-72.3202772000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="291"/>
     </node>
     <node visible="true" id="292" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5372294999999987" lon="-72.3204850999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="292"/>
     </node>
     <node visible="true" id="293" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373686999999983" lon="-72.3214037999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="293"/>
     </node>
     <node visible="true" id="294" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5374609999999969" lon="-72.3219632999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="294"/>
     </node>
     <node visible="true" id="295" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5375394000000000" lon="-72.3224986999999828">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="295"/>
     </node>
     <node visible="true" id="296" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376307000000011" lon="-72.3231492999999830">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="stop"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{81a6187d-d916-4a81-aa17-94f68776c7ab}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="296"/>
     </node>
     <node visible="true" id="297" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365311999999953" lon="-72.3264197000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="297"/>
     </node>
     <node visible="true" id="298" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5373813000000034" lon="-72.3264941999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="298"/>
     </node>
     <node visible="true" id="299" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5400680999999992" lon="-72.3250303999999886">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="299"/>
     </node>
     <node visible="true" id="300" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5391809999999992" lon="-72.3253897999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="300"/>
     </node>
     <node visible="true" id="301" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5392884999999978" lon="-72.3227243999999985">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{48ab65ec-d39b-4f60-bc59-d7014ac7b2b5}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="301"/>
     </node>
     <node visible="true" id="302" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5384291999999995" lon="-72.3229546000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="302"/>
     </node>
     <node visible="true" id="303" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376342999999970" lon="-72.3231746999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="303"/>
     </node>
     <node visible="true" id="304" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370183000000033" lon="-72.3233347999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="304"/>
     </node>
     <node visible="true" id="305" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369831000000005" lon="-72.3233447000000069">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{1326769a-8a75-444d-ad3e-3a738f29ba0f}"/>
         <tag k="attribution" v="osm"/>
         <tag k="hazard" v="hole"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="305"/>
     </node>
     <node visible="true" id="306" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5365698999999964" lon="-72.3234609999999947">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{d279fefb-4f03-4401-9913-e9efb583b578}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="306"/>
     </node>
     <node visible="true" id="307" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5363597999999961" lon="-72.3235262999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="307"/>
     </node>
     <node visible="true" id="308" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5363116999999988" lon="-72.3235423999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="308"/>
     </node>
     <node visible="true" id="309" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5362673999999998" lon="-72.3235573000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="309"/>
     </node>
     <node visible="true" id="310" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5359891999999959" lon="-72.3236505999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="310"/>
     </node>
     <node visible="true" id="311" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356811000000015" lon="-72.3237538999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="311"/>
     </node>
     <node visible="true" id="312" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5353565999999965" lon="-72.3238506999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="312"/>
     </node>
     <node visible="true" id="313" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5351417000000005" lon="-72.3239240000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="313"/>
     </node>
     <node visible="true" id="314" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366730000000004" lon="-72.3248975000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="314"/>
     </node>
     <node visible="true" id="315" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397852000000007" lon="-72.3242061999999919">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="315"/>
     </node>
     <node visible="true" id="316" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5396119000000006" lon="-72.3236703999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="316"/>
     </node>
     <node visible="true" id="317" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5374605999999993" lon="-72.3242173999999807">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="317"/>
     </node>
     <node visible="true" id="318" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366855000000008" lon="-72.3244143999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="318"/>
     </node>
     <node visible="true" id="319" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403231999999996" lon="-72.3257317999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="319"/>
     </node>
     <node visible="true" id="320" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5388826000000009" lon="-72.3262148000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="320"/>
     </node>
     <node visible="true" id="321" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5375264999999985" lon="-72.3266737999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="321"/>
     </node>
     <node visible="true" id="323" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3280385879899796">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="323"/>
     </node>
     <node visible="true" id="324" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403989999999972" lon="-72.3259989404899954">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="324"/>
     </node>
     <node visible="true" id="325" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5377295083800036" lon="-72.3288710000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="325"/>
     </node>
     <node visible="true" id="326" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3267597983099932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="326"/>
     </node>
     <node visible="true" id="327" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3272072333300002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="327"/>
     </node>
     <node visible="true" id="328" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403989999999972" lon="-72.3223644889999804">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="328"/>
     </node>
     <node visible="true" id="329" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3150090145799851">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="329"/>
     </node>
     <node visible="true" id="330" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5366336007600019" lon="-72.3288710000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="330"/>
     </node>
     <node visible="true" id="331" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5397330716000006" lon="-72.3141080000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="331"/>
     </node>
     <node visible="true" id="332" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3205941675799977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="332"/>
     </node>
     <node visible="true" id="333" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3280539105499969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="333"/>
     </node>
     <node visible="true" id="334" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5398994374300052" lon="-72.3288710000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="334"/>
     </node>
     <node visible="true" id="335" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000043" lon="-72.3259733383899999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="335"/>
     </node>
     <node visible="true" id="336" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3166034801800066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="336"/>
     </node>
     <node visible="true" id="337" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367703622800057" lon="-72.3141080000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="337"/>
     </node>
     <node visible="true" id="338" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5385956343399982" lon="-72.3288710000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="338"/>
     </node>
     <node visible="true" id="339" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3245908687599979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="339"/>
     </node>
     <node visible="true" id="340" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3183117269000064">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="340"/>
     </node>
     <node visible="true" id="341" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3233705351999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="341"/>
     </node>
     <node visible="true" id="342" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3197667580799930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="342"/>
     </node>
     <node visible="true" id="346" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370709336599973" lon="-72.3141080000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="346"/>
     </node>
     <node visible="true" id="347" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370756218400032" lon="-72.3141080000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="347"/>
     </node>
     <node visible="true" id="350" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5390348832699985" lon="-72.3141080000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="350"/>
     </node>
     <node visible="true" id="351" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5381484616900032" lon="-72.3141080000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="351"/>
     </node>
     <node visible="true" id="352" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403989999999972" lon="-72.3183314022600001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="352"/>
     </node>
     <node visible="true" id="353" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3215153048100063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="353"/>
     </node>
     <node visible="true" id="354" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5403990000000007" lon="-72.3228967640099967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="354"/>
     </node>
     <node visible="true" id="356" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5350056000000052" lon="-72.3193674999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="356"/>
     </node>
     <node visible="true" id="357" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5350400999999962" lon="-72.3193432000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="357"/>
     </node>
     <node visible="true" id="358" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5352235000000043" lon="-72.3193782000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="358"/>
     </node>
     <node visible="true" id="359" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5355672000000027" lon="-72.3195110999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="359"/>
     </node>
     <node visible="true" id="360" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5356170000000020" lon="-72.3195304000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="360"/>
     </node>
     <node visible="true" id="361" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5362409999999969" lon="-72.3198127999999940">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="361"/>
     </node>
     <node visible="true" id="362" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5364487000000011" lon="-72.3198921999999982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="362"/>
     </node>
     <node visible="true" id="363" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5367528000000021" lon="-72.3199907000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="363"/>
     </node>
     <node visible="true" id="364" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5368391999999993" lon="-72.3200307000000038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="364"/>
     </node>
     <node visible="true" id="365" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369066999999923" lon="-72.3201049999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="365"/>
     </node>
     <node visible="true" id="366" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5369725000000010" lon="-72.3201957999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="366"/>
     </node>
     <node visible="true" id="367" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5370032000000009" lon="-72.3202182999999934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="367"/>
     </node>
     <node visible="true" id="368" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5377071999999998" lon="-72.3241546999999798">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="368"/>
     </node>
     <node visible="true" id="369" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5376019000000021" lon="-72.3237696000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="369"/>
     </node>
     <node visible="true" id="370" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121" lat="18.5394183999999989" lon="-72.3281865000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="370"/>
     </node>
     <way visible="true" id="-8705" timestamp="2017-06-07T15:19:29Z" version="1">
         <nd ref="-2"/>
@@ -1768,25 +1353,24 @@
         <nd ref="-97"/>
         <nd ref="-96"/>
         <nd ref="315"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.114Z"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{00b2b754-a805-42fe-a7c0-60fe86d05092}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8705"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{00b2b754-a805-42fe-a7c0-60fe86d05092}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.114Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-8694" timestamp="2017-06-07T15:19:29Z" version="1">
         <nd ref="356"/>
@@ -1821,6 +1405,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1832,9 +1418,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-8694"/>
     </way>
     <way visible="true" id="-7" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="137"/>
@@ -1853,6 +1436,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Route de Bourdon"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -1870,9 +1455,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-7"/>
     </way>
     <way visible="true" id="-5" timestamp="2017-06-07T15:19:29Z" version="1">
         <nd ref="-101"/>
@@ -1888,25 +1470,24 @@
         <nd ref="-105"/>
         <nd ref="-104"/>
         <nd ref="-6"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.112Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="median" v="no"/>
-        <tag k="location" v="surface"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{7ce9692f-4849-440e-979c-916936f16365}}"/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="surface" v="paved"/>
         <tag k="seasonal" v="no"/>
-        <tag k="lanes" v="2"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{7ce9692f-4849-440e-979c-916936f16365}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.112Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-4" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120">
         <nd ref="-5285"/>
@@ -1917,10 +1498,9 @@
         <nd ref="-115"/>
         <nd ref="-114"/>
         <nd ref="-5"/>
-        <tag k="source:datetime" v="2017-06-07T15:19:29Z"/>
         <tag k="hoot:status" v="2"/>
+        <tag k="source:datetime" v="2017-06-07T15:19:29Z"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-4"/>
     </way>
     <way visible="true" id="-2" timestamp="2017-06-07T15:19:29Z" version="1" changeset="120">
         <nd ref="-128"/>
@@ -1929,11 +1509,10 @@
         <nd ref="-101"/>
         <nd ref="-100"/>
         <nd ref="-3"/>
+        <tag k="hoot:status" v="2"/>
         <tag k="uuid" v="{5bf40a5c-9e5f-42df-ae1e-72ce4ef1151e}"/>
         <tag k="source:datetime" v="2016-03-18T15:25:10Z"/>
-        <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-2"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="25"/>
@@ -1941,42 +1520,39 @@
         <nd ref="23"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="knowledge;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{3ec71294-5faf-444b-a342-2b2a53382524}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="28"/>
         <nd ref="27"/>
         <nd ref="26"/>
         <tag k="source" v="Yahoo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Rigaud"/>
         <tag k="uuid" v="{b616a53c-af19-440d-82f1-e7ce9f096b39}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="30"/>
         <nd ref="29"/>
         <tag k="source" v="IOM_drone;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{090e51cd-c24b-46e2-a4dd-bd3ff779af45}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="33"/>
@@ -1984,47 +1560,45 @@
         <nd ref="31"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{83f76981-3d8a-4617-bf04-b2a44ae7655f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="40"/>
         <nd ref="39"/>
         <nd ref="38"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{dfcab291-5d38-4d86-85d9-14bb5ddce212}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="68"/>
         <nd ref="166"/>
         <tag k="source" v="GeoEye; Bing; knowledge/guestimate;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{cce3779a-8d98-4585-bb37-dabbb0230fca}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="FIXME" v="to survey: classification, name"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="293"/>
         <nd ref="163"/>
         <tag k="source" v="NOAA, 2010-01-21;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="keepme" v="yes"/>
@@ -2032,9 +1606,7 @@
         <tag k="uuid" v="{9980ec9a-245a-4dad-9913-50163839b94c}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="258"/>
@@ -2045,6 +1617,7 @@
         <nd ref="222"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Louissaint"/>
@@ -2055,9 +1628,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="52"/>
@@ -2065,15 +1636,14 @@
         <nd ref="50"/>
         <nd ref="127"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Malebranche"/>
         <tag k="uuid" v="{00ed8137-6cbd-4f6b-b1a8-feaf1adea020}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="291"/>
@@ -2082,6 +1652,7 @@
         <nd ref="53"/>
         <nd ref="41"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="paved:date" v="2012-11-17"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -2091,22 +1662,19 @@
         <tag k="uuid" v="{9f98a3d7-ac2b-4735-9983-13d27d8150b8}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="291"/>
         <nd ref="106"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{29375430-6a85-418b-80c7-f499db556ad2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="70"/>
@@ -2116,36 +1684,35 @@
         <nd ref="100"/>
         <nd ref="68"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e7fffbb6-80c3-4981-afa6-891e31cc6a46}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
         <tag k="access" v="private"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="143"/>
         <nd ref="72"/>
         <nd ref="71"/>
         <tag k="source" v="Bing; survey; Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Bourand"/>
         <tag k="uuid" v="{02ba0661-6fc4-4c28-b95e-a874f66ef349}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="14" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="221"/>
         <nd ref="137"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -2157,9 +1724,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="77"/>
@@ -2170,6 +1735,7 @@
         <nd ref="141"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; Bing; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Bruant"/>
@@ -2179,15 +1745,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="78"/>
         <nd ref="230"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Desrouleaux"/>
@@ -2198,9 +1763,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="87"/>
@@ -2213,30 +1776,28 @@
         <nd ref="80"/>
         <nd ref="79"/>
         <tag k="source" v="Bing; Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{16691048-5a85-4146-9401-dc48324a0eee}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
         <tag k="access" v="private"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="302"/>
         <nd ref="91"/>
         <nd ref="90"/>
         <tag k="source" v="World Bank, 2010/01/21-2010-01/22;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Champagne"/>
         <tag k="uuid" v="{cd71282d-28a9-4563-a0fc-582c04e85039}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="306"/>
@@ -2257,6 +1818,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Lamartinière"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2275,15 +1838,13 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GPS; survey;osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="97"/>
         <nd ref="96"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Justin 2ème"/>
@@ -2294,44 +1855,41 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="127"/>
         <nd ref="98"/>
         <nd ref="248"/>
         <tag k="source" v="http://hypercube.telascience.org/tiles/1.0.0/worldbank-21-900913/!/!/!.jpg; DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Caroline"/>
         <tag k="uuid" v="{0d9e65e9-8f41-4dce-807c-3836b4cbe6ad}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="295"/>
         <nd ref="167"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Rivière 1re"/>
         <tag k="uuid" v="{6f14d463-4cba-4a92-b7e9-b0d8e24fa2ef}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="161"/>
         <nd ref="99"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Pierre Louis"/>
@@ -2342,9 +1900,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="105"/>
@@ -2354,6 +1910,7 @@
         <nd ref="101"/>
         <nd ref="100"/>
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="service" v="parking_aisle"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
@@ -2361,14 +1918,13 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
         <tag k="access" v="private"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="106"/>
         <nd ref="367"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2376,9 +1932,7 @@
         <tag k="uuid" v="{3bffb444-8b26-4d6c-ae3b-6585384d5c4e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="141"/>
@@ -2386,6 +1940,7 @@
         <nd ref="107"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Hérard 1re"/>
@@ -2396,15 +1951,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="27" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="109"/>
         <nd ref="108"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Hérard 2e"/>
@@ -2415,9 +1969,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="258"/>
@@ -2426,6 +1978,7 @@
         <tag k="smoothness" v="bad"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Louissaint"/>
@@ -2436,9 +1989,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="165"/>
@@ -2449,6 +2000,7 @@
         <nd ref="114"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Cabèche"/>
@@ -2459,9 +2011,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="124"/>
@@ -2471,28 +2021,26 @@
         <nd ref="120"/>
         <nd ref="307"/>
         <tag k="source" v="survey; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="service" v="parking_aisle"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c50bf950-c8ad-427a-9d5d-075ce878b04d}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="222"/>
         <nd ref="125"/>
         <tag k="source" v="Bing; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{dd8d71ed-bb9f-40d0-97cb-41e0f15cff33}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="232"/>
@@ -2502,6 +2050,7 @@
         <nd ref="144"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Butte"/>
@@ -2512,9 +2061,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="223"/>
@@ -2522,6 +2069,7 @@
         <nd ref="257"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -2532,9 +2080,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="256"/>
@@ -2542,6 +2088,7 @@
         <nd ref="130"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -2552,15 +2099,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="144"/>
         <nd ref="150"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="bridge" v="yes"/>
@@ -2573,29 +2119,27 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="164"/>
         <nd ref="151"/>
         <tag k="source" v="Google 2010-01-17; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Corridor Citron"/>
         <tag k="uuid" v="{3f1e2e0c-1c0c-4d6f-8378-89081b1df3f6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="153"/>
         <nd ref="152"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Coumbite"/>
@@ -2607,9 +2151,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="188"/>
@@ -2621,6 +2163,7 @@
         <nd ref="154"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue T. Guilbaud"/>
@@ -2631,15 +2174,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="160"/>
         <nd ref="196"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Mercy"/>
@@ -2650,9 +2192,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <way visible="true" id="40" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="30"/>
@@ -2673,6 +2213,7 @@
         <nd ref="172"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="incline" v="yes"/>
@@ -2684,9 +2225,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="40"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="187"/>
@@ -2694,6 +2233,7 @@
         <nd ref="193"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Morelly"/>
@@ -2704,9 +2244,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="193"/>
@@ -2718,6 +2256,7 @@
         <nd ref="30"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle M. Solomon"/>
@@ -2728,9 +2267,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="43" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="197"/>
@@ -2739,6 +2276,7 @@
         <nd ref="194"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Célie"/>
@@ -2749,15 +2287,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="198"/>
         <nd ref="265"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Lavaud 3e"/>
@@ -2768,9 +2305,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="44"/>
     </way>
     <way visible="true" id="45" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="263"/>
@@ -2778,14 +2313,13 @@
         <nd ref="201"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="knowledge;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6e9b593b-9898-4290-887f-4ab1b83a0cdf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="45"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="23"/>
@@ -2793,14 +2327,13 @@
         <nd ref="203"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="knowledge;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f2ae3136-3b0c-4e57-b85b-5b4914b7193a}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="47" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="304"/>
@@ -2809,21 +2342,21 @@
         <nd ref="205"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary_link"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Lamartinière"/>
         <tag k="uuid" v="{48069790-f416-4d6a-bb47-88459388c74e}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="47"/>
     </way>
     <way visible="true" id="48" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="209"/>
         <nd ref="370"/>
         <nd ref="208"/>
         <tag k="source" v="Haiti DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Ascensio"/>
@@ -2831,32 +2364,29 @@
         <tag k="uuid" v="{5cccf88e-df69-48f5-801b-d501e7489356}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="48"/>
     </way>
     <way visible="true" id="49" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="218"/>
         <nd ref="217"/>
         <nd ref="216"/>
         <nd ref="243"/>
-        <tag k="smoothness" v="bad"/>
-        <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
-        <tag k="highway" v="service"/>
         <tag k="service" v="alley"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Ruelle Dullin"/>
-        <tag k="uuid" v="{c78bbd5d-464b-417c-be27-65484468aa64}"/>
-        <tag k="narrow" v="yes"/>
-        <tag k="practicability" v="4wd_less_than_3.5mt"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="operational_status" v="open"/>
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="attribution" v="osm"/>
         <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="49"/>
+        <tag k="name" v="Ruelle Dullin"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="smoothness" v="bad"/>
+        <tag k="narrow" v="yes"/>
+        <tag k="uuid" v="{c78bbd5d-464b-417c-be27-65484468aa64}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="practicability" v="4wd_less_than_3.5mt"/>
+        <tag k="highway" v="service"/>
     </way>
     <way visible="true" id="50" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="238"/>
@@ -2864,15 +2394,14 @@
         <nd ref="11"/>
         <nd ref="219"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Clermont"/>
         <tag k="uuid" v="{a2123fc5-5b97-4576-a112-6da76456981f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="50"/>
     </way>
     <way visible="true" id="51" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="223"/>
@@ -2880,6 +2409,7 @@
         <nd ref="221"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -2890,9 +2420,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="51"/>
     </way>
     <way visible="true" id="52" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="239"/>
@@ -2901,6 +2429,7 @@
         <nd ref="300"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Clesca"/>
@@ -2912,23 +2441,20 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="52"/>
     </way>
     <way visible="true" id="53" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="240"/>
         <nd ref="226"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Nemorin"/>
         <tag k="uuid" v="{85010b3e-b5fc-42ce-9132-b524447cdbaf}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="53"/>
     </way>
     <way visible="true" id="54" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="30"/>
@@ -2939,6 +2465,7 @@
         <nd ref="227"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle M. Solomon"/>
@@ -2949,9 +2476,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="54"/>
     </way>
     <way visible="true" id="55" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="237"/>
@@ -2959,6 +2484,7 @@
         <nd ref="42"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Duncombe"/>
@@ -2969,9 +2495,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="55"/>
     </way>
     <way visible="true" id="56" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="241"/>
@@ -2980,15 +2504,14 @@
         <nd ref="238"/>
         <nd ref="320"/>
         <tag k="source" v="Haiti DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Muller"/>
         <tag k="uuid" v="{4d90be44-e379-4065-a7cf-30d086768574}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="56"/>
     </way>
     <way visible="true" id="57" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="246"/>
@@ -2998,6 +2521,7 @@
         <nd ref="242"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Justin 1ère"/>
@@ -3008,22 +2532,19 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="57"/>
     </way>
     <way visible="true" id="58" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="249"/>
         <nd ref="317"/>
         <tag k="source" v="Bing; survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{9043421d-cd69-476d-a086-1af14cc2ec50}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="58"/>
     </way>
     <way visible="true" id="59" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="255"/>
@@ -3033,20 +2554,20 @@
         <nd ref="251"/>
         <nd ref="250"/>
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{94871729-193f-44fa-8cc2-55423914bbdd}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="59"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="257"/>
         <nd ref="256"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -3057,9 +2578,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
     <way visible="true" id="61" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="262"/>
@@ -3069,6 +2588,7 @@
         <nd ref="258"/>
         <tag k="oneway" v="yes"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Passerine"/>
@@ -3077,15 +2597,14 @@
         <tag k="operational_status" v="open"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="61"/>
     </way>
     <way visible="true" id="62" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="268"/>
         <nd ref="267"/>
         <nd ref="266"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Cicéron"/>
@@ -3096,9 +2615,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="62"/>
     </way>
     <way visible="true" id="63" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="356"/>
@@ -3128,6 +2645,8 @@
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="DMA Topo Map;very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="addr:housenumber" v="8"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Fernand"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3147,15 +2666,13 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GPS; survey;osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="63"/>
     </way>
     <way visible="true" id="64" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="290"/>
         <nd ref="289"/>
         <nd ref="294"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="keepme" v="yes"/>
@@ -3163,9 +2680,7 @@
         <tag k="uuid" v="{f6fee008-bb24-499a-ac06-542773f610e2}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="64"/>
     </way>
     <way visible="true" id="65" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="303"/>
@@ -3176,6 +2691,7 @@
         <nd ref="292"/>
         <nd ref="291"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Rivière"/>
@@ -3183,15 +2699,14 @@
         <tag k="uuid" v="{ee13d6fe-3a36-4c0c-b9a4-9cb3599a61bb}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="65"/>
     </way>
     <way visible="true" id="66" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="298"/>
         <nd ref="297"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Camille Léon"/>
@@ -3199,15 +2714,14 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="66"/>
     </way>
     <way visible="true" id="67" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="300"/>
         <nd ref="299"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="footway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Clesca"/>
@@ -3218,9 +2732,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="67"/>
     </way>
     <way visible="true" id="68" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="313"/>
@@ -3240,6 +2752,7 @@
         <nd ref="301"/>
         <tag k="source" v="osm"/>
         <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Martin Luther King"/>
@@ -3247,30 +2760,27 @@
         <tag k="type:haiti" v="Autre Route"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="68"/>
     </way>
     <way visible="true" id="69" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="315"/>
         <nd ref="314"/>
-        <tag k="smoothness" v="intermediate"/>
-        <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Rue Carlstroem"/>
-        <tag k="uuid" v="{b947ae5d-0995-419a-a02e-37b2ba19206c}"/>
         <tag k="alt_name" v="Rue Castrom"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="FIXME" v="survey road name spelling(s)"/>
-        <tag k="operational_status" v="open"/>
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="attribution" v="osm"/>
         <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="69"/>
+        <tag k="name" v="Rue Carlstroem"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="uuid" v="{b947ae5d-0995-419a-a02e-37b2ba19206c}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="FIXME" v="survey road name spelling(s)"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="highway" v="residential"/>
     </way>
     <way visible="true" id="70" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="318"/>
@@ -3280,6 +2790,7 @@
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
         <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Robin"/>
@@ -3290,9 +2801,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="70"/>
     </way>
     <way visible="true" id="71" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="321"/>
@@ -3301,6 +2810,7 @@
         <nd ref="319"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Berne"/>
@@ -3311,9 +2821,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="71"/>
     </way>
     <way visible="true" id="72" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="367"/>
@@ -3329,6 +2837,7 @@
         <nd ref="357"/>
         <nd ref="356"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e668c62c-26c3-4971-907a-0ba09e87fbad}"/>
@@ -3336,27 +2845,25 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="FIXME" v="check road names"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="72"/>
     </way>
     <way visible="true" id="73" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="369"/>
         <nd ref="368"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{3959fb3a-f246-48eb-bf95-285e9d3d971b}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="73"/>
     </way>
     <way visible="true" id="74" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="370"/>
         <nd ref="15"/>
         <tag k="source" v="Haiti DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="impassable" v="yes"/>
@@ -3364,22 +2871,19 @@
         <tag k="uuid" v="{66a9e7d8-809f-4e02-b496-9cc33eacd741}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="74"/>
     </way>
     <way visible="true" id="75" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="2"/>
         <nd ref="1"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{938289a5-f7b9-4035-a1e2-a3c232ffbf8f}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="75"/>
     </way>
     <way visible="true" id="76" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="9"/>
@@ -3387,42 +2891,39 @@
         <nd ref="7"/>
         <nd ref="6"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{650db61c-ab74-4f6f-a48d-fcd6651b47ff}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="76"/>
     </way>
     <way visible="true" id="77" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="11"/>
         <nd ref="10"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4d819223-19d0-421a-b67b-f7f85895acee}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="77"/>
     </way>
     <way visible="true" id="78" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="15"/>
         <nd ref="14"/>
         <nd ref="13"/>
         <tag k="source" v="Haiti DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Ascensio"/>
         <tag k="uuid" v="{4a7af8ef-cd82-419e-a487-746ce1e308df}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="78"/>
     </way>
     <way visible="true" id="79" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="17"/>
@@ -3430,30 +2931,28 @@
         <nd ref="16"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Price"/>
         <tag k="uuid" v="{68b3a771-cfdd-4e8d-8a53-4fb824d1c806}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="79"/>
     </way>
     <way visible="true" id="80" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="19"/>
         <nd ref="18"/>
         <tag k="source:name" v="DMA Topo Map"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Lanose"/>
         <tag k="uuid" v="{602f4688-8c5c-4ea7-bc5d-4f63c728d364}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="80"/>
     </way>
     <way visible="true" id="81" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="22"/>
@@ -3461,47 +2960,45 @@
         <nd ref="20"/>
         <nd ref="39"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ab9ef582-77f4-4ac6-a0d5-ddd9c4844009}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="81"/>
     </way>
     <way visible="true" id="83" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="323"/>
         <nd ref="5"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ec126bf7-c203-4fed-94c5-e3e3bba10972}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="83"/>
     </way>
     <way visible="true" id="84" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="4"/>
         <nd ref="3"/>
         <nd ref="324"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7be46502-5878-4866-b485-7ee6a2abe6bb}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="84"/>
     </way>
     <way visible="true" id="85" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="325"/>
         <nd ref="288"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Vilmenay"/>
@@ -3512,9 +3009,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="85"/>
     </way>
     <way visible="true" id="86" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="270"/>
@@ -3524,6 +3019,7 @@
         <nd ref="326"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Jérémie 2e"/>
@@ -3534,9 +3030,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="86"/>
     </way>
     <way visible="true" id="87" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="42"/>
@@ -3544,6 +3038,7 @@
         <nd ref="327"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Jérémie 1re"/>
@@ -3554,9 +3049,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="87"/>
     </way>
     <way visible="true" id="88" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="301"/>
@@ -3566,6 +3059,7 @@
         <nd ref="328"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Avenue Martin Luther King"/>
@@ -3576,24 +3070,21 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="88"/>
     </way>
     <way visible="true" id="89" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="248"/>
         <nd ref="247"/>
         <nd ref="329"/>
         <tag k="source" v="NGA;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Nogues"/>
         <tag k="uuid" v="{6b2ae4d3-b6c8-459a-b95a-9207074ed770}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="89"/>
     </way>
     <way visible="true" id="90" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="330"/>
@@ -3602,6 +3093,7 @@
         <nd ref="234"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="3e Rue du Travail"/>
@@ -3612,9 +3104,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="90"/>
     </way>
     <way visible="true" id="91" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="331"/>
@@ -3622,6 +3112,7 @@
         <nd ref="232"/>
         <tag k="smoothness" v="good"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Acacia Prolongée"/>
@@ -3629,9 +3120,7 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="paved"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="91"/>
     </way>
     <way visible="true" id="92" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="332"/>
@@ -3644,6 +3133,7 @@
         <nd ref="290"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Nazon 1re"/>
@@ -3654,9 +3144,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="92"/>
     </way>
     <way visible="true" id="93" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="334"/>
@@ -3666,6 +3154,7 @@
         <nd ref="333"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Lavaud 2e"/>
@@ -3676,9 +3165,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="93"/>
     </way>
     <way visible="true" id="94" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="335"/>
@@ -3712,6 +3199,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Lalue"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3729,9 +3218,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="94"/>
     </way>
     <way visible="true" id="95" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="150"/>
@@ -3744,6 +3230,7 @@
         <nd ref="336"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Butte"/>
@@ -3754,9 +3241,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="95"/>
     </way>
     <way visible="true" id="96" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="41"/>
@@ -3775,6 +3260,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Route de Bourdon"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -3792,9 +3279,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="96"/>
     </way>
     <way visible="true" id="97" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="298"/>
@@ -3815,6 +3299,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Avenue Lamartinière"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -3833,9 +3319,6 @@
         <tag k="source" v="GPS; survey; CNIGS/FOCS/OIM;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="97"/>
     </way>
     <way visible="true" id="98" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="171"/>
@@ -3843,6 +3326,7 @@
         <nd ref="339"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS; Bing;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Laraque"/>
@@ -3853,9 +3337,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="98"/>
     </way>
     <way visible="true" id="99" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="111"/>
@@ -3863,6 +3345,7 @@
         <nd ref="340"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Saint Juste"/>
@@ -3873,9 +3356,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="99"/>
     </way>
     <way visible="true" id="100" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="169"/>
@@ -3885,6 +3366,7 @@
         <nd ref="341"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Vaillant"/>
@@ -3895,9 +3377,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="100"/>
     </way>
     <way visible="true" id="101" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="342"/>
@@ -3915,6 +3395,7 @@
         <nd ref="162"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="incline" v="yes"/>
@@ -3926,9 +3407,7 @@
         <tag k="surface" v="asphalt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="101"/>
     </way>
     <way visible="true" id="104" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="346"/>
@@ -3938,6 +3417,7 @@
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Butte"/>
@@ -3948,42 +3428,37 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="104"/>
     </way>
     <way visible="true" id="105" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="57"/>
         <nd ref="347"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="service" v="driveway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c2f3271b-4825-4eec-836a-0f9295454a44}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="105"/>
     </way>
     <way visible="true" id="107" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="350"/>
         <nd ref="45"/>
         <nd ref="232"/>
-        <tag k="source:datetime" v="2017-06-07T15:19:30Z"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="source:datetime" v="2017-06-07T15:19:30Z"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="107"/>
     </way>
     <way visible="true" id="108" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="262"/>
         <nd ref="46"/>
         <nd ref="130"/>
         <nd ref="351"/>
-        <tag k="source:datetime" v="2017-06-07T15:19:30Z"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="source:datetime" v="2017-06-07T15:19:30Z"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="108"/>
     </way>
     <way visible="true" id="109" timestamp="2017-06-07T15:19:30Z" version="1">
         <nd ref="142"/>
@@ -3995,6 +3470,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Christ-Roi"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -4010,22 +3487,18 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="survey; GPS-adjusted Bing;osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="109"/>
     </way>
     <way visible="true" id="110" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="79"/>
         <nd ref="353"/>
         <tag k="source" v="Google, 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{816a8c3b-170e-41d1-962e-d28b4d7f2f83}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="110"/>
     </way>
     <way visible="true" id="111" timestamp="2017-06-07T15:19:30Z" version="1" changeset="121">
         <nd ref="354"/>
@@ -4034,6 +3507,7 @@
         <nd ref="35"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Vaillant"/>
@@ -4044,8 +3518,6 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="111"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/pap-009/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-009/Expected.osm
@@ -3,985 +3,750 @@
     <bounds minlat="18.535023" minlon="-72.31931799999998" maxlat="18.541033" maxlon="-72.30984303951"/>
     <node visible="true" id="-1069" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5353201512111383" lon="-72.3107862509725550">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-1069"/>
     </node>
     <node visible="true" id="-119" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5365136853899983" lon="-72.3098430395099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-119"/>
     </node>
     <node visible="true" id="-74" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5353642759499948" lon="-72.3107361399599995">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5355525179199994" lon="-72.3106933577000035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5356712068999983" lon="-72.3106511124699978">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5357207948299987" lon="-72.3106334625299922">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5360174185399948" lon="-72.3104880028199943">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5361160321999989" lon="-72.3104286333699804">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5362969293400006" lon="-72.3103197259100057">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5365308057200053" lon="-72.3101999355699974">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-66" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5365792922899963" lon="-72.3101514490000028">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-66"/>
     </node>
     <node visible="true" id="-65" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5366106659500005" lon="-72.3100915538300058">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-65"/>
     </node>
     <node visible="true" id="-64" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5366135180999976" lon="-72.3099803199399958">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-64"/>
     </node>
     <node visible="true" id="-63" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5365992573500016" lon="-72.3099346855200054">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-63"/>
     </node>
     <node visible="true" id="-62" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122" lat="18.5365593272300053" lon="-72.3098747903499941">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-62"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5388678999999961" lon="-72.3181138000000061">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5393676999999961" lon="-72.3179496999999856">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5410156999999955" lon="-72.3182943999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5406657999999993" lon="-72.3182781000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5405632999999952" lon="-72.3182759999999831">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5404820999999984" lon="-72.3182922999999960">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5402105000000006" lon="-72.3184166000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395493000000045" lon="-72.3147512000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5389030000000012" lon="-72.3139431000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5383761999999983" lon="-72.3140420999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5372909999999997" lon="-72.3143939999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5373087999999981" lon="-72.3160572999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5371000000000024" lon="-72.3153242000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368275000000011" lon="-72.3148953999999975">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5391927999999986" lon="-72.3151634999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5390351999999972" lon="-72.3152366999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5385777000000047" lon="-72.3145362000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5371695000000045" lon="-72.3140860999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5371088999999998" lon="-72.3141003000000069">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{3969c33a-259c-46b2-9c8e-d4f0b87775df}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370686000000013" lon="-72.3142765000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370712999999974" lon="-72.3141090000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370454000000002" lon="-72.3140383000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369801999999986" lon="-72.3139161000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368554999999979" lon="-72.3138148999999970">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5391794000000019" lon="-72.3130400999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5386029999999984" lon="-72.3132082999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5381466999999951" lon="-72.3133512999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5375325000000011" lon="-72.3135122999999993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5373941000000002" lon="-72.3136008000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5372875999999955" lon="-72.3137105999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5371607000000012" lon="-72.3137691000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370029999999986" lon="-72.3138256000000013">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369141999999982" lon="-72.3138560999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367100999999970" lon="-72.3139678000000004">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5365347999999983" lon="-72.3140125000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5364969999999971" lon="-72.3139991999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5363852999999992" lon="-72.3138849999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5362073000000009" lon="-72.3139682000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5360547000000011" lon="-72.3139788999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5357190000000003" lon="-72.3141640000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5356249999999960" lon="-72.3140996000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5353756999999959" lon="-72.3141774000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5408378999999961" lon="-72.3182718999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5407691999999997" lon="-72.3180652000000066">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5379259999999988" lon="-72.3187276000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5380889999999958" lon="-72.3186575999999945">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5382534999999962" lon="-72.3185160999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5384685000000005" lon="-72.3184353999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5386386999999999" lon="-72.3184064999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5391179999999984" lon="-72.3183114999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5387641000000052" lon="-72.3116916999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5387030999999993" lon="-72.3118767999999932">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5386038999999982" lon="-72.3120162999999820">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395529000000039" lon="-72.3150044999999864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369022000000037" lon="-72.3191362999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370090999999952" lon="-72.3181440999999978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5373348000000036" lon="-72.3189579000000009">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5404051999999986" lon="-72.3183286000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5402580000000015" lon="-72.3179279999999807">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5402178000000006" lon="-72.3178092999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366855000000044" lon="-72.3148426000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5409043999999987" lon="-72.3121794000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5409600999999995" lon="-72.3124416999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5409627000000015" lon="-72.3125559000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5408850999999970" lon="-72.3125789999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5404228999999958" lon="-72.3127403999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5374996000000039" lon="-72.3167766999999913">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395116999999949" lon="-72.3151703999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395262000000010" lon="-72.3150121000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395585000000018" lon="-72.3148278999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5378589999999974" lon="-72.3164806999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5377583000000001" lon="-72.3142208999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="101" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5351615999999950" lon="-72.3106733999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="101"/>
     </node>
     <node visible="true" id="102" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5352874999999990" lon="-72.3107614000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="102"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5353708000000026" lon="-72.3108247999999918">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="104" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5354893999999959" lon="-72.3109117000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="104"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5358526999999995" lon="-72.3111510999999894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5359828000000029" lon="-72.3112368000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5364543999999967" lon="-72.3115475000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366000999999976" lon="-72.3116519000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366995000000010" lon="-72.3117660999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367197999999966" lon="-72.3118027000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367363999999988" lon="-72.3118418999999903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367662999999965" lon="-72.3119398999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368089000000005" lon="-72.3121207999999882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369088999999967" lon="-72.3131060000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369032000000011" lon="-72.3134591000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368296000000008" lon="-72.3138045000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368035999999989" lon="-72.3139414999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366277000000004" lon="-72.3148213000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5365266999999960" lon="-72.3153065999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="120" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5364991999999980" lon="-72.3156218999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="120"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5365256999999986" lon="-72.3158897999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5365797999999948" lon="-72.3161405999999971">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="123" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366603999999988" lon="-72.3164096000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="123"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367582999999989" lon="-72.3166322999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369338000000035" lon="-72.3169412000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370959999999947" lon="-72.3172543000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5371807000000004" lon="-72.3174522999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5376987999999976" lon="-72.3188097999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5378936999999979" lon="-72.3192822999999976">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="traffic_signals"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c99fa486-f443-4cd7-9751-9733f95bffcf}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395390999999954" lon="-72.3153697999999849">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5409530000000018" lon="-72.3171396999999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5404890000000009" lon="-72.3166980000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5400349999999996" lon="-72.3162212000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397569999999980" lon="-72.3159313000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5396877999999958" lon="-72.3158217000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5396198999999982" lon="-72.3156862999999959">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395882000000043" lon="-72.3155828000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395559999999975" lon="-72.3154494000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5359037999999998" lon="-72.3149248000000000">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366435000000003" lon="-72.3147435000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5374493999999999" lon="-72.3181497999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5382363000000012" lon="-72.3177358999999882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <node visible="true" id="143" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5384078000000017" lon="-72.3176770000000033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="143"/>
     </node>
     <node visible="true" id="144" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5385609000000002" lon="-72.3177083000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="144"/>
     </node>
     <node visible="true" id="145" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5387532000000022" lon="-72.3177601999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="145"/>
     </node>
     <node visible="true" id="146" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5389280999999997" lon="-72.3176955999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="146"/>
     </node>
     <node visible="true" id="147" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5375748999999992" lon="-72.3157426999999871">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="147"/>
     </node>
     <node visible="true" id="148" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5398391999999959" lon="-72.3160256999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="148"/>
     </node>
     <node visible="true" id="149" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5398840000000007" lon="-72.3161686999999915">
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{75deeb1f-df89-4d9d-a512-45450e61c640}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="149"/>
     </node>
     <node visible="true" id="150" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5399748999999971" lon="-72.3163772000000051">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="150"/>
     </node>
     <node visible="true" id="151" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5400427000000008" lon="-72.3166236999999938">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="151"/>
     </node>
     <node visible="true" id="152" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5400671999999993" lon="-72.3169448000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="152"/>
     </node>
     <node visible="true" id="153" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5401046999999970" lon="-72.3171806999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="153"/>
     </node>
     <node visible="true" id="154" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5401163000000011" lon="-72.3173678999999936">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="154"/>
     </node>
     <node visible="true" id="155" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5401004000000000" lon="-72.3174698999999919">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="155"/>
     </node>
     <node visible="true" id="156" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5400368999999969" lon="-72.3175367999999992">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="156"/>
     </node>
     <node visible="true" id="157" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5399613000000052" lon="-72.3175807999999876">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="157"/>
     </node>
     <node visible="true" id="158" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397815000000001" lon="-72.3177330999999839">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="158"/>
     </node>
     <node visible="true" id="159" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5396934999999949" lon="-72.3178198999999893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="159"/>
     </node>
     <node visible="true" id="160" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5396151000000025" lon="-72.3178575000000023">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="160"/>
     </node>
     <node visible="true" id="161" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5393833000000043" lon="-72.3179439000000031">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6601d06e-773e-4bee-966b-3e6de5be59c4}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="161"/>
     </node>
     <node visible="true" id="162" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5398152000000032" lon="-72.3173167000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="162"/>
     </node>
     <node visible="true" id="163" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5398858999999980" lon="-72.3176184000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="163"/>
     </node>
     <node visible="true" id="164" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5391859000000032" lon="-72.3175642999999866">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="164"/>
     </node>
     <node visible="true" id="165" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5388452000000008" lon="-72.3167865000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="165"/>
     </node>
     <node visible="true" id="166" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5388769999999958" lon="-72.3166896999999977">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="166"/>
     </node>
     <node visible="true" id="167" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5391340000000007" lon="-72.3165137999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="167"/>
     </node>
     <node visible="true" id="168" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5393472999999958" lon="-72.3164186999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="168"/>
     </node>
     <node visible="true" id="169" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5394237000000004" lon="-72.3164088999999990">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="169"/>
     </node>
     <node visible="true" id="171" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5399360000000044" lon="-72.3130134999999967">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="171"/>
     </node>
     <node visible="true" id="172" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370157000000013" lon="-72.3150782000000021">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="172"/>
     </node>
     <node visible="true" id="173" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5372231999999997" lon="-72.3149679999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="173"/>
     </node>
     <node visible="true" id="174" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5373449000000008" lon="-72.3149207000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="174"/>
     </node>
     <node visible="true" id="175" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5379341000000011" lon="-72.3146521999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="175"/>
     </node>
     <node visible="true" id="177" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369500999999985" lon="-72.3165498999999983">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="177"/>
     </node>
     <node visible="true" id="178" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5373711000000014" lon="-72.3163870000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="178"/>
     </node>
     <node visible="true" id="179" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5376606000000024" lon="-72.3162769000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="179"/>
     </node>
     <node visible="true" id="180" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395593000000005" lon="-72.3186816000000050">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="180"/>
     </node>
     <node visible="true" id="181" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395536999999990" lon="-72.3186663999999979">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="dip"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{93649268-e796-4815-8370-fd043dfacf87}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="181"/>
     </node>
     <node visible="true" id="182" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5394410000000001" lon="-72.3183575999999988">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="182"/>
     </node>
     <node visible="true" id="183" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5394425000000034" lon="-72.3182189999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="183"/>
     </node>
     <node visible="true" id="184" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5394403000000025" lon="-72.3181223999999929">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="184"/>
     </node>
     <node visible="true" id="185" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5395754999999980" lon="-72.3147806000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="185"/>
     </node>
     <node visible="true" id="186" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5396383000000000" lon="-72.3146090000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="186"/>
     </node>
     <node visible="true" id="187" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397433999999990" lon="-72.3140534000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="187"/>
     </node>
     <node visible="true" id="188" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397618000000008" lon="-72.3137392000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="188"/>
     </node>
     <node visible="true" id="189" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397658000000014" lon="-72.3135304999999846">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="189"/>
     </node>
     <node visible="true" id="190" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397487999999981" lon="-72.3133844999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="190"/>
     </node>
     <node visible="true" id="191" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397229999999986" lon="-72.3131903999999963">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="191"/>
     </node>
     <node visible="true" id="192" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5397780999999959" lon="-72.3130160999999845">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="192"/>
     </node>
     <node visible="true" id="193" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5399045999999963" lon="-72.3128913000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="193"/>
     </node>
     <node visible="true" id="194" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5401005000000012" lon="-72.3127125999999976">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="194"/>
     </node>
     <node visible="true" id="195" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5402576000000003" lon="-72.3125663000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="195"/>
     </node>
     <node visible="true" id="196" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5405616000000002" lon="-72.3121940000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="196"/>
     </node>
     <node visible="true" id="197" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5407410000000006" lon="-72.3120260000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="197"/>
     </node>
     <node visible="true" id="198" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5408255000000004" lon="-72.3119743999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="198"/>
     </node>
     <node visible="true" id="199" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5408981000000033" lon="-72.3119286000000017">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="traffic_calming" v="bump"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{bae305d1-d7f5-44a2-9d5b-4647d73887c4}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="199"/>
     </node>
     <node visible="true" id="200" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5405091999999989" lon="-72.3149894999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="200"/>
     </node>
     <node visible="true" id="201" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5402212000000013" lon="-72.3150404999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="201"/>
     </node>
     <node visible="true" id="202" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5399734999999950" lon="-72.3150430999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="202"/>
     </node>
     <node visible="true" id="203" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368702999999968" lon="-72.3126182999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="203"/>
     </node>
     <node visible="true" id="204" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368077999999983" lon="-72.3126234000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="204"/>
     </node>
     <node visible="true" id="205" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367684999999973" lon="-72.3126014999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="205"/>
     </node>
     <node visible="true" id="206" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5366384000000011" lon="-72.3124298000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="206"/>
     </node>
     <node visible="true" id="207" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5364393000000014" lon="-72.3122405999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="207"/>
     </node>
     <node visible="true" id="208" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5363224000000031" lon="-72.3121964999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="208"/>
     </node>
     <node visible="true" id="209" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5361622999999973" lon="-72.3122117000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="209"/>
     </node>
     <node visible="true" id="210" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5360560999999997" lon="-72.3122674999999902">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="210"/>
     </node>
     <node visible="true" id="211" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5359776000000060" lon="-72.3123349999999903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="211"/>
     </node>
     <node visible="true" id="212" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5358231999999994" lon="-72.3127154000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="212"/>
     </node>
     <node visible="true" id="213" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5357352000000013" lon="-72.3128264999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="213"/>
     </node>
     <node visible="true" id="214" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5356327000000007" lon="-72.3129026000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="214"/>
     </node>
     <node visible="true" id="215" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5354870000000034" lon="-72.3129086999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="215"/>
     </node>
     <node visible="true" id="216" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5353542000000004" lon="-72.3128600000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="216"/>
     </node>
     <node visible="true" id="217" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5380752000000015" lon="-72.3150578000000053">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="217"/>
     </node>
     <node visible="true" id="218" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5381489000000030" lon="-72.3163681000000054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="218"/>
     </node>
     <node visible="true" id="219" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5367514999999976" lon="-72.3148213000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="219"/>
     </node>
     <node visible="true" id="220" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368293000000008" lon="-72.3147565000000014">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="220"/>
     </node>
     <node visible="true" id="221" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5369330999999988" lon="-72.3146208999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="221"/>
     </node>
     <node visible="true" id="222" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370257999999950" lon="-72.3144716999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="222"/>
     </node>
     <node visible="true" id="223" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5370559999999998" lon="-72.3144075000000015">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="223"/>
     </node>
     <node visible="true" id="224" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5381637000000019" lon="-72.3168598999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="224"/>
     </node>
     <node visible="true" id="225" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5381635999999972" lon="-72.3172830999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="225"/>
     </node>
     <node visible="true" id="226" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5373133000000045" lon="-72.3177869999999956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="226"/>
     </node>
     <node visible="true" id="227" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5406295999999919" lon="-72.3168713000000025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="227"/>
     </node>
     <node visible="true" id="228" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5406611000000012" lon="-72.3168239000000028">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="228"/>
     </node>
     <node visible="true" id="229" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5384892000000043" lon="-72.3121315000000067">
         <tag k="source" v="survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="barrier" v="gate"/>
         <tag k="uuid" v="{8d4869a1-96de-4437-9dd0-93565027e584}"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="229"/>
     </node>
     <node visible="true" id="230" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5384135999999984" lon="-72.3122196000000059">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="230"/>
     </node>
     <node visible="true" id="231" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5383478999999980" lon="-72.3123188999999797">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="231"/>
     </node>
     <node visible="true" id="232" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5382997999999972" lon="-72.3124267000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="232"/>
     </node>
     <node visible="true" id="233" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5382449999999999" lon="-72.3125777999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="233"/>
     </node>
     <node visible="true" id="234" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5382235000000009" lon="-72.3126962000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="234"/>
     </node>
     <node visible="true" id="235" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5381840000000047" lon="-72.3127711000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="235"/>
     </node>
     <node visible="true" id="236" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5380846999999989" lon="-72.3128071000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="236"/>
     </node>
     <node visible="true" id="237" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5379795999999928" lon="-72.3127956000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="237"/>
     </node>
     <node visible="true" id="238" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5374023000000001" lon="-72.3126560999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="238"/>
     </node>
     <node visible="true" id="239" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5371904000000001" lon="-72.3126342999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="239"/>
     </node>
     <node visible="true" id="240" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5368775999999968" lon="-72.3127147999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="240"/>
     </node>
     <node visible="true" id="247" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5393512999999999" lon="-72.3137102000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="247"/>
     </node>
     <node visible="true" id="248" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5389107999999965" lon="-72.3138636999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="248"/>
     </node>
     <node visible="true" id="249" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5388469999999970" lon="-72.3139325000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="249"/>
     </node>
     <node visible="true" id="250" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5350230000000025" lon="-72.3126479762599956">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="250"/>
     </node>
     <node visible="true" id="251" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5410330000000023" lon="-72.3148359999200068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="251"/>
     </node>
     <node visible="true" id="252" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5410330000000023" lon="-72.3118435046399952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="252"/>
     </node>
     <node visible="true" id="255" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5410329999999988" lon="-72.3172256163999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="255"/>
     </node>
     <node visible="true" id="256" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5350229999999989" lon="-72.3105791219499991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="256"/>
     </node>
     <node visible="true" id="257" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5379080617500023" lon="-72.3193179999999813">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="257"/>
     </node>
     <node visible="true" id="261" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123" lat="18.5410330000000023" lon="-72.3182932683800033">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="261"/>
     </node>
     <way visible="true" id="-1554" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="257"/>
@@ -1027,6 +792,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Route de Bourdon"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -1044,9 +811,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1554"/>
     </way>
     <way visible="true" id="-1" timestamp="2017-06-07T15:21:35Z" version="1" changeset="122">
         <nd ref="-1069"/>
@@ -1069,6 +833,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -1080,22 +846,18 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="9"/>
         <nd ref="8"/>
         <tag k="source" v="IOM_drone;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{090e51cd-c24b-46e2-a4dd-bd3ff779af45}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="223"/>
@@ -1112,6 +874,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Butte"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1129,9 +893,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="219"/>
@@ -1142,6 +903,7 @@
         <nd ref="178"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Louissaint"/>
@@ -1152,9 +914,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="35"/>
@@ -1162,30 +922,28 @@
         <nd ref="33"/>
         <nd ref="97"/>
         <tag k="source" v="Google 2010-01-17;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Malebranche"/>
         <tag k="uuid" v="{00ed8137-6cbd-4f6b-b1a8-feaf1adea020}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="40"/>
         <nd ref="37"/>
         <nd ref="36"/>
         <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="service" v="driveway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c2f3271b-4825-4eec-836a-0f9295454a44}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="116"/>
@@ -1199,6 +957,7 @@
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
         <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="unclassified"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Butte"/>
@@ -1209,9 +968,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="52"/>
@@ -1225,6 +982,7 @@
         <nd ref="44"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse P. Weiner"/>
@@ -1235,9 +993,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="61"/>
@@ -1251,19 +1007,19 @@
         <nd ref="53"/>
         <nd ref="117"/>
         <tag k="source" v="GeoEye;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{67a9b0b5-d2ef-4b13-b6ab-f79fa3424084}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="63"/>
         <nd ref="62"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Romane"/>
@@ -1274,15 +1030,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
     </way>
     <way visible="true" id="14" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="177"/>
         <nd ref="124"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -1294,9 +1049,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="14"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="74"/>
@@ -1307,6 +1060,7 @@
         <nd ref="128"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; Bing; CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="track"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Bruant"/>
@@ -1316,15 +1070,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="75"/>
         <nd ref="183"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Desrouleaux"/>
@@ -1335,9 +1088,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="229"/>
@@ -1345,30 +1096,28 @@
         <nd ref="77"/>
         <nd ref="76"/>
         <tag k="source" v="GeoEye1, GeoEye, 2010-01-16; survey;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{70733414-00ef-46b6-9beb-192ca1b78552}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
         <tag k="access" v="private"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="97"/>
         <nd ref="79"/>
         <nd ref="202"/>
         <tag k="source" v="http://hypercube.telascience.org/tiles/1.0.0/worldbank-21-900913/!/!/!.jpg; DMA Topo;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Caroline"/>
         <tag k="uuid" v="{0d9e65e9-8f41-4dce-807c-3836b4cbe6ad}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="128"/>
@@ -1376,6 +1125,7 @@
         <nd ref="80"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Hérard 1re"/>
@@ -1386,15 +1136,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="82"/>
         <nd ref="81"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Hérard 2e"/>
@@ -1405,9 +1154,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="85"/>
@@ -1415,6 +1162,7 @@
         <nd ref="83"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Saint Juste"/>
@@ -1425,9 +1173,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="219"/>
@@ -1439,6 +1185,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Louissaint"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="bad"/>
@@ -1457,9 +1205,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="4wd_less_than_3.5mt"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="91"/>
@@ -1469,28 +1214,26 @@
         <nd ref="87"/>
         <nd ref="198"/>
         <tag k="source" v="google 2010-01-21;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="living_street"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7e4dc1b9-0792-4ffa-9661-c5b8d1cde9d5}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="concrete"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="178"/>
         <nd ref="95"/>
         <tag k="source" v="Bing; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="service"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{dd8d71ed-bb9f-40d0-97cb-41e0f15cff33}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="185"/>
@@ -1506,6 +1249,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Butte"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1524,9 +1269,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
     </way>
     <way visible="true" id="27" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="179"/>
@@ -1534,6 +1276,7 @@
         <nd ref="218"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -1544,9 +1287,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="217"/>
@@ -1554,6 +1295,7 @@
         <nd ref="100"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -1564,15 +1306,14 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="140"/>
         <nd ref="139"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Coumbite"/>
@@ -1584,9 +1325,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="164"/>
@@ -1598,6 +1337,7 @@
         <nd ref="141"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue T. Guilbaud"/>
@@ -1608,15 +1348,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="147"/>
         <nd ref="174"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Mercy"/>
@@ -1627,9 +1366,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="9"/>
@@ -1650,6 +1387,7 @@
         <nd ref="148"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="incline" v="yes"/>
@@ -1661,9 +1399,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="163"/>
@@ -1671,6 +1407,7 @@
         <nd ref="169"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Morelly"/>
@@ -1681,9 +1418,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="169"/>
@@ -1695,6 +1430,7 @@
         <nd ref="9"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle M. Solomon"/>
@@ -1705,15 +1441,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="193"/>
         <nd ref="171"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Jacob"/>
@@ -1724,9 +1459,7 @@
         <tag k="surface" v="gravel"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="175"/>
@@ -1735,6 +1468,7 @@
         <nd ref="172"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Célie"/>
@@ -1745,9 +1479,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="179"/>
@@ -1755,6 +1487,7 @@
         <nd ref="177"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -1765,9 +1498,7 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="9"/>
@@ -1778,6 +1509,7 @@
         <nd ref="180"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle M. Solomon"/>
@@ -1788,15 +1520,14 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <way visible="true" id="40" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="218"/>
         <nd ref="217"/>
         <tag k="smoothness" v="bad"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Mercier"/>
@@ -1807,9 +1538,7 @@
         <tag k="surface" v="dirt"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="40"/>
     </way>
     <way visible="true" id="41" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="223"/>
@@ -1823,6 +1552,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Passerine"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -1839,15 +1570,13 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="highway" v="unclassified"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="41"/>
     </way>
     <way visible="true" id="42" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="226"/>
         <nd ref="225"/>
         <nd ref="224"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Cicéron"/>
@@ -1858,22 +1587,19 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="42"/>
     </way>
     <way visible="true" id="43" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="228"/>
         <nd ref="227"/>
         <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="path"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{811a0ad6-e9bc-43bd-aef0-36d7ec368bd6}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="43"/>
     </way>
     <way visible="true" id="44" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="240"/>
@@ -1890,6 +1616,7 @@
         <nd ref="229"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Théodule"/>
@@ -1900,24 +1627,21 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="44"/>
     </way>
     <way visible="true" id="46" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="249"/>
         <nd ref="248"/>
         <nd ref="247"/>
         <tag k="source" v="survey; World Bank, 2010/01/21-2010-01/22;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Impasse Chabrier"/>
         <tag k="uuid" v="{ebe99bb9-05b0-4535-b5f7-3bb247da1e59}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="46"/>
     </way>
     <way visible="true" id="50" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="250"/>
@@ -1941,6 +1665,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Dalencourt"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -1958,9 +1684,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="50"/>
     </way>
     <way visible="true" id="51" timestamp="2017-06-07T15:21:37Z" version="1" changeset="123">
         <nd ref="202"/>
@@ -1968,15 +1691,14 @@
         <nd ref="200"/>
         <nd ref="251"/>
         <tag k="source" v="NGA;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Ruelle Nogues"/>
         <tag k="uuid" v="{6b2ae4d3-b6c8-459a-b95a-9207074ed770}"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="51"/>
     </way>
     <way visible="true" id="52" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="252"/>
@@ -1997,6 +1719,7 @@
         <nd ref="185"/>
         <tag k="smoothness" v="good"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="tertiary"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Acacia Prolongée"/>
@@ -2004,9 +1727,7 @@
         <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
         <tag k="surface" v="paved"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="52"/>
     </way>
     <way visible="true" id="55" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="138"/>
@@ -2026,6 +1747,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Ruelle Butte"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -2043,9 +1766,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="light_truck_less_than_10mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="55"/>
     </way>
     <way visible="true" id="60" timestamp="2017-06-07T15:21:37Z" version="1">
         <nd ref="129"/>
@@ -2063,6 +1783,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Christ-Roi"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -2078,8 +1800,5 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="survey; GPS-adjusted Bing;osm;mgcp"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="60"/>
     </way>
 </osm>

--- a/test-files/cases/network/conflicts/pap-010/Expected.osm
+++ b/test-files/cases/network/conflicts/pap-010/Expected.osm
@@ -3,335 +3,252 @@
     <bounds minlat="18.5323089135" minlon="-72.313396" maxlat="18.537589" maxlon="-72.303172"/>
     <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5343271712882256" lon="-72.3098938308312995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-159"/>
     </node>
     <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5353701521525522" lon="-72.3108243069201251">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-158"/>
     </node>
     <node visible="true" id="-80" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5365136853899983" lon="-72.3098430395099996">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-80"/>
     </node>
     <node visible="true" id="-79" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5353642759499948" lon="-72.3107361399599995">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-79"/>
     </node>
     <node visible="true" id="-78" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5355525179199994" lon="-72.3106933577000035">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-78"/>
     </node>
     <node visible="true" id="-77" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5356712068999983" lon="-72.3106511124699978">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-77"/>
     </node>
     <node visible="true" id="-76" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5357207948299951" lon="-72.3106334625299922">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-76"/>
     </node>
     <node visible="true" id="-75" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5360174185399948" lon="-72.3104880028199943">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-75"/>
     </node>
     <node visible="true" id="-74" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5361160321999989" lon="-72.3104286333699804">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-74"/>
     </node>
     <node visible="true" id="-73" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5362969293399971" lon="-72.3103197259100057">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-73"/>
     </node>
     <node visible="true" id="-72" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5365308057199982" lon="-72.3101999355699974">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-72"/>
     </node>
     <node visible="true" id="-71" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5365792922899999" lon="-72.3101514490000028">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-71"/>
     </node>
     <node visible="true" id="-70" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5366106659500005" lon="-72.3100915538300058">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-70"/>
     </node>
     <node visible="true" id="-69" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5366135180999976" lon="-72.3099803199399958">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-69"/>
     </node>
     <node visible="true" id="-68" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5365992573500051" lon="-72.3099346855200054">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-68"/>
     </node>
     <node visible="true" id="-67" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5365593272300053" lon="-72.3098747903499941">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-67"/>
     </node>
     <node visible="true" id="-36" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5340634496000014" lon="-72.3130369681600058">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-35" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5340742123899993" lon="-72.3130315867600046">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-35"/>
     </node>
     <node visible="true" id="-34" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5340871356400072" lon="-72.3130251251400011">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-34"/>
     </node>
     <node visible="true" id="-32" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5338603010699963" lon="-72.3133809752600030">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-32"/>
     </node>
     <node visible="true" id="-31" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5338374838600011" lon="-72.3132526284699964">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-31"/>
     </node>
     <node visible="true" id="-30" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5338517446099971" lon="-72.3131613596299871">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-30"/>
     </node>
     <node visible="true" id="-29" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5339068479799991" lon="-72.3131172769400052">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-29"/>
     </node>
     <node visible="true" id="-28" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5339230483900010" lon="-72.3131043166099943">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-28"/>
     </node>
     <node visible="true" id="-27" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5339800914099975" lon="-72.3130786472499949">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-27"/>
     </node>
     <node visible="true" id="-2" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124" lat="18.5338698913200020" lon="-72.3133959999999973">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-2"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5323712999999977" lon="-72.3033022000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5324324000000011" lon="-72.3034152000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5325475000000033" lon="-72.3036364999999961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5327206000000047" lon="-72.3039423999999968">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5328343999999987" lon="-72.3041821999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5329805000000043" lon="-72.3047239999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5331696999999984" lon="-72.3055119999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5335529000000037" lon="-72.3070282999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5337856000000052" lon="-72.3079709999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5340659999999957" lon="-72.3089937000000020">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5343604999999982" lon="-72.3100086999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5344453000000051" lon="-72.3101817000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5345464000000000" lon="-72.3102740000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5348532000000006" lon="-72.3104660000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5349770999999990" lon="-72.3105479000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5351615999999950" lon="-72.3106733999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5352875000000026" lon="-72.3107614000000041">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5353707999999919" lon="-72.3108247999999918">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5354893999999994" lon="-72.3109117000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5358526999999995" lon="-72.3111510999999894">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5359828000000029" lon="-72.3112368000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5364544000000002" lon="-72.3115475000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5366001000000082" lon="-72.3116519000000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5366995000000010" lon="-72.3117660999999998">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5367198000000002" lon="-72.3118027000000012">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5367363999999952" lon="-72.3118418999999903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5367663000000000" lon="-72.3119398999999987">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5368088999999969" lon="-72.3121207999999882">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5369088999999967" lon="-72.3131060000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5368703000000004" lon="-72.3126182999999969">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5368077999999912" lon="-72.3126234000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5367684999999973" lon="-72.3126014999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5366383999999975" lon="-72.3124298000000039">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5364392999999978" lon="-72.3122405999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5363223999999960" lon="-72.3121964999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5361622999999973" lon="-72.3122117000000060">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5360560999999997" lon="-72.3122674999999902">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5359775999999989" lon="-72.3123349999999903">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5358231999999994" lon="-72.3127154000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5357352000000013" lon="-72.3128264999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5356327000000043" lon="-72.3129026000000010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5354869999999998" lon="-72.3129086999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5353542000000004" lon="-72.3128600000000006">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5349025999999952" lon="-72.3125708999999972">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5347943999999956" lon="-72.3125023999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5347064000000010" lon="-72.3124750000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5346040000000052" lon="-72.3125114999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5344885000000019" lon="-72.3125997999999868">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5343441999999996" lon="-72.3128264999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5342145000000009" lon="-72.3129282000000018">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5341165999999973" lon="-72.3129809999999935">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5374023000000001" lon="-72.3126560999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5371904000000036" lon="-72.3126342999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5368775999999968" lon="-72.3127147999999949">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5375890000000005" lon="-72.3127012145900068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5323089134999996" lon="-72.3031720000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125" lat="18.5369042186100010" lon="-72.3133959999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <way visible="true" id="-150" timestamp="2017-06-07T15:24:11Z" version="1">
         <nd ref="66"/>
@@ -375,6 +292,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Route de Bourdon"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="lanes" v="2"/>
@@ -392,9 +311,6 @@
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm;mgcp"/>
         <tag k="highway" v="secondary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-150"/>
     </way>
     <way visible="true" id="-5" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124">
         <nd ref="-2"/>
@@ -404,25 +320,24 @@
         <nd ref="-29"/>
         <nd ref="-28"/>
         <nd ref="-27"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.112Z"/>
-        <tag k="location" v="surface"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{7ce9692f-4849-440e-979c-916936f16365}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-5"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{7ce9692f-4849-440e-979c-916936f16365}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.112Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="-3" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124">
         <nd ref="-158"/>
@@ -445,6 +360,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="error:circular" v="15"/>
         <tag k="source:datetime" v="2010-01-13"/>
         <tag k="lanes" v="2"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
@@ -456,9 +373,6 @@
         <tag k="location" v="surface"/>
         <tag k="source" v="mgcp"/>
         <tag k="highway" v="road"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-3"/>
     </way>
     <way visible="true" id="-1" timestamp="2017-06-07T15:24:10Z" version="1" changeset="124">
         <nd ref="-27"/>
@@ -466,25 +380,24 @@
         <nd ref="-35"/>
         <nd ref="-34"/>
         <nd ref="58"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="width:minimum_traveled_way" v="5"/>
-        <tag k="source" v="mgcp"/>
-        <tag k="highway" v="road"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.112Z"/>
-        <tag k="location" v="overground"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="uuid" v="{{35d90f64-9ace-46a0-8fcb-aacadeef4c83}}"/>
-        <tag k="source:datetime" v="2010-01-13"/>
         <tag k="source:description" v="IKONOS Imagery"/>
         <tag k="surface" v="paved"/>
-        <tag k="lanes" v="2"/>
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{35d90f64-9ace-46a0-8fcb-aacadeef4c83}}"/>
+        <tag k="width:minimum_traveled_way" v="5"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.112Z"/>
+        <tag k="location" v="overground"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125">
         <nd ref="58"/>
@@ -515,6 +428,8 @@
         <tag k="seasonal" v="no"/>
         <tag k="condition" v="functional"/>
         <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Rue Dalencourt"/>
         <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
         <tag k="smoothness" v="intermediate"/>
@@ -532,9 +447,6 @@
         <tag k="source" v="CNIGS/OIM/FOCS;osm;mgcp"/>
         <tag k="practicability" v="heavy_truck_less_than_20mt"/>
         <tag k="highway" v="tertiary"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:24:11Z" version="1" changeset="125">
         <nd ref="61"/>
@@ -543,6 +455,7 @@
         <nd ref="64"/>
         <tag k="smoothness" v="intermediate"/>
         <tag k="source" v="survey; CNIGS/OIM/FOCS;osm"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue Théodule"/>
@@ -553,8 +466,6 @@
         <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
         <tag k="attribution" v="osm"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
 </osm>

--- a/test-files/cases/roundabouts/rcase-001/Expected.osm
+++ b/test-files/cases/roundabouts/rcase-001/Expected.osm
@@ -3,599 +3,455 @@
     <bounds minlat="18.544216" minlon="-72.3495523" maxlat="18.549036" maxlon="-72.340941"/>
     <node visible="true" id="-36" timestamp="2017-06-07T15:16:55Z" version="1" changeset="116" lat="18.5442160000000023" lon="-72.3478980242130802">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-36"/>
     </node>
     <node visible="true" id="-16" timestamp="2017-06-07T15:16:55Z" version="1" changeset="116" lat="18.5443991773701953" lon="-72.3478369650896980">
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-16"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463604999999880" lon="-72.3472852000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="2" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460960999999998" lon="-72.3473560000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="2"/>
     </node>
     <node visible="true" id="3" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5450757999999958" lon="-72.3476198999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="3"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463306999999951" lon="-72.3468486999999811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463741999999989" lon="-72.3469943000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486996999999931" lon="-72.3468201000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473485999999994" lon="-72.3471519000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="9" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5453608999999950" lon="-72.3495522999999991">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="9"/>
     </node>
     <node visible="true" id="10" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5452998999999963" lon="-72.3490373000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="10"/>
     </node>
     <node visible="true" id="11" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5453150999999963" lon="-72.3489567999999821">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="11"/>
     </node>
     <node visible="true" id="12" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5452845999999951" lon="-72.3486886000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="12"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466423999999961" lon="-72.3473252000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466267000000009" lon="-72.3472605999999843">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466064999999993" lon="-72.3472294999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465656999999986" lon="-72.3471934999999888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465194999999952" lon="-72.3471851000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464517999999963" lon="-72.3471875999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464157999999948" lon="-72.3472036000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463824999999964" lon="-72.3472366000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463569999999969" lon="-72.3473331999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463771999999949" lon="-72.3473943000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464067999999962" lon="-72.3474285999999864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464469999999935" lon="-72.3474513000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465071999999971" lon="-72.3474671000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466037999999962" lon="-72.3474214999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488974999999989" lon="-72.3487492999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485582999999998" lon="-72.3486496000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483136000000002" lon="-72.3485107999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5467543999999975" lon="-72.3474721000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466247999999965" lon="-72.3473883000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="32" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488980999999988" lon="-72.3480011000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="32"/>
     </node>
     <node visible="true" id="33" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490354999999987" lon="-72.3477780000000052">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="33"/>
     </node>
     <node visible="true" id="34" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490145999999960" lon="-72.3478599000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="34"/>
     </node>
     <node visible="true" id="35" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490172999999956" lon="-72.3479245999999989">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="35"/>
     </node>
     <node visible="true" id="36" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487392999999976" lon="-72.3478243999999791">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="36"/>
     </node>
     <node visible="true" id="37" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487493000000008" lon="-72.3478123999999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="37"/>
     </node>
     <node visible="true" id="38" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487417000000043" lon="-72.3477318999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="38"/>
     </node>
     <node visible="true" id="39" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486882999999949" lon="-72.3476540999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="39"/>
     </node>
     <node visible="true" id="40" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485676999999960" lon="-72.3477299000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="40"/>
     </node>
     <node visible="true" id="41" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488967999999979" lon="-72.3475440999999933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="41"/>
     </node>
     <node visible="true" id="42" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487977000000015" lon="-72.3475494999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="42"/>
     </node>
     <node visible="true" id="43" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487263999999961" lon="-72.3475468000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="43"/>
     </node>
     <node visible="true" id="44" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486222000000041" lon="-72.3476540999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="44"/>
     </node>
     <node visible="true" id="45" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485204999999951" lon="-72.3475011999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="45"/>
     </node>
     <node visible="true" id="46" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486285999999936" lon="-72.3475236999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="46"/>
     </node>
     <node visible="true" id="47" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486769000000038" lon="-72.3475559000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="47"/>
     </node>
     <node visible="true" id="48" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490087000000017" lon="-72.3484480000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="48"/>
     </node>
     <node visible="true" id="49" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489628999999958" lon="-72.3484159000000062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="49"/>
     </node>
     <node visible="true" id="50" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489248000000018" lon="-72.3484050999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="50"/>
     </node>
     <node visible="true" id="51" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488916999999951" lon="-72.3484050999999937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="51"/>
     </node>
     <node visible="true" id="52" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488382999999999" lon="-72.3483649000000071">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="52"/>
     </node>
     <node visible="true" id="53" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487696999999940" lon="-72.3483300000000042">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="53"/>
     </node>
     <node visible="true" id="54" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487010000000012" lon="-72.3483085999999957">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="54"/>
     </node>
     <node visible="true" id="55" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486746999999994" lon="-72.3481852999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="55"/>
     </node>
     <node visible="true" id="56" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488499000000004" lon="-72.3481440000000049">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="56"/>
     </node>
     <node visible="true" id="57" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489234999999972" lon="-72.3481244999999973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="57"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483119999999957" lon="-72.3469141999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="59" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5476449999999957" lon="-72.3437440999999950">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="59"/>
     </node>
     <node visible="true" id="60" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488587000000003" lon="-72.3478295999999830">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="60"/>
     </node>
     <node visible="true" id="61" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487091999999976" lon="-72.3478702000000027">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="61"/>
     </node>
     <node visible="true" id="62" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486083999999956" lon="-72.3478893999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="62"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5461508999999971" lon="-72.3474597999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="64" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460811999999962" lon="-72.3483207999999962">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="64"/>
     </node>
     <node visible="true" id="65" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463805999999956" lon="-72.3483935000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="65"/>
     </node>
     <node visible="true" id="66" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466134999999959" lon="-72.3485043000000019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="66"/>
     </node>
     <node visible="true" id="67" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471076000000004" lon="-72.3487724999999955">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="67"/>
     </node>
     <node visible="true" id="68" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5472447999999979" lon="-72.3488854000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="68"/>
     </node>
     <node visible="true" id="69" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473764999999986" lon="-72.3490165000000047">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="69"/>
     </node>
     <node visible="true" id="70" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5474521999999986" lon="-72.3491154999999964">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="70"/>
     </node>
     <node visible="true" id="71" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5475540000000017" lon="-72.3492241999999948">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="71"/>
     </node>
     <node visible="true" id="72" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5476506999999948" lon="-72.3493176999999861">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="72"/>
     </node>
     <node visible="true" id="73" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5477011999999988" lon="-72.3493753999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="73"/>
     </node>
     <node visible="true" id="74" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471021999999977" lon="-72.3412442999999996">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="74"/>
     </node>
     <node visible="true" id="75" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5459917999999959" lon="-72.3429339000000056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="75"/>
     </node>
     <node visible="true" id="76" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473763999999939" lon="-72.3425907000000024">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="76"/>
     </node>
     <node visible="true" id="77" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5481617999999990" lon="-72.3460184000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="77"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5462543999999987" lon="-72.3464747000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="79" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5443711999999969" lon="-72.3469414000000057">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="79"/>
     </node>
     <node visible="true" id="80" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471399000000012" lon="-72.3414185000000032">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="80"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451784999999951" lon="-72.3416548999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5454871999999966" lon="-72.3430367999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5457570999999959" lon="-72.3441762000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5445850000000014" lon="-72.3478640999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="85" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5482358000000040" lon="-72.3411717999999979">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="85"/>
     </node>
     <node visible="true" id="86" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484754999999950" lon="-72.3423156000000063">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="86"/>
     </node>
     <node visible="true" id="87" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487228999999978" lon="-72.3434648000000067">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="87"/>
     </node>
     <node visible="true" id="88" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489697000000007" lon="-72.3446454999999986">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="88"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471023999999964" lon="-72.3477086000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="90" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5472575999999947" lon="-72.3476361000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="90"/>
     </node>
     <node visible="true" id="91" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484690999999984" lon="-72.3473520000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="91"/>
     </node>
     <node visible="true" id="92" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487508000000005" lon="-72.3472802999999800">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="92"/>
     </node>
     <node visible="true" id="93" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484420000000014" lon="-72.3473618000000016">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="93"/>
     </node>
     <node visible="true" id="94" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484700999999959" lon="-72.3474982000000040">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="94"/>
     </node>
     <node visible="true" id="95" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485251999999967" lon="-72.3477656999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="95"/>
     </node>
     <node visible="true" id="96" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485524999999960" lon="-72.3478984999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="96"/>
     </node>
     <node visible="true" id="97" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486138999999959" lon="-72.3481967000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="97"/>
     </node>
     <node visible="true" id="98" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486349999999973" lon="-72.3482991000000055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="98"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487046999999947" lon="-72.3487044000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460012999999968" lon="-72.3454937999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="101" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5479269999999943" lon="-72.3450419999999923">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="101"/>
     </node>
     <node visible="true" id="102" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490224999999960" lon="-72.3447800999999941">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="102"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465459999999958" lon="-72.3474619999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="104" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5470576999999963" lon="-72.3478314999999981">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="104"/>
     </node>
     <node visible="true" id="105" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5482264999999948" lon="-72.3486065999999965">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="105"/>
     </node>
     <node visible="true" id="106" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485025999999955" lon="-72.3487513000000035">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="106"/>
     </node>
     <node visible="true" id="107" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486416999999975" lon="-72.3488001999999994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="107"/>
     </node>
     <node visible="true" id="108" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486936000000000" lon="-72.3488177999999920">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="108"/>
     </node>
     <node visible="true" id="109" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488603999999988" lon="-72.3488607999999829">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="109"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451003000000014" lon="-72.3477426000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="111" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3466479838299961">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="111"/>
     </node>
     <node visible="true" id="112" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3488785603699966">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="112"/>
     </node>
     <node visible="true" id="113" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3459388062899933">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="113"/>
     </node>
     <node visible="true" id="114" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3447770649799793">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="114"/>
     </node>
     <node visible="true" id="115" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3472163173999832">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="115"/>
     </node>
     <node visible="true" id="116" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5481833481800003" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="116"/>
     </node>
     <node visible="true" id="117" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3448408807699934">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="117"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5450276523399928" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="119" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3409679649199973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="119"/>
     </node>
     <node visible="true" id="120" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3458156529400043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="120"/>
     </node>
     <node visible="true" id="121" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999987" lon="-72.3469670106999985">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="121"/>
     </node>
     <node visible="true" id="122" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442160000000023" lon="-72.3433536260800025">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="122"/>
     </node>
     <node visible="true" id="123" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3421889451300046">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="123"/>
     </node>
     <node visible="true" id="124" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3418932164200044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="124"/>
     </node>
     <node visible="true" id="125" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3484123481800054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="125"/>
     </node>
     <node visible="true" id="126" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3476930497400019">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="126"/>
     </node>
     <node visible="true" id="127" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3477771650599806">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="127"/>
     </node>
     <node visible="true" id="128" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490359999999974" lon="-72.3479855952899982">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="128"/>
     </node>
     <node visible="true" id="129" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3486075393099952">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="129"/>
     </node>
     <node visible="true" id="130" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442160000000023" lon="-72.3445897743199993">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="130"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3487509983399946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3479753262299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="133" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442160000000023" lon="-72.3462816993999951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="133"/>
     </node>
     <node visible="true" id="134" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5470361288099994" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="134"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000045" lon="-72.3467378757499944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="136" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3446083533700062">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="136"/>
     </node>
     <node visible="true" id="137" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3433872431200058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="137"/>
     </node>
     <node visible="true" id="138" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999951" lon="-72.3478569061299908">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="138"/>
     </node>
     <node visible="true" id="139" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486804999999997" lon="-72.3467308000000031">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="139"/>
     </node>
     <node visible="true" id="140" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483079999999987" lon="-72.3468175999999943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="140"/>
     </node>
     <node visible="true" id="141" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473270999999968" lon="-72.3470496999999995">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="141"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465999000000004" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <way visible="true" id="-14" timestamp="2017-06-07T15:16:55Z" version="1">
         <nd ref="-36"/>
         <nd ref="-16"/>
         <nd ref="84"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="condition" v="functional"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="location" v="surface"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="median" v="yes"/>
-        <tag k="uuid" v="{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
-        <tag k="source" v="mgcp"/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2010-01-13"/>
-        <tag k="highway" v="road"/>
-        <tag k="lanes" v="4"/>
         <tag k="surface" v="paved"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="2"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-14"/>
+        <tag k="source:datetime" v="2010-01-13"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="median" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="source" v="mgcp"/>
+        <tag k="highway" v="road"/>
     </way>
     <way visible="true" id="1" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="18"/>
@@ -603,60 +459,57 @@
         <nd ref="5"/>
         <nd ref="78"/>
         <nd ref="100"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Rue des Casernes"/>
-        <tag k="lanes" v="2"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="alt_name" v="Rue Paul VI"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{bedb912f-331a-4271-8595-0731b4a42bc0};{{c6d3e710-ade5-42b6-b935-f17a2a510c96}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="1"/>
+        <tag k="name" v="Rue des Casernes"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{bedb912f-331a-4271-8595-0731b4a42bc0};{{c6d3e710-ade5-42b6-b935-f17a2a510c96}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="2" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="139"/>
         <nd ref="7"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
-        <tag k="uuid" v="{19d7e8e8-2ddf-4aaf-ba23-d79480c07ed0}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="service"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="service"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{19d7e8e8-2ddf-4aaf-ba23-d79480c07ed0}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="2"/>
     </way>
     <way visible="true" id="3" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="141"/>
         <nd ref="8"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
-        <tag k="uuid" v="{80416c3c-d608-4d6a-a59a-346ada5f1e6d}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="service"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="service"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{80416c3c-d608-4d6a-a59a-346ada5f1e6d}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="3"/>
     </way>
     <way visible="true" id="4" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="110"/>
@@ -664,28 +517,26 @@
         <nd ref="11"/>
         <nd ref="10"/>
         <nd ref="9"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="geoeye;osm"/>
-        <tag k="uuid" v="{c7acd2eb-accb-4b34-ae66-4463e5c8f664}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="unclassified"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{c7acd2eb-accb-4b34-ae66-4463e5c8f664}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="4"/>
     </way>
     <way visible="true" id="5" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="89"/>
         <nd ref="104"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{4aa747a3-768b-43c2-a7c2-188ce187a200}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="secondary_link"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="secondary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{4aa747a3-768b-43c2-a7c2-188ce187a200}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="5"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="31"/>
@@ -707,29 +558,27 @@
         <nd ref="14"/>
         <nd ref="13"/>
         <nd ref="31"/>
-        <tag k="junction" v="roundabout"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="GeoEye;osm"/>
-        <tag k="uuid" v="{6d02aaea-648c-4b09-8acf-8cf0b4fd4124}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="secondary"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{6d02aaea-648c-4b09-8acf-8cf0b4fd4124}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="junction" v="roundabout"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="7" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="32"/>
         <nd ref="35"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{83dbfc5a-f894-4fe3-9d14-63fdb4425af6}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{83dbfc5a-f894-4fe3-9d14-63fdb4425af6}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="7"/>
     </way>
     <way visible="true" id="8" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="95"/>
@@ -740,45 +589,42 @@
         <nd ref="37"/>
         <nd ref="36"/>
         <nd ref="61"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{1b094678-4e70-4726-9c60-efc6c19f6588}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{1b094678-4e70-4726-9c60-efc6c19f6588}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="8"/>
     </way>
     <way visible="true" id="9" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="47"/>
         <nd ref="46"/>
         <nd ref="45"/>
         <nd ref="94"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{9095d65f-b9d2-425b-a4e0-fb8b61eada23}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{9095d65f-b9d2-425b-a4e0-fb8b61eada23}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="9"/>
     </way>
     <way visible="true" id="10" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="57"/>
         <nd ref="56"/>
         <nd ref="55"/>
         <nd ref="97"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{83455e56-898e-4fa5-8e16-7b62ddefa087}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{83455e56-898e-4fa5-8e16-7b62ddefa087}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="10"/>
     </way>
     <way visible="true" id="11" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="74"/>
@@ -789,50 +635,48 @@
         <nd ref="77"/>
         <nd ref="140"/>
         <nd ref="58"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Rue Pavée"/>
-        <tag k="lanes" v="2"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="seasonal" v="no"/>
         <tag k="surface" v="paved"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="median" v="no"/>
-        <tag k="source:haiti" v="CNIGS and CartONG"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="operational_status" v="open"/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="type:haiti" v="Autre Route"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{586bbde5-a2b1-4dc8-85e0-c0ca6892cb25};{{6b828d43-7973-4098-a098-d10430882622}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="11"/>
+        <tag k="name" v="Rue Pavée"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="type:haiti" v="Autre Route"/>
+        <tag k="uuid" v="{586bbde5-a2b1-4dc8-85e0-c0ca6892cb25};{{6b828d43-7973-4098-a098-d10430882622}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="median" v="no"/>
+        <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="12" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="96"/>
         <nd ref="62"/>
         <nd ref="61"/>
         <nd ref="60"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{fd518d81-26c8-4bbf-8604-3538476bea30}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{fd518d81-26c8-4bbf-8604-3538476bea30}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="12"/>
     </way>
     <way visible="true" id="13" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="73"/>
@@ -846,15 +690,14 @@
         <nd ref="65"/>
         <nd ref="64"/>
         <nd ref="63"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{4007d710-d32a-4585-8483-8c2e146ebfdf}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="service"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="service"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{4007d710-d32a-4585-8483-8c2e146ebfdf}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="13"/>
     </way>
     <way visible="true" id="15" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="108"/>
@@ -865,29 +708,27 @@
         <nd ref="95"/>
         <nd ref="94"/>
         <nd ref="93"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{3d5251db-486f-4dde-b1ab-46bab5cdeecc}"/>
-        <tag k="name" v="Rue Antonio Macéo"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Rue Antonio Macéo"/>
+        <tag k="uuid" v="{3d5251db-486f-4dde-b1ab-46bab5cdeecc}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="15"/>
     </way>
     <way visible="true" id="16" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="3"/>
         <nd ref="110"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="geoeye;osm"/>
-        <tag k="uuid" v="{cdea7081-4c1c-4220-9bc9-50b3cf92b5d9}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="secondary_link"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="secondary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{cdea7081-4c1c-4220-9bc9-50b3cf92b5d9}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="16"/>
     </way>
     <way visible="true" id="17" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="142"/>
@@ -895,29 +736,28 @@
         <nd ref="140"/>
         <nd ref="139"/>
         <nd ref="111"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="survey; OSM-adjusted Bing;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Avenue Marie Jeanne"/>
-        <tag k="lanes" v="4"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="yes"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.132Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{04371857-9646-4a0a-a3a2-84792edc3095};{{4c6565c4-9ac3-4175-a398-7633e498309d}}"/>
-        <tag k="location" v="surface"/>
+        <tag k="surface" v="paved"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="17"/>
+        <tag k="name" v="Avenue Marie Jeanne"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{04371857-9646-4a0a-a3a2-84792edc3095};{{4c6565c4-9ac3-4175-a398-7633e498309d}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.132Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="survey; OSM-adjusted Bing;osm;mgcp"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="18" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="112"/>
@@ -928,30 +768,29 @@
         <nd ref="105"/>
         <nd ref="104"/>
         <nd ref="103"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="GRU/COSMHA;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
         <tag k="loc_name" v="Bicentenaire"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Boulevard Harry Truman"/>
-        <tag k="lanes" v="4"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="yes"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{f049a1aa-7af3-4d05-9ab6-dd06f0ac1735};{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
-        <tag k="location" v="surface"/>
+        <tag k="surface" v="paved"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="18"/>
+        <tag k="name" v="Boulevard Harry Truman"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{f049a1aa-7af3-4d05-9ab6-dd06f0ac1735};{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="GRU/COSMHA;osm;mgcp"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="19" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="114"/>
@@ -959,21 +798,20 @@
         <nd ref="101"/>
         <nd ref="100"/>
         <nd ref="113"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm"/>
-        <tag k="uuid" v="{542f83fc-7015-49f8-b3c0-3266c7dcb0e8}"/>
-        <tag k="name" v="Rue du Magasin de l'État"/>
-        <tag k="attribution" v="osm"/>
         <tag k="smoothness" v="bad"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="surface" v="paved"/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Rue du Magasin de l'État"/>
+        <tag k="uuid" v="{542f83fc-7015-49f8-b3c0-3266c7dcb0e8}"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="surface" v="paved"/>
+        <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="19"/>
     </way>
     <way visible="true" id="20" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="115"/>
@@ -982,16 +820,15 @@
         <nd ref="93"/>
         <nd ref="90"/>
         <nd ref="89"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{dc81339f-b308-4492-80e5-c71e2c93ea82}"/>
-        <tag k="name" v="Avenue Pie XII"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Avenue Pie XII"/>
+        <tag k="uuid" v="{dc81339f-b308-4492-80e5-c71e2c93ea82}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="20"/>
     </way>
     <way visible="true" id="21" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="117"/>
@@ -1001,22 +838,21 @@
         <nd ref="86"/>
         <nd ref="85"/>
         <nd ref="116"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
-        <tag k="uuid" v="{048f14df-927e-46eb-bf4c-5b4a8e9878a0}"/>
-        <tag k="name" v="Rue des Miracles"/>
-        <tag k="attribution" v="osm"/>
         <tag k="smoothness" v="intermediate"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="surface" v="paved"/>
+        <tag k="source" v="CNIGS/OIM/ FOCS;osm"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Rue des Miracles"/>
+        <tag k="uuid" v="{048f14df-927e-46eb-bf4c-5b4a8e9878a0}"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="surface" v="paved"/>
+        <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="21"/>
     </way>
     <way visible="true" id="22" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="100"/>
@@ -1024,55 +860,53 @@
         <nd ref="82"/>
         <nd ref="81"/>
         <nd ref="118"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="source:oneway" v="survey"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Rue des Casernes"/>
-        <tag k="lanes" v="2"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="alt_name" v="Rue Paul VI"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{aa585538-f526-4588-90bb-1ecb75f6e4c7};{{c6d3e710-ade5-42b6-b935-f17a2a510c96}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="source:oneway" v="survey"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="22"/>
+        <tag k="name" v="Rue des Casernes"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{aa585538-f526-4588-90bb-1ecb75f6e4c7};{{c6d3e710-ade5-42b6-b935-f17a2a510c96}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="tertiary"/>
     </way>
     <way visible="true" id="23" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="119"/>
         <nd ref="85"/>
         <nd ref="80"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source" v="hot_iom_cosmha;osm"/>
-        <tag k="uuid" v="{f96525ff-be49-4bbf-a3a1-408d7b62e749}"/>
-        <tag k="name" v="Rue du Peuple"/>
-        <tag k="attribution" v="osm"/>
         <tag k="smoothness" v="bad"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="surface" v="paved"/>
+        <tag k="source" v="hot_iom_cosmha;osm"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Rue du Peuple"/>
+        <tag k="uuid" v="{f96525ff-be49-4bbf-a3a1-408d7b62e749}"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="surface" v="paved"/>
+        <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="23"/>
     </way>
     <way visible="true" id="24" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="121"/>
@@ -1080,21 +914,20 @@
         <nd ref="78"/>
         <nd ref="77"/>
         <nd ref="120"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm"/>
-        <tag k="uuid" v="{b1f70967-a5f1-4674-8456-98670a0b0151}"/>
-        <tag k="name" v="Rue du Quai"/>
-        <tag k="attribution" v="osm"/>
         <tag k="smoothness" v="intermediate"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="surface" v="paved"/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Rue du Quai"/>
+        <tag k="uuid" v="{b1f70967-a5f1-4674-8456-98670a0b0151}"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="surface" v="paved"/>
+        <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="24"/>
     </way>
     <way visible="true" id="25" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="123"/>
@@ -1103,53 +936,51 @@
         <nd ref="75"/>
         <nd ref="82"/>
         <nd ref="122"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="history" v="Retrieved from v20"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
         <tag k="source" v="hot_iom_cosmha;osm"/>
-        <tag k="uuid" v="{bda03ea6-9749-4b9d-8656-7a75688fd3e0}"/>
+        <tag k="history" v="Retrieved from v20"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="Rue du Centre"/>
+        <tag k="uuid" v="{bda03ea6-9749-4b9d-8656-7a75688fd3e0}"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="surface" v="paved"/>
+        <tag k="operational_status_quality" v="confirmed"/>
         <tag k="surface_condition" v="Smooth_greater_than_40kph"/>
         <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="surface" v="paved"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="25"/>
     </way>
     <way visible="true" id="26" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="124"/>
         <nd ref="81"/>
         <nd ref="74"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Rue Enterrement"/>
-        <tag k="lanes" v="2"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.137Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{5ad58b3e-9d34-4f27-932d-510055c97ad4};{{bf4e75b9-d448-4509-a41f-d254d704fef9}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="bad"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="26"/>
+        <tag k="name" v="Rue Enterrement"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="bad"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{5ad58b3e-9d34-4f27-932d-510055c97ad4};{{bf4e75b9-d448-4509-a41f-d254d704fef9}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.137Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="unclassified"/>
     </way>
     <way visible="true" id="27" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="98"/>
@@ -1161,15 +992,14 @@
         <nd ref="49"/>
         <nd ref="48"/>
         <nd ref="125"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{67d71af3-7f1a-447a-b664-c4a747b7277b}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{67d71af3-7f1a-447a-b664-c4a747b7277b}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="27"/>
     </way>
     <way visible="true" id="28" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="44"/>
@@ -1178,15 +1008,14 @@
         <nd ref="42"/>
         <nd ref="41"/>
         <nd ref="126"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{6a07b25b-60a7-4944-8e1d-361936b2eb89}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{6a07b25b-60a7-4944-8e1d-361936b2eb89}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="28"/>
     </way>
     <way visible="true" id="29" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="128"/>
@@ -1194,21 +1023,20 @@
         <nd ref="34"/>
         <nd ref="33"/>
         <nd ref="127"/>
-        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="foot" v="yes"/>
+        <tag k="source" v="osm"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="cycleway"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="access" v="no"/>
         <tag k="bicycle" v="no"/>
         <tag k="horse" v="permissive"/>
-        <tag k="source" v="osm"/>
         <tag k="uuid" v="{a81c2324-a892-4bb5-be79-558818935ceb}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="cycleway"/>
         <tag k="segregated" v="no"/>
-        <tag k="hoot:status" v="1"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="access" v="no"/>
+        <tag k="motor_vehicle" v="permissive"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="29"/>
     </way>
     <way visible="true" id="30" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="129"/>
@@ -1218,48 +1046,46 @@
         <nd ref="60"/>
         <nd ref="42"/>
         <nd ref="92"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{0c8279b7-71f3-4f70-be9d-1b40a954cd69}"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="footway"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{0c8279b7-71f3-4f70-be9d-1b40a954cd69}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="30"/>
     </way>
     <way visible="true" id="31" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="130"/>
         <nd ref="83"/>
         <nd ref="59"/>
-        <tag k="width:minimum_traveled_way" v="10"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
         <tag k="loc_name" v="Grand Rue"/>
-        <tag k="ref" v="RN 2"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
-        <tag k="lanes" v="4"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.137Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{72466a5c-1197-4004-80ab-1965beeb6d89};{{57700a2f-b508-4758-bd8c-a156feade7b9}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="31"/>
+        <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
+        <tag k="ref" v="RN 2"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{72466a5c-1197-4004-80ab-1965beeb6d89};{{57700a2f-b508-4758-bd8c-a156feade7b9}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="10"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.137Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="31"/>
@@ -1270,18 +1096,17 @@
         <nd ref="99"/>
         <nd ref="27"/>
         <nd ref="131"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="loc_name" v="Bicentenaire"/>
         <tag k="source" v="GRU/COSMHA;osm"/>
-        <tag k="uuid" v="{d0f92e87-96d4-482e-8081-3c0a61e78517}"/>
-        <tag k="name" v="Boulevard Harry Truman"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="secondary"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Boulevard Harry Truman"/>
+        <tag k="uuid" v="{d0f92e87-96d4-482e-8081-3c0a61e78517}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="loc_name" v="Bicentenaire"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="22"/>
@@ -1289,100 +1114,97 @@
         <nd ref="110"/>
         <nd ref="84"/>
         <nd ref="132"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="name" v="Boulevard Harry Truman"/>
-        <tag k="lanes" v="4"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
         <tag k="surface" v="paved"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="median" v="yes"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="operational_status" v="open"/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{e2ee93da-504b-403b-8f6b-5d53482020e6};{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
+        <tag k="name" v="Boulevard Harry Truman"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{e2ee93da-504b-403b-8f6b-5d53482020e6};{{6a141b6c-44bb-41e8-b52e-6ec8a5602ed5}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="median" v="yes"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.136Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="34" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="84"/>
         <nd ref="79"/>
         <nd ref="133"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Rue du Champ de Mars"/>
-        <tag k="lanes" v="2"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{c869fdc4-8a7d-45c7-a47a-09611507cf41};{{5cfcb674-fbc6-4c61-ac3f-e29f68dd8bf9}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="34"/>
+        <tag k="name" v="Rue du Champ de Mars"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{c869fdc4-8a7d-45c7-a47a-09611507cf41};{{5cfcb674-fbc6-4c61-ac3f-e29f68dd8bf9}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="unclassified"/>
     </way>
     <way visible="true" id="35" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="134"/>
         <nd ref="74"/>
-        <tag k="width:minimum_traveled_way" v="8"/>
-        <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
-        <tag k="note" v="oneway very possibly continues both(?) directions"/>
-        <tag k="source:oneway" v="survey"/>
-        <tag k="name" v="Rue Pavée"/>
-        <tag k="lanes" v="2"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
-        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
-        <tag k="source:haiti" v="CNIGS and CartONG"/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="fixme" v="survey if oneway continues one/both directions"/>
-        <tag k="type:haiti" v="Autre Route"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{287bf291-fb97-4c17-9ebf-0246029b4f53};{{6b828d43-7973-4098-a098-d10430882622}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="source:oneway" v="survey"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="35"/>
+        <tag k="name" v="Rue Pavée"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="2"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="type:haiti" v="Autre Route"/>
+        <tag k="uuid" v="{287bf291-fb97-4c17-9ebf-0246029b4f53};{{6b828d43-7973-4098-a098-d10430882622}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="8"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="fixme" v="survey if oneway continues one/both directions"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:haiti" v="CNIGS and CartONG"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.133Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="note" v="oneway very possibly continues both(?) directions"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/OIM/ FOCS;osm;mgcp"/>
+        <tag k="practicability" v="heavy_truck_less_than_20mt"/>
+        <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="135"/>
@@ -1390,64 +1212,61 @@
         <nd ref="58"/>
         <nd ref="8"/>
         <nd ref="13"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="oneway" v="yes"/>
         <tag k="source" v="survey; OSM-adjusted Bing;osm"/>
-        <tag k="uuid" v="{b211a83c-4c16-49e1-82db-f9c74b3aef73}"/>
-        <tag k="name" v="Avenue Marie Jeanne"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="tertiary"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Avenue Marie Jeanne"/>
+        <tag k="uuid" v="{b211a83c-4c16-49e1-82db-f9c74b3aef73}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
     <way visible="true" id="37" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="136"/>
         <nd ref="88"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{3ba8056c-2b4e-4105-a2ad-5809a6047816}"/>
-        <tag k="name" v="Rue Courbe"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="residential"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Rue Courbe"/>
+        <tag k="uuid" v="{3ba8056c-2b4e-4105-a2ad-5809a6047816}"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="37"/>
     </way>
     <way visible="true" id="38" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="59"/>
         <nd ref="87"/>
         <nd ref="137"/>
-        <tag k="width:minimum_traveled_way" v="10"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
-        <tag k="condition" v="functional"/>
         <tag k="loc_name" v="Grand Rue"/>
-        <tag k="ref" v="RN 1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
-        <tag k="lanes" v="4"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="seasonal" v="no"/>
-        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
-        <tag k="surface" v="paved"/>
-        <tag k="median" v="no"/>
-        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
         <tag k="source:description" v="IKONOS Imagery"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.137Z"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="highway" v="primary"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
-        <tag k="uuid" v="{9c7f2d0f-e445-447c-b5d3-97a8db294eae};{{57700a2f-b508-4758-bd8c-a156feade7b9}}"/>
-        <tag k="location" v="surface"/>
-        <tag k="smoothness" v="intermediate"/>
+        <tag k="surface" v="paved"/>
         <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="condition" v="functional"/>
+        <tag k="source:name" v="very_high_resolution_commercial_monoscopic_imagery"/>
         <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="38"/>
+        <tag k="name" v="Boulevard Jean-Jacques Dessalines"/>
+        <tag k="ref" v="RN 1"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z;2010-01-13"/>
+        <tag k="smoothness" v="intermediate"/>
+        <tag k="lanes" v="4"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="uuid" v="{9c7f2d0f-e445-447c-b5d3-97a8db294eae};{{57700a2f-b508-4758-bd8c-a156feade7b9}}"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="width:minimum_traveled_way" v="10"/>
+        <tag k="source:copyright" v="© 2010. Her Majesty the Queen in Right of Canada."/>
+        <tag k="attribution" v="osm"/>
+        <tag k="median" v="no"/>
+        <tag k="source:ingest:datetime" v="2016-03-16T16:46:59.137Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm;mgcp"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="highway" v="primary"/>
     </way>
     <way visible="true" id="39" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="138"/>
@@ -1455,51 +1274,47 @@
         <nd ref="3"/>
         <nd ref="2"/>
         <nd ref="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="operational_status_quality" v="confirmed"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="operational_status" v="open"/>
-        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
-        <tag k="source" v="CNIGS/GIS /DTM;osm"/>
-        <tag k="uuid" v="{7b8fd54a-7dd5-4d7d-8f2a-2d864b49ba7c}"/>
-        <tag k="name" v="Boulevard Harry Truman"/>
-        <tag k="attribution" v="osm"/>
         <tag k="smoothness" v="intermediate"/>
-        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="surface" v="paved"/>
+        <tag k="source" v="CNIGS/GIS /DTM;osm"/>
+        <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Boulevard Harry Truman"/>
+        <tag k="uuid" v="{7b8fd54a-7dd5-4d7d-8f2a-2d864b49ba7c}"/>
+        <tag k="practicability" v="truck_+_trailer_greater_than_20mt"/>
+        <tag k="source:datetime" v="2016-03-16T16:50:52Z"/>
+        <tag k="operational_status" v="open"/>
+        <tag k="surface" v="paved"/>
+        <tag k="operational_status_quality" v="confirmed"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="39"/>
     </way>
     <relation visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="33" role="reviewee"/>
         <member type="way" ref="-14" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-111"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-14" role="reviewee"/>
         <member type="way" ref="39" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-110"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="140" role="reviewee"/>
         <member type="way" ref="11" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Highway"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="type" v="review"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:id" v="-109"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/roundabouts/rcase-002/Expected.osm
+++ b/test-files/cases/roundabouts/rcase-002/Expected.osm
@@ -3,171 +3,129 @@
     <bounds minlat="18.544216" minlon="-72.34875099833999" maxlat="18.549036" maxlon="-72.340941"/>
     <node visible="true" id="-41777" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457702303256262" lon="-72.3442470443381751">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41777"/>
     </node>
     <node visible="true" id="-41715" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5466478874399954" lon="-72.3473433557199854">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41715"/>
     </node>
     <node visible="true" id="-40995" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5455867051699954" lon="-72.3476116699099947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-40995"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463604999999916" lon="-72.3472852000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463306999999951" lon="-72.3468486999999811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463742000000025" lon="-72.3469943000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489995571299993" lon="-72.3466758285599951">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5475853312299996" lon="-72.3470325986200038">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466397696399952" lon="-72.3472697109899912">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466065000000029" lon="-72.3472294999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465656999999915" lon="-72.3471934999999888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465194999999987" lon="-72.3471851000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464517999999963" lon="-72.3471875999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464157999999948" lon="-72.3472036000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463824999999964" lon="-72.3472366000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463570000000004" lon="-72.3473331999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463771999999949" lon="-72.3473943000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464067999999997" lon="-72.3474285999999864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464469999999970" lon="-72.3474513000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465072000000006" lon="-72.3474671000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="26" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466037999999962" lon="-72.3474214999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="26"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488974999999954" lon="-72.3487492999999944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5485582999999963" lon="-72.3486496000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483135999999966" lon="-72.3485107999999997">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5467543999999975" lon="-72.3474721000000045">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466247999999965" lon="-72.3473883000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486539430799979" lon="-72.3467616052100055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5461508999999971" lon="-72.3474597999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5462543999999916" lon="-72.3464747000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451784999999987" lon="-72.3416548999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5454871999999966" lon="-72.3430367999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5457570999999994" lon="-72.3441762000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5445850000000014" lon="-72.3478640999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471023999999964" lon="-72.3477086000000043">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487046999999947" lon="-72.3487044000000026">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460012999999968" lon="-72.3454937999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465459999999993" lon="-72.3474619999999931">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451003000000014" lon="-72.3477426000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5450276523399964" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000010" lon="-72.3487509983399946">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999987" lon="-72.3479753262299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465998999999968" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <way visible="true" id="-169" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="18"/>
@@ -181,12 +139,11 @@
         <nd ref="81"/>
         <nd ref="118"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z;2017-06-07T15:16:55Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-169"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="31"/>
@@ -209,13 +166,12 @@
         <nd ref="-41715"/>
         <nd ref="31"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z"/>
         <tag k="junction" v="roundabout"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="31"/>
@@ -227,12 +183,11 @@
         <nd ref="27"/>
         <nd ref="131"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z;2017-06-07T15:16:55Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="22"/>
@@ -242,12 +197,11 @@
         <nd ref="84"/>
         <nd ref="132"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z;2017-06-07T15:16:55Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="7"/>
@@ -255,11 +209,10 @@
         <nd ref="8"/>
         <nd ref="13"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z;2017-06-07T15:16:55Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
 </osm>

--- a/test-files/cases/roundabouts/rcase-003/Expected.osm
+++ b/test-files/cases/roundabouts/rcase-003/Expected.osm
@@ -3,187 +3,141 @@
     <bounds minlat="18.544216" minlon="-72.34882018686" maxlat="18.549036" maxlon="-72.340941"/>
     <node visible="true" id="-42782" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5457702303256262" lon="-72.3442470443381893">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42782"/>
     </node>
     <node visible="true" id="-42713" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5479677734299955" lon="-72.3483445972899943">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42713"/>
     </node>
     <node visible="true" id="-42693" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5476712851000016" lon="-72.3481425668099973">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42693"/>
     </node>
     <node visible="true" id="-42666" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5466060218899962" lon="-72.3474271575300065">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42666"/>
     </node>
     <node visible="true" id="-42649" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5466283242699959" lon="-72.3473856444200010">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-42649"/>
     </node>
     <node visible="true" id="-41909" timestamp="1970-01-01T00:00:00Z" version="1" lat="18.5455867051699919" lon="-72.3476116699099947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-41909"/>
     </node>
     <node visible="true" id="1" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463604999999951" lon="-72.3472852000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="1"/>
     </node>
     <node visible="true" id="5" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463306999999951" lon="-72.3468486999999811">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="5"/>
     </node>
     <node visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463741999999989" lon="-72.3469943000000058">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="6"/>
     </node>
     <node visible="true" id="7" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5486996999999967" lon="-72.3468201000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="7"/>
     </node>
     <node visible="true" id="8" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5473485999999994" lon="-72.3471519000000001">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="8"/>
     </node>
     <node visible="true" id="13" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466423999999996" lon="-72.3473252000000002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="13"/>
     </node>
     <node visible="true" id="14" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466266999999974" lon="-72.3472605999999843">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="14"/>
     </node>
     <node visible="true" id="15" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5466065000000029" lon="-72.3472294999999974">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="15"/>
     </node>
     <node visible="true" id="16" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465656999999986" lon="-72.3471934999999888">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="16"/>
     </node>
     <node visible="true" id="17" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465194999999952" lon="-72.3471851000000044">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="17"/>
     </node>
     <node visible="true" id="18" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464517999999963" lon="-72.3471875999999980">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="18"/>
     </node>
     <node visible="true" id="19" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464157999999983" lon="-72.3472036000000003">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="19"/>
     </node>
     <node visible="true" id="20" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463825000000000" lon="-72.3472366000000022">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="20"/>
     </node>
     <node visible="true" id="21" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463569999999969" lon="-72.3473331999999942">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="21"/>
     </node>
     <node visible="true" id="22" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5463771999999949" lon="-72.3473943000000048">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="22"/>
     </node>
     <node visible="true" id="23" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464067999999997" lon="-72.3474285999999864">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="23"/>
     </node>
     <node visible="true" id="24" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5464470000000006" lon="-72.3474513000000030">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="24"/>
     </node>
     <node visible="true" id="25" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465071999999971" lon="-72.3474671000000029">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="25"/>
     </node>
     <node visible="true" id="27" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5488424007399964" lon="-72.3488004995000011">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="27"/>
     </node>
     <node visible="true" id="28" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5484927055099966" lon="-72.3486800429499937">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="28"/>
     </node>
     <node visible="true" id="29" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5482991691899954" lon="-72.3485578481899978">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="29"/>
     </node>
     <node visible="true" id="30" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5468436094100007" lon="-72.3476090932699947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="30"/>
     </node>
     <node visible="true" id="31" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465670761899979" lon="-72.3474519534400002">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="31"/>
     </node>
     <node visible="true" id="58" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5483119999999992" lon="-72.3469141999999863">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="58"/>
     </node>
     <node visible="true" id="63" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5461509000000042" lon="-72.3474597999999958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="63"/>
     </node>
     <node visible="true" id="78" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5462543999999987" lon="-72.3464747000000017">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="78"/>
     </node>
     <node visible="true" id="81" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451784999999951" lon="-72.3416548999999947">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="81"/>
     </node>
     <node visible="true" id="82" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5454872000000002" lon="-72.3430367999999930">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="82"/>
     </node>
     <node visible="true" id="83" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5457570999999959" lon="-72.3441762000000068">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="83"/>
     </node>
     <node visible="true" id="84" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5445850000000014" lon="-72.3478640999999953">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="84"/>
     </node>
     <node visible="true" id="89" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5471023999999964" lon="-72.3477777885200055">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="89"/>
     </node>
     <node visible="true" id="99" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5487427447599984" lon="-72.3487652859000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="99"/>
     </node>
     <node visible="true" id="100" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5460013000000004" lon="-72.3454937999999999">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="100"/>
     </node>
     <node visible="true" id="103" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465302571399953" lon="-72.3474633837700054">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="103"/>
     </node>
     <node visible="true" id="110" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5451002999999979" lon="-72.3477426000000037">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="110"/>
     </node>
     <node visible="true" id="118" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5450276523399964" lon="-72.3409410000000008">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="118"/>
     </node>
     <node visible="true" id="131" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5489927077600036" lon="-72.3488201868599958">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="131"/>
     </node>
     <node visible="true" id="132" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5442159999999987" lon="-72.3479753262299994">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="132"/>
     </node>
     <node visible="true" id="135" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5490360000000045" lon="-72.3467378757499944">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="135"/>
     </node>
     <node visible="true" id="142" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117" lat="18.5465998999999968" lon="-72.3472215000000034">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="142"/>
     </node>
     <way visible="true" id="-148" timestamp="2017-06-07T15:16:56Z" version="1">
         <nd ref="18"/>
@@ -197,12 +151,11 @@
         <nd ref="81"/>
         <nd ref="118"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z;2017-06-07T15:16:55Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-148"/>
     </way>
     <way visible="true" id="6" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="31"/>
@@ -226,13 +179,12 @@
         <nd ref="-42666"/>
         <nd ref="31"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="1"/>
         <tag k="highway" v="secondary"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z"/>
         <tag k="junction" v="roundabout"/>
-        <tag k="hoot:status" v="1"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="6"/>
     </way>
     <way visible="true" id="32" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="31"/>
@@ -246,12 +198,11 @@
         <nd ref="27"/>
         <nd ref="131"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="32"/>
     </way>
     <way visible="true" id="33" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="22"/>
@@ -261,12 +212,11 @@
         <nd ref="84"/>
         <nd ref="132"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="33"/>
     </way>
     <way visible="true" id="36" timestamp="2017-06-07T15:16:56Z" version="1" changeset="117">
         <nd ref="135"/>
@@ -275,11 +225,10 @@
         <nd ref="8"/>
         <nd ref="13"/>
         <tag k="source" v="Unknown"/>
+        <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:datetime" v="2017-06-07T15:16:56Z;2017-06-07T15:16:55Z"/>
-        <tag k="hoot:status" v="3"/>
         <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="36"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/building-1/Expected.osm
+++ b/test-files/cases/unifying/building-1/Expected.osm
@@ -11,8 +11,9 @@
         <nd ref="-4264921"/>
         <nd ref="-4264919"/>
         <nd ref="-4264925"/>
-        <tag k="building" v="yes"/>
-        <tag k="uuid" v="B;D"/>
         <tag k="name" v="foo"/>
+        <tag k="uuid" v="B;D"/>
+        <tag k="building" v="yes"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/building-2/Expected.osm
+++ b/test-files/cases/unifying/building-2/Expected.osm
@@ -16,8 +16,8 @@
         <nd ref="-5318597"/>
         <nd ref="-5318598"/>
         <nd ref="-5318595"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="building 2"/>
+        <tag k="building" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5401868" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -27,19 +27,19 @@
         <nd ref="-5318592"/>
         <nd ref="-5318594"/>
         <nd ref="-5318586"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="building 1"/>
+        <tag k="building" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5401868" role="reviewee"/>
         <member type="way" ref="-5401869" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Building"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Unmatched buildings are overlapping."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Unmatched buildings are overlapping."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/building-3/Expected.osm
+++ b/test-files/cases/unifying/building-3/Expected.osm
@@ -19,14 +19,14 @@
         <nd ref="-47645"/>
         <nd ref="-47646"/>
         <nd ref="-47643"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="amenity" v="restaurant"/>
+        <tag k="name" v="Cheddar's Casual Cafe"/>
+        <tag k="alt_name" v="Cheddar's"/>
+        <tag k="hoot:building:match" v="true"/>
+        <tag k="building" v="yes"/>
         <tag k="REF1" v="Cheddar's"/>
         <tag k="REF2" v="Cheddar's"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:building:match" v="true"/>
-        <tag k="alt_name" v="Cheddar's"/>
-        <tag k="building" v="yes"/>
-        <tag k="name" v="Cheddar's Casual Cafe"/>
-        <tag k="amenity" v="restaurant"/>
         <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/building-4/Expected.osm
+++ b/test-files/cases/unifying/building-4/Expected.osm
@@ -50,9 +50,10 @@
         <nd ref="-779"/>
         <nd ref="-772"/>
         <nd ref="-778"/>
-        <tag k="REF2" v="Target"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="Target Pharmacy"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Target"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-798" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-771"/>
@@ -61,9 +62,10 @@
         <nd ref="-777"/>
         <nd ref="-778"/>
         <nd ref="-771"/>
-        <tag k="REF2" v="Target"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="Target - Aurora South"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Target"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-770"/>
@@ -74,9 +76,10 @@
         <nd ref="-774"/>
         <nd ref="-775"/>
         <nd ref="-770"/>
-        <tag k="REF2" v="Target"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="Target Grocery"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF2" v="Target"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-796" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-659"/>
@@ -84,9 +87,10 @@
         <nd ref="-747"/>
         <nd ref="-769"/>
         <nd ref="-659"/>
-        <tag k="REF1" v="Target"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="Target - South"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Target"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-771" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-749"/>
@@ -119,9 +123,10 @@
         <nd ref="-675"/>
         <nd ref="-677"/>
         <nd ref="-749"/>
-        <tag k="REF1" v="Target"/>
-        <tag k="building" v="yes"/>
         <tag k="name" v="Target"/>
+        <tag k="building" v="yes"/>
+        <tag k="REF1" v="Target"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-799" role="reviewee"/>
@@ -129,12 +134,12 @@
         <member type="way" ref="-797" role="reviewee"/>
         <member type="way" ref="-796" role="reviewee"/>
         <member type="way" ref="-771" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Building"/>
-        <tag k="hoot:review:members" v="5"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Merging multiple buildings from each data source is error prone and requires a human eye."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Merging multiple buildings from each data source is error prone and requires a human eye."/>
+        <tag k="hoot:review:members" v="5"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/building-5/Expected.osm
+++ b/test-files/cases/unifying/building-5/Expected.osm
@@ -154,12 +154,13 @@
         <nd ref="-130"/>
         <nd ref="-131"/>
         <nd ref="-126"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{414eab16-310d-464e-93cd-cb316b45d507}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2014-06-28T07:50:34.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-27" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-112"/>
@@ -169,12 +170,13 @@
         <nd ref="-116"/>
         <nd ref="-117"/>
         <nd ref="-112"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{43d45970-6335-46f6-b6cc-e7cb3f7ea473}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2014-06-28T07:50:34.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-26" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-108"/>
@@ -182,13 +184,14 @@
         <nd ref="-110"/>
         <nd ref="-111"/>
         <nd ref="-108"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{72dd5e7c-9608-4824-9090-7fd2532c6873}"/>
         <tag k="amenity" v="public_building"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{72dd5e7c-9608-4824-9090-7fd2532c6873}"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-06-16T10:51:43.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-25" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-102"/>
@@ -196,13 +199,14 @@
         <nd ref="-104"/>
         <nd ref="-105"/>
         <nd ref="-102"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="addr:city" v="Pyongyang 평양"/>
-        <tag k="building" v="house"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{f05c74c0-55ce-4dcd-99fb-a4f443305f1e}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="house"/>
         <tag k="source:datetime" v="2013-12-16T22:00:34.000Z"/>
+        <tag k="addr:city" v="Pyongyang 평양"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-22" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-87"/>
@@ -210,12 +214,13 @@
         <nd ref="-89"/>
         <nd ref="-90"/>
         <nd ref="-87"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{84912110-53fe-4ee1-8d9b-a5279c3832ca}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-04-10T20:41:17.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-21" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-77"/>
@@ -229,12 +234,13 @@
         <nd ref="-85"/>
         <nd ref="-86"/>
         <nd ref="-77"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{c6e2c966-7c56-44cc-bd23-91f3aecbe9f7}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:54.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-20" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-71"/>
@@ -244,12 +250,13 @@
         <nd ref="-75"/>
         <nd ref="-76"/>
         <nd ref="-71"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{e56cb9e9-825a-4823-885a-a53286a00920}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:54.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-19" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-61"/>
@@ -257,12 +264,13 @@
         <nd ref="-63"/>
         <nd ref="-64"/>
         <nd ref="-61"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{677df91d-fae7-4eaf-ae18-d2aa040551bc}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:54.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-18" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-57"/>
@@ -270,12 +278,13 @@
         <nd ref="-59"/>
         <nd ref="-60"/>
         <nd ref="-57"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{017e9783-be30-45c2-ab2d-2b1ae4aa3c21}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:55.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-17" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-49"/>
@@ -287,12 +296,13 @@
         <nd ref="-55"/>
         <nd ref="-56"/>
         <nd ref="-49"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6d0afaea-a5a9-418b-bdd4-0a37b1d018e3}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:55.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-16" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-43"/>
@@ -302,12 +312,13 @@
         <nd ref="-47"/>
         <nd ref="-48"/>
         <nd ref="-43"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{5f77c891-839a-41fc-bf74-3a3c608dc38b}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:55.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-15" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-39"/>
@@ -315,12 +326,13 @@
         <nd ref="-41"/>
         <nd ref="-42"/>
         <nd ref="-39"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{d4b902ed-f94e-47fd-ab56-e1867a5812a8}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:55.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-14" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-33"/>
@@ -328,12 +340,13 @@
         <nd ref="-35"/>
         <nd ref="-36"/>
         <nd ref="-33"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{51aba3f2-2279-4a3e-98c6-d922bdb4a6d6}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2014-06-28T07:48:10.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-12" timestamp="2018-01-10T18:20:40Z" version="1" changeset="14856">
         <nd ref="-25"/>
@@ -341,12 +354,13 @@
         <nd ref="-27"/>
         <nd ref="-28"/>
         <nd ref="-25"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{7ad7ab4f-065f-42ec-8cc3-7d90d85b7e82}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2014-06-28T07:48:10.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24"/>
@@ -354,12 +368,12 @@
         <nd ref="-38"/>
         <nd ref="-23"/>
         <nd ref="-24"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{b3cc76f2-1ae6-4ac5-b2ca-4046310aeb64}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-04-10T13:22:41.000Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -374,12 +388,12 @@
         <nd ref="-69"/>
         <nd ref="-70"/>
         <nd ref="-65"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{4ea51e08-2643-4571-b0a8-14f5e309f944}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-10-05T07:50:54.000Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -387,21 +401,21 @@
         <nd ref="-99"/>
         <nd ref="-17"/>
         <nd ref="-18"/>
-        <tag k="historic" v="monument"/>
-        <tag k="start_date" v="1982"/>
-        <tag k="name:zh" v="主題思想塔"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="height" v="5"/>
-        <tag k="addr:city" v="Pyongyang 평양"/>
-        <tag k="name:es" v="Torre Juche"/>
-        <tag k="building" v="yes"/>
-        <tag k="source" v="osm"/>
-        <tag k="uuid" v="{a44e8fa1-efd6-434b-b92e-4bf4af962865}"/>
-        <tag k="name" v="주체사상탑"/>
         <tag k="wikipedia" v="es:Torre Juche"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="source" v="osm"/>
+        <tag k="historic" v="monument"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="주체사상탑"/>
+        <tag k="name:zh" v="主題思想塔"/>
         <tag k="tourism" v="attraction"/>
+        <tag k="uuid" v="{a44e8fa1-efd6-434b-b92e-4bf4af962865}"/>
+        <tag k="building" v="yes"/>
+        <tag k="start_date" v="1982"/>
+        <tag k="addr:city" v="Pyongyang 평양"/>
         <tag k="source:datetime" v="2014-08-15T12:19:09.000Z"/>
+        <tag k="name:es" v="Torre Juche"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="height" v="5"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -410,13 +424,13 @@
         <nd ref="-107"/>
         <nd ref="-13"/>
         <nd ref="-14"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{5505dee5-781f-40fa-8ec9-d16ef6aba3a7}"/>
         <tag k="amenity" v="public_building"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{5505dee5-781f-40fa-8ec9-d16ef6aba3a7}"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-06-16T10:51:43.000Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -428,12 +442,12 @@
         <nd ref="-11"/>
         <nd ref="-122"/>
         <nd ref="-118"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{67ccb898-4998-460d-ae4c-644508594fd0}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2014-06-28T07:50:34.000Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -457,12 +471,12 @@
         <nd ref="-133"/>
         <nd ref="-5"/>
         <nd ref="-6"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6ad440da-ec6b-4300-be0c-2f760e833591}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2011-04-10T13:09:01.000Z"/>
+        <tag k="attribution" v="osm"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -471,16 +485,16 @@
         <nd ref="-4"/>
         <nd ref="8449"/>
         <nd ref="8446"/>
-        <tag k="width" v="15"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="height" v="21"/>
-        <tag k="length" v="70"/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm;Bing"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{da9dfa18-a887-40d7-8750-475a63cd14a4};{d21de8a5-dd9d-40b8-b1d2-cdcde07fa245}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2017-11-30T17:17:27Z;2011-10-05T07:40:59.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="width" v="15"/>
+        <tag k="height" v="21"/>
+        <tag k="condition" v="functional"/>
+        <tag k="length" v="70"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="748" timestamp="2018-01-10T18:15:58Z" version="1" changeset="14855">
@@ -489,11 +503,12 @@
         <nd ref="4531"/>
         <nd ref="4532"/>
         <nd ref="4529"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{6739b3ac-bc84-4018-b100-3d77e61254a9}"/>
-        <tag k="attribution" v="osm"/>
         <tag k="source:datetime" v="2017-11-30T17:17:28Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="751" timestamp="2018-01-10T18:15:58Z" version="1" changeset="14855">
         <nd ref="4545"/>
@@ -509,11 +524,12 @@
         <nd ref="4555"/>
         <nd ref="4556"/>
         <nd ref="4545"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{ac7a8da6-b829-4f96-86f0-bd05ee6d0446}"/>
-        <tag k="attribution" v="osm"/>
         <tag k="source:datetime" v="2017-11-30T17:17:28Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="1020" timestamp="2018-01-10T18:15:58Z" version="1" changeset="14855">
         <nd ref="6073"/>
@@ -521,16 +537,17 @@
         <nd ref="6075"/>
         <nd ref="6076"/>
         <nd ref="6073"/>
-        <tag k="width" v="13"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="height" v="18"/>
-        <tag k="length" v="82"/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{95d410fa-03c8-43ec-be57-d7b8a9b77a5c};{dd6777ab-6799-4de9-83bb-91cf06e03851}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2017-11-30T17:17:27Z;2011-04-10T20:41:18.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="width" v="13"/>
+        <tag k="height" v="18"/>
+        <tag k="condition" v="functional"/>
+        <tag k="length" v="82"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="1021" timestamp="2018-01-10T18:15:58Z" version="1" changeset="14855">
         <nd ref="6077"/>
@@ -538,16 +555,17 @@
         <nd ref="6079"/>
         <nd ref="6080"/>
         <nd ref="6077"/>
-        <tag k="width" v="13"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="height" v="31"/>
-        <tag k="length" v="76"/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{57627fc4-6008-4286-9a3a-8467af381fd9};{482cc2f0-ca65-492d-82b7-5ec566710974}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2017-11-30T17:17:27Z;2011-04-10T20:41:16.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="width" v="13"/>
+        <tag k="height" v="31"/>
+        <tag k="condition" v="functional"/>
+        <tag k="length" v="76"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="1172" timestamp="2018-01-10T18:15:58Z" version="1" changeset="14855">
         <nd ref="7104"/>
@@ -555,16 +573,17 @@
         <nd ref="7106"/>
         <nd ref="7107"/>
         <nd ref="7104"/>
-        <tag k="width" v="14"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="height" v="20"/>
-        <tag k="length" v="66"/>
-        <tag k="building" v="yes"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{2ed42705-af19-4a1b-a4cc-dadd1426ea99};{684a005b-6502-4da3-ad3e-2ac65fd38b4f}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2017-11-30T17:17:27Z;2014-06-28T07:48:10.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="width" v="14"/>
+        <tag k="height" v="20"/>
+        <tag k="condition" v="functional"/>
+        <tag k="length" v="66"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-369579" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5" role="outer"/>
@@ -575,47 +594,48 @@
     <relation visible="true" id="-369578" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2" role="reviewee"/>
         <member type="way" ref="-16" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Building"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Unmatched buildings are overlapping."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Unmatched buildings are overlapping."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-369576" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-5" role="outer"/>
         <member type="way" ref="-4" role="outer"/>
-	<member type="relation" ref="-369579" role="outline"/>
-        <tag k="width" v="45"/>
-        <tag k="condition" v="functional"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="height" v="20"/>
-        <tag k="length" v="75"/>
-        <tag k="building" v="yes"/>
+        <member type="relation" ref="-369579" role="outline"/>
         <tag k="source" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="uuid" v="{824d0dbe-ec1e-4a8f-bcbb-23ff49fe548a};{873e78a6-303a-4493-ae45-cb3a1bc26592}"/>
-        <tag k="attribution" v="osm"/>
+        <tag k="building" v="yes"/>
         <tag k="source:datetime" v="2017-11-30T17:17:27Z;2014-06-28T07:50:34.000Z"/>
-        <tag k="type" v="multipolygon"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="width" v="45"/>
+        <tag k="height" v="20"/>
+        <tag k="condition" v="functional"/>
+        <tag k="length" v="75"/>
         <tag k="error:circular" v="15"/>
+        <tag k="type" v="multipolygon"/>
     </relation>
     <relation visible="true" id="-369575" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="751" role="outer"/>
         <member type="way" ref="748" role="inner"/>
-	<member type="way" ref="751" role="outline"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name:ru" v="Научно-исследовательский институт кинематографа"/>
-        <tag k="name:ko" v="영화과학연구소"/>
-        <tag k="building" v="yes"/>
+        <member type="way" ref="751" role="outline"/>
         <tag k="source" v="osm"/>
-        <tag k="uuid" v="{5f03b739-5b66-4ae6-ac78-2e2b7b0a2041}"/>
+        <tag k="amenity" v="public_building"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="name" v="영화과학연구소"/>
         <tag k="office" v="research"/>
-        <tag k="amenity" v="public_building"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="source:datetime" v="2015-05-14T11:24:43.000Z"/>
+        <tag k="name:ko" v="영화과학연구소"/>
         <tag k="name:en" v="Cinematography Science Research"/>
+        <tag k="uuid" v="{5f03b739-5b66-4ae6-ac78-2e2b7b0a2041}"/>
+        <tag k="name:ru" v="Научно-исследовательский институт кинематографа"/>
+        <tag k="building" v="yes"/>
+        <tag k="source:datetime" v="2015-05-14T11:24:43.000Z"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
         <tag k="type" v="multipolygon"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/highway-5534/Expected.osm
+++ b/test-files/cases/unifying/highway-5534/Expected.osm
@@ -6,33 +6,33 @@
     <way visible="true" id="-2786416" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2786411"/>
         <nd ref="-2786412"/>
-        <tag k="ref:road:type" v="road"/>
-        <tag k="source" v="tdsv40;nfdd"/>
-        <tag k="condition" v="functional"/>
-        <tag k="oneway" v="no"/>
-        <tag k="security:dissemination_control:non_ic" v="DS"/>
         <tag k="security:resource_owner" v="USA;United States"/>
+        <tag k="surface" v="flexible_pavement"/>
+        <tag k="layer" v="0"/>
+        <tag k="cartographic_scale:lower" v="25000"/>
         <tag k="seasonal" v="fair"/>
         <tag k="in_tunnel" v="no"/>
-        <tag k="layer" v="0"/>
-        <tag k="surface" v="flexible_pavement"/>
-        <tag k="incline:interval:closure" v="closed_interval"/>
-        <tag k="cartographic_scale:upper" v="1"/>
-        <tag k="attribution" v="u.s._national_geospatial-intelligence_agency_(nga);usNationalGeoIntelAgency"/>
-        <tag k="cartographic_scale:lower" v="25000"/>
-        <tag k="source:ingest:datetime" v="2015-03-26T17:44:15.935Z"/>
-        <tag k="divider" v="no"/>
+        <tag k="condition" v="functional"/>
         <tag k="security:classification" v="U;unclassified"/>
-        <tag k="median:interval:closure" v="closed_interval"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="length" v="165.74065410260101"/>
-        <tag k="uuid" v="{877fe7a8-7a12-4bcc-b2e0-f18802af3495};{2c5fb14a-730a-4a96-b809-ef1e93f516ec}"/>
-        <tag k="on_bridge" v="no"/>
         <tag k="etds:link_id" v="2C5FB14A-730A-4A96-B809-EF1E93F516EC"/>
-        <tag k="ref:road_class" v="local"/>
-        <tag k="location" v="surface"/>
-        <tag k="security:non_ic_dissemination_control" v="limited_distribution"/>
-        <tag k="ref:road:class" v="local"/>
         <tag k="error:circular" v="15"/>
+        <tag k="length" v="165.74065410260101"/>
+        <tag k="median:interval:closure" v="closed_interval"/>
+        <tag k="ref:road:type" v="road"/>
+        <tag k="security:dissemination_control:non_ic" v="DS"/>
+        <tag k="ref:road_class" v="local"/>
+        <tag k="uuid" v="{877fe7a8-7a12-4bcc-b2e0-f18802af3495};{2c5fb14a-730a-4a96-b809-ef1e93f516ec}"/>
+        <tag k="divider" v="no"/>
+        <tag k="on_bridge" v="no"/>
+        <tag k="ref:road:class" v="local"/>
+        <tag k="attribution" v="u.s._national_geospatial-intelligence_agency_(nga);usNationalGeoIntelAgency"/>
+        <tag k="oneway" v="no"/>
+        <tag k="cartographic_scale:upper" v="1"/>
+        <tag k="security:non_ic_dissemination_control" v="limited_distribution"/>
+        <tag k="source:ingest:datetime" v="2015-03-26T17:44:15.935Z"/>
+        <tag k="location" v="surface"/>
+        <tag k="incline:interval:closure" v="closed_interval"/>
+        <tag k="source" v="tdsv40;nfdd"/>
+        <tag k="highway" v="secondary"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/highway-578/Expected.osm
+++ b/test-files/cases/unifying/highway-578/Expected.osm
@@ -22,11 +22,13 @@
         <nd ref="-81157"/>
         <nd ref="-81155"/>
         <tag k="highway" v="footway"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81188" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-81154"/>
         <nd ref="-81181"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81187" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-81181"/>
@@ -38,11 +40,13 @@
         <nd ref="-80970"/>
         <nd ref="-81158"/>
         <tag k="highway" v="footway"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81183" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-81178"/>
         <nd ref="-80971"/>
         <tag k="highway" v="track"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81182" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-80970"/>
@@ -55,11 +59,13 @@
         <nd ref="-77527"/>
         <nd ref="-81163"/>
         <tag k="highway" v="secondary"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81178" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77529"/>
         <nd ref="-81175"/>
         <tag k="highway" v="primary"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-81177" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-81175"/>
@@ -71,10 +77,12 @@
         <nd ref="-81160"/>
         <nd ref="-81161"/>
         <tag k="highway" v="footway"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-77537" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77531"/>
         <nd ref="-77533"/>
         <tag k="highway" v="primary"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/highway-662/Expected.osm
+++ b/test-files/cases/unifying/highway-662/Expected.osm
@@ -7,14 +7,15 @@
     <way visible="true" id="-99162" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-99147"/>
         <nd ref="-99141"/>
-        <tag k="note" v="2c;2a"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="2c;2a"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-99159" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-99141"/>
         <nd ref="-99148"/>
-        <tag k="note" v="2a"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="2a"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/highway-search-radius-1/Expected.osm
+++ b/test-files/cases/unifying/highway-search-radius-1/Expected.osm
@@ -1,75 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="0.00318231145" minlon="-7.625760999999989e-05" maxlat="0.00641527647" maxlon="0.005985084699999999"/>
+    <bounds minlat="0.00318231145" minlon="-7.625760999999989e-5" maxlat="0.00641527647" maxlon="0.005985084699999999"/>
     <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0033548285096528" lon="0.0059647944607357"/>
     <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0051235458882351" lon="0.0005717796483473"/>
     <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0060751017000000" lon="-0.0000762576100000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0051170997300000" lon="0.0002994294300000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0031823114500000" lon="0.0007064237300000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062253765200000" lon="0.0031327359200000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0052673745500000" lon="0.0035084229600000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042530195300000" lon="0.0037338351900000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0033325862700000" lon="0.0039154172600000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062036877700000" lon="0.0049582067700000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0033108975200000" lon="0.0057408881200000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062560189900000" lon="0.0051956993100000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0053062438800000" lon="0.0055501363700000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0042407229600000" lon="0.0057909797300000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032514137400000" lon="0.0059850847000000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0064152764700000" lon="0.0034558457500000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0054333030000000" lon="0.0037660100600000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0043677820700000" lon="0.0040068534200000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0033784728500000" lon="0.0042009583900000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0062191150700000" lon="0.0006813779300000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0052548516500000" lon="0.0005686718200000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0041966664700000" lon="0.0005937176200000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0032073572500000" lon="0.0007878225900000">
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <way visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-114"/>
         <nd ref="-141"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-141"/>
@@ -83,18 +105,21 @@
         <nd ref="-53"/>
         <nd ref="-126"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-129"/>
         <nd ref="-128"/>
         <nd ref="-137"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-137"/>
         <nd ref="-56"/>
         <nd ref="-58"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-53"/>
@@ -109,6 +134,7 @@
         <nd ref="-123"/>
         <nd ref="-122"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-90"/>
@@ -116,5 +142,6 @@
         <nd ref="-92"/>
         <nd ref="-93"/>
         <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-1/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-1/Expected.osm
@@ -11,21 +11,21 @@
         <nd ref="-18109"/>
         <nd ref="-18110"/>
         <nd ref="-18107"/>
-        <tag k="REF1" v="00011f"/>
-        <tag k="building:levels" v="2"/>
-        <tag k="roof:shape" v="flat"/>
-        <tag k="REF2" v="00011f"/>
         <tag k="source:name" v="IDP/City Graphic"/>
-        <tag k="condition" v="functional"/>
+        <tag k="building:levels" v="2"/>
         <tag k="hoot:poipolygon:poismerged" v="2"/>
-        <tag k="height" v="9"/>
-        <tag k="security:classification" v="unclassified"/>
-        <tag k="operational_status" v="operational"/>
-        <tag k="building" v="yes"/>
-        <tag k="source:res_owner" v="USA"/>
-        <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
         <tag k="amenity" v="police"/>
+        <tag k="roof:shape" v="flat"/>
+        <tag k="security:non_ic_dissem_ctl" v="limited_distribution"/>
+        <tag k="security:classification" v="unclassified"/>
+        <tag k="source:res_owner" v="USA"/>
+        <tag k="building" v="yes"/>
+        <tag k="operational_status" v="operational"/>
+        <tag k="REF1" v="00011f"/>
         <tag k="attribution" v="usNationalGeoIntelAgency"/>
+        <tag k="REF2" v="00011f"/>
+        <tag k="height" v="9"/>
+        <tag k="condition" v="functional"/>
         <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-10/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-10/Expected.osm
@@ -64,14 +64,14 @@
         <nd ref="-61611"/>
         <nd ref="-61609"/>
         <nd ref="795"/>
-        <tag k="addr:full" v="8070 S BLACKSTONE PKWY"/>
-        <tag k="addr:street" v="S BLACKSTONE PKWY"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="height" v="37"/>
-        <tag k="addr:city" v="AURORA"/>
-        <tag k="building" v="Residential"/>
-        <tag k="addr:housenumber" v="8070"/>
+        <tag k="addr:street" v="S BLACKSTONE PKWY"/>
         <tag k="addr:postcode" v="80016"/>
+        <tag k="building" v="Residential"/>
+        <tag k="addr:city" v="AURORA"/>
+        <tag k="addr:housenumber" v="8070"/>
+        <tag k="addr:full" v="8070 S BLACKSTONE PKWY"/>
+        <tag k="height" v="37"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="122" timestamp="2017-10-22T16:59:54Z" version="1" changeset="186">
@@ -88,15 +88,15 @@
         <nd ref="702"/>
         <nd ref="701"/>
         <nd ref="712"/>
-        <tag k="addr:full" v="8050 S BLACKSTONE PKWY"/>
-        <tag k="addr:street" v="S BLACKSTONE PKWY"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="height" v="37"/>
-        <tag k="addr:city" v="AURORA"/>
-        <tag k="building" v="Residential"/>
-        <tag k="addr:housenumber" v="8050"/>
-        <tag k="source:datetime" v="2017-10-22T16:59:54Z"/>
+        <tag k="addr:street" v="S BLACKSTONE PKWY"/>
         <tag k="addr:postcode" v="80016"/>
+        <tag k="building" v="Residential"/>
+        <tag k="addr:city" v="AURORA"/>
+        <tag k="source:datetime" v="2017-10-22T16:59:54Z"/>
+        <tag k="addr:housenumber" v="8050"/>
+        <tag k="addr:full" v="8050 S BLACKSTONE PKWY"/>
+        <tag k="height" v="37"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="125" timestamp="2017-10-22T16:59:54Z" version="1" changeset="186">
@@ -120,15 +120,15 @@
         <nd ref="749"/>
         <nd ref="748"/>
         <nd ref="766"/>
-        <tag k="addr:full" v="8060 S BLACKSTONE PKWY"/>
-        <tag k="addr:street" v="S BLACKSTONE PKWY"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="height" v="32"/>
-        <tag k="addr:city" v="AURORA"/>
-        <tag k="building" v="Residential"/>
-        <tag k="addr:housenumber" v="8060"/>
-        <tag k="source:datetime" v="2017-10-22T16:59:54Z"/>
+        <tag k="addr:street" v="S BLACKSTONE PKWY"/>
         <tag k="addr:postcode" v="80016"/>
+        <tag k="building" v="Residential"/>
+        <tag k="addr:city" v="AURORA"/>
+        <tag k="source:datetime" v="2017-10-22T16:59:54Z"/>
+        <tag k="addr:housenumber" v="8060"/>
+        <tag k="addr:full" v="8060 S BLACKSTONE PKWY"/>
+        <tag k="height" v="32"/>
         <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-2/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-2/Expected.osm
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="0.004415911553967119" minlon="5.97372708019433e-05" maxlat="0.006186612290206156" maxlon="0.001929360328719445"/>
+    <bounds minlat="0.004415911553967119" minlon="5.97372708019433e-5" maxlat="0.006186612290206156" maxlon="0.001929360328719445"/>
     <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0061462428029057" lon="0.0000597372708019">
-        <tag k="poi" v="yes"/>
-        <tag k="uuid" v="E"/>
         <tag k="name" v="foo"/>
+        <tag k="uuid" v="E"/>
+        <tag k="poi" v="yes"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0061590821735556" lon="0.0001431008508867"/>
     <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0061866122902062" lon="0.0018705944176551"/>
@@ -16,19 +17,20 @@
         <nd ref="-18"/>
         <nd ref="-16"/>
         <nd ref="-22"/>
-        <tag k="building" v="yes"/>
-        <tag k="uuid" v="B;D"/>
         <tag k="name" v="foo"/>
+        <tag k="uuid" v="B;D"/>
+        <tag k="building" v="yes"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-23" role="reviewee"/>
         <member type="way" ref="-26" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (11m; score: 2/2), type: no (score: 0/1), name: yes (score: 1/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (11m; score: 2/2), type: no (score: 0/1), name: yes (score: 1/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-3/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-3/Expected.osm
@@ -8,8 +8,9 @@
     <node visible="true" id="-24971" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3490478039999517" lon="42.5514396970000348"/>
     <node visible="true" id="-24970" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3490852669999641" lon="42.5516078410000773"/>
     <node visible="true" id="-24966" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3492685831374159" lon="42.5515572110446385">
-        <tag k="man_made" v="tower"/>
         <tag k="uuid" v="b"/>
+        <tag k="man_made" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <way visible="true" id="-24971" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-24975"/>
@@ -20,19 +21,20 @@
         <nd ref="-24970"/>
         <nd ref="-24975"/>
         <tag k="hoot:poipolygon:poismerged" v="2"/>
-        <tag k="building" v="mosque"/>
-        <tag k="uuid" v="c;a;d"/>
         <tag k="amenity" v="place_of_worship"/>
+        <tag k="uuid" v="c;a;d"/>
+        <tag k="building" v="mosque"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-24966" role="reviewee"/>
         <member type="way" ref="-24971" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-4/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-4/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="-0.3616716205538067" minlon="42.55135990104369" maxlat="-0.3614845364747481" maxlon="42.55153441226798"/>
     <node visible="true" id="-1149303" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3616647473931919" lon="42.5514026487499279">
-        <tag k="man_made" v="tower"/>
         <tag k="uuid" v="B"/>
+        <tag k="man_made" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-1149299" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3614845364747481" lon="42.5513694564133402"/>
     <node visible="true" id="-1149297" timestamp="1970-01-01T00:00:00Z" version="1" lat="-0.3614935889301875" lon="42.5515344122679835"/>
@@ -17,19 +18,20 @@
         <nd ref="-1149291"/>
         <nd ref="-1149293"/>
         <nd ref="-1149299"/>
-        <tag k="building" v="mosque"/>
-        <tag k="uuid" v="A;C"/>
         <tag k="amenity" v="place_of_worship"/>
+        <tag k="uuid" v="A;C"/>
+        <tag k="building" v="mosque"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-1149303" role="reviewee"/>
         <member type="way" ref="-1149301" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-5/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-5/Expected.osm
@@ -11,8 +11,9 @@
         <nd ref="-25973"/>
         <nd ref="-25974"/>
         <nd ref="-25971"/>
-        <tag k="note" v="building;POI"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
+        <tag k="note" v="building;POI"/>
         <tag k="building" v="yes"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-6/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-6/Expected.osm
@@ -12,17 +12,20 @@
         <nd ref="-377374"/>
         <nd ref="-377376"/>
         <nd ref="-377363"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-377372" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-377374"/>
         <nd ref="-377370"/>
         <nd ref="-377368"/>
         <nd ref="-377366"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-377365" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-377363"/>
         <nd ref="-377364"/>
         <nd ref="-377366"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-377415" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-377372" role="outer"/>
@@ -31,6 +34,7 @@
         <tag k="hoot:poipolygon:poismerged" v="1"/>
         <tag k="note" v="POI"/>
         <tag k="building" v="yes"/>
+        <tag k="error:circular" v="15"/>
         <tag k="type" v="multipolygon"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-7/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-7/Expected.osm
@@ -39,16 +39,16 @@
         <nd ref="-461567"/>
         <nd ref="-461568"/>
         <nd ref="-461560"/>
-        <tag k="REF1" v="009cdc"/>
-        <tag k="REF2" v="009cdc"/>
-        <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="hoot:mismatch" v="1"/>
         <tag k="hoot:status" v="3"/>
+        <tag k="hoot:poipolygon:poismerged" v="1"/>
+        <tag k="name" v="Pier 35"/>
+        <tag k="uuid" v="{f5cb9318-6902-464a-86fb-54bf5779bbb4};{4a6e0f71-9db8-49f1-8238-04dcd019aeea}"/>
         <tag k="alt_name" v="PIER 35"/>
         <tag k="building" v="yes"/>
-        <tag k="uuid" v="{f5cb9318-6902-464a-86fb-54bf5779bbb4};{4a6e0f71-9db8-49f1-8238-04dcd019aeea}"/>
+        <tag k="hoot:mismatch" v="1"/>
+        <tag k="REF1" v="009cdc"/>
+        <tag k="REF2" v="009cdc"/>
         <tag k="hoot:wrong" v="1"/>
-        <tag k="name" v="Pier 35"/>
         <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-8/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-8/Expected.osm
@@ -28,9 +28,10 @@
         <nd ref="-1148841"/>
         <nd ref="-1148836"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="created_by" v="Potlatch 0.10f"/>
-        <tag k="operator" v="San Francisco Unified School District"/>
-        <tag k="name" v="Hilltop Special Services Center"/>
         <tag k="amenity" v="school"/>
+        <tag k="created_by" v="Potlatch 0.10f"/>
+        <tag k="name" v="Hilltop Special Services Center"/>
+        <tag k="operator" v="San Francisco Unified School District"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-9/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-9/Expected.osm
@@ -201,10 +201,10 @@
         <nd ref="-2861739"/>
         <nd ref="-2861737"/>
         <nd ref="-2861929"/>
-        <tag k="leisure" v="park"/>
-        <tag k="uuid" v="b"/>
         <tag k="area" v="yes"/>
         <tag k="name" v="Buena Vista Park"/>
+        <tag k="uuid" v="b"/>
+        <tag k="leisure" v="park"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2861953" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -214,10 +214,10 @@
         <nd ref="-2861729"/>
         <nd ref="-2861735"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="leisure" v="pitch"/>
-        <tag k="uuid" v="a;c"/>
         <tag k="name" v="Buena Vista Park Tennis Courts"/>
+        <tag k="uuid" v="a;c"/>
         <tag k="sport" v="tennis"/>
+        <tag k="leisure" v="pitch"/>
         <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-1/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-1/Expected.osm
@@ -2,12 +2,14 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74042059716" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404205971600035" lon="-77.5819958773300016">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85811" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404049064499958" lon="-77.5819851484899914">
-        <tag k="name" v="poi2"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -27,29 +29,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85811" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-10/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-10/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563418999" minlon="-77.58212998777999" maxlat="38.74061306795999" maxlon="-77.58176788755"/>
     <node visible="true" id="-85929" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403855545699898" lon="-77.5821299877799930">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85928" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405586736499927" lon="-77.5819683826699986"/>
     <node visible="true" id="-85926" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405435059899901" lon="-77.5819207734599985"/>
@@ -31,8 +32,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -44,29 +46,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85917" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-11/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-11/Expected.osm
@@ -27,8 +27,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -41,8 +42,9 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi1"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-12/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-12/Expected.osm
@@ -27,8 +27,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -40,10 +41,11 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="alt_types" v="amenity=theatre"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi1"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_types" v="amenity=theatre"/>
+        <tag k="alt_name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-13/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-13/Expected.osm
@@ -4,24 +4,24 @@
     <node visible="true" id="-88127" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7698899390499960" lon="-122.4293803842399910"/>
     <node visible="true" id="-88116" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7696630407699985" lon="-122.4290196842400036"/>
     <node visible="true" id="-87923" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7698981389900013" lon="-122.4292103842399797">
-        <tag k="REF1" v="0011e0"/>
-        <tag k="addr:street" v="Duboce Avenue"/>
-        <tag k="social_facility:for" v="aids"/>
-        <tag k="name" v="Maitri AIDS hospice"/>
         <tag k="amenity" v="social_facility"/>
+        <tag k="addr:street" v="Duboce Avenue"/>
+        <tag k="name" v="Maitri AIDS hospice"/>
+        <tag k="social_facility:for" v="aids"/>
+        <tag k="REF1" v="0011e0"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-87921" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7699587385300006" lon="-122.4291477842400013">
-        <tag k="REF1" v="000d15"/>
-        <tag k="name" v="Duboce &amp; Church"/>
-        <tag k="local_ref" v="N Judah"/>
         <tag k="highway" v="bus_stop"/>
+        <tag k="local_ref" v="N Judah"/>
+        <tag k="name" v="Duboce &amp; Church"/>
+        <tag k="REF1" v="000d15"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-87865" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7699064389300005" lon="-122.4290384842399817">
-        <tag k="REF1" v="002e73"/>
         <tag k="addr:street" v="Church Street"/>
         <tag k="shop" v="thift_store"/>
+        <tag k="REF1" v="002e73"/>
         <tag k="addr:housenumber" v="100"/>
         <tag k="error:circular" v="15"/>
     </node>
@@ -33,30 +33,30 @@
         <nd ref="-88127"/>
         <nd ref="-87923"/>
         <nd ref="-87865"/>
-        <tag k="REF1" v="009253"/>
         <tag k="building" v="yes"/>
+        <tag k="REF1" v="009253"/>
         <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-87923" role="reviewee"/>
         <member type="way" ref="-87948" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-87865" role="reviewee"/>
         <member type="way" ref="-87948" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-14/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-14/Expected.osm
@@ -4,24 +4,24 @@
     <node visible="true" id="-88127" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7698899390499960" lon="-122.4293803842399910"/>
     <node visible="true" id="-88116" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7696630407699985" lon="-122.4290196842400036"/>
     <node visible="true" id="-87923" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7698981389900013" lon="-122.4292103842399797">
-        <tag k="REF1" v="0011e0"/>
-        <tag k="addr:street" v="Duboce Avenue"/>
-        <tag k="social_facility:for" v="aids"/>
-        <tag k="name" v="Maitri AIDS hospice"/>
         <tag k="amenity" v="social_facility"/>
+        <tag k="addr:street" v="Duboce Avenue"/>
+        <tag k="name" v="Maitri AIDS hospice"/>
+        <tag k="social_facility:for" v="aids"/>
+        <tag k="REF1" v="0011e0"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-87921" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7699587385300006" lon="-122.4291477842400013">
-        <tag k="REF1" v="000d15"/>
-        <tag k="name" v="Duboce &amp; Church"/>
-        <tag k="local_ref" v="N Judah"/>
         <tag k="highway" v="bus_stop"/>
+        <tag k="local_ref" v="N Judah"/>
+        <tag k="name" v="Duboce &amp; Church"/>
+        <tag k="REF1" v="000d15"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-87865" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7699064389300005" lon="-122.4290384842399817">
-        <tag k="REF1" v="002e73"/>
         <tag k="addr:street" v="Church Street"/>
         <tag k="shop" v="thift_store"/>
+        <tag k="REF1" v="002e73"/>
         <tag k="addr:housenumber" v="100"/>
         <tag k="error:circular" v="15"/>
     </node>
@@ -33,30 +33,30 @@
         <nd ref="-88127"/>
         <nd ref="-87923"/>
         <nd ref="-87865"/>
-        <tag k="REF1" v="009253"/>
         <tag k="building" v="yes"/>
+        <tag k="REF1" v="009253"/>
         <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-87923" role="reviewee"/>
         <member type="way" ref="-87948" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-87865" role="reviewee"/>
         <member type="way" ref="-87948" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 2, which is less than the required score of 3. Matches: distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-2/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-2/Expected.osm
@@ -19,11 +19,11 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="alt_types" v="alt_types=amenity=theatre;amenity=community_centre"/>
         <tag k="hoot:poipolygon:poismerged" v="2"/>
         <tag k="amenity" v="arts_centre"/>
         <tag k="name" v="poly1"/>
         <tag k="alt_types" v="amenity=theatre;amenity=community_centre"/>
         <tag k="alt_name" v="poi1;poi2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-3/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-3/Expected.osm
@@ -2,12 +2,14 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74051683341" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405168334099983" lon="-77.5820454981899985">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85811" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404619160000010" lon="-77.5820193466500001">
-        <tag k="name" v="poi2"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -27,29 +29,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85811" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-4/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-4/Expected.osm
@@ -2,12 +2,14 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74051683341" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405168334099983" lon="-77.5820454981899985">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85811" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404619160000010" lon="-77.5820193466500001">
-        <tag k="name" v="poi2"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -27,29 +29,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85811" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-5/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-5/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74045425152" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404542515199992" lon="-77.5820248521099955">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284699954" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -24,19 +25,20 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi2"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-6/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-6/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74045425152" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404542515199992" lon="-77.5820248521099955">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284699954" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -23,21 +24,22 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="alt_types" v="amenity=theatre"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi2"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_types" v="amenity=theatre"/>
+        <tag k="alt_name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-7/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-7/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74022173723999" minlon="-77.58210987120999" maxlat="38.74060300360999" maxlon="-77.58177304884001"/>
     <node visible="true" id="-88415" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404147412699871" lon="-77.5819209555199905">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-88414" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405486092900020" lon="-77.5819735439600038"/>
     <node visible="true" id="-88412" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405334416299993" lon="-77.5819259347500036"/>
@@ -31,8 +32,9 @@
         <nd ref="-88412"/>
         <nd ref="-88414"/>
         <nd ref="-88400"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-88416" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-88384"/>
@@ -44,29 +46,30 @@
         <nd ref="-88396"/>
         <nd ref="-88398"/>
         <nd ref="-88384"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-88415" role="reviewee"/>
         <member type="way" ref="-88416" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-88415" role="reviewee"/>
         <member type="way" ref="-88418" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-8/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-8/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74023326560999" minlon="-77.58210552410999" maxlat="38.74060300361" maxlon="-77.58177304884001"/>
     <node visible="true" id="-88690" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404147412699942" lon="-77.5819209555199905">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-88689" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405486092900020" lon="-77.5819735439600038"/>
     <node visible="true" id="-88687" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405334416299993" lon="-77.5819259347500036"/>
@@ -31,8 +32,9 @@
         <nd ref="-88687"/>
         <nd ref="-88689"/>
         <nd ref="-88675"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-88691" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-88659"/>
@@ -44,29 +46,30 @@
         <nd ref="-88671"/>
         <nd ref="-88673"/>
         <nd ref="-88659"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-88690" role="reviewee"/>
         <member type="way" ref="-88691" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-88690" role="reviewee"/>
         <member type="way" ref="-88693" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-9/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-auto-merge-9/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563418999" minlon="-77.58212998777999" maxlat="38.74061306795999" maxlon="-77.58176788755"/>
     <node visible="true" id="-85929" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403855545699898" lon="-77.5821299877799930">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85928" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405586736499927" lon="-77.5819683826699986"/>
     <node visible="true" id="-85926" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405435059899901" lon="-77.5819207734599985"/>
@@ -31,8 +32,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -44,29 +46,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85917" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-1/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-1/Expected.osm
@@ -2,12 +2,14 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74042059716" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404205971600035" lon="-77.5819958773300016">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85811" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404049064499958" lon="-77.5819851484899914">
-        <tag k="name" v="poi2"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -27,29 +29,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85811" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-10/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-10/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563418999" minlon="-77.58212998777999" maxlat="38.74061306795999" maxlon="-77.58176788755"/>
     <node visible="true" id="-85929" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403855545699898" lon="-77.5821299877799930">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85928" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405586736499927" lon="-77.5819683826699986"/>
     <node visible="true" id="-85926" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405435059899901" lon="-77.5819207734599985"/>
@@ -31,8 +32,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -44,18 +46,19 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-11/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-11/Expected.osm
@@ -27,8 +27,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -41,8 +42,9 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi1"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-12/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-12/Expected.osm
@@ -27,8 +27,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -41,8 +42,9 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi1"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-2/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-2/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74042059716" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404205971600035" lon="-77.5819958773300016">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -24,8 +25,9 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi2"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-3/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-3/Expected.osm
@@ -2,12 +2,14 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74051683341" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405168334099983" lon="-77.5820454981899985">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85811" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404619160000010" lon="-77.5820193466500001">
-        <tag k="name" v="poi2"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -27,29 +29,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85811" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-4/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-4/Expected.osm
@@ -2,12 +2,14 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74051683341" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405168334099983" lon="-77.5820454981899985">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85811" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404619160000010" lon="-77.5820193466500001">
-        <tag k="name" v="poi2"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284700096" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -27,18 +29,19 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85811" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-5/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-5/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74045425152" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404542515199992" lon="-77.5820248521099955">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284699954" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -24,19 +25,20 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi2"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85812" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-6/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-6/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563419" minlon="-77.58210987120999" maxlat="38.74045425152" maxlon="-77.58186579018999"/>
     <node visible="true" id="-85812" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404542515199992" lon="-77.5820248521099955">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85810" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403395284699954" lon="-77.5820696380699957"/>
     <node visible="true" id="-85808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403269758899924" lon="-77.5820106294799814"/>
@@ -24,8 +25,9 @@
         <nd ref="-85810"/>
         <nd ref="-85797"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi2"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-7/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-7/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74022173723999" minlon="-77.58210987120999" maxlat="38.74060300360999" maxlon="-77.58177304884001"/>
     <node visible="true" id="-88415" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7404147412699871" lon="-77.5819209555199905">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-88414" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405486092900020" lon="-77.5819735439600038"/>
     <node visible="true" id="-88412" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405334416299993" lon="-77.5819259347500036"/>
@@ -31,8 +32,9 @@
         <nd ref="-88412"/>
         <nd ref="-88414"/>
         <nd ref="-88400"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-88416" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-88384"/>
@@ -44,29 +46,30 @@
         <nd ref="-88396"/>
         <nd ref="-88398"/>
         <nd ref="-88384"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-88415" role="reviewee"/>
         <member type="way" ref="-88416" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-88415" role="reviewee"/>
         <member type="way" ref="-88418" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-8/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-8/Expected.osm
@@ -27,8 +27,9 @@
         <nd ref="-88687"/>
         <nd ref="-88689"/>
         <nd ref="-88675"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-88691" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-88659"/>
@@ -41,8 +42,9 @@
         <nd ref="-88673"/>
         <nd ref="-88659"/>
         <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="alt_name" v="poi1"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="alt_name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-9/Expected.osm
+++ b/test-files/cases/unifying/poi-polygon/poi-polygon-keep-closest-match-only-9/Expected.osm
@@ -2,8 +2,9 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.74020563418999" minlon="-77.58212998777999" maxlat="38.74061306795999" maxlon="-77.58176788755"/>
     <node visible="true" id="-85929" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7403855545699898" lon="-77.5821299877799930">
-        <tag k="name" v="poi1"/>
         <tag k="amenity" v="theatre"/>
+        <tag k="name" v="poi1"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-85928" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405586736499927" lon="-77.5819683826699986"/>
     <node visible="true" id="-85926" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.7405435059899901" lon="-77.5819207734599985"/>
@@ -31,8 +32,9 @@
         <nd ref="-85926"/>
         <nd ref="-85928"/>
         <nd ref="-85915"/>
-        <tag k="name" v="poly2"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly2"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-85799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-85797"/>
@@ -44,29 +46,30 @@
         <nd ref="-85808"/>
         <nd ref="-85810"/>
         <nd ref="-85797"/>
-        <tag k="name" v="poly1"/>
         <tag k="amenity" v="arts_centre"/>
+        <tag k="name" v="poly1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85799" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-85929" role="reviewee"/>
         <member type="way" ref="-85917" role="reviewee"/>
-        <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
         <tag k="hoot:review:sort_order" v="1"/>
+        <tag k="hoot:review:note" v="Features had an additive similarity score of 1, which is less than the required score of 3. Matches: distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, max distance allowed for review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
 </osm>

--- a/test-files/cases/unifying/stadium-1/Expected.osm
+++ b/test-files/cases/unifying/stadium-1/Expected.osm
@@ -11,9 +11,10 @@
         <nd ref="-688916"/>
         <nd ref="-688918"/>
         <nd ref="-688912"/>
-        <tag k="leisure" v="stadium"/>
-        <tag k="building" v="yes"/>
-        <tag k="uuid" v="A;B"/>
         <tag k="name" v="Broncos"/>
+        <tag k="uuid" v="A;B"/>
+        <tag k="building" v="yes"/>
+        <tag k="leisure" v="stadium"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>


### PR DESCRIPTION
Since the `vases` don't compare the files byte-by-byte but compares them using `TestUtils::compareMaps` the `Expected.osm` files haven't been updated to the new tag ordering schema that came about with Qt5.  Comparing results when making changes is considerably harder when a strict `diff` shows changes that don't necessarily come from the current changes.  This will fix that problem in all of the `cases`.