### PR TITLE
Enable `reader.conflate.use.data.source.ids.2` for attribute conflation

### DIFF
--- a/conf/core/AttributeConflation.conf
+++ b/conf/core/AttributeConflation.conf
@@ -16,6 +16,7 @@
   "poi.polygon.allow.cross.conflation.merging": "true",
   "poi.polygon.auto.merge.many.poi.to.one.poly.matches": "true",
   "reader.conflate.use.data.source.ids.1": "false",
+  "reader.conflate.use.data.source.ids.2": "true",
   "remove.elements.visitor.chain.element.criteria": "false",
   "remove.elements.visitor.element.criteria": "hoot::TagKeyCriterion;hoot::ReviewRelationCriterion",
   "remove.elements.visitor.recursive": "false",

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -31,24 +31,24 @@
 #include <geos/geom/GeometryFactory.h>
 
 // Hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/conflate/stats/ConflateStatsHelper.h>
+#include <hoot/core/conflate/DiffConflator.h>
 #include <hoot/core/conflate/UnifyingConflator.h>
+#include <hoot/core/conflate/stats/ConflateStatsHelper.h>
 #include <hoot/core/criterion/StatusCriterion.h>
-#include <hoot/core/io/MapStatsWriter.h>
-#include <hoot/core/ops/CalculateStatsOp.h>
-#include <hoot/core/ops/NamedOp.h>
 #include <hoot/core/info/IoSingleStat.h>
-#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/io/MapStatsWriter.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/io/OsmXmlWriter.h>
-#include <hoot/core/util/Log.h>
+#include <hoot/core/ops/CalculateStatsOp.h>
+#include <hoot/core/ops/NamedOp.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/IoUtils.h>
-#include <hoot/core/conflate/DiffConflator.h>
-#include <hoot/core/visitors/CountUniqueReviewsVisitor.h>
-#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/Progress.h>
+#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/CountUniqueReviewsVisitor.h>
 
 // Standard
 #include <fstream>
@@ -184,32 +184,60 @@ int ConflateCmd::runSimple(QStringList args)
   }
   int currentTask = 1;
 
-  // read input 1
-  progress.set(
-    _getJobPercentComplete(currentTask - 1),
-    "Loading reference map: ..." + input1.right(maxFilePrintLength) + "...");
   OsmMapPtr map(new OsmMap());
-  IoUtils::loadMap(map, input1, ConfigOptions().getReaderConflateUseDataSourceIds1(),
-                   Status::Unknown1);
-  currentTask++;
-
   ChangesetProviderPtr pTagChanges;
-  if (isDiffConflate)
+
+  //  Loading order is important if datasource IDs 2 is true but 1 is not
+  if (!ConfigOptions().getReaderConflateUseDataSourceIds1() &&
+       ConfigOptions().getReaderConflateUseDataSourceIds2() &&
+      !isDiffConflate)
   {
-    // Store original IDs for tag diff
+    //  For Attribute conflation, the secondary IDs are the ones that we want
+    //  to preserve.  So loading them first allows for all of them to be loaded
+    //  without conflict, even if they are negative.  Then the reference dataset
+    //  is loaded with negative IDs
     progress.set(
-      _getJobPercentComplete(currentTask - 1), "Storing original features for tag differential...");
-    diffConflator.storeOriginalMap(map);
-    diffConflator.markInputElements(map);
+      _getJobPercentComplete(currentTask - 1),
+      "Loading secondary map: ..." + input2.right(maxFilePrintLength) + "...");
+    IoUtils::loadMap(
+      map, input2, ConfigOptions().getReaderConflateUseDataSourceIds2(), Status::Unknown2);
+    currentTask++;
+
+    // read input 1
+    progress.set(
+      _getJobPercentComplete(currentTask - 1),
+      "Loading reference map: ..." + input1.right(maxFilePrintLength) + "...");
+    IoUtils::loadMap(map, input1, ConfigOptions().getReaderConflateUseDataSourceIds1(),
+                     Status::Unknown1);
     currentTask++;
   }
+  else
+  {
+    // read input 1
+    progress.set(
+      _getJobPercentComplete(currentTask - 1),
+      "Loading reference map: ..." + input1.right(maxFilePrintLength) + "...");
+    IoUtils::loadMap(map, input1, ConfigOptions().getReaderConflateUseDataSourceIds1(),
+                     Status::Unknown1);
+    currentTask++;
 
-  progress.set(
-    _getJobPercentComplete(currentTask - 1),
-    "Loading secondary map: ..." + input2.right(maxFilePrintLength) + "...");
-  IoUtils::loadMap(
-    map, input2, ConfigOptions().getReaderConflateUseDataSourceIds2(), Status::Unknown2);
-  currentTask++;
+    if (isDiffConflate)
+    {
+      // Store original IDs for tag diff
+      progress.set(
+        _getJobPercentComplete(currentTask - 1), "Storing original features for tag differential...");
+      diffConflator.storeOriginalMap(map);
+      diffConflator.markInputElements(map);
+      currentTask++;
+    }
+
+    progress.set(
+      _getJobPercentComplete(currentTask - 1),
+      "Loading secondary map: ..." + input2.right(maxFilePrintLength) + "...");
+    IoUtils::loadMap(
+      map, input2, ConfigOptions().getReaderConflateUseDataSourceIds2(), Status::Unknown2);
+    currentTask++;
+  }
 
   double inputBytes = IoSingleStat(IoSingleStat::RChar).value - bytesRead;
   LOG_VART(inputBytes);

--- a/test-files/cases/attribute/network/highway-2888-reviews-by-score/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2888-reviews-by-score/Expected.osm
@@ -1,133 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="4.16848169976" minlon="73.50070843439001" maxlat="4.180162998169999" maxlon="73.51883655624"/>
-    <node visible="true" id="-1799" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1759623362674168" lon="73.5026682661406170">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1734" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1797596278676927" lon="73.5092299319423574">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1711" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1722668849725260" lon="73.5022735773988956">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1639" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1794516316119212" lon="73.5084169111925974">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1638" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1731848790157127" lon="73.5023748512333412">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1630" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1771946860820695" lon="73.5027896690011744">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1616" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1741055159683373" lon="73.5024536987735075">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1548" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1765731277000286" lon="73.5027313992581668">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1537" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1773921248794155" lon="73.5028062568999445">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1502" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1788151229388246" lon="73.5066593438483693">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1472" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1735120022629237" lon="73.5024061897148187">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1453" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1781489820082571" lon="73.5053707550013229">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1442" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1796333228133795" lon="73.5088970080014406">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1439" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1794882154148372" lon="73.5085157531500073">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1438" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1793132681347167" lon="73.5080400302208261">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1436" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1791930937874167" lon="73.5077117487793430">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1429" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1729158657953747" lon="73.5023381900521287">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1427" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1783177368545346" lon="73.5053392763576312">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1425" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1781977467585820" lon="73.5049945717283890">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1423" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1781064968203863" lon="73.5047228528450063">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1420" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1779904045813279" lon="73.5044293979169083">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1419" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1778830717608324" lon="73.5040982922900952">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1417" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1777918095419766" lon="73.5038347521338977">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1415" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1775794675366269" lon="73.5032664596243990">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1413" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1753475810404908" lon="73.5025942616264274">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1411" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1791302854033212" lon="73.5075411617840615">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1409" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1789568557056240" lon="73.5070544787504474">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1406" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1789052276953562" lon="73.5068962008104592">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1405" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1787822381640867" lon="73.5065746747084461">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1403" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1786646023994996" lon="73.5062753560929423">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1401" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1785597990613983" lon="73.5060255942155436">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1398" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1785557707136682" lon="73.5059509184540900">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1397" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1784529160037946" lon="73.5056584072197126">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1351" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1777234318313505" lon="73.5036540766527509">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1343" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1792447845698408" lon="73.5078353533348690">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1324" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1737192380212891" lon="73.5024189060423083">
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="amenity" v="police"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Police Station"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2014-10-08T02:06:40.000Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-    </node>
-    <node visible="true" id="-1287" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1780915598090109" lon="73.5059929203423366">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1260" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1747161081617534" lon="73.5025194898918670">
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-1251" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1776441109306344" lon="73.5034554893008902">
-        <tag k="hoot:status" v="2"/>
-    </node>
     <node visible="true" id="-1177" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1753916048199997" lon="73.5032219321300033">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -3659,7 +3532,178 @@
     <node visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717205287399990" lon="73.5031247058399941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-865" timestamp="2019-01-24T18:58:28Z" version="1">
+    <node visible="true" id="74" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1776441109306344" lon="73.5034554893008902">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="83" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1747161081617534" lon="73.5025194898918670">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="110" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1780915598090109" lon="73.5059929203423366">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="147" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1737192380212891" lon="73.5024189060423083">
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="amenity" v="police"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Police Station"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2014-10-08T02:06:40.000Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+    </node>
+    <node visible="true" id="166" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1792447845698408" lon="73.5078353533348690">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="174" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1777234318313505" lon="73.5036540766527509">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="220" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1784529160037946" lon="73.5056584072197126">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="221" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1785557707136682" lon="73.5059509184540900">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="224" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1785597990613983" lon="73.5060255942155436">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="226" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1786646023994996" lon="73.5062753560929423">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="228" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1787822381640867" lon="73.5065746747084461">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="229" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1789052276953562" lon="73.5068962008104592">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="232" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1789568557056240" lon="73.5070544787504474">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="234" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1791302854033212" lon="73.5075411617840615">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="236" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1753475810404908" lon="73.5025942616264274">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="238" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1775794675366269" lon="73.5032664596243990">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="240" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1777918095419766" lon="73.5038347521338977">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="242" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1778830717608324" lon="73.5040982922900952">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="243" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1779904045813279" lon="73.5044293979169083">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="246" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1781064968203863" lon="73.5047228528450063">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="248" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1781977467585820" lon="73.5049945717283890">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="250" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1783177368545346" lon="73.5053392763576312">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="252" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1729158657953747" lon="73.5023381900521287">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="259" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1791930937874167" lon="73.5077117487793430">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="261" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1793132681347167" lon="73.5080400302208261">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="262" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1794882154148372" lon="73.5085157531500073">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="265" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1796333228133795" lon="73.5088970080014406">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="276" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1781489820082571" lon="73.5053707550013229">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="295" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1735120022629237" lon="73.5024061897148187">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="325" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1788151229388246" lon="73.5066593438483693">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="360" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1773921248794155" lon="73.5028062568999445">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="371" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1765731277000286" lon="73.5027313992581668">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="439" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1741055159683373" lon="73.5024536987735075">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="453" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1771946860820695" lon="73.5027896690011744">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="461" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1731848790157127" lon="73.5023748512333412">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="462" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1794516316119212" lon="73.5084169111925974">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="534" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1722668849725260" lon="73.5022735773988956">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="557" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1797596278676927" lon="73.5092299319423574">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="622" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800" lat="4.1759623362674168" lon="73.5026682661406170">
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <way visible="true" id="-767" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-663"/>
+        <nd ref="-665"/>
+        <nd ref="-667"/>
+        <nd ref="-669"/>
+        <nd ref="-235"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="554.9"/>
+    </way>
+    <way visible="true" id="-764" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-323"/>
+        <nd ref="-673"/>
+        <nd ref="-674"/>
+        <nd ref="-675"/>
+        <nd ref="-661"/>
+        <nd ref="-662"/>
+        <nd ref="-663"/>
+        <nd ref="-672"/>
+        <nd ref="-319"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kandi Dhon Maniku Goalhi"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="557.8"/>
+    </way>
+    <way visible="true" id="-756" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-930"/>
         <nd ref="-929"/>
         <nd ref="-928"/>
@@ -3713,7 +3757,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="28910"/>
     </way>
-    <way visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-748" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-891"/>
         <nd ref="-890"/>
         <nd ref="-902"/>
@@ -3732,51 +3776,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141.5"/>
     </way>
-    <way visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-663"/>
-        <nd ref="-665"/>
-        <nd ref="-667"/>
-        <nd ref="-669"/>
-        <nd ref="-235"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="554.9"/>
-    </way>
-    <way visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-323"/>
-        <nd ref="-673"/>
-        <nd ref="-674"/>
-        <nd ref="-675"/>
-        <nd ref="-661"/>
-        <nd ref="-662"/>
-        <nd ref="-663"/>
-        <nd ref="-672"/>
-        <nd ref="-319"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="Bing"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Kandi Dhon Maniku Goalhi"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="557.8"/>
-    </way>
-    <way visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-656" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-521"/>
         <nd ref="-517"/>
         <nd ref="-483"/>
@@ -3800,7 +3800,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
     </way>
-    <way visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-623" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-466"/>
         <nd ref="-465"/>
         <nd ref="-463"/>
@@ -3833,7 +3833,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.6"/>
     </way>
-    <way visible="true" id="-484" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-411" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-199"/>
         <nd ref="-720"/>
         <nd ref="-719"/>
@@ -3876,7 +3876,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="676.4"/>
     </way>
-    <way visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-408" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-167"/>
         <nd ref="-168"/>
         <nd ref="-169"/>
@@ -3908,39 +3908,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="412.4"/>
     </way>
-    <way visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-1172"/>
-        <nd ref="-764"/>
-        <nd ref="-763"/>
-        <tag k="source" v="Bing"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Sabudheli Magu"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="124.3"/>
-    </way>
-    <way visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-1145"/>
-        <nd ref="-1144"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="Unknown"/>
-        <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="125.9"/>
-    </way>
-    <way visible="true" id="-377" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-397" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-237"/>
         <nd ref="-235"/>
         <nd ref="-319"/>
@@ -4008,7 +3976,39 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="19486.7"/>
     </way>
-    <way visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-351" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-1172"/>
+        <nd ref="-764"/>
+        <nd ref="-763"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sabudheli Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="124.3"/>
+    </way>
+    <way visible="true" id="-310" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-1145"/>
+        <nd ref="-1144"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="Unknown"/>
+        <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="125.9"/>
+    </way>
+    <way visible="true" id="-209" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
         <nd ref="-321"/>
         <nd ref="-23"/>
@@ -4027,7 +4027,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="156"/>
     </way>
-    <way visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-197" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-31"/>
         <nd ref="-30"/>
         <nd ref="-29"/>
@@ -4058,74 +4058,6 @@
         <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1341.4"/>
-    </way>
-    <way visible="true" id="-355" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800">
-        <nd ref="-1287"/>
-        <nd ref="-1453"/>
-        <nd ref="-1425"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="Bing"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Chanbeylee Magu"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2014-11-28T17:34:21.000Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-    </way>
-    <way visible="true" id="-296" timestamp="2019-01-14T12:12:36Z" version="1">
-        <nd ref="-1734"/>
-        <nd ref="-1442"/>
-        <nd ref="-1439"/>
-        <nd ref="-1639"/>
-        <nd ref="-1438"/>
-        <nd ref="-1343"/>
-        <nd ref="-1436"/>
-        <nd ref="-1411"/>
-        <nd ref="-1409"/>
-        <nd ref="-1406"/>
-        <nd ref="-1502"/>
-        <nd ref="-1405"/>
-        <nd ref="-1403"/>
-        <nd ref="-1401"/>
-        <nd ref="-1398"/>
-        <nd ref="-1397"/>
-        <nd ref="-1427"/>
-        <nd ref="-1425"/>
-        <nd ref="-1423"/>
-        <nd ref="-1420"/>
-        <nd ref="-1419"/>
-        <nd ref="-1417"/>
-        <nd ref="-1351"/>
-        <nd ref="-1251"/>
-        <nd ref="-1415"/>
-        <nd ref="-1537"/>
-        <nd ref="-1630"/>
-        <nd ref="-1548"/>
-        <nd ref="-1799"/>
-        <nd ref="-1413"/>
-        <nd ref="-1260"/>
-        <nd ref="-1616"/>
-        <nd ref="-1324"/>
-        <nd ref="-1472"/>
-        <nd ref="-1638"/>
-        <nd ref="-1429"/>
-        <nd ref="-1711"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
     </way>
     <way visible="true" id="-185" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919">
         <nd ref="-1097"/>
@@ -7348,8 +7280,76 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="717"/>
     </way>
-    <relation visible="true" id="-1139" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-296" role="reviewee"/>
+    <way visible="true" id="111" timestamp="2019-01-14T12:12:36Z" version="1">
+        <nd ref="557"/>
+        <nd ref="265"/>
+        <nd ref="262"/>
+        <nd ref="462"/>
+        <nd ref="261"/>
+        <nd ref="166"/>
+        <nd ref="259"/>
+        <nd ref="234"/>
+        <nd ref="232"/>
+        <nd ref="229"/>
+        <nd ref="325"/>
+        <nd ref="228"/>
+        <nd ref="226"/>
+        <nd ref="224"/>
+        <nd ref="221"/>
+        <nd ref="220"/>
+        <nd ref="250"/>
+        <nd ref="248"/>
+        <nd ref="246"/>
+        <nd ref="243"/>
+        <nd ref="242"/>
+        <nd ref="240"/>
+        <nd ref="174"/>
+        <nd ref="74"/>
+        <nd ref="238"/>
+        <nd ref="360"/>
+        <nd ref="453"/>
+        <nd ref="371"/>
+        <nd ref="622"/>
+        <nd ref="236"/>
+        <nd ref="83"/>
+        <nd ref="439"/>
+        <nd ref="147"/>
+        <nd ref="295"/>
+        <nd ref="461"/>
+        <nd ref="252"/>
+        <nd ref="534"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+    </way>
+    <way visible="true" id="170" timestamp="2019-01-14T12:12:36Z" version="1" changeset="800">
+        <nd ref="110"/>
+        <nd ref="276"/>
+        <nd ref="248"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Chanbeylee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2014-11-28T17:34:21.000Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+    </way>
+    <relation visible="true" id="-1136" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="way" ref="111" role="reviewee"/>
         <member type="way" ref="-166" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
         <tag k="hoot:status" v="3"/>
@@ -7360,11 +7360,11 @@
         <tag k="hoot:review:score" v="0.459373"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-1138" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-1135" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-173" role="reviewee"/>
-        <member type="way" ref="-355" role="reviewee"/>
         <member type="way" ref="-58" role="reviewee"/>
-        <member type="way" ref="-296" role="reviewee"/>
+        <member type="way" ref="170" role="reviewee"/>
+        <member type="way" ref="111" role="reviewee"/>
         <member type="way" ref="-166" role="reviewee"/>
         <tag k="hoot:review:type" v="Highway"/>
         <tag k="hoot:status" v="3"/>

--- a/test-files/cases/attribute/network/highway-2888/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2888/Expected.osm
@@ -3532,7 +3532,51 @@
     <node visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717205287399990" lon="73.5031247058399941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-865" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-767" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-663"/>
+        <nd ref="-665"/>
+        <nd ref="-667"/>
+        <nd ref="-669"/>
+        <nd ref="-235"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="554.9"/>
+    </way>
+    <way visible="true" id="-764" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-323"/>
+        <nd ref="-673"/>
+        <nd ref="-674"/>
+        <nd ref="-675"/>
+        <nd ref="-661"/>
+        <nd ref="-662"/>
+        <nd ref="-663"/>
+        <nd ref="-672"/>
+        <nd ref="-319"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Kandi Dhon Maniku Goalhi"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="557.8"/>
+    </way>
+    <way visible="true" id="-756" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-930"/>
         <nd ref="-929"/>
         <nd ref="-928"/>
@@ -3586,7 +3630,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="28910"/>
     </way>
-    <way visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-748" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-891"/>
         <nd ref="-890"/>
         <nd ref="-902"/>
@@ -3605,51 +3649,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="141.5"/>
     </way>
-    <way visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-663"/>
-        <nd ref="-665"/>
-        <nd ref="-667"/>
-        <nd ref="-669"/>
-        <nd ref="-235"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="554.9"/>
-    </way>
-    <way visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-323"/>
-        <nd ref="-673"/>
-        <nd ref="-674"/>
-        <nd ref="-675"/>
-        <nd ref="-661"/>
-        <nd ref="-662"/>
-        <nd ref="-663"/>
-        <nd ref="-672"/>
-        <nd ref="-319"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source" v="Bing"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Kandi Dhon Maniku Goalhi"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:23.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="557.8"/>
-    </way>
-    <way visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-656" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-521"/>
         <nd ref="-517"/>
         <nd ref="-483"/>
@@ -3673,7 +3673,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
     </way>
-    <way visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-623" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-466"/>
         <nd ref="-465"/>
         <nd ref="-463"/>
@@ -3706,7 +3706,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.6"/>
     </way>
-    <way visible="true" id="-484" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-411" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-199"/>
         <nd ref="-720"/>
         <nd ref="-719"/>
@@ -3749,7 +3749,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="676.4"/>
     </way>
-    <way visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-408" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-167"/>
         <nd ref="-168"/>
         <nd ref="-169"/>
@@ -3781,39 +3781,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="412.4"/>
     </way>
-    <way visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-1172"/>
-        <nd ref="-764"/>
-        <nd ref="-763"/>
-        <tag k="source" v="Bing"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Sabudheli Magu"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="124.3"/>
-    </way>
-    <way visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-1145"/>
-        <nd ref="-1144"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Boduthakurufaanu magu"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="Unknown"/>
-        <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="125.9"/>
-    </way>
-    <way visible="true" id="-377" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-397" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-237"/>
         <nd ref="-235"/>
         <nd ref="-319"/>
@@ -3881,7 +3849,39 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="19486.7"/>
     </way>
-    <way visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-351" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-1172"/>
+        <nd ref="-764"/>
+        <nd ref="-763"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Sabudheli Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2014-11-28T17:29:46.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="124.3"/>
+    </way>
+    <way visible="true" id="-310" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-1145"/>
+        <nd ref="-1144"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Boduthakurufaanu magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="Unknown"/>
+        <tag k="source:datetime" v="2011-06-11T18:24:40.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="125.9"/>
+    </way>
+    <way visible="true" id="-209" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
         <nd ref="-321"/>
         <nd ref="-23"/>
@@ -3900,7 +3900,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="156"/>
     </way>
-    <way visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-197" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-31"/>
         <nd ref="-30"/>
         <nd ref="-29"/>

--- a/test-files/cases/attribute/network/highway-2927-bridge-2/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-bridge-2/Expected.osm
@@ -1,1156 +1,1124 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="7.6988" minlon="-72.36539999999999" maxlat="7.703000000000001" maxlon="-72.3584"/>
-    <node visible="true" id="-812" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012521346404696" lon="-72.3611555565896225">
-        <tag k="hoot:status" v="3"/>
-        <tag k="bdw-id" v="{6e6f4cd8-5809-48d4-83fc-129aa455a20b}"/>
-    </node>
-    <node visible="true" id="-811" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013861911808847" lon="-72.3616633883052458">
-        <tag k="hoot:status" v="3"/>
-        <tag k="bdw-id" v="{eef519b5-7a1e-4101-9627-7014a8403704}"/>
-    </node>
-    <node visible="true" id="-805" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997880287896709" lon="-72.3619894089128906">
+    <node visible="true" id="-720" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997880287896709" lon="-72.3619894089128906">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b65b630-0b42-4715-9290-c164a5660436}"/>
     </node>
-    <node visible="true" id="-799" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006278906475814" lon="-72.3616258434131652">
+    <node visible="true" id="-714" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006278906475814" lon="-72.3616258434131652">
         <tag k="hoot:status" v="3"/>
         <tag k="bdw-id" v="{e5b2c0cd-d8ba-4cc7-b325-67c9d49414ce}"/>
     </node>
-    <node visible="true" id="-367" timestamp="2012-07-12T16:14:15Z" version="1" changeset="12197232" user="punkadiddle" uid="152973" lat="7.6999007391641490" lon="-72.3619783335608560">
-        <tag k="hoot:status" v="2"/>
-        <tag k="bdw-id" v="{269ded8c-88fd-4792-bcbb-6b71cfeb3454}"/>
+    <node visible="true" id="-708" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012521346404696" lon="-72.3611555565896225">
+        <tag k="hoot:status" v="3"/>
+        <tag k="bdw-id" v="{6e6f4cd8-5809-48d4-83fc-129aa455a20b}"/>
     </node>
-    <node visible="true" id="-342" timestamp="2012-07-12T16:14:12Z" version="1" changeset="12197232" user="punkadiddle" uid="152973" lat="7.7002507785244116" lon="-72.3620289331979478">
-        <tag k="hoot:status" v="2"/>
-        <tag k="bdw-id" v="{a9a65f8c-0819-4829-ae40-9546ed6e98f5}"/>
+    <node visible="true" id="-707" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013861911808847" lon="-72.3616633883052458">
+        <tag k="hoot:status" v="3"/>
+        <tag k="bdw-id" v="{eef519b5-7a1e-4101-9627-7014a8403704}"/>
     </node>
-    <node visible="true" id="-326" timestamp="2012-07-10T16:22:04Z" version="1" changeset="12175062" user="punkadiddle" uid="152973" lat="7.7012125526970445" lon="-72.3609961014727787">
-        <tag k="hoot:status" v="2"/>
-        <tag k="bdw-id" v="{e3af4f8e-5eec-4c79-aab4-56fe2420d431}"/>
-    </node>
-    <node visible="true" id="-296" timestamp="2012-07-10T14:56:00Z" version="1" changeset="12174490" user="punkadiddle" uid="152973" lat="7.7006208228703041" lon="-72.3620566530983780">
-        <tag k="hoot:status" v="2"/>
-        <tag k="bdw-id" v="{297b891c-b3f1-4647-a704-a2bdf767ad75}"/>
-    </node>
-    <node visible="true" id="-293" timestamp="2012-07-10T14:55:54Z" version="1" changeset="12174490" user="punkadiddle" uid="152973" lat="7.7006193181646276" lon="-72.3618603108395320">
-        <tag k="hoot:status" v="2"/>
-        <tag k="bdw-id" v="{f302ecab-f75b-43dc-a73f-4a34012e3ef7}"/>
-    </node>
-    <node visible="true" id="-268" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000125445999998" lon="-72.3589731062100014">
+    <node visible="true" id="-290" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000125445999998" lon="-72.3589731062100014">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{982630d9-e726-433a-bcd7-a33ef723c34f}"/>
     </node>
-    <node visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998995600399986" lon="-72.3589844938999960">
+    <node visible="true" id="-289" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998995600399986" lon="-72.3589844938999960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee7f5868-82c8-4f17-b42c-7ce7c75afca2}"/>
     </node>
-    <node visible="true" id="-266" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998106361499987" lon="-72.3589917918399976">
+    <node visible="true" id="-288" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998106361499987" lon="-72.3589917918399976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{af37fca5-b78d-4cda-a388-95b1ddc59266}"/>
     </node>
-    <node visible="true" id="-265" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993994747499999" lon="-72.3590126697099976">
+    <node visible="true" id="-287" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993994747499999" lon="-72.3590126697099976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{960765e7-e8e7-424b-bb72-93a6897bb679}"/>
     </node>
-    <node visible="true" id="-264" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993151479199993" lon="-72.3590223339899978">
+    <node visible="true" id="-286" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993151479199993" lon="-72.3590223339899978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b34ba694-1b12-433b-85a2-120cfe899e15}"/>
     </node>
-    <node visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992909182700000" lon="-72.3590288738100043">
+    <node visible="true" id="-285" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992909182700000" lon="-72.3590288738100043">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{398ad070-2704-4c96-9344-0d30bd3aeea5}"/>
     </node>
-    <node visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992585774999984" lon="-72.3590461502100055">
+    <node visible="true" id="-284" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992585774999984" lon="-72.3590461502100055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1a6777ee-9fa9-4ac4-915b-98ee76819e3d}"/>
     </node>
-    <node visible="true" id="-261" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992385942999970" lon="-72.3590730195799807">
+    <node visible="true" id="-283" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992385942999970" lon="-72.3590730195799807">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{09df298a-2d0b-401c-9907-eb8dc9e19397}"/>
     </node>
-    <node visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992321979699989" lon="-72.3590979001800036">
+    <node visible="true" id="-282" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992321979699989" lon="-72.3590979001800036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{616e8c64-a870-4dba-94b4-e98da5cf92d1}"/>
     </node>
-    <node visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992300854399973" lon="-72.3591403953499821">
+    <node visible="true" id="-281" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992300854399973" lon="-72.3591403953499821">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a30fc37c-8163-4d47-ac10-a8e469983153}"/>
     </node>
-    <node visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992334148500019" lon="-72.3592847030199948">
+    <node visible="true" id="-280" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992334148500019" lon="-72.3592847030199948">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c57bf62d-ad47-4dc7-86f6-693e6617d0dc}"/>
     </node>
-    <node visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026718036500013" lon="-72.3587359608799972">
+    <node visible="true" id="-279" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026718036500013" lon="-72.3587359608799972">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f337b438-01a8-4916-98a0-8a020ef93866}"/>
     </node>
-    <node visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024847145999997" lon="-72.3587602470999940">
+    <node visible="true" id="-278" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024847145999997" lon="-72.3587602470999940">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ecbb75b5-d097-4d8f-b9ac-aa4c466078cb}"/>
     </node>
-    <node visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013714084200000" lon="-72.3587790233400057">
+    <node visible="true" id="-277" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013714084200000" lon="-72.3587790233400057">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8c4823d6-673d-4fc6-8cb2-2c7f7c7065b4}"/>
     </node>
-    <node visible="true" id="-254" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013424454900008" lon="-72.3588624947000056">
+    <node visible="true" id="-276" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013424454900008" lon="-72.3588624947000056">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{95d2cd0d-d83b-426c-9b37-ca2f145adcf2}"/>
     </node>
-    <node visible="true" id="-253" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008197799199980" lon="-72.3597623706800022">
+    <node visible="true" id="-275" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008197799199980" lon="-72.3597623706800022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{41ee920a-d2ed-432d-b3c9-163eac3b363b}"/>
     </node>
-    <node visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008092709699989" lon="-72.3595223599700006">
+    <node visible="true" id="-274" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008092709699989" lon="-72.3595223599700006">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c9817e93-2182-4fc8-8a78-f81830bca66d}"/>
     </node>
-    <node visible="true" id="-251" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007744741800002" lon="-72.3589044947500071">
+    <node visible="true" id="-273" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007744741800002" lon="-72.3589044947500071">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c753f0f7-9ac3-4325-a21d-790d48100f62}"/>
     </node>
-    <node visible="true" id="-250" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012598976399991" lon="-72.3597289086799975">
+    <node visible="true" id="-272" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012598976399991" lon="-72.3597289086799975">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6b071116-3bdb-4a14-b0c9-4bf96b96d606}"/>
     </node>
-    <node visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012764845499984" lon="-72.3593171985600065">
+    <node visible="true" id="-271" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012764845499984" lon="-72.3593171985600065">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{981feaca-838d-4552-ac59-a3e1d3d37557}"/>
     </node>
-    <node visible="true" id="-248" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012955818400020" lon="-72.3590066044900055">
+    <node visible="true" id="-270" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012955818400020" lon="-72.3590066044900055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ea76cb0d-0e1b-4a77-87ab-3c3b89b6bc3f}"/>
     </node>
-    <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013077781100003" lon="-72.3589521360100036">
+    <node visible="true" id="-269" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013077781100003" lon="-72.3589521360100036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dc8d2fd1-3c53-4243-8404-cbc639cdf774}"/>
     </node>
-    <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999971438299974" lon="-72.3587579203200022">
+    <node visible="true" id="-268" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999971438299974" lon="-72.3587579203200022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5b351244-e61f-4d90-8a3f-2976296fa5ad}"/>
     </node>
-    <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000668045399996" lon="-72.3598254307700017">
+    <node visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000668045399996" lon="-72.3598254307700017">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{395dc79e-32f0-49da-873f-d02e840a4e85}"/>
     </node>
-    <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000550239600019" lon="-72.3596615684899973">
+    <node visible="true" id="-266" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000550239600019" lon="-72.3596615684899973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{41cda987-2dcd-4cec-979d-e87cd45307d6}"/>
     </node>
-    <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024430316399988" lon="-72.3587628416200062">
+    <node visible="true" id="-265" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024430316399988" lon="-72.3587628416200062">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0d532bc7-5901-49fb-9af5-7ac26f155bfe}"/>
     </node>
-    <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022753596499989" lon="-72.3587660034399960">
+    <node visible="true" id="-264" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022753596499989" lon="-72.3587660034399960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b87fd95b-9069-4b25-9acd-8bfd2e7b30f4}"/>
     </node>
-    <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019420064599977" lon="-72.3587949213199835">
+    <node visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019420064599977" lon="-72.3587949213199835">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8f039b12-3202-400f-8ad6-c1fb64585b9a}"/>
     </node>
-    <node visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017087688199979" lon="-72.3588288453800033">
+    <node visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017087688199979" lon="-72.3588288453800033">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a3014fe8-999a-4e77-b0ed-3b1300b319bf}"/>
     </node>
-    <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011678514400019" lon="-72.3588790485100048">
+    <node visible="true" id="-261" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011678514400019" lon="-72.3588790485100048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{85c81f2a-f885-4316-8bf4-ab29e166b691}"/>
     </node>
-    <node visible="true" id="-238" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007611580700006" lon="-72.3586901564100060">
+    <node visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007611580700006" lon="-72.3586901564100060">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5b1dbf2f-e2b5-4f49-8a5b-2b5f78982efb}"/>
     </node>
-    <node visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024746729499984" lon="-72.3585429223900007">
+    <node visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024746729499984" lon="-72.3585429223900007">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{018aab14-7edd-44c8-9742-cc31146db1e6}"/>
     </node>
-    <node visible="true" id="-236" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025112673000011" lon="-72.3596282107299942">
+    <node visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025112673000011" lon="-72.3596282107299942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{89d1fec9-de0d-4d6f-97ef-e76e45e3dd77}"/>
     </node>
-    <node visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025058843299998" lon="-72.3593829638100061">
+    <node visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025058843299998" lon="-72.3593829638100061">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee9280ea-54c9-41bc-a529-72f3cb065e4c}"/>
     </node>
-    <node visible="true" id="-234" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002443052199983" lon="-72.3589490580299923">
+    <node visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002443052199983" lon="-72.3589490580299923">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{24e16643-fab4-4920-b770-536a667b00ad}"/>
     </node>
-    <node visible="true" id="-233" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006631927900013" lon="-72.3622576000999942">
+    <node visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006631927900013" lon="-72.3622576000999942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{abb89eaa-f7e1-48ef-a20d-daccb382e6dc}"/>
     </node>
-    <node visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006467123899993" lon="-72.3621917521900002">
+    <node visible="true" id="-254" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006467123899993" lon="-72.3621917521900002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e822a229-32f9-49bf-8259-92e7209883c7}"/>
     </node>
-    <node visible="true" id="-231" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006359377100004" lon="-72.3621451826700053">
+    <node visible="true" id="-253" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006359377100004" lon="-72.3621451826700053">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{32de3d30-84d3-4478-bb8b-2c0f560a6a7d}"/>
     </node>
-    <node visible="true" id="-230" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026271959599999" lon="-72.3630450196699968">
+    <node visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026271959599999" lon="-72.3630450196699968">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{118a81bb-a69f-4d92-bbfd-bb1495693a02}"/>
     </node>
-    <node visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024136314199989" lon="-72.3631098588599997">
+    <node visible="true" id="-251" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024136314199989" lon="-72.3631098588599997">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{06556a1e-4599-48a4-9954-80c574157f42}"/>
     </node>
-    <node visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018343149700002" lon="-72.3632777502100026">
+    <node visible="true" id="-250" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018343149700002" lon="-72.3632777502100026">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{78838ae7-12eb-4638-87ae-9d20c4a63f20}"/>
     </node>
-    <node visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023457846799985" lon="-72.3620573045100031">
+    <node visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023457846799985" lon="-72.3620573045100031">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6185f7cc-d893-4348-9535-873732391681}"/>
     </node>
-    <node visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021065329700003" lon="-72.3621256362999929">
+    <node visible="true" id="-248" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021065329700003" lon="-72.3621256362999929">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3731555f-5c69-4a2f-a2a2-19c139166164}"/>
     </node>
-    <node visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015651482700020" lon="-72.3622890368200018">
+    <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015651482700020" lon="-72.3622890368200018">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{81f5baf5-2787-49b8-90d4-2e796f47325d}"/>
     </node>
-    <node visible="true" id="-224" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012623905600011" lon="-72.3606986641199939">
+    <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012623905600011" lon="-72.3606986641199939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c989a443-e7b0-4ec3-a5d4-a1d8d467b90d}"/>
     </node>
-    <node visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012264768899996" lon="-72.3606929453199967">
+    <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012264768899996" lon="-72.3606929453199967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{03691619-b190-44e5-af12-0b718693aec9}"/>
     </node>
-    <node visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011946802500004" lon="-72.3606873789299954">
+    <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011946802500004" lon="-72.3606873789299954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{74d94055-e32a-448f-ae0c-f623710810d3}"/>
     </node>
-    <node visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005899704199976" lon="-72.3597828621900021">
+    <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005899704199976" lon="-72.3597828621900021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d6ff1f49-845e-4e4c-85dd-c807cb229f24}"/>
     </node>
-    <node visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004508032499999" lon="-72.3645342810900019">
+    <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004508032499999" lon="-72.3645342810900019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cb9f5bc1-0820-48e2-b355-32c68cd4a795}"/>
     </node>
-    <node visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003871811100009" lon="-72.3643266931999989">
+    <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003871811100009" lon="-72.3643266931999989">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{08681d5f-a5b7-4611-8ea3-c77d6be244b9}"/>
     </node>
-    <node visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002798132799999" lon="-72.3639517346500014">
+    <node visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002798132799999" lon="-72.3639517346500014">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7e1534df-0a76-4e7d-8e5c-796c313781c8}"/>
     </node>
-    <node visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002040256299988" lon="-72.3637306485599936">
+    <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002040256299988" lon="-72.3637306485599936">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6207ef23-ff4b-4311-84d3-74d3590cb32c}"/>
     </node>
-    <node visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008287735000005" lon="-72.3605437910899951">
+    <node visible="true" id="-238" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008287735000005" lon="-72.3605437910899951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb318626-0651-4678-a706-d458a0f7b740}"/>
     </node>
-    <node visible="true" id="-215" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008253843899990" lon="-72.3605705059400037">
+    <node visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008253843899990" lon="-72.3605705059400037">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5acf5d01-cea8-4d8c-b07e-c72cd816b073}"/>
     </node>
-    <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007972569599996" lon="-72.3607473959300052">
+    <node visible="true" id="-236" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007972569599996" lon="-72.3607473959300052">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4de83773-cb12-4014-a352-9a3186263975}"/>
     </node>
-    <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029913144300020" lon="-72.3643388391599842">
+    <node visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029913144300020" lon="-72.3643388391599842">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2dd1952f-5b09-4c08-b7a7-5950135e532a}"/>
     </node>
-    <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029451957799990" lon="-72.3642402141099979">
+    <node visible="true" id="-234" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029451957799990" lon="-72.3642402141099979">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{572b05ea-e0fe-4344-bd1a-79aba66e0e23}"/>
     </node>
-    <node visible="true" id="-211" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029194344199992" lon="-72.3641647013199929">
+    <node visible="true" id="-233" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029194344199992" lon="-72.3641647013199929">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{15646cdf-f8f5-454a-93c9-f60c215d85a6}"/>
     </node>
-    <node visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029000823099993" lon="-72.3640872884299995">
+    <node visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029000823099993" lon="-72.3640872884299995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cd4862c7-97ce-4b2f-a312-0a4c70ac5bd2}"/>
     </node>
-    <node visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028743568799989" lon="-72.3639080177500063">
+    <node visible="true" id="-231" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028743568799989" lon="-72.3639080177500063">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6014bb75-2061-4041-9614-32caeff0fc5e}"/>
     </node>
-    <node visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028559585300016" lon="-72.3638136811500061">
+    <node visible="true" id="-230" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028559585300016" lon="-72.3638136811500061">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{294a16bf-825f-4ab1-9c0f-1092f547b442}"/>
     </node>
-    <node visible="true" id="-207" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029272476499990" lon="-72.3629551069300021">
+    <node visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029272476499990" lon="-72.3629551069300021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d3544fd0-7f36-4db6-9b3c-8d55a20ede05}"/>
     </node>
-    <node visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028236705099973" lon="-72.3629831259799943">
+    <node visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028236705099973" lon="-72.3629831259799943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8b69cf3d-0c67-4afe-b55e-3484e5a211bc}"/>
     </node>
-    <node visible="true" id="-205" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027090382500001" lon="-72.3651492070899991">
+    <node visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027090382500001" lon="-72.3651492070899991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6cb57a87-35bb-4b55-b541-8d3f38dcd8c5}"/>
     </node>
-    <node visible="true" id="-204" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026454572700009" lon="-72.3650829173700032">
+    <node visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026454572700009" lon="-72.3650829173700032">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9ba2c828-3cb0-4e23-978e-175a5f9c0a1a}"/>
     </node>
-    <node visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015378418000013" lon="-72.3622036787599967">
+    <node visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015378418000013" lon="-72.3622036787599967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0622996b-12af-4779-8f5b-e824949ed7be}"/>
     </node>
-    <node visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014912199299994" lon="-72.3620477259700010">
+    <node visible="true" id="-224" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014912199299994" lon="-72.3620477259700010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ab76e169-e37a-41a4-9338-a8af40ccc6a2}"/>
     </node>
-    <node visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6990490502900002" lon="-72.3592864234800004">
+    <node visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6990490502900002" lon="-72.3592864234800004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fe3e54f6-c119-410b-9817-24a70ed71ab2}"/>
     </node>
-    <node visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023333015699986" lon="-72.3620129969399954">
+    <node visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023333015699986" lon="-72.3620129969399954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8702c164-0903-496a-9f7e-740ab9d4a563}"/>
     </node>
-    <node visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021926759499992" lon="-72.3616215999099950">
+    <node visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021926759499992" lon="-72.3616215999099950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4c39a9b8-0abd-466f-9c60-14f8c579e90d}"/>
     </node>
-    <node visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021745098799972" lon="-72.3615513291699841">
+    <node visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021745098799972" lon="-72.3615513291699841">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{83013c28-fe21-4143-8c06-afe4273fdddd}"/>
     </node>
-    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017758671699976" lon="-72.3630599810399957">
+    <node visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017758671699976" lon="-72.3630599810399957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5bd7ddcc-49c6-469a-93b5-c427377cdbff}"/>
     </node>
-    <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016327996199978" lon="-72.3625044378700011">
+    <node visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016327996199978" lon="-72.3625044378700011">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{250c22dd-780b-44a5-aec3-5840c98bc7af}"/>
     </node>
-    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012088752899990" lon="-72.3643351878800019">
+    <node visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012088752899990" lon="-72.3643351878800019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3e643060-ed6a-432f-a653-e20e3752bc77}"/>
     </node>
-    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011570231600031" lon="-72.3641177542399987">
+    <node visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011570231600031" lon="-72.3641177542399987">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cfcd1c0a-050e-451a-a572-2ee9d49b3056}"/>
     </node>
-    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009986579199978" lon="-72.3635211022599805">
+    <node visible="true" id="-215" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009986579199978" lon="-72.3635211022599805">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3ba124af-3a0a-4357-9ec0-5daabdd54dbc}"/>
     </node>
-    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014475595599965" lon="-72.3618958642800010">
+    <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014475595599965" lon="-72.3618958642800010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e47c790e-aaa7-4699-85b1-9b13c9e0afeb}"/>
     </node>
-    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012185099100012" lon="-72.3610281801099973">
+    <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012185099100012" lon="-72.3610281801099973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b58dd51-6a6c-4991-85d8-8310d90aee65}"/>
     </node>
-    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012058795200025" lon="-72.3609601674999965">
+    <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012058795200025" lon="-72.3609601674999965">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2bfac72f-c5eb-4eda-bccb-39ae86bd1547}"/>
     </node>
-    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011854733399998" lon="-72.3607682998599984">
+    <node visible="true" id="-211" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011854733399998" lon="-72.3607682998599984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7a8e8f48-a3ad-43f4-bf37-a7bfffa4fd47}"/>
     </node>
-    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011867500899989" lon="-72.3607269335499979">
+    <node visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011867500899989" lon="-72.3607269335499979">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2517d848-fc83-4184-bcb5-145f8998d9fa}"/>
     </node>
-    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024978803100019" lon="-72.3653636431100011">
+    <node visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024978803100019" lon="-72.3653636431100011">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{19a73972-2edb-44b8-93d7-dd70ec0ba05a}"/>
     </node>
-    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029593477100011" lon="-72.3653755295199943">
+    <node visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029593477100011" lon="-72.3653755295199943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{24bd8d78-8ac7-40b4-bf34-f2f1e0e9d174}"/>
     </node>
-    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028953822399995" lon="-72.3653253606699991">
+    <node visible="true" id="-207" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028953822399995" lon="-72.3653253606699991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bfe364dd-a50a-4f35-9324-8004397ffda9}"/>
     </node>
-    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028264479300015" lon="-72.3652641111099939">
+    <node visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028264479300015" lon="-72.3652641111099939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fad979c8-3563-4e4d-b0f2-0922deb597f3}"/>
     </node>
-    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027073002500011" lon="-72.3609297702300012">
+    <node visible="true" id="-205" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027073002500011" lon="-72.3609297702300012">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c00c4d6e-18cf-4014-b189-c7a024821a61}"/>
     </node>
-    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024966756600008" lon="-72.3608927498199961">
+    <node visible="true" id="-204" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024966756600008" lon="-72.3608927498199961">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ac868205-8c68-42e5-8503-34adf8ed90ef}"/>
     </node>
-    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016897398499991" lon="-72.3648851958499932">
+    <node visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016897398499991" lon="-72.3648851958499932">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{aaa495db-bb2c-4d14-b6f1-852d77945dd2}"/>
     </node>
-    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016640244399994" lon="-72.3648701313099991">
+    <node visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016640244399994" lon="-72.3648701313099991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d5d0a69d-76e9-4e17-8b74-0e4b84b56812}"/>
     </node>
-    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016019476799995" lon="-72.3648422017000001">
+    <node visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016019476799995" lon="-72.3648422017000001">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7b21e8df-b452-4ed2-a820-a45834862a9c}"/>
     </node>
-    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015621251499988" lon="-72.3648169241400012">
+    <node visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015621251499988" lon="-72.3648169241400012">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{52359d05-ecca-42e8-9d49-0f9dc18d7e03}"/>
     </node>
-    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015320594699999" lon="-72.3648214196999930">
+    <node visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015320594699999" lon="-72.3648214196999930">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{048ace9f-5506-4de2-bdd3-9523b46c6c6a}"/>
     </node>
-    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015020998500017" lon="-72.3648431532299838">
+    <node visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015020998500017" lon="-72.3648431532299838">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b54181d4-a211-41c1-984f-3812a57be74d}"/>
     </node>
-    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013769878999989" lon="-72.3649754676700070">
+    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013769878999989" lon="-72.3649754676700070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2cb73e9b-5dc9-4d46-aeae-75de34976546}"/>
     </node>
-    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013116965700004" lon="-72.3650257533199976">
+    <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013116965700004" lon="-72.3650257533199976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{39f5b7b6-9133-4b66-8695-b27845493733}"/>
     </node>
-    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011985683099997" lon="-72.3651106152599937">
+    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011985683099997" lon="-72.3651106152599937">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a3f0b378-1bf3-4e44-8e81-3b81b47a55b6}"/>
     </node>
-    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006126074400001" lon="-72.3621489709500025">
+    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006126074400001" lon="-72.3621489709500025">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4aa38a15-1d1a-496d-a6ac-c11d125801f3}"/>
     </node>
-    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005910945099982" lon="-72.3621499434400022">
+    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005910945099982" lon="-72.3621499434400022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7db3022e-6731-4b4e-8f6d-da72dced98aa}"/>
     </node>
-    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005495876499994" lon="-72.3621442957399950">
+    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005495876499994" lon="-72.3621442957399950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6a4cec9f-62ae-4a45-bd74-fc3b5336cc88}"/>
     </node>
-    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003910035800018" lon="-72.3620746576300036">
+    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003910035800018" lon="-72.3620746576300036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb1529f2-de86-427b-b4fb-cda4954c891d}"/>
     </node>
-    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002851133800005" lon="-72.3620377767099825">
+    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002851133800005" lon="-72.3620377767099825">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ab8bb983-17c8-4cc2-8d8a-50cdb7f5b830}"/>
     </node>
-    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001765405099993" lon="-72.3620098119699833">
+    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001765405099993" lon="-72.3620098119699833">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a43e29c7-5c4b-49ec-a12e-3fb954ce9b1e}"/>
     </node>
-    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000151722999997" lon="-72.3619831066999950">
+    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000151722999997" lon="-72.3619831066999950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{607c8fb3-2d66-428a-8421-ca69d4fd6b36}"/>
     </node>
-    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998794510700019" lon="-72.3619774456099947">
+    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998794510700019" lon="-72.3619774456099947">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0813dba4-e3d7-4fdb-a9a6-eb05878ba17c}"/>
     </node>
-    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998032185799987" lon="-72.3619853627400005">
+    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998032185799987" lon="-72.3619853627400005">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a8c1b1d5-6513-4514-ab87-8cf7b65c72b7}"/>
     </node>
-    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997383847400007" lon="-72.3620026328199941">
+    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997383847400007" lon="-72.3620026328199941">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{64c29c0a-72de-4ae5-982e-675d405758a0}"/>
     </node>
-    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995928115399996" lon="-72.3620593355500006">
+    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995928115399996" lon="-72.3620593355500006">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b6af514b-2a6e-47fb-ab24-aa8dae8659f3}"/>
     </node>
-    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013270798199986" lon="-72.3648078769700049">
+    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013270798199986" lon="-72.3648078769700049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5c313c81-5777-4a62-9640-7d07b261562b}"/>
     </node>
-    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013010982400001" lon="-72.3646917833000032">
+    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013010982400001" lon="-72.3646917833000032">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{49a05c15-a62c-4777-9905-b53a030e1b2c}"/>
     </node>
-    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012490775000018" lon="-72.3645015987799951">
+    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012490775000018" lon="-72.3645015987799951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{18fe3d45-f033-4b11-beb4-2979965f70dc}"/>
     </node>
-    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018812826899969" lon="-72.3645933403099946">
+    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018812826899969" lon="-72.3645933403099946">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2ac6ec6d-b9b4-42f3-b016-843d4db288c8}"/>
     </node>
-    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018605171900001" lon="-72.3645600612099855">
+    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018605171900001" lon="-72.3645600612099855">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cbf15011-67eb-4a89-855a-e2ab76c6cf69}"/>
     </node>
-    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018431562299989" lon="-72.3645263168699984">
+    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018431562299989" lon="-72.3645263168699984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9232806a-aae7-4c76-b722-c73c118779cd}"/>
     </node>
-    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018131116899982" lon="-72.3644459178999995">
+    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018131116899982" lon="-72.3644459178999995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a4804903-408d-443e-b664-1640d62563ff}"/>
     </node>
-    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017914866500004" lon="-72.3643983965900048">
+    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017914866500004" lon="-72.3643983965900048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b9d5b900-227f-45d6-b75f-91d3f7d503b0}"/>
     </node>
-    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016739074900000" lon="-72.3641703957000004">
+    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016739074900000" lon="-72.3641703957000004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{44a846b4-3b66-4ef8-8469-38289351ef3b}"/>
     </node>
-    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999122416799990" lon="-72.3598398665299953">
+    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999122416799990" lon="-72.3598398665299953">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{97da5ee2-a050-49e1-9ee1-1c25fb1d5df0}"/>
     </node>
-    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997171014199992" lon="-72.3598605828299952">
+    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997171014199992" lon="-72.3598605828299952">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{547715c1-5fd7-4c84-83e9-07a34d33e514}"/>
     </node>
-    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996722981099985" lon="-72.3598742513199937">
+    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996722981099985" lon="-72.3598742513199937">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fce33577-9e74-4dcb-bc0d-ee698213e37a}"/>
     </node>
-    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996323785100005" lon="-72.3598990515200029">
+    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996323785100005" lon="-72.3598990515200029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a8fbb3ef-0ecc-4426-b7a3-ef431231e0b5}"/>
     </node>
-    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008073074299999" lon="-72.3635727247900036">
+    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008073074299999" lon="-72.3635727247900036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7bc2131a-998c-4eb2-8327-308a3fc6230b}"/>
     </node>
-    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004169135099989" lon="-72.3636700057400049">
+    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004169135099989" lon="-72.3636700057400049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c1643b44-18b1-4a64-aad9-6987e1964038}"/>
     </node>
-    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025105688900011" lon="-72.3604663040100036">
+    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025105688900011" lon="-72.3604663040100036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ef317431-bd4b-4aae-9cbb-efec060dbbba}"/>
     </node>
-    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025134469500003" lon="-72.3602217308899895">
+    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025134469500003" lon="-72.3602217308899895">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4449e8a9-e837-44f4-93de-a2d440f3c7c5}"/>
     </node>
-    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009705876999988" lon="-72.3634189647799957">
+    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009705876999988" lon="-72.3634189647799957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb8d560b-afba-41f3-a550-e4782b5e6a0c}"/>
     </node>
-    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009115960299992" lon="-72.3632323317799973">
+    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009115960299992" lon="-72.3632323317799973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f02672bc-5098-44cc-8aae-7d17fab617bf}"/>
     </node>
-    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008676288800002" lon="-72.3630775018600048">
+    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008676288800002" lon="-72.3630775018600048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{763e8292-46a2-4045-b10a-601f81a4f3e3}"/>
     </node>
-    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028380173500004" lon="-72.3637438608899970">
+    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028380173500004" lon="-72.3637438608899970">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c1b24ce7-377f-46f7-8fbe-d64e60a15d3c}"/>
     </node>
-    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027048353199978" lon="-72.3632830014399957">
+    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027048353199978" lon="-72.3632830014399957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9f9d7e20-ae6a-4b64-8731-6efbe69b7694}"/>
     </node>
-    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026376565999994" lon="-72.3638784585599950">
+    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026376565999994" lon="-72.3638784585599950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8aff790a-de78-4972-a6c7-8256771bcd55}"/>
     </node>
-    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021681667799973" lon="-72.3640271775699944">
+    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021681667799973" lon="-72.3640271775699944">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0749bc5-4981-4e42-a91f-cd65c6101338}"/>
     </node>
-    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020382077799994" lon="-72.3640629748000066">
+    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020382077799994" lon="-72.3640629748000066">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a02de9d0-d7c1-4d80-82a5-f52744f735dc}"/>
     </node>
-    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019855596399998" lon="-72.3638471517800070">
+    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019855596399998" lon="-72.3638471517800070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c01ea5a7-6169-48b2-a547-8e3cf0c6d9d0}"/>
     </node>
-    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017943246200025" lon="-72.3646545002600021">
+    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017943246200025" lon="-72.3646545002600021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e75e3182-39f4-4a2e-9000-b3da70366cc8}"/>
     </node>
-    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017613183100000" lon="-72.3646789551700067">
+    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017613183100000" lon="-72.3646789551700067">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9d2e75b8-7b3e-4212-a6d3-13ffce9bd5b5}"/>
     </node>
-    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016925778499994" lon="-72.3647298860600046">
+    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016925778499994" lon="-72.3647298860600046">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{43170a0b-5530-4103-a1db-21ce1da0f13b}"/>
     </node>
-    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015033074300012" lon="-72.3647676287800010">
+    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015033074300012" lon="-72.3647676287800010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{47cef29e-8cb0-4bcb-bd96-f32e89861003}"/>
     </node>
-    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019125718900012" lon="-72.3653594478400066">
+    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019125718900012" lon="-72.3653594478400066">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{53fe45e8-12b6-4cd8-a776-1b0f38d075aa}"/>
     </node>
-    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019170361199976" lon="-72.3652935094499981">
+    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019170361199976" lon="-72.3652935094499981">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{953fa01d-77bb-40e9-b414-c9276745c00a}"/>
     </node>
-    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019098487599980" lon="-72.3652112486099952">
+    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019098487599980" lon="-72.3652112486099952">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{65abc668-4648-4d8f-8f0e-0ff31c7651b3}"/>
     </node>
-    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018988007800004" lon="-72.3651629165800045">
+    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018988007800004" lon="-72.3651629165800045">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00eae29a-18ee-4083-9d9b-6ce3beb4ebcb}"/>
     </node>
-    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018695400000006" lon="-72.3650857263500029">
+    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018695400000006" lon="-72.3650857263500029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1ebc0ac8-8992-4d6b-8c91-b6bc962193b5}"/>
     </node>
-    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018368800699992" lon="-72.3650283159600036">
+    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018368800699992" lon="-72.3650283159600036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0a8b03e8-8cf1-4cb4-a6c6-743c9423e16f}"/>
     </node>
-    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017855075299995" lon="-72.3649637669900017">
+    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017855075299995" lon="-72.3649637669900017">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{73f1a3d4-f061-477d-aa78-0167bc45d078}"/>
     </node>
-    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017530332899975" lon="-72.3649325465199951">
+    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017530332899975" lon="-72.3649325465199951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7f41aff8-101a-456d-85b7-4d65109fab2c}"/>
     </node>
-    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012823693799994" lon="-72.3648179282999990">
+    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012823693799994" lon="-72.3648179282999990">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{aa207c4c-6123-4b19-9124-f867b4665a24}"/>
     </node>
-    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012374695599979" lon="-72.3648322397200019">
+    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012374695599979" lon="-72.3648322397200019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f567cdc7-60ea-4580-85d9-914239eddac4}"/>
     </node>
-    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006060287499993" lon="-72.3650699608899970">
+    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006060287499993" lon="-72.3650699608899970">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee9ae638-b3fc-41a5-886d-82cc4f355eb9}"/>
     </node>
-    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008923923800001" lon="-72.3607497208700039">
+    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008923923800001" lon="-72.3607497208700039">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00282eb6-07d9-4490-a60e-d8541a07ec51}"/>
     </node>
-    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008460567700006" lon="-72.3607534871499922">
+    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008460567700006" lon="-72.3607534871499922">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{27b64afd-85ec-4d9e-889c-96f38249e170}"/>
     </node>
-    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017029639099981" lon="-72.3648606462199950">
+    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017029639099981" lon="-72.3648606462199950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e813d633-c35d-4d36-af1b-170d39b085e7}"/>
     </node>
-    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017121249399993" lon="-72.3648359878300056">
+    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017121249399993" lon="-72.3648359878300056">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e7e8ea7e-62f1-461a-9f9e-cdb3307f77dd}"/>
     </node>
-    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017322410099993" lon="-72.3647497908099950">
+    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017322410099993" lon="-72.3647497908099950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{52724a1d-a920-4605-b298-1cd4bca5d8e5}"/>
     </node>
-    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005652468600010" lon="-72.3649338501799946">
+    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005652468600010" lon="-72.3649338501799946">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ce494fa3-d0a3-4cd6-9cca-b5bef17f4acc}"/>
     </node>
-    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005029935499989" lon="-72.3647064545199896">
+    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005029935499989" lon="-72.3647064545199896">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{efbcf4d1-45de-4f80-a7f3-200b90b4f26b}"/>
     </node>
-    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023699280499995" lon="-72.3596330036399991">
+    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023699280499995" lon="-72.3596330036399991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f8906d8b-524d-4fc9-a16b-2f3c32d399d8}"/>
     </node>
-    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014893720299993" lon="-72.3597033407099985">
+    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014893720299993" lon="-72.3597033407099985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f32070c6-9028-4e04-b9b2-6e6a295d1ee3}"/>
     </node>
-    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012677290700005" lon="-72.3606008227500013">
+    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012677290700005" lon="-72.3606008227500013">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e4fbe1ff-f723-431b-96fb-40f240a591ea}"/>
     </node>
-    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012565179399992" lon="-72.3599581959600044">
+    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012565179399992" lon="-72.3599581959600044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{10a8a646-89e4-4325-a1c0-0bba91edd235}"/>
     </node>
-    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006222338299990" lon="-72.3620713771800013">
+    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006222338299990" lon="-72.3620713771800013">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{29b4e035-bf6f-4c0a-8ea4-3d453ca11958}"/>
     </node>
-    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006166110400009" lon="-72.3620127005400064">
+    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006166110400009" lon="-72.3620127005400064">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3236cbd6-48d9-454d-a8c4-1371a982eaf6}"/>
     </node>
-    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006200294399987" lon="-72.3618202711599992">
+    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006200294399987" lon="-72.3618202711599992">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f5a74281-96eb-4f5e-b481-651edb664c2b}"/>
     </node>
-    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006146626000005" lon="-72.3617239950699940">
+    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006146626000005" lon="-72.3617239950699940">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{65842328-7e41-408d-a5ae-934a30e075e0}"/>
     </node>
-    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006174317799978" lon="-72.3616800897999894">
+    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006174317799978" lon="-72.3616800897999894">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0dccbbc-e9eb-46d7-b79b-120abe29eded}"/>
     </node>
-    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021432854499992" lon="-72.3644346259099933">
+    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021432854499992" lon="-72.3644346259099933">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ff09ca3d-4dc3-47a8-8646-aa0fa7e82936}"/>
     </node>
-    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021206720000004" lon="-72.3643814086800035">
+    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021206720000004" lon="-72.3643814086800035">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4d5d8d79-a11f-4de2-b6dc-15547a6d7cbd}"/>
     </node>
-    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021015211100012" lon="-72.3643231872499939">
+    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021015211100012" lon="-72.3643231872499939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5a9206d5-800f-4011-965d-f301a8d427eb}"/>
     </node>
-    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026129862400001" lon="-72.3604632380500021">
+    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026129862400001" lon="-72.3604632380500021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{824ffa86-73f5-400e-849e-67fa91014a0f}"/>
     </node>
-    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020204485399999" lon="-72.3645026282299995">
+    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020204485399999" lon="-72.3645026282299995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6d7b17e4-660a-4bad-bd27-3f9ac8c26f45}"/>
     </node>
-    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008388564899990" lon="-72.3604372371499949">
+    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008388564899990" lon="-72.3604372371499949">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{83b1e61c-ba23-4c55-968d-955604dab858}"/>
     </node>
-    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008414641999989" lon="-72.3603488479899966">
+    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008414641999989" lon="-72.3603488479899966">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f58efa1d-1534-4d88-a24a-65f0e8a8b94c}"/>
     </node>
-    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014684370100017" lon="-72.3607199184299930">
+    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014684370100017" lon="-72.3607199184299930">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d24f3529-f6f0-414e-8d8e-60da4d196983}"/>
     </node>
-    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011480890199993" lon="-72.3597396552600003">
+    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011480890199993" lon="-72.3597396552600003">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1f08e79d-65f6-4645-9193-d71b5f53fc5d}"/>
     </node>
-    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011314008299978" lon="-72.3606690550100069">
+    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011314008299978" lon="-72.3606690550100069">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0fdb3dcf-8b32-41f0-90be-c389007acb55}"/>
     </node>
-    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7010350738799991" lon="-72.3606303437099996">
+    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7010350738799991" lon="-72.3606303437099996">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c3670158-c9c6-4ff0-8a58-c1b76a1ec4e5}"/>
     </node>
-    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008914643399997" lon="-72.3605619019399882">
+    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008914643399997" lon="-72.3605619019399882">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d8cb4c59-7766-4836-be2c-e8c19fba607f}"/>
     </node>
-    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027208787900010" lon="-72.3596191073200004">
+    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027208787900010" lon="-72.3596191073200004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3eeb7ede-2b3d-4c29-9e44-9d07960fa336}"/>
     </node>
-    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009478563300000" lon="-72.3643993500499931">
+    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009478563300000" lon="-72.3643993500499931">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0c5f531f-dc9d-4838-be76-22f347450aa0}"/>
     </node>
-    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007024150600003" lon="-72.3644763970700069">
+    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007024150600003" lon="-72.3644763970700069">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3f4b8bd2-df1c-4138-b4fd-3260d8fe0ec3}"/>
     </node>
-    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005803708500009" lon="-72.3645073528099942">
+    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005803708500009" lon="-72.3645073528099942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{eb14e619-d0c3-4d9a-979f-ccbb797c6951}"/>
     </node>
-    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008241934799990" lon="-72.3605447727200044">
+    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008241934799990" lon="-72.3605447727200044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9967ecd7-f1a3-4fc8-914e-e2f78db509fc}"/>
     </node>
-    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007832027999976" lon="-72.3605486476500062">
+    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007832027999976" lon="-72.3605486476500062">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{138c095d-54fd-445b-90c5-923650b541e3}"/>
     </node>
-    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007356230099999" lon="-72.3605422724999983">
+    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007356230099999" lon="-72.3605422724999983">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{22806f5a-e73a-4ba9-af2e-160f454900fe}"/>
     </node>
-    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004424406699998" lon="-72.3603875287600005">
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004424406699998" lon="-72.3603875287600005">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00d30ebe-52c8-45c5-bc86-5b1dc30bbe06}"/>
     </node>
-    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999463079099986" lon="-72.3601460936800009">
+    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999463079099986" lon="-72.3601460936800009">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{caee4c3f-bf77-40c2-b541-e49caf11c2fe}"/>
     </node>
-    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998361407499969" lon="-72.3600846000900049">
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998361407499969" lon="-72.3600846000900049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{af319fcf-ad29-45dc-8031-c484298dc8ab}"/>
     </node>
-    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997747674000001" lon="-72.3600422314799943">
+    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997747674000001" lon="-72.3600422314799943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{59ba072e-e835-424e-9638-3a46a515d8f3}"/>
     </node>
-    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996897282199992" lon="-72.3599654490699891">
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996897282199992" lon="-72.3599654490699891">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e030d272-c409-4fc0-9339-9554f98ca67d}"/>
     </node>
-    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000669276699982" lon="-72.3637773729799960">
+    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000669276699982" lon="-72.3637773729799960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{698ee339-549a-4414-833d-70c41bf96aa3}"/>
     </node>
-    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997781354999999" lon="-72.3638605285700010">
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997781354999999" lon="-72.3638605285700010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{119ff15b-1a2e-4924-a6b3-d30e2cf7f7a0}"/>
     </node>
-    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997060737399972" lon="-72.3638749536899866">
+    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997060737399972" lon="-72.3638749536899866">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{249b4a4c-a063-4402-a9c1-dc9b0daf2923}"/>
     </node>
-    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996463546499987" lon="-72.3638948664100070">
+    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996463546499987" lon="-72.3638948664100070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{022159b5-d615-40cd-8e0b-7e15a2f3fffd}"/>
     </node>
-    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025429482899987" lon="-72.3619990111400000">
+    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025429482899987" lon="-72.3619990111400000">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{628254ce-ddf5-4a6d-8e2b-604d49b8740c}"/>
     </node>
-    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025063127400015" lon="-72.3607880166299964">
+    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025063127400015" lon="-72.3607880166299964">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0f9afdde-b63b-4bc1-9563-1baa4b85e28c}"/>
     </node>
-    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005030098099985" lon="-72.3651013186299963">
+    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005030098099985" lon="-72.3651013186299963">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b42fe56c-6b69-4eb8-9dc8-4cc15abf7100}"/>
     </node>
-    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003987303299999" lon="-72.3651280253599936">
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003987303299999" lon="-72.3651280253599936">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{de968008-487e-45f7-b75d-cc6a7e3c3b02}"/>
     </node>
-    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996794169599996" lon="-72.3652826818200055">
+    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996794169599996" lon="-72.3652826818200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{12b490fd-a953-4a29-858b-871368ccd8ba}"/>
     </node>
-    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994617584999991" lon="-72.3653356666000036">
+    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994617584999991" lon="-72.3653356666000036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b6be1c87-29d1-4959-9da4-9d17d7e664b8}"/>
     </node>
-    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005950625799988" lon="-72.3622759602600070">
+    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005950625799988" lon="-72.3622759602600070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dbc43ee4-a923-4289-afe8-1459523ab536}"/>
     </node>
-    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004419767799988" lon="-72.3623265571600029">
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004419767799988" lon="-72.3623265571600029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2e997e60-15a4-40d4-b464-f033b5e1e192}"/>
     </node>
-    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002421877699998" lon="-72.3623841271899977">
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002421877699998" lon="-72.3623841271899977">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0489272e-8d70-46b9-b3a7-bc232913d425}"/>
     </node>
-    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001300551699998" lon="-72.3624071531999959">
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001300551699998" lon="-72.3624071531999959">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c64c8768-ce14-47a8-9c38-8ace6941987b}"/>
     </node>
-    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263536499997" lon="-72.3629389733599879">
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263536499997" lon="-72.3629389733599879">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c626b399-6782-461d-917a-0cf0996b1fdb}"/>
     </node>
-    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002326456700017" lon="-72.3629951913199960">
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002326456700017" lon="-72.3629951913199960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{90fcd827-fbd0-48ae-a4d6-09673f960de9}"/>
     </node>
-    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263687200001" lon="-72.3630515204099964">
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263687200001" lon="-72.3630515204099964">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7931c590-92d0-45e3-9827-de3955aed059}"/>
     </node>
-    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001738660599983" lon="-72.3633648031100023">
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001738660599983" lon="-72.3633648031100023">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0767e414-fe2f-4e87-86b1-83c5065f4304}"/>
     </node>
-    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001659247899985" lon="-72.3634536496399789">
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001659247899985" lon="-72.3634536496399789">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{39843252-90f8-4328-a1f2-80fab8e6b8b6}"/>
     </node>
-    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001675363100013" lon="-72.3635159822700018">
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001675363100013" lon="-72.3635159822700018">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{105fc6d8-94f1-4ef4-ba69-3046dff39d16}"/>
     </node>
-    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001798178699969" lon="-72.3636234875299920">
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001798178699969" lon="-72.3636234875299920">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ec320852-50a3-4e2c-aeda-0fd3e6195a7c}"/>
     </node>
-    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025861574699990" lon="-72.3629225343800044">
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025861574699990" lon="-72.3629225343800044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cc54749b-a8ec-4890-85c3-09a892963506}"/>
     </node>
-    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024048346499994" lon="-72.3623002673199949">
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024048346499994" lon="-72.3623002673199949">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1b331fd7-7f67-4919-90e4-05086bf62cbf}"/>
     </node>
-    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013730528799984" lon="-72.3620810506499907">
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013730528799984" lon="-72.3620810506499907">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a7735e22-4c30-4d65-a692-ff1ed1f9376f}"/>
     </node>
-    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008919916799989" lon="-72.3622094409199974">
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008919916799989" lon="-72.3622094409199974">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{85994d76-029a-4614-9df7-7b500fa1d7f1}"/>
     </node>
-    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025805898900002" lon="-72.3650112703899993">
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025805898900002" lon="-72.3650112703899993">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{12c8cfe5-2c80-4416-a6c6-7dd032a41850}"/>
     </node>
-    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025182392699998" lon="-72.3649374931300002">
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025182392699998" lon="-72.3649374931300002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f6efc0ea-6a32-4bce-b27b-56022d012add}"/>
     </node>
-    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022252799000022" lon="-72.3645673879100002">
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022252799000022" lon="-72.3645673879100002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{133a2d8b-e32e-4e50-ad73-c4854fcc925b}"/>
     </node>
-    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021796015300001" lon="-72.3645015413899984">
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021796015300001" lon="-72.3645015413899984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8746ed36-9f0b-4eb7-9558-3fae339f6750}"/>
     </node>
-    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026958136299992" lon="-72.3650447362499989">
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026958136299992" lon="-72.3650447362499989">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ddd4701d-ab0c-42dc-8c75-900e0dc3af5e}"/>
     </node>
-    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992193064799999" lon="-72.3588999086399838">
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992193064799999" lon="-72.3588999086399838">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bbac7ebe-6c98-42a8-ae6e-b09b73364b98}"/>
     </node>
-    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991501087799987" lon="-72.3586803331299961">
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991501087799987" lon="-72.3586803331299961">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3e41468b-4ec7-41ce-a48d-39b762301e90}"/>
     </node>
-    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013292813500005" lon="-72.3648242249600031">
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013292813500005" lon="-72.3648242249600031">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{98c4d4ed-44cc-405e-972f-de5696f366be}"/>
     </node>
-    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013324558299985" lon="-72.3648735912399985">
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013324558299985" lon="-72.3648735912399985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9d22553e-4320-44c6-a1b3-e20179af825f}"/>
     </node>
-    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013304654399999" lon="-72.3649230197300000">
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013304654399999" lon="-72.3649230197300000">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dd91b33a-be42-4891-bc91-2be90c51b853}"/>
     </node>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992473837099986" lon="-72.3588367156799990">
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992473837099986" lon="-72.3588367156799990">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d51893a6-3df0-4d94-ae99-a0291cf1f8b2}"/>
     </node>
-    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991559975199992" lon="-72.3588277695599942">
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991559975199992" lon="-72.3588277695599942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a05ed439-4959-4ec7-a534-1e3cb1be92fc}"/>
     </node>
-    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995335028499996" lon="-72.3597741646800046">
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995335028499996" lon="-72.3597741646800046">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{26a7a9c4-a267-4a2a-8720-d176d5fa1034}"/>
     </node>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993052853000004" lon="-72.3595089049200055">
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993052853000004" lon="-72.3595089049200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9893a976-8d41-4fa8-8b7f-7784f22cb53f}"/>
     </node>
-    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992779188700000" lon="-72.3594700869700063">
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992779188700000" lon="-72.3594700869700063">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{de4ac387-e204-40b6-a872-bac62a736235}"/>
     </node>
-    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992564190600010" lon="-72.3594277203900020">
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992564190600010" lon="-72.3594277203900020">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0f095b9-7fbc-4361-b994-d85f4e67855b}"/>
     </node>
-    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992412347999988" lon="-72.3593826898599985">
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992412347999988" lon="-72.3593826898599985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{66fa7879-ad20-47e4-9140-c3c7de8a9f52}"/>
     </node>
-    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988183784600013" lon="-72.3644868463200055">
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988183784600013" lon="-72.3644868463200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{347874d6-7887-4085-9a1a-24efd90a2479}"/>
     </node>
-    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988550299999998" lon="-72.3644932968399814">
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988550299999998" lon="-72.3644932968399814">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{62350f3f-463b-42fb-8b9e-e32eb8a3b174}"/>
     </node>
-    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988897343599980" lon="-72.3645093670400001">
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988897343599980" lon="-72.3645093670400001">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{517b3307-09b5-4b3a-b497-e5bf7adf0d64}"/>
     </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994340143300004" lon="-72.3648455978899960">
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994340143300004" lon="-72.3648455978899960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f354a4b8-acc1-4762-bfe4-1cdc0422cb72}"/>
     </node>
-    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994883816500002" lon="-72.3648748282899987">
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994883816500002" lon="-72.3648748282899987">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b778ee8d-262a-40b4-aa1d-4e2b3ff58d14}"/>
     </node>
-    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995300524399983" lon="-72.3648891177899998">
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995300524399983" lon="-72.3648891177899998">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{083899ed-ba61-47ce-8baf-6616ec0677ec}"/>
     </node>
-    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995468363599979" lon="-72.3648901012099941">
+    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995468363599979" lon="-72.3648901012099941">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4132d23d-4212-4639-a6b3-e5b6935de61c}"/>
     </node>
-    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995612977999981" lon="-72.3648866791999978">
+    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995612977999981" lon="-72.3648866791999978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{06bf1610-0e90-49fc-9114-36b379c4660a}"/>
     </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995737206600010" lon="-72.3648786283799978">
+    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995737206600010" lon="-72.3648786283799978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{575d3611-dc51-40ab-b2d8-c2561e00890b}"/>
     </node>
-    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996182300299996" lon="-72.3648208084500055">
+    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996182300299996" lon="-72.3648208084500055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fd69d246-ec48-48f9-9317-26fae1eae0fe}"/>
     </node>
-    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996632180000013" lon="-72.3647774958599967">
+    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996632180000013" lon="-72.3647774958599967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9058c10d-26e0-4c35-ad74-e9aaed0ea42b}"/>
     </node>
-    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996960073499991" lon="-72.3647552536900065">
+    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996960073499991" lon="-72.3647552536900065">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{15f50f45-3907-4fb8-907a-bc3bc30b02ee}"/>
     </node>
-    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997367568100019" lon="-72.3647365293199982">
+    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997367568100019" lon="-72.3647365293199982">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3bafbefa-9894-45a8-a7cb-69912c23d12c}"/>
     </node>
-    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999384750299988" lon="-72.3646676866299856">
+    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999384750299988" lon="-72.3646676866299856">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c4a1cf21-416f-414f-b333-94cc84807c1c}"/>
     </node>
-    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000524529499996" lon="-72.3646327131999954">
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000524529499996" lon="-72.3646327131999954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3d83ceeb-0418-4a95-b4ab-5fc7705850f7}"/>
     </node>
-    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003252868600010" lon="-72.3645614283999947">
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003252868600010" lon="-72.3645614283999947">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b1399b5-2753-4066-bc56-b8e3aefe90e7}"/>
     </node>
-    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3644779235235234">
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3644779235235234">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991389118199240" lon="-72.3584000000000032">
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991389118199240" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992284381644600" lon="-72.3584000000000032">
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992284381644600" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3587000267866642">
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3587000267866642">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3648749865446348">
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3648749865446348">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993110867921271" lon="-72.3653999999999940">
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993110867921271" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3595948439905925">
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3595948439905925">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3604333847607819">
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3604333847607819">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019046245402620" lon="-72.3653999999999940">
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019046245402620" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3637694387719250">
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3637694387719250">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007915076878293" lon="-72.3653999999999940">
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007915076878293" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999976" lon="-72.3609894875373385">
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999976" lon="-72.3609894875373385">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029956433356528" lon="-72.3653999999999940">
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029956433356528" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024584100726941" lon="-72.3653999999999940">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024584100726941" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3592806677495304">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3592806677495304">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3629401351312538">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3629401351312538">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3643537384355255">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3643537384355255">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024697672642928" lon="-72.3584000000000032">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024697672642928" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007453994198976" lon="-72.3584000000000032">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007453994198976" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999766979966902" lon="-72.3584000000000032">
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999766979966902" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014734418771242" lon="-72.3584000000000032">
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014734418771242" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3587182734695205">
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3587182734695205">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-1971" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-812"/>
-        <nd ref="-191"/>
-        <nd ref="-326"/>
-        <nd ref="-190"/>
-        <nd ref="-189"/>
-        <nd ref="-188"/>
-        <nd ref="-222"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
-        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
-    </way>
-    <way visible="true" id="-1970" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-811"/>
-        <nd ref="-812"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="layer" v="1"/>
-        <tag k="source:datetime" v="2018-05-22T21:24:39Z;2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
-        <tag k="bdw-id" v="{40ea34f9-03b9-46b5-b9ad-7e71a1b00175}"/>
-    </way>
-    <way visible="true" id="-1969" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-202"/>
-        <nd ref="-192"/>
-        <nd ref="-811"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-10T16:22:23Z"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-    </way>
-    <way visible="true" id="-1968" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-805"/>
-        <nd ref="-163"/>
-        <nd ref="-162"/>
+    <node visible="true" id="1820405014" timestamp="2012-07-10T14:55:54Z" version="1" changeset="12174490" user="punkadiddle" uid="152973" lat="7.7006193181646276" lon="-72.3618603108395320">
+        <tag k="hoot:status" v="2"/>
+        <tag k="bdw-id" v="{f302ecab-f75b-43dc-a73f-4a34012e3ef7}"/>
+    </node>
+    <node visible="true" id="1820405164" timestamp="2012-07-10T14:56:00Z" version="1" changeset="12174490" user="punkadiddle" uid="152973" lat="7.7006208228703041" lon="-72.3620566530983780">
+        <tag k="hoot:status" v="2"/>
+        <tag k="bdw-id" v="{297b891c-b3f1-4647-a704-a2bdf767ad75}"/>
+    </node>
+    <node visible="true" id="1820492756" timestamp="2012-07-10T16:22:04Z" version="1" changeset="12175062" user="punkadiddle" uid="152973" lat="7.7012125526970445" lon="-72.3609961014727787">
+        <tag k="hoot:status" v="2"/>
+        <tag k="bdw-id" v="{e3af4f8e-5eec-4c79-aab4-56fe2420d431}"/>
+    </node>
+    <node visible="true" id="1823084483" timestamp="2012-07-12T16:14:12Z" version="1" changeset="12197232" user="punkadiddle" uid="152973" lat="7.7002507785244116" lon="-72.3620289331979478">
+        <tag k="hoot:status" v="2"/>
+        <tag k="bdw-id" v="{a9a65f8c-0819-4829-ae40-9546ed6e98f5}"/>
+    </node>
+    <node visible="true" id="1823084653" timestamp="2012-07-12T16:14:15Z" version="1" changeset="12197232" user="punkadiddle" uid="152973" lat="7.6999007391641490" lon="-72.3619783335608560">
+        <tag k="hoot:status" v="2"/>
+        <tag k="bdw-id" v="{269ded8c-88fd-4792-bcbb-6b71cfeb3454}"/>
+    </node>
+    <way visible="true" id="-143978" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-720"/>
+        <nd ref="-185"/>
+        <nd ref="-184"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="bridge" v="yes"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{607c2a36-d410-462c-bcfe-cf528efb36d2}"/>
     </way>
-    <way visible="true" id="-1967" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-231"/>
-        <nd ref="-172"/>
-        <nd ref="-171"/>
-        <nd ref="-170"/>
-        <nd ref="-169"/>
-        <nd ref="-168"/>
-        <nd ref="-342"/>
-        <nd ref="-167"/>
-        <nd ref="-166"/>
-        <nd ref="-367"/>
-        <nd ref="-165"/>
-        <nd ref="-164"/>
-        <nd ref="-805"/>
+    <way visible="true" id="-143977" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-253"/>
+        <nd ref="-194"/>
+        <nd ref="-193"/>
+        <nd ref="-192"/>
+        <nd ref="-191"/>
+        <nd ref="-190"/>
+        <nd ref="1823084483"/>
+        <nd ref="-189"/>
+        <nd ref="-188"/>
+        <nd ref="1823084653"/>
+        <nd ref="-187"/>
+        <nd ref="-186"/>
+        <nd ref="-720"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{05125c57-c79d-4118-98f5-342027ffbd88}"/>
     </way>
-    <way visible="true" id="-1966" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-799"/>
-        <nd ref="-214"/>
+    <way visible="true" id="-143976" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-714"/>
+        <nd ref="-236"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="bridge" v="yes"/>
@@ -1158,468 +1126,548 @@
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{206c3cb6-55ad-4745-95a6-7b713f797b58}"/>
     </way>
-    <way visible="true" id="-1965" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-231"/>
-        <nd ref="-109"/>
-        <nd ref="-296"/>
-        <nd ref="-108"/>
-        <nd ref="-293"/>
-        <nd ref="-107"/>
-        <nd ref="-106"/>
-        <nd ref="-105"/>
-        <nd ref="-799"/>
+    <way visible="true" id="-143975" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-253"/>
+        <nd ref="-131"/>
+        <nd ref="1820405164"/>
+        <nd ref="-130"/>
+        <nd ref="1820405014"/>
+        <nd ref="-129"/>
+        <nd ref="-128"/>
+        <nd ref="-127"/>
+        <nd ref="-714"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-260"/>
-        <nd ref="-259"/>
-        <nd ref="-258"/>
+    <way visible="true" id="-143974" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-708"/>
+        <nd ref="-213"/>
+        <nd ref="1820492756"/>
+        <nd ref="-212"/>
+        <nd ref="-211"/>
+        <nd ref="-210"/>
+        <nd ref="-244"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
+    </way>
+    <way visible="true" id="-143973" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-707"/>
+        <nd ref="-708"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="layer" v="1"/>
+        <tag k="source:datetime" v="2018-05-22T21:24:39Z;2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{40ea34f9-03b9-46b5-b9ad-7e71a1b00175}"/>
+    </way>
+    <way visible="true" id="-143972" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-224"/>
+        <nd ref="-214"/>
+        <nd ref="-707"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-10T16:22:23Z"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+    </way>
+    <way visible="true" id="-142153" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-282"/>
+        <nd ref="-281"/>
+        <nd ref="-280"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
-    <way visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-268"/>
-        <nd ref="-267"/>
-        <nd ref="-266"/>
-        <nd ref="-265"/>
-        <nd ref="-264"/>
-        <nd ref="-263"/>
-        <nd ref="-262"/>
-        <nd ref="-261"/>
-        <nd ref="-260"/>
+    <way visible="true" id="-142142" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-290"/>
+        <nd ref="-289"/>
+        <nd ref="-288"/>
+        <nd ref="-287"/>
+        <nd ref="-286"/>
+        <nd ref="-285"/>
+        <nd ref="-284"/>
+        <nd ref="-283"/>
+        <nd ref="-282"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-253"/>
-        <nd ref="-252"/>
-        <nd ref="-251"/>
+    <way visible="true" id="-142141" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-275"/>
+        <nd ref="-274"/>
+        <nd ref="-273"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
-    <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-250"/>
-        <nd ref="-249"/>
-        <nd ref="-248"/>
-        <nd ref="-247"/>
-        <nd ref="-254"/>
+    <way visible="true" id="-142140" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-272"/>
+        <nd ref="-271"/>
+        <nd ref="-270"/>
+        <nd ref="-269"/>
+        <nd ref="-276"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-245"/>
-        <nd ref="-244"/>
-        <nd ref="-268"/>
+    <way visible="true" id="-142139" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-267"/>
+        <nd ref="-266"/>
+        <nd ref="-290"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
     </way>
-    <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-256"/>
-        <nd ref="-243"/>
-        <nd ref="-242"/>
-        <nd ref="-241"/>
-        <nd ref="-240"/>
-        <nd ref="-254"/>
+    <way visible="true" id="-142138" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-278"/>
+        <nd ref="-265"/>
+        <nd ref="-264"/>
+        <nd ref="-263"/>
+        <nd ref="-262"/>
+        <nd ref="-276"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-254"/>
-        <nd ref="-239"/>
-        <nd ref="-251"/>
+    <way visible="true" id="-142137" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-276"/>
+        <nd ref="-261"/>
+        <nd ref="-273"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-236"/>
-        <nd ref="-235"/>
-        <nd ref="-256"/>
+    <way visible="true" id="-142136" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-258"/>
+        <nd ref="-257"/>
+        <nd ref="-278"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
-    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-251"/>
-        <nd ref="-234"/>
-        <nd ref="-268"/>
+    <way visible="true" id="-142135" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-273"/>
+        <nd ref="-256"/>
+        <nd ref="-290"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-233"/>
-        <nd ref="-232"/>
-        <nd ref="-231"/>
+    <way visible="true" id="-142134" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-255"/>
+        <nd ref="-254"/>
+        <nd ref="-253"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{537c0976-006b-4203-a95e-03026a59dfa7}"/>
     </way>
-    <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-230"/>
-        <nd ref="-229"/>
-        <nd ref="-228"/>
+    <way visible="true" id="-142133" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-252"/>
+        <nd ref="-251"/>
+        <nd ref="-250"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-227"/>
-        <nd ref="-226"/>
-        <nd ref="-225"/>
+    <way visible="true" id="-142132" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-249"/>
+        <nd ref="-248"/>
+        <nd ref="-247"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{9cbc6adc-20c7-4565-a103-a9cc523d8c95}"/>
     </way>
-    <way visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-224"/>
-        <nd ref="-223"/>
-        <nd ref="-222"/>
-        <nd ref="-120"/>
-        <nd ref="-119"/>
-        <nd ref="-214"/>
+    <way visible="true" id="-142131" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-246"/>
+        <nd ref="-245"/>
+        <nd ref="-244"/>
+        <nd ref="-142"/>
+        <nd ref="-141"/>
+        <nd ref="-236"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-253"/>
-        <nd ref="-221"/>
-        <nd ref="-245"/>
+    <way visible="true" id="-142130" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-275"/>
+        <nd ref="-243"/>
+        <nd ref="-267"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-220"/>
-        <nd ref="-219"/>
-        <nd ref="-218"/>
-        <nd ref="-217"/>
+    <way visible="true" id="-142129" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-242"/>
+        <nd ref="-241"/>
+        <nd ref="-240"/>
+        <nd ref="-239"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
     </way>
-    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
-        <nd ref="-215"/>
-        <nd ref="-214"/>
+    <way visible="true" id="-142128" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-238"/>
+        <nd ref="-237"/>
+        <nd ref="-236"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:16Z"/>
         <tag k="bdw-id" v="{ce5ed05b-ab6e-4533-becd-513a7bbb445a}"/>
     </way>
-    <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-205"/>
-        <nd ref="-204"/>
+    <way visible="true" id="-142127" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-227"/>
+        <nd ref="-226"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
-    <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142126" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-247"/>
         <nd ref="-225"/>
-        <nd ref="-203"/>
-        <nd ref="-202"/>
+        <nd ref="-224"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-227"/>
-        <nd ref="-200"/>
-        <nd ref="-199"/>
-        <nd ref="-198"/>
+    <way visible="true" id="-142125" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-249"/>
+        <nd ref="-222"/>
+        <nd ref="-221"/>
+        <nd ref="-220"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-228"/>
-        <nd ref="-197"/>
-        <nd ref="-196"/>
-        <nd ref="-225"/>
+    <way visible="true" id="-142124" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-250"/>
+        <nd ref="-219"/>
+        <nd ref="-218"/>
+        <nd ref="-247"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-195"/>
-        <nd ref="-194"/>
-        <nd ref="-193"/>
+    <way visible="true" id="-142123" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-217"/>
+        <nd ref="-216"/>
+        <nd ref="-215"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-161"/>
-        <nd ref="-160"/>
-        <nd ref="-159"/>
-        <nd ref="-195"/>
+    <way visible="true" id="-142120" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-183"/>
+        <nd ref="-182"/>
+        <nd ref="-181"/>
+        <nd ref="-217"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-158"/>
-        <nd ref="-157"/>
-        <nd ref="-156"/>
-        <nd ref="-155"/>
-        <nd ref="-154"/>
-        <nd ref="-153"/>
+    <way visible="true" id="-142119" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-180"/>
+        <nd ref="-179"/>
+        <nd ref="-178"/>
+        <nd ref="-177"/>
+        <nd ref="-176"/>
+        <nd ref="-175"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{6aa81513-dca3-45e8-9132-c60073bb31b1}"/>
     </way>
-    <way visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-245"/>
-        <nd ref="-152"/>
-        <nd ref="-151"/>
-        <nd ref="-150"/>
-        <nd ref="-149"/>
+    <way visible="true" id="-142118" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-267"/>
+        <nd ref="-174"/>
+        <nd ref="-173"/>
+        <nd ref="-172"/>
+        <nd ref="-171"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-193"/>
-        <nd ref="-148"/>
-        <nd ref="-147"/>
-        <nd ref="-217"/>
+    <way visible="true" id="-142117" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-215"/>
+        <nd ref="-170"/>
+        <nd ref="-169"/>
+        <nd ref="-239"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-146"/>
-        <nd ref="-145"/>
-        <nd ref="-236"/>
+    <way visible="true" id="-142116" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-168"/>
+        <nd ref="-167"/>
+        <nd ref="-258"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
-    <way visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-193"/>
-        <nd ref="-144"/>
-        <nd ref="-143"/>
-        <nd ref="-142"/>
-        <nd ref="-233"/>
+    <way visible="true" id="-142115" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-215"/>
+        <nd ref="-166"/>
+        <nd ref="-165"/>
+        <nd ref="-164"/>
+        <nd ref="-255"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-228"/>
-        <nd ref="-193"/>
+    <way visible="true" id="-142114" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-250"/>
+        <nd ref="-215"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-208"/>
-        <nd ref="-141"/>
-        <nd ref="-140"/>
+    <way visible="true" id="-142113" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-230"/>
+        <nd ref="-163"/>
+        <nd ref="-162"/>
+        <nd ref="-252"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-208"/>
-        <nd ref="-139"/>
-        <nd ref="-138"/>
-        <nd ref="-137"/>
+    <way visible="true" id="-142112" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-230"/>
+        <nd ref="-161"/>
+        <nd ref="-160"/>
+        <nd ref="-159"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
     </way>
-    <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-137"/>
-        <nd ref="-136"/>
-        <nd ref="-228"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-    </way>
-    <way visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142111" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-159"/>
         <nd ref="-158"/>
-        <nd ref="-135"/>
-        <nd ref="-134"/>
-        <nd ref="-133"/>
-        <nd ref="-132"/>
-        <nd ref="-161"/>
+        <nd ref="-250"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-161"/>
-        <nd ref="-123"/>
-        <nd ref="-122"/>
-        <nd ref="-121"/>
+    <way visible="true" id="-142110" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-180"/>
+        <nd ref="-157"/>
+        <nd ref="-156"/>
+        <nd ref="-155"/>
+        <nd ref="-154"/>
+        <nd ref="-183"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+    </way>
+    <way visible="true" id="-142109" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-183"/>
+        <nd ref="-145"/>
+        <nd ref="-144"/>
+        <nd ref="-143"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
     </way>
-    <way visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-181"/>
-        <nd ref="-118"/>
-        <nd ref="-117"/>
-        <nd ref="-116"/>
-        <nd ref="-134"/>
+    <way visible="true" id="-142107" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-203"/>
+        <nd ref="-140"/>
+        <nd ref="-139"/>
+        <nd ref="-138"/>
+        <nd ref="-156"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{06fdfdf2-6ac0-45a9-8895-42ee0c3a20d1}"/>
     </way>
-    <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-121"/>
-        <nd ref="-115"/>
-        <nd ref="-114"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-142106" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-143"/>
+        <nd ref="-137"/>
+        <nd ref="-136"/>
+        <nd ref="-242"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
     </way>
-    <way visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-236"/>
-        <nd ref="-113"/>
-        <nd ref="-112"/>
-        <nd ref="-250"/>
+    <way visible="true" id="-142105" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-258"/>
+        <nd ref="-135"/>
+        <nd ref="-134"/>
+        <nd ref="-272"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-224"/>
-        <nd ref="-111"/>
-        <nd ref="-110"/>
-        <nd ref="-250"/>
+    <way visible="true" id="-142104" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-246"/>
+        <nd ref="-133"/>
+        <nd ref="-132"/>
+        <nd ref="-272"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-104"/>
-        <nd ref="-103"/>
-        <nd ref="-102"/>
-        <nd ref="-137"/>
+    <way visible="true" id="-142102" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-159"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-104"/>
-        <nd ref="-100"/>
-        <nd ref="-158"/>
+    <way visible="true" id="-142101" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-126"/>
+        <nd ref="-122"/>
+        <nd ref="-180"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
-        <nd ref="-99"/>
-        <nd ref="-98"/>
-        <nd ref="-253"/>
+    <way visible="true" id="-142100" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-238"/>
+        <nd ref="-121"/>
+        <nd ref="-120"/>
+        <nd ref="-275"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
-    <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-182"/>
-        <nd ref="-97"/>
-        <nd ref="-224"/>
+    <way visible="true" id="-142099" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-204"/>
+        <nd ref="-119"/>
+        <nd ref="-246"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-250"/>
-        <nd ref="-96"/>
-        <nd ref="-253"/>
+    <way visible="true" id="-142098" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-272"/>
+        <nd ref="-118"/>
+        <nd ref="-275"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-222"/>
-        <nd ref="-95"/>
-        <nd ref="-94"/>
-        <nd ref="-93"/>
-        <nd ref="-216"/>
+    <way visible="true" id="-142097" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-244"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-115"/>
+        <nd ref="-238"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-195"/>
-        <nd ref="-91"/>
-        <nd ref="-90"/>
-        <nd ref="-89"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-142096" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-217"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-242"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{b63b8bca-9850-40b8-a253-3bbd2aca3dd2}"/>
     </way>
-    <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
+    <way visible="true" id="-142095" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-238"/>
+        <nd ref="-110"/>
+        <nd ref="-109"/>
+        <nd ref="-108"/>
+        <nd ref="-107"/>
+        <nd ref="-106"/>
+        <nd ref="-105"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-171"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 12"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
+        <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
+    </way>
+    <way visible="true" id="-142094" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-239"/>
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-99"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+    </way>
+    <way visible="true" id="-142093" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-98"/>
+        <nd ref="-249"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
+    </way>
+    <way visible="true" id="-142092" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-204"/>
+        <nd ref="-97"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
+        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
+    </way>
+    <way visible="true" id="-142091" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-255"/>
+        <nd ref="-92"/>
+        <nd ref="-91"/>
+        <nd ref="-90"/>
+        <nd ref="-89"/>
         <nd ref="-88"/>
         <nd ref="-87"/>
         <nd ref="-86"/>
@@ -1627,364 +1675,316 @@
         <nd ref="-84"/>
         <nd ref="-83"/>
         <nd ref="-82"/>
-        <nd ref="-81"/>
-        <nd ref="-149"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="name" v="Avenida 12"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
-        <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
-    </way>
-    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-217"/>
-        <nd ref="-80"/>
-        <nd ref="-79"/>
-        <nd ref="-78"/>
-        <nd ref="-77"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-    </way>
-    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-76"/>
-        <nd ref="-227"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
-    </way>
-    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-182"/>
-        <nd ref="-75"/>
-        <nd ref="-146"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
-        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
-    </way>
-    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-233"/>
-        <nd ref="-70"/>
-        <nd ref="-69"/>
-        <nd ref="-68"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-64"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-61"/>
-        <nd ref="-60"/>
-        <nd ref="-217"/>
+        <nd ref="-239"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
     </way>
-    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-230"/>
-        <nd ref="-59"/>
-        <nd ref="-58"/>
-        <nd ref="-227"/>
+    <way visible="true" id="-142090" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-252"/>
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-249"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-202"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-233"/>
+    <way visible="true" id="-142089" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-224"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-255"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
     </way>
-    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-204"/>
-        <nd ref="-55"/>
-        <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-104"/>
+    <way visible="true" id="-142088" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-226"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-126"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
-    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-260"/>
-        <nd ref="-50"/>
-        <nd ref="-45"/>
-        <nd ref="-20"/>
+    <way visible="true" id="-142087" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-282"/>
+        <nd ref="-72"/>
+        <nd ref="-67"/>
+        <nd ref="-42"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
-    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-161"/>
-        <nd ref="-48"/>
-        <nd ref="-47"/>
-        <nd ref="-46"/>
-        <nd ref="-174"/>
+    <way visible="true" id="-142086" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-183"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-196"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
         <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
     </way>
-    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-149"/>
-        <nd ref="-43"/>
-        <nd ref="-42"/>
-        <nd ref="-41"/>
-        <nd ref="-40"/>
-        <nd ref="-39"/>
-        <nd ref="-258"/>
+    <way visible="true" id="-142085" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-171"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-280"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
     </way>
-    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-178"/>
-        <nd ref="-132"/>
+    <way visible="true" id="-142084" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-200"/>
+        <nd ref="-154"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{01bf0fd7-c3f0-45ef-9565-1c25f24b0446}"/>
     </way>
-    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22"/>
-        <nd ref="-38"/>
-        <nd ref="-37"/>
-        <nd ref="-36"/>
-        <nd ref="-35"/>
-        <nd ref="-34"/>
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-25"/>
-        <nd ref="-24"/>
-        <nd ref="-23"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-142083" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-44"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-242"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:24:57Z;2012-07-12T16:14:19Z;2012-07-12T16:24:56Z"/>
         <tag k="bdw-id" v="{d6bb5ef0-cba5-4f65-bb54-309479757568}"/>
     </way>
-    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21"/>
-        <nd ref="-49"/>
-        <nd ref="-44"/>
-        <nd ref="-50"/>
+    <way visible="true" id="-142082" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-43"/>
+        <nd ref="-71"/>
+        <nd ref="-66"/>
+        <nd ref="-72"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
-    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19"/>
-        <nd ref="-49"/>
+    <way visible="true" id="-142080" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-41"/>
+        <nd ref="-71"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{6e1509b9-a960-4bd6-845e-6ac143dc8d18}"/>
     </way>
-    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18"/>
-        <nd ref="-51"/>
-        <nd ref="-204"/>
+    <way visible="true" id="-142079" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-40"/>
+        <nd ref="-73"/>
+        <nd ref="-226"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{efc93331-7a05-42f4-a7fc-78ab5793d04d}"/>
     </way>
-    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-121"/>
-        <nd ref="-74"/>
-        <nd ref="-73"/>
-        <nd ref="-72"/>
-        <nd ref="-71"/>
-        <nd ref="-17"/>
+    <way visible="true" id="-142078" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-143"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-93"/>
+        <nd ref="-39"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
     </way>
-    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16"/>
-        <nd ref="-92"/>
-        <nd ref="-236"/>
+    <way visible="true" id="-142077" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38"/>
+        <nd ref="-114"/>
+        <nd ref="-258"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-101"/>
-        <nd ref="-146"/>
+    <way visible="true" id="-142076" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37"/>
+        <nd ref="-123"/>
+        <nd ref="-168"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 11"/>
         <tag k="source:datetime" v="2012-07-10T17:03:23Z"/>
         <tag k="bdw-id" v="{d3f5dac4-74c6-42fe-b0bf-bad11de41657}"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-14"/>
-        <nd ref="-131"/>
-        <nd ref="-130"/>
-        <nd ref="-129"/>
-        <nd ref="-128"/>
-        <nd ref="-127"/>
-        <nd ref="-126"/>
-        <nd ref="-125"/>
-        <nd ref="-124"/>
-        <nd ref="-181"/>
+    <way visible="true" id="-142075" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36"/>
+        <nd ref="-153"/>
+        <nd ref="-152"/>
+        <nd ref="-151"/>
+        <nd ref="-150"/>
+        <nd ref="-149"/>
+        <nd ref="-148"/>
+        <nd ref="-147"/>
+        <nd ref="-146"/>
+        <nd ref="-203"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{6cdcf24d-4846-4e30-9360-c782f3239ee5}"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-208"/>
+    <way visible="true" id="-142074" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35"/>
+        <nd ref="-230"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-181"/>
-        <nd ref="-180"/>
-        <nd ref="-179"/>
-        <nd ref="-178"/>
-        <nd ref="-177"/>
-        <nd ref="-176"/>
-        <nd ref="-175"/>
-        <nd ref="-174"/>
-        <nd ref="-173"/>
-        <nd ref="-12"/>
+    <way visible="true" id="-142073" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-203"/>
+        <nd ref="-202"/>
+        <nd ref="-201"/>
+        <nd ref="-200"/>
+        <nd ref="-199"/>
+        <nd ref="-198"/>
+        <nd ref="-197"/>
+        <nd ref="-196"/>
+        <nd ref="-195"/>
+        <nd ref="-34"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
         <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-183"/>
-        <nd ref="-182"/>
+    <way visible="true" id="-142072" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33"/>
+        <nd ref="-205"/>
+        <nd ref="-204"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-186"/>
-        <nd ref="-185"/>
-        <nd ref="-184"/>
-        <nd ref="-205"/>
+    <way visible="true" id="-142071" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32"/>
+        <nd ref="-208"/>
+        <nd ref="-207"/>
+        <nd ref="-206"/>
+        <nd ref="-227"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-205"/>
-        <nd ref="-187"/>
-        <nd ref="-9"/>
+    <way visible="true" id="-142070" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-227"/>
+        <nd ref="-209"/>
+        <nd ref="-31"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{e1882670-308b-4243-9802-b0f59e00fcd8}"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-258"/>
-        <nd ref="-201"/>
-        <nd ref="-8"/>
+    <way visible="true" id="-142069" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-280"/>
+        <nd ref="-223"/>
+        <nd ref="-30"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:30:24Z"/>
         <tag k="bdw-id" v="{841e511f-12b8-465b-8dcf-3f2e88245c4f}"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7"/>
-        <nd ref="-207"/>
-        <nd ref="-206"/>
-        <nd ref="-230"/>
+    <way visible="true" id="-142068" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="-229"/>
+        <nd ref="-228"/>
+        <nd ref="-252"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-6"/>
-        <nd ref="-213"/>
-        <nd ref="-212"/>
-        <nd ref="-211"/>
-        <nd ref="-210"/>
-        <nd ref="-209"/>
-        <nd ref="-208"/>
+    <way visible="true" id="-142067" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-235"/>
+        <nd ref="-234"/>
+        <nd ref="-233"/>
+        <nd ref="-232"/>
+        <nd ref="-231"/>
+        <nd ref="-230"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-256"/>
-        <nd ref="-237"/>
-        <nd ref="-5"/>
+    <way visible="true" id="-142066" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-278"/>
+        <nd ref="-259"/>
+        <nd ref="-27"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Calle 16"/>
         <tag k="source:datetime" v="2012-07-10T17:03:25Z"/>
         <tag k="bdw-id" v="{7b9e474f-b2b4-4427-bae9-a57622382722}"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-251"/>
-        <nd ref="-238"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-142065" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-273"/>
+        <nd ref="-260"/>
+        <nd ref="-26"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142064" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-290"/>
         <nd ref="-268"/>
-        <nd ref="-246"/>
-        <nd ref="-3"/>
+        <nd ref="-25"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-255"/>
-        <nd ref="-254"/>
+    <way visible="true" id="-142063" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24"/>
+        <nd ref="-277"/>
+        <nd ref="-276"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-257"/>
-        <nd ref="-256"/>
+    <way visible="true" id="-142062" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23"/>
+        <nd ref="-279"/>
+        <nd ref="-278"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>

--- a/test-files/cases/attribute/network/highway-2927-multiple-types-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-multiple-types-1/Expected.osm
@@ -1,644 +1,627 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.5063" minlon="-66.90266" maxlat="10.50933" maxlon="-66.89794699999999"/>
-    <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075377200199984" lon="-66.8999424799399947">
+    <node visible="true" id="-220" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075377200199984" lon="-66.8999424799399947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073352537799973" lon="-66.8990133738400061">
+    <node visible="true" id="-219" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073352537799973" lon="-66.8990133738400061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072683640099989" lon="-66.8990233080599950">
+    <node visible="true" id="-218" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072683640099989" lon="-66.8990233080599950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072011718899994" lon="-66.8990308773600049">
+    <node visible="true" id="-217" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072011718899994" lon="-66.8990308773600049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071682123500008" lon="-66.8990337162099991">
+    <node visible="true" id="-216" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071682123500008" lon="-66.8990337162099991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071000859000012" lon="-66.8990379307799969">
+    <node visible="true" id="-215" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071000859000012" lon="-66.8990379307799969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070321465099976" lon="-66.8990445452599971">
+    <node visible="true" id="-214" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070321465099976" lon="-66.8990445452599971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069644769599986" lon="-66.8990535515700060">
+    <node visible="true" id="-213" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069644769599986" lon="-66.8990535515700060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068971596799976" lon="-66.8990649387500014">
+    <node visible="true" id="-212" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068971596799976" lon="-66.8990649387500014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068302767099979" lon="-66.8990786929099954">
+    <node visible="true" id="-211" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068302767099979" lon="-66.8990786929099954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067639095099956" lon="-66.8990947973099992">
+    <node visible="true" id="-210" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067639095099956" lon="-66.8990947973099992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066981389500000" lon="-66.8991132323200048">
+    <node visible="true" id="-209" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066981389500000" lon="-66.8991132323200048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066330451599992" lon="-66.8991339754799839">
+    <node visible="true" id="-208" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066330451599992" lon="-66.8991339754799839">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065991354400001" lon="-66.8991457931099944">
+    <node visible="true" id="-207" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065991354400001" lon="-66.8991457931099944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065369998999980" lon="-66.8991808702199791">
+    <node visible="true" id="-206" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065369998999980" lon="-66.8991808702199791">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064761136999998" lon="-66.8992181171399949">
+    <node visible="true" id="-205" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064761136999998" lon="-66.8992181171399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064165510099983" lon="-66.8992574884999840">
+    <node visible="true" id="-204" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064165510099983" lon="-66.8992574884999840">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063583844000004" lon="-66.8992989363299984">
+    <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063583844000004" lon="-66.8992989363299984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063016847399968" lon="-66.8993424101299894">
+    <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063016847399968" lon="-66.8993424101299894">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080110682999983" lon="-66.9023204815299977">
+    <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080110682999983" lon="-66.9023204815299977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080157422199978" lon="-66.9023084269200012">
+    <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080157422199978" lon="-66.9023084269200012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080198679799981" lon="-66.9022961697200031">
+    <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080198679799981" lon="-66.9022961697200031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080234370099976" lon="-66.9022837353600011">
+    <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080234370099976" lon="-66.9022837353600011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080264419200002" lon="-66.9022711496699998">
+    <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080264419200002" lon="-66.9022711496699998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080288764500001" lon="-66.9022584387400059">
+    <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080288764500001" lon="-66.9022584387400059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080307355600002" lon="-66.9022456289699790">
+    <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080307355600002" lon="-66.9022456289699790">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080320153899986" lon="-66.9022327469400011">
+    <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080320153899986" lon="-66.9022327469400011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080327132899995" lon="-66.9022198193700035">
+    <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080327132899995" lon="-66.9022198193700035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080328278100001" lon="-66.9022068730999990">
+    <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080328278100001" lon="-66.9022068730999990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080323586999977" lon="-66.9021939349899952">
+    <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080323586999977" lon="-66.9021939349899952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080313069499987" lon="-66.9021810318999997">
+    <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080313069499987" lon="-66.9021810318999997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080296747399977" lon="-66.9021681905900039">
+    <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080296747399977" lon="-66.9021681905900039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080274654399997" lon="-66.9021554377300021">
+    <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080274654399997" lon="-66.9021554377300021">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077602018099991" lon="-66.9019608399800063">
+    <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077602018099991" lon="-66.9019608399800063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072674942200024" lon="-66.9016812216199952">
+    <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072674942200024" lon="-66.9016812216199952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067556583899986" lon="-66.9013769333299990">
+    <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067556583899986" lon="-66.9013769333299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073261783799996" lon="-66.8987263520100015">
+    <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073261783799996" lon="-66.8987263520100015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072803441799998" lon="-66.8984187934499914">
+    <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072803441799998" lon="-66.8984187934499914">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066152618600004" lon="-66.8984401191300009">
+    <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066152618600004" lon="-66.8984401191300009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089760357599982" lon="-66.9011001908299932">
+    <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089760357599982" lon="-66.9011001908299932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084638829199992" lon="-66.9006832217600049">
+    <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084638829199992" lon="-66.9006832217600049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084490193099978" lon="-66.9006774795900014">
+    <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084490193099978" lon="-66.9006774795900014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084339664399984" lon="-66.9006722650899945">
+    <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084339664399984" lon="-66.9006722650899945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084187426400000" lon="-66.9006675846000007">
+    <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084187426400000" lon="-66.9006675846000007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084033664499987" lon="-66.9006634438400027">
+    <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084033664499987" lon="-66.9006634438400027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083878566299962" lon="-66.9006598478399894">
+    <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083878566299962" lon="-66.9006598478399894">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083722320499984" lon="-66.9006568009799878">
+    <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083722320499984" lon="-66.9006568009799878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083565117600006" lon="-66.9006543069800017">
+    <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083565117600006" lon="-66.9006543069800017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083407149099983" lon="-66.9006523688800030">
+    <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083407149099983" lon="-66.9006523688800030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083248607400002" lon="-66.9006509890400025">
+    <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083248607400002" lon="-66.9006509890400025">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083089685799980" lon="-66.9006501691300031">
+    <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083089685799980" lon="-66.9006501691300031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082930577799978" lon="-66.9006499101599985">
+    <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082930577799978" lon="-66.9006499101599985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082771477199994" lon="-66.9006502124399987">
+    <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082771477199994" lon="-66.9006502124399987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082595245399979" lon="-66.9006512038099999">
+    <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082595245399979" lon="-66.9006512038099999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074846600500003" lon="-66.9007861025600050">
+    <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074846600500003" lon="-66.9007861025600050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067216292700003" lon="-66.9009464602499975">
+    <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067216292700003" lon="-66.9009464602499975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066933640299993" lon="-66.9009582118199972">
+    <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066933640299993" lon="-66.9009582118199972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066655218899978" lon="-66.9009709529899936">
+    <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066655218899978" lon="-66.9009709529899936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066381367599977" lon="-66.9009846682399996">
+    <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066381367599977" lon="-66.9009846682399996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066112420100026" lon="-66.9009993408800057">
+    <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066112420100026" lon="-66.9009993408800057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065848703999976" lon="-66.9010149530000007">
+    <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065848703999976" lon="-66.9010149530000007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065590540699976" lon="-66.9010314856100052">
+    <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065590540699976" lon="-66.9010314856100052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065338244599982" lon="-66.9010489185500035">
+    <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065338244599982" lon="-66.9010489185500035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065092123199975" lon="-66.9010672305900016">
+    <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065092123199975" lon="-66.9010672305900016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064852476399988" lon="-66.9010863994100049">
+    <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064852476399988" lon="-66.9010863994100049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064619595999975" lon="-66.9011064016600017">
+    <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064619595999975" lon="-66.9011064016600017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064393765799995" lon="-66.9011272129699961">
+    <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064393765799995" lon="-66.9011272129699961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064175260899990" lon="-66.9011488079799932">
+    <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064175260899990" lon="-66.9011488079799932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064042021799988" lon="-66.9011627459599936">
+    <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064042021799988" lon="-66.9011627459599936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063870420499974" lon="-66.9012000042399961">
+    <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063870420499974" lon="-66.9012000042399961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063726633800005" lon="-66.9012384457499962">
+    <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063726633800005" lon="-66.9012384457499962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063611453199997" lon="-66.9012778588000003">
+    <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063611453199997" lon="-66.9012778588000003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063525512999991" lon="-66.9013180263899869">
+    <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063525512999991" lon="-66.9013180263899869">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063469286300002" lon="-66.9013587273300061">
+    <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063469286300002" lon="-66.9013587273300061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063443082899983" lon="-66.9013997375199949">
+    <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063443082899983" lon="-66.9013997375199949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063447046999983" lon="-66.9014408311499977">
+    <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063447046999983" lon="-66.9014408311499977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063481156700007" lon="-66.9014817819400065">
+    <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063481156700007" lon="-66.9014817819400065">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063545224200006" lon="-66.9015223644099990">
+    <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063545224200006" lon="-66.9015223644099990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063638896899985" lon="-66.9015623550899932">
+    <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063638896899985" lon="-66.9015623550899932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063761658800008" lon="-66.9016015337900001">
+    <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063761658800008" lon="-66.9016015337900001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063912833999993" lon="-66.9016396847899983">
+    <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063912833999993" lon="-66.9016396847899983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064091590199986" lon="-66.9016765979999946">
+    <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064091590199986" lon="-66.9016765979999946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064296942999995" lon="-66.9017120701799968">
+    <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064296942999995" lon="-66.9017120701799968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064527761799980" lon="-66.9017459059999879">
+    <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064527761799980" lon="-66.9017459059999879">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069241426099982" lon="-66.9024637357100005">
+    <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069241426099982" lon="-66.9024637357100005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069578427000003" lon="-66.9025617388099789">
+    <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069578427000003" lon="-66.9025617388099789">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085585902499989" lon="-66.9016759834800041">
+    <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085585902499989" lon="-66.9016759834800041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075739353999982" lon="-66.9000768396799970">
+    <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075739353999982" lon="-66.9000768396799970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082147958999990" lon="-66.9025298977699805">
+    <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082147958999990" lon="-66.9025298977699805">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080246836499995" lon="-66.9021427997700044">
+    <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080246836499995" lon="-66.9021427997700044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081916148999976" lon="-66.9021967271600033">
+    <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081916148999976" lon="-66.9021967271600033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082880034400006" lon="-66.9022063841899950">
+    <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082880034400006" lon="-66.9022063841899950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080058559099996" lon="-66.9023323085500010">
+    <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080058559099996" lon="-66.9023323085500010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082208136300004" lon="-66.9023667924499961">
+    <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082208136300004" lon="-66.9023667924499961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078633333099969" lon="-66.9023475808800043">
+    <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078633333099969" lon="-66.9023475808800043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069272716599986" lon="-66.9024728352599993">
+    <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069272716599986" lon="-66.9024728352599993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068978317999964" lon="-66.9024770390499839">
+    <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068978317999964" lon="-66.9024770390499839">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068682494899992" lon="-66.9024800535400033">
+    <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068682494899992" lon="-66.9024800535400033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068385717700004" lon="-66.9024818739499807">
+    <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068385717700004" lon="-66.9024818739499807">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068088458200002" lon="-66.9024824973800065">
+    <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068088458200002" lon="-66.9024824973800065">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067791188999990" lon="-66.9024819228500007">
+    <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067791188999990" lon="-66.9024819228500007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067494382799982" lon="-66.9024801512699980">
+    <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067494382799982" lon="-66.9024801512699980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067198511599980" lon="-66.9024771854400058">
+    <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067198511599980" lon="-66.9024771854400058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066904045599987" lon="-66.9024730300999977">
+    <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066904045599987" lon="-66.9024730300999977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066611453200007" lon="-66.9024676918500063">
+    <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066611453200007" lon="-66.9024676918500063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066321199499981" lon="-66.9024611791700039">
+    <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066321199499981" lon="-66.9024611791700039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066033745999992" lon="-66.9024535024200020">
+    <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066033745999992" lon="-66.9024535024200020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065749549799996" lon="-66.9024446738000051">
+    <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065749549799996" lon="-66.9024446738000051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065469062699979" lon="-66.9024347073599870">
+    <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065469062699979" lon="-66.9024347073599870">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065192730599986" lon="-66.9024236189400057">
+    <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065192730599986" lon="-66.9024236189400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064920992999991" lon="-66.9024114261700049">
+    <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064920992999991" lon="-66.9024114261700049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079992294599975" lon="-66.8988626414400045">
+    <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079992294599975" lon="-66.8988626414400045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077623694300009" lon="-66.8989987836200015">
+    <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077623694300009" lon="-66.8989987836200015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076509287499977" lon="-66.8990451847499941">
+    <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076509287499977" lon="-66.8990451847499941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076327100599993" lon="-66.8990532784499976">
+    <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076327100599993" lon="-66.8990532784499976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076153222500022" lon="-66.8990630618999944">
+    <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076153222500022" lon="-66.8990630618999944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075989183999976" lon="-66.8990744489599933">
+    <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075989183999976" lon="-66.8990744489599933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075836429000002" lon="-66.8990873393999976">
+    <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075836429000002" lon="-66.8990873393999976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075696302299981" lon="-66.8991016197300041">
+    <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075696302299981" lon="-66.8991016197300041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075570037400006" lon="-66.8991171642500007">
+    <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075570037400006" lon="-66.8991171642500007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075458745900008" lon="-66.8991338361200008">
+    <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075458745900008" lon="-66.8991338361200008">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075363407599998" lon="-66.8991514885699985">
+    <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075363407599998" lon="-66.8991514885699985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075284861499991" lon="-66.8991699662099961">
+    <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075284861499991" lon="-66.8991699662099961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075223799299984" lon="-66.8991891063699882">
+    <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075223799299984" lon="-66.8991891063699882">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075180758400002" lon="-66.8992087405599989">
+    <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075180758400002" lon="-66.8992087405599989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075156117800006" lon="-66.8992286959399962">
+    <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075156117800006" lon="-66.8992286959399962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075150094399987" lon="-66.8992487968399985">
+    <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075150094399987" lon="-66.8992487968399985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075162741099994" lon="-66.8992688663099955">
+    <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075162741099994" lon="-66.8992688663099955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075193946700001" lon="-66.8992887276699975">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075193946700001" lon="-66.8992887276699975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075177010099985" lon="-66.8993920471500019">
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075177010099985" lon="-66.8993920471500019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076342153300022" lon="-66.8999983574800012">
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076342153300022" lon="-66.8999983574800012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078674621299974" lon="-66.9008672305400012">
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078674621299974" lon="-66.9008672305400012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081310488200010" lon="-66.9019488675299954">
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081310488200010" lon="-66.9019488675299954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076487450999974" lon="-66.9000524823700005">
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076487450999974" lon="-66.9000524823700005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077129303400003" lon="-66.9000381607200012">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077129303400003" lon="-66.9000381607200012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085709374999983" lon="-66.8998653134499932">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085709374999983" lon="-66.8998653134499932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076185124599988" lon="-66.8999166434399939">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076185124599988" lon="-66.8999166434399939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076767757899994" lon="-66.8998738871599983">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076767757899994" lon="-66.8998738871599983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085450696200002" lon="-66.8997414667800001">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085450696200002" lon="-66.8997414667800001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091091437099990" lon="-66.9021158291200067">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091091437099990" lon="-66.9021158291200067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088988646400008" lon="-66.9021110002500023">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088988646400008" lon="-66.9021110002500023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086704276400003" lon="-66.9021656548400045">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086704276400003" lon="-66.9021656548400045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083125509399959" lon="-66.9022836681899804">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083125509399959" lon="-66.9022836681899804">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088045681099977" lon="-66.9026277258600004">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088045681099977" lon="-66.9026277258600004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082851248800004" lon="-66.9023496594799951">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082851248800004" lon="-66.9023496594799951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088878673099977" lon="-66.9000970889999991">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088878673099977" lon="-66.9000970889999991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088469021400002" lon="-66.9000703169800062">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088469021400002" lon="-66.9000703169800062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088091845399987" lon="-66.9000390495800019">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088091845399987" lon="-66.9000390495800019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087751952799984" lon="-66.9000036853699811">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087751952799984" lon="-66.9000036853699811">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087453675999960" lon="-66.8999646751099988">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087453675999960" lon="-66.8999646751099988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087200817199982" lon="-66.8999225160499975">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087200817199982" lon="-66.8999225160499975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086996599300004" lon="-66.8998777455900040">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086996599300004" lon="-66.8998777455900040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086843625499977" lon="-66.8998309343899962">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086843625499977" lon="-66.8998309343899962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086771310000007" lon="-66.8997959613599846">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086771310000007" lon="-66.8997959613599846">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086743845699999" lon="-66.8997826791299985">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086743845699999" lon="-66.8997826791299985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086698531699980" lon="-66.8997335949199936">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086698531699980" lon="-66.8997335949199936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086708260999977" lon="-66.8996843073999941">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086708260999977" lon="-66.8996843073999941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086772909799997" lon="-66.8996354448299968">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086772909799997" lon="-66.8996354448299968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086891653900025" lon="-66.8995876300299983">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086891653900025" lon="-66.8995876300299983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087062979699990" lon="-66.8995414724900002">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087062979699990" lon="-66.8995414724900002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087284703399977" lon="-66.8994975605500031">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087284703399977" lon="-66.8994975605500031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087553998799983" lon="-66.8994564539499947">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087553998799983" lon="-66.8994564539499947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092547383599975" lon="-66.8988241885100052">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092547383599975" lon="-66.8988241885100052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091938274399990" lon="-66.9008290948000024">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091938274399990" lon="-66.9008290948000024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089872306800007" lon="-66.9011045272900020">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089872306800007" lon="-66.9011045272900020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078442156499978" lon="-66.8979469999999878">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078442156499978" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080166959699994" lon="-66.8979469999999878">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080166959699994" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079621843600020" lon="-66.8980172303800060">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079621843600020" lon="-66.8980172303800060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073355844799998" lon="-66.8983959509299950">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073355844799998" lon="-66.8983959509299950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072800635700006" lon="-66.8983993553400040">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072800635700006" lon="-66.8983993553400040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072735327399993" lon="-66.8979469999999878">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072735327399993" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092991859399962" lon="-66.8979525441699963">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092991859399962" lon="-66.8979525441699963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092608681199984" lon="-66.8979827626999963">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092608681199984" lon="-66.8979827626999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092215299599978" lon="-66.8980116115399994">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092215299599978" lon="-66.8980116115399994">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091812193800003" lon="-66.8980390555200017">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091812193800003" lon="-66.8980390555200017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091399855100001" lon="-66.8980650612299996">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091399855100001" lon="-66.8980650612299996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091240928199969" lon="-66.8980745550099982">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091240928199969" lon="-66.8980745550099982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084822232099988" lon="-66.8985161486299944">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084822232099988" lon="-66.8985161486299944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083496723199996" lon="-66.8985560080299990">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083496723199996" lon="-66.8985560080299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079699015599992" lon="-66.8987880248100026">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079699015599992" lon="-66.8987880248100026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079104082800008" lon="-66.8988204772399939">
+    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079104082800008" lon="-66.8988204772399939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078498304099988" lon="-66.8988508118599867">
+    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078498304099988" lon="-66.8988508118599867">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077882417299975" lon="-66.8988789917100064">
+    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077882417299975" lon="-66.8988789917100064">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077257173099987" lon="-66.8989049824500057">
+    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077257173099987" lon="-66.8989049824500057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076623333000008" lon="-66.8989287524299954">
+    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076623333000008" lon="-66.8989287524299954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075981669399976" lon="-66.8989502726900014">
+    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075981669399976" lon="-66.8989502726900014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075332963999983" lon="-66.8989695169999976">
+    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075332963999983" lon="-66.8989695169999976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074678007199971" lon="-66.8989864619200034">
+    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074678007199971" lon="-66.8989864619200034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074017596899996" lon="-66.8990010867999985">
+    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074017596899996" lon="-66.8990010867999985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9012373024223024">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9012373024223024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9006735384839999">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9006735384839999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093300000000003" lon="-66.9003953972457026">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093300000000003" lon="-66.9003953972457026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.8987901743431763">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.8987901743431763">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5088619095409896" lon="-66.9026599999999974">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5088619095409896" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9021468873523020">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9021468873523020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9023145890520965">
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9023145890520965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082281497036991" lon="-66.9026599999999974">
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082281497036991" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9003284747380604">
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9003284747380604">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5069729286564915" lon="-66.9026599999999974">
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5069729286564915" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999995" lon="-66.8984462481496678">
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999995" lon="-66.8984462481496678">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9011125992666820">
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9011125992666820">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.8993437981101806">
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.8993437981101806">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999960" lon="-66.9001776895871814">
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999960" lon="-66.9001776895871814">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-70"/>
-        <nd ref="-73"/>
+    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-67"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
-        <tag k="highway" v="traffic_signals"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e}"/>
-        <tag k="source:datetime" v="2014-05-13T02:51:38.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-50"/>
-        <nd ref="-49"/>
-        <nd ref="-48"/>
-        <nd ref="-47"/>
-        <nd ref="-46"/>
-        <nd ref="-45"/>
-        <nd ref="-44"/>
-        <nd ref="-43"/>
-        <nd ref="-42"/>
-        <nd ref="-41"/>
-        <nd ref="-11"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-28"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -656,12 +639,12 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3"/>
-        <nd ref="-168"/>
-        <nd ref="-169"/>
-        <nd ref="-170"/>
-        <nd ref="-114"/>
+    <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20"/>
+        <nd ref="-185"/>
+        <nd ref="-186"/>
+        <nd ref="-187"/>
+        <nd ref="-131"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. La Estrella"/>
@@ -683,23 +666,23 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-114"/>
-        <nd ref="-171"/>
-        <nd ref="-172"/>
-        <nd ref="-173"/>
-        <nd ref="-174"/>
-        <nd ref="-175"/>
-        <nd ref="-176"/>
-        <nd ref="-177"/>
-        <nd ref="-178"/>
-        <nd ref="-179"/>
-        <nd ref="-180"/>
-        <nd ref="-181"/>
-        <nd ref="-182"/>
-        <nd ref="-183"/>
-        <nd ref="-184"/>
-        <nd ref="-111"/>
+    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-131"/>
+        <nd ref="-188"/>
+        <nd ref="-189"/>
+        <nd ref="-190"/>
+        <nd ref="-191"/>
+        <nd ref="-192"/>
+        <nd ref="-193"/>
+        <nd ref="-194"/>
+        <nd ref="-195"/>
+        <nd ref="-196"/>
+        <nd ref="-197"/>
+        <nd ref="-198"/>
+        <nd ref="-199"/>
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-128"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. del Parque"/>
@@ -721,10 +704,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-118"/>
-        <nd ref="-108"/>
+    <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22"/>
+        <nd ref="-135"/>
+        <nd ref="-125"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -741,10 +724,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-71"/>
-        <nd ref="-72"/>
-        <nd ref="-70"/>
+    <way visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <nd ref="-87"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -762,11 +745,28 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-15"/>
-        <nd ref="-167"/>
-        <nd ref="-166"/>
-        <nd ref="-34"/>
+    <way visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-87"/>
+        <nd ref="-90"/>
+        <nd ref="-84"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
+        <tag k="highway" v="traffic_signals"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e}"/>
+        <tag k="source:datetime" v="2014-05-13T02:51:38.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-32"/>
+        <nd ref="-184"/>
+        <nd ref="-183"/>
+        <nd ref="-51"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -782,10 +782,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-39"/>
-        <nd ref="-117"/>
-        <nd ref="-112"/>
+    <way visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-56"/>
+        <nd ref="-134"/>
+        <nd ref="-129"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Gamboa"/>
@@ -807,9 +807,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="residential"/>
     </way>
-    <way visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-74"/>
-        <nd ref="-15"/>
+    <way visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-91"/>
+        <nd ref="-32"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -825,9 +825,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-71"/>
-        <nd ref="-113"/>
+    <way visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-88"/>
+        <nd ref="-130"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Caracas"/>
@@ -849,10 +849,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-114"/>
-        <nd ref="-113"/>
-        <nd ref="-112"/>
+    <way visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-131"/>
+        <nd ref="-130"/>
+        <nd ref="-129"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z"/>
@@ -866,9 +866,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-61"/>
-        <nd ref="-112"/>
+    <way visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-78"/>
+        <nd ref="-129"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z"/>
@@ -882,9 +882,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-59"/>
-        <nd ref="-61"/>
+    <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-76"/>
+        <nd ref="-78"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z"/>
@@ -898,9 +898,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-59"/>
-        <nd ref="-110"/>
+    <way visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-76"/>
+        <nd ref="-127"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z"/>
@@ -914,28 +914,28 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-67"/>
-        <nd ref="-74"/>
-        <nd ref="-75"/>
-        <nd ref="-76"/>
-        <nd ref="-77"/>
-        <nd ref="-78"/>
-        <nd ref="-79"/>
-        <nd ref="-80"/>
-        <nd ref="-81"/>
-        <nd ref="-82"/>
-        <nd ref="-83"/>
+    <way visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-84"/>
-        <nd ref="-85"/>
-        <nd ref="-86"/>
-        <nd ref="-87"/>
-        <nd ref="-88"/>
-        <nd ref="-89"/>
-        <nd ref="-90"/>
         <nd ref="-91"/>
         <nd ref="-92"/>
-        <nd ref="-26"/>
+        <nd ref="-93"/>
+        <nd ref="-94"/>
+        <nd ref="-95"/>
+        <nd ref="-96"/>
+        <nd ref="-97"/>
+        <nd ref="-98"/>
+        <nd ref="-99"/>
+        <nd ref="-100"/>
+        <nd ref="-101"/>
+        <nd ref="-102"/>
+        <nd ref="-103"/>
+        <nd ref="-104"/>
+        <nd ref="-105"/>
+        <nd ref="-106"/>
+        <nd ref="-107"/>
+        <nd ref="-108"/>
+        <nd ref="-109"/>
+        <nd ref="-43"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -951,11 +951,11 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-50"/>
-        <nd ref="-68"/>
-        <nd ref="-69"/>
-        <nd ref="-70"/>
+    <way visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-67"/>
+        <nd ref="-85"/>
+        <nd ref="-86"/>
+        <nd ref="-87"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -978,13 +978,13 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-1"/>
-        <nd ref="-203"/>
+    <way visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-18"/>
+        <nd ref="-220"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
         <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-50"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -1007,9 +1007,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-38"/>
-        <nd ref="-36"/>
+    <way visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-55"/>
+        <nd ref="-53"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1026,11 +1026,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-37"/>
-        <nd ref="-36"/>
-        <nd ref="-35"/>
-        <nd ref="-34"/>
+    <way visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-54"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -1047,9 +1047,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-15" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-34"/>
-        <nd ref="-33"/>
+    <way visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-51"/>
+        <nd ref="-50"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -1066,25 +1066,25 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-16"/>
-        <nd ref="-17"/>
-        <nd ref="-18"/>
-        <nd ref="-19"/>
-        <nd ref="-20"/>
-        <nd ref="-21"/>
-        <nd ref="-22"/>
-        <nd ref="-23"/>
-        <nd ref="-24"/>
-        <nd ref="-25"/>
-        <nd ref="-26"/>
-        <nd ref="-27"/>
-        <nd ref="-28"/>
-        <nd ref="-29"/>
-        <nd ref="-30"/>
-        <nd ref="-31"/>
+    <way visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-32"/>
+        <nd ref="-33"/>
+        <nd ref="-34"/>
+        <nd ref="-35"/>
+        <nd ref="-36"/>
+        <nd ref="-37"/>
+        <nd ref="-38"/>
+        <nd ref="-39"/>
+        <nd ref="-40"/>
+        <nd ref="-41"/>
+        <nd ref="-42"/>
+        <nd ref="-43"/>
+        <nd ref="-44"/>
+        <nd ref="-45"/>
+        <nd ref="-46"/>
+        <nd ref="-47"/>
+        <nd ref="-48"/>
+        <nd ref="-49"/>
         <tag k="maxspeed:conditional" v="110 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -1118,9 +1118,9 @@
         <tag k="destination" v="Cota Mil"/>
         <tag k="highway" v="motorway_link"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-39"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-56"/>
+        <nd ref="-31"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -1138,10 +1138,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-40"/>
-        <nd ref="-39"/>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Gamboa"/>
@@ -1163,17 +1163,17 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="residential"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-12"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-55"/>
-        <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-51"/>
-        <nd ref="-50"/>
+    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="30"/>
@@ -1191,10 +1191,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.705Z"/>
@@ -1208,12 +1208,12 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-9"/>
-        <nd ref="-64"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-61"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.703Z"/>
@@ -1227,25 +1227,25 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-109"/>
-        <nd ref="-108"/>
-        <nd ref="-107"/>
-        <nd ref="-106"/>
-        <nd ref="-105"/>
-        <nd ref="-104"/>
-        <nd ref="-103"/>
-        <nd ref="-102"/>
-        <nd ref="-101"/>
-        <nd ref="-100"/>
-        <nd ref="-99"/>
-        <nd ref="-98"/>
-        <nd ref="-97"/>
-        <nd ref="-96"/>
-        <nd ref="-95"/>
-        <nd ref="-94"/>
-        <nd ref="-93"/>
-        <nd ref="-8"/>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-123"/>
+        <nd ref="-122"/>
+        <nd ref="-121"/>
+        <nd ref="-120"/>
+        <nd ref="-119"/>
+        <nd ref="-118"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-115"/>
+        <nd ref="-114"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-110"/>
+        <nd ref="-25"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1262,10 +1262,10 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-110"/>
-        <nd ref="-115"/>
-        <nd ref="-7"/>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-127"/>
+        <nd ref="-132"/>
+        <nd ref="-24"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="30"/>
@@ -1283,10 +1283,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-6"/>
-        <nd ref="-116"/>
-        <nd ref="-70"/>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23"/>
+        <nd ref="-133"/>
+        <nd ref="-87"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -1309,25 +1309,8 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-108"/>
-        <nd ref="-119"/>
-        <nd ref="-120"/>
-        <nd ref="-121"/>
-        <nd ref="-122"/>
-        <nd ref="-123"/>
-        <nd ref="-124"/>
+    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-125"/>
-        <nd ref="-126"/>
-        <nd ref="-127"/>
-        <nd ref="-128"/>
-        <nd ref="-129"/>
-        <nd ref="-130"/>
-        <nd ref="-131"/>
-        <nd ref="-132"/>
-        <nd ref="-133"/>
-        <nd ref="-134"/>
-        <nd ref="-135"/>
         <nd ref="-136"/>
         <nd ref="-137"/>
         <nd ref="-138"/>
@@ -1357,7 +1340,24 @@
         <nd ref="-162"/>
         <nd ref="-163"/>
         <nd ref="-164"/>
-        <nd ref="-39"/>
+        <nd ref="-165"/>
+        <nd ref="-166"/>
+        <nd ref="-167"/>
+        <nd ref="-168"/>
+        <nd ref="-169"/>
+        <nd ref="-170"/>
+        <nd ref="-171"/>
+        <nd ref="-172"/>
+        <nd ref="-173"/>
+        <nd ref="-174"/>
+        <nd ref="-175"/>
+        <nd ref="-176"/>
+        <nd ref="-177"/>
+        <nd ref="-178"/>
+        <nd ref="-179"/>
+        <nd ref="-180"/>
+        <nd ref="-181"/>
+        <nd ref="-56"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1374,10 +1374,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34"/>
-        <nd ref="-165"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-51"/>
+        <nd ref="-182"/>
+        <nd ref="-21"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1393,10 +1393,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-110"/>
-        <nd ref="-111"/>
-        <nd ref="-109"/>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-127"/>
+        <nd ref="-128"/>
+        <nd ref="-126"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1413,27 +1413,27 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-185"/>
-        <nd ref="-186"/>
-        <nd ref="-187"/>
-        <nd ref="-188"/>
-        <nd ref="-189"/>
-        <nd ref="-190"/>
-        <nd ref="-191"/>
-        <nd ref="-192"/>
-        <nd ref="-193"/>
-        <nd ref="-194"/>
-        <nd ref="-195"/>
-        <nd ref="-196"/>
-        <nd ref="-197"/>
-        <nd ref="-198"/>
-        <nd ref="-199"/>
-        <nd ref="-200"/>
-        <nd ref="-201"/>
+    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19"/>
         <nd ref="-202"/>
-        <nd ref="-15"/>
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-205"/>
+        <nd ref="-206"/>
+        <nd ref="-207"/>
+        <nd ref="-208"/>
+        <nd ref="-209"/>
+        <nd ref="-210"/>
+        <nd ref="-211"/>
+        <nd ref="-212"/>
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <nd ref="-217"/>
+        <nd ref="-218"/>
+        <nd ref="-219"/>
+        <nd ref="-32"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>

--- a/test-files/cases/attribute/network/highway-2927-name-preservation-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-name-preservation-1/Expected.osm
@@ -1,272 +1,272 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.5053" minlon="-66.91539999999999" maxlat="10.509974" maxlon="-66.9121"/>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
+    <node visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
+    <node visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195199992" lon="-66.9148632606599989">
+    <node visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195199992" lon="-66.9148632606599989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
+    <node visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063683161199997" lon="-66.9141438720999986">
+    <node visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063683161199997" lon="-66.9141438720999986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063046214299991" lon="-66.9137310251299908">
+    <node visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063046214299991" lon="-66.9137310251299908">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062701718099962" lon="-66.9134486574999841">
+    <node visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062701718099962" lon="-66.9134486574999841">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061558192900009" lon="-66.9128470437499914">
+    <node visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061558192900009" lon="-66.9128470437499914">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
+    <node visible="true" id="-96" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
+    <node visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077143307200007" lon="-66.9144740333299808">
+    <node visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077143307200007" lon="-66.9144740333299808">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076331381000010" lon="-66.9140663332899948">
+    <node visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076331381000010" lon="-66.9140663332899948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075232974400006" lon="-66.9135307329499938">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075232974400006" lon="-66.9135307329499938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074059489500016" lon="-66.9129728706199955">
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074059489500016" lon="-66.9129728706199955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072912215099983" lon="-66.9124406098300000">
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072912215099983" lon="-66.9124406098300000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299979" lon="-66.9151838086699939">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299979" lon="-66.9151838086699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699981" lon="-66.9151444806499995">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699981" lon="-66.9151444806499995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054585547299997" lon="-66.9141921468900023">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054585547299997" lon="-66.9141921468900023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090706364099997" lon="-66.9122308439799980">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090706364099997" lon="-66.9122308439799980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086560423599984" lon="-66.9123156418699949">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086560423599984" lon="-66.9123156418699949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084297682300001" lon="-66.9123656226399959">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084297682300001" lon="-66.9123656226399959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080861369300003" lon="-66.9124369873999996">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080861369300003" lon="-66.9124369873999996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073236140899997" lon="-66.9126214131100028">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073236140899997" lon="-66.9126214131100028">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067621643700004" lon="-66.9127523923900043">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067621643700004" lon="-66.9127523923900043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062531555899987" lon="-66.9128357700700036">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062531555899987" lon="-66.9128357700700036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059741293800002" lon="-66.9128861039500009">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059741293800002" lon="-66.9128861039500009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055539111399998" lon="-66.9129797883599906">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055539111399998" lon="-66.9129797883599906">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546600005" lon="-66.9153896753699939">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546600005" lon="-66.9153896753699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457499988" lon="-66.9149623942000034">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457499988" lon="-66.9149623942000034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089687944999994" lon="-66.9146354390299933">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089687944999994" lon="-66.9146354390299933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088704779800004" lon="-66.9141622602300004">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088704779800004" lon="-66.9141622602300004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087785479200004" lon="-66.9135799125899950">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087785479200004" lon="-66.9135799125899950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087181938499974" lon="-66.9132615540100062">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087181938499974" lon="-66.9132615540100062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086206540999996" lon="-66.9126907318800050">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086206540999996" lon="-66.9126907318800050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164699986" lon="-66.9153835618100032">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164699986" lon="-66.9153835618100032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844300016" lon="-66.9148101529700057">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844300016" lon="-66.9148101529700057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077674644700014" lon="-66.9143090046700024">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077674644700014" lon="-66.9143090046700024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076714456500007" lon="-66.9138736961400014">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076714456500007" lon="-66.9138736961400014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075811864599995" lon="-66.9134289360400061">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075811864599995" lon="-66.9134289360400061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074946056699989" lon="-66.9130123914499961">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074946056699989" lon="-66.9130123914499961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074074731200007" lon="-66.9126005575199940">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074074731200007" lon="-66.9126005575199940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054666680699977" lon="-66.9142282606800052">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054666680699977" lon="-66.9142282606800052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073260069600014" lon="-66.9122176839899936">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073260069600014" lon="-66.9122176839899936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072371582699979" lon="-66.9122143048799956">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072371582699979" lon="-66.9122143048799956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085595781700007" lon="-66.9122740378600014">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085595781700007" lon="-66.9122740378600014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091017258699981" lon="-66.9122257277799974">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091017258699981" lon="-66.9122257277799974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061393139499994" lon="-66.9127610980299892">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061393139499994" lon="-66.9127610980299892">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097398742500001" lon="-66.9121124348600063">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097398742500001" lon="-66.9121124348600063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9133403110199936">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9133403110199936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099533721900009" lon="-66.9133447353499946">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099533721900009" lon="-66.9133447353499946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095799554799996" lon="-66.9134116472999949">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095799554799996" lon="-66.9134116472999949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087610510700014" lon="-66.9135981024499955">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087610510700014" lon="-66.9135981024499955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081582664799988" lon="-66.9137211045599969">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081582664799988" lon="-66.9137211045599969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075320805299999" lon="-66.9138658912099942">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075320805299999" lon="-66.9138658912099942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064590959299995" lon="-66.9140936995999880">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064590959299995" lon="-66.9140936995999880">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056531235300028" lon="-66.9142396904399988">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056531235300028" lon="-66.9142396904399988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054783852299991" lon="-66.9142804157000057">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054783852299991" lon="-66.9142804157000057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089406039699984" lon="-66.9144997629800002">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089406039699984" lon="-66.9144997629800002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093437194699995" lon="-66.9144127489399949">
+    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093437194699995" lon="-66.9144127489399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097353135099976" lon="-66.9143263374599968">
+    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097353135099976" lon="-66.9143263374599968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099296585699999" lon="-66.9142859718599965">
+    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099296585699999" lon="-66.9142859718599965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9142793794799928">
+    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9142793794799928">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099738187200042" lon="-66.9132791853800057">
+    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099738187200042" lon="-66.9132791853800057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098883177500007" lon="-66.9128676939699858">
+    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098883177500007" lon="-66.9128676939699858">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097656522800023" lon="-66.9122512857699974">
+    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097656522800023" lon="-66.9122512857699974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9130318683858576">
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9130318683858576">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5056288723729843" lon="-66.9153999999999911">
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5056288723729843" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9134683360734925">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9134683360734925">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9152942938446245">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9152942938446245">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079111408341266" lon="-66.9153999999999911">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079111408341266" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5066138849631390" lon="-66.9153999999999911">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5066138849631390" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097897933941198" lon="-66.9120999999999952">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097897933941198" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060273581464099" lon="-66.9120999999999952">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060273581464099" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5096175760148949" lon="-66.9120999999999952">
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5096175760148949" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5085220341878234" lon="-66.9120999999999952">
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5085220341878234" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097376145495947" lon="-66.9120999999999952">
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097376145495947" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5072142058022049" lon="-66.9120999999999952">
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5072142058022049" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5073020421552741" lon="-66.9120999999999952">
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5073020421552741" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9142674929639298">
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9142674929639298">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079935626786458" lon="-66.9153999999999911">
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079935626786458" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5091249962365421" lon="-66.9153999999999911">
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5091249962365421" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25"/>
-        <nd ref="-40"/>
-        <nd ref="-64"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-42"/>
+        <nd ref="-57"/>
+        <nd ref="-81"/>
+        <nd ref="-31"/>
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -291,9 +291,9 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="road"/>
     </way>
-    <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+    <way visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-51"/>
         <nd ref="-34"/>
-        <nd ref="-17"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.696Z"/>
@@ -307,16 +307,16 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-25"/>
+    <way visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-44"/>
+        <nd ref="-43"/>
+        <nd ref="-42"/>
         <tag k="alt_name" v="Av. Norte;Avenida Norte"/>
         <tag k="surface" v="paved"/>
         <tag k="z_order" v="-999999"/>
@@ -340,12 +340,12 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-20"/>
-        <nd ref="-21"/>
-        <nd ref="-22"/>
-        <nd ref="-23"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-37"/>
+        <nd ref="-38"/>
+        <nd ref="-39"/>
+        <nd ref="-40"/>
+        <nd ref="-41"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -361,10 +361,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-19"/>
-        <nd ref="-18"/>
-        <nd ref="-17"/>
+    <way visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-36"/>
+        <nd ref="-35"/>
+        <nd ref="-34"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.710Z"/>
@@ -378,19 +378,19 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-8"/>
-        <nd ref="-36"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-61"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-55"/>
-        <nd ref="-16"/>
+    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25"/>
+        <nd ref="-53"/>
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-33"/>
         <tag k="sidewalk" v="both"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
@@ -407,17 +407,17 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-72"/>
-        <nd ref="-71"/>
-        <nd ref="-70"/>
-        <nd ref="-69"/>
-        <nd ref="-68"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-25"/>
+    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32"/>
+        <nd ref="-89"/>
+        <nd ref="-88"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-42"/>
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -441,9 +441,9 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-71"/>
-        <nd ref="-13"/>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-88"/>
+        <nd ref="-30"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur 2"/>
@@ -463,17 +463,17 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-12"/>
-        <nd ref="-79"/>
-        <nd ref="-78"/>
-        <nd ref="-77"/>
-        <nd ref="-76"/>
-        <nd ref="-75"/>
-        <nd ref="-74"/>
-        <nd ref="-73"/>
-        <nd ref="-38"/>
-        <nd ref="-5"/>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-93"/>
+        <nd ref="-92"/>
+        <nd ref="-91"/>
+        <nd ref="-90"/>
+        <nd ref="-55"/>
+        <nd ref="-22"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.682Z;2019-01-17T19:50:05.664Z"/>
@@ -487,17 +487,17 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-87"/>
-        <nd ref="-86"/>
-        <nd ref="-85"/>
-        <nd ref="-84"/>
-        <nd ref="-83"/>
-        <nd ref="-82"/>
-        <nd ref="-81"/>
-        <nd ref="-80"/>
-        <nd ref="-35"/>
+    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-99"/>
+        <nd ref="-98"/>
+        <nd ref="-97"/>
+        <nd ref="-52"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -516,9 +516,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-34"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27"/>
+        <nd ref="-51"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.704Z"/>
@@ -532,9 +532,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35"/>
-        <nd ref="-9"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-52"/>
+        <nd ref="-26"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -551,9 +551,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-37"/>
-        <nd ref="-7"/>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-54"/>
+        <nd ref="-24"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -569,9 +569,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34"/>
-        <nd ref="-6"/>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-51"/>
+        <nd ref="-23"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.685Z"/>
@@ -585,9 +585,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-40"/>
-        <nd ref="-3"/>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-57"/>
+        <nd ref="-20"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur"/>
@@ -610,17 +610,17 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-47"/>
-        <nd ref="-46"/>
-        <nd ref="-45"/>
-        <nd ref="-44"/>
-        <nd ref="-43"/>
-        <nd ref="-42"/>
-        <nd ref="-41"/>
-        <nd ref="-39"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-56"/>
+        <nd ref="-21"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.681Z;2019-01-17T19:50:05.676Z"/>
@@ -634,17 +634,17 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1"/>
+    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-41"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
         <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-24"/>
-        <nd ref="-51"/>
-        <nd ref="-50"/>
-        <nd ref="-49"/>
-        <nd ref="-48"/>
-        <nd ref="-37"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>

--- a/test-files/cases/attribute/network/highway-2927-unmarked-ref-divided-road-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-2927-unmarked-ref-divided-road-1/Expected.osm
@@ -1,213 +1,213 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.4997" minlon="-66.92059999999999" maxlat="10.5029" maxlon="-66.91669999999999"/>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998810231100013" lon="-66.9189074321199939">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998810231100013" lon="-66.9189074321199939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998604597799989" lon="-66.9188191467099927">
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998604597799989" lon="-66.9188191467099927">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4997972783799991" lon="-66.9185478879700071">
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4997972783799991" lon="-66.9185478879700071">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000853238699996" lon="-66.9187692859299972">
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000853238699996" lon="-66.9187692859299972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5004951816999998" lon="-66.9186780643999981">
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5004951816999998" lon="-66.9186780643999981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011153773500006" lon="-66.9185667172800009">
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011153773500006" lon="-66.9185667172800009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002144495099987" lon="-66.9203518304800014">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002144495099987" lon="-66.9203518304800014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001903106799990" lon="-66.9201516782899972">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001903106799990" lon="-66.9201516782899972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001468854300004" lon="-66.9199419429599942">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001468854300004" lon="-66.9199419429599942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000569472900001" lon="-66.9196014045700025">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000569472900001" lon="-66.9196014045700025">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000239723099984" lon="-66.9194572242199968">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000239723099984" lon="-66.9194572242199968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311725999975" lon="-66.9202954139200017">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311725999975" lon="-66.9202954139200017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011785931099979" lon="-66.9176940783000020">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011785931099979" lon="-66.9176940783000020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5009767157099994" lon="-66.9167081692999943">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5009767157099994" lon="-66.9167081692999943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000006" lon="-66.9179020508999969">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000006" lon="-66.9179020508999969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699997" lon="-66.9171032446199803">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699997" lon="-66.9171032446199803">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800004" lon="-66.9191175683799884">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800004" lon="-66.9191175683799884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579600003" lon="-66.9184036784899945">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579600003" lon="-66.9184036784899945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768699987" lon="-66.9184060968199930">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768699987" lon="-66.9184060968199930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014790620700023" lon="-66.9185278235199945">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014790620700023" lon="-66.9185278235199945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611200013" lon="-66.9182588634100028">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611200013" lon="-66.9182588634100028">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654500014" lon="-66.9182879955099850">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654500014" lon="-66.9182879955099850">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439092000015" lon="-66.9179112165300012">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439092000015" lon="-66.9179112165300012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799974" lon="-66.9172775671599993">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799974" lon="-66.9172775671599993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328599982" lon="-66.9184260814800069">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328599982" lon="-66.9184260814800069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905700006" lon="-66.9183505367499976">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905700006" lon="-66.9183505367499976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014555671500016" lon="-66.9184526182300061">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014555671500016" lon="-66.9184526182300061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013612691200020" lon="-66.9185075180800055">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013612691200020" lon="-66.9185075180800055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013524818399997" lon="-66.9184683888800009">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013524818399997" lon="-66.9184683888800009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014334137999992" lon="-66.9188287745400032">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014334137999992" lon="-66.9188287745400032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013709919200000" lon="-66.9185508130999978">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013709919200000" lon="-66.9185508130999978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5008864321500006" lon="-66.9200366815399974">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5008864321500006" lon="-66.9200366815399974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002040527599974" lon="-66.9202656235199953">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002040527599974" lon="-66.9202656235199953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099994" lon="-66.9194331024600046">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099994" lon="-66.9194331024600046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226899997" lon="-66.9196067043800014">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226899997" lon="-66.9196067043800014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930899984" lon="-66.9197283843299999">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930899984" lon="-66.9197283843299999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800021" lon="-66.9199025736400017">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800021" lon="-66.9199025736400017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5011113656299990" lon="-66.9173657575999954">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5011113656299990" lon="-66.9173657575999954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5008601733099987" lon="-66.9174064675100055">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5008601733099987" lon="-66.9174064675100055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5000216885800004" lon="-66.9176102020399810">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5000216885800004" lon="-66.9176102020399810">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800002" lon="-66.9178452289699948">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800002" lon="-66.9178452289699948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5025802255145120" lon="-66.9205999999999932">
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5025802255145120" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5023860765049317" lon="-66.9205999999999932">
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5023860765049317" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022740980780522" lon="-66.9205999999999932">
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022740980780522" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9198328378480340">
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9198328378480340">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5018478484657400" lon="-66.9205999999999932">
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5018478484657400" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9181414315535363">
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9181414315535363">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9182340475983892">
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9182340475983892">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5028999999999986" lon="-66.9195911270657859">
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5028999999999986" lon="-66.9195911270657859">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022209583745791" lon="-66.9166999999999916">
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022209583745791" lon="-66.9166999999999916">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5009748792788962" lon="-66.9166999999999916">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5009748792788962" lon="-66.9166999999999916">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9199789801348146">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9199789801348146">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5002515743978755" lon="-66.9205999999999932">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5002515743978755" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9181243895426690">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9181243895426690">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4996999999999989" lon="-66.9188525813828505">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4996999999999989" lon="-66.9188525813828505">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9176873631122788">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9176873631122788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-18"/>
-        <nd ref="-19"/>
-        <nd ref="-20"/>
-        <nd ref="-39"/>
+    <way visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-43"/>
+        <nd ref="-44"/>
+        <nd ref="-45"/>
+        <nd ref="-64"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -231,12 +231,34 @@
         <tag k="highway" v="secondary"/>
     </way>
     <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35"/>
-        <nd ref="-34"/>
-        <nd ref="-55"/>
-        <nd ref="-20"/>
-        <nd ref="-54"/>
-        <nd ref="-6"/>
+        <nd ref="-53"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-70"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-80"/>
+        <nd ref="-45"/>
+        <nd ref="-79"/>
+        <nd ref="-31"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -259,9 +281,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-17"/>
-        <nd ref="-16"/>
+    <way visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-42"/>
+        <nd ref="-41"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
@@ -275,9 +297,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-45"/>
-        <nd ref="-42"/>
+    <way visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-70"/>
+        <nd ref="-67"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
@@ -291,10 +313,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-37"/>
-        <nd ref="-44"/>
-        <nd ref="-42"/>
+    <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-62"/>
+        <nd ref="-69"/>
+        <nd ref="-67"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -319,12 +341,12 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-39"/>
-        <nd ref="-40"/>
-        <nd ref="-17"/>
-        <nd ref="-41"/>
-        <nd ref="-37"/>
+    <way visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-64"/>
+        <nd ref="-65"/>
+        <nd ref="-42"/>
+        <nd ref="-66"/>
+        <nd ref="-62"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
@@ -338,9 +360,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-38"/>
-        <nd ref="-37"/>
+    <way visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-63"/>
+        <nd ref="-62"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
@@ -354,10 +376,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-35"/>
-        <nd ref="-36"/>
-        <nd ref="-37"/>
+    <way visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-60"/>
+        <nd ref="-61"/>
+        <nd ref="-62"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -382,18 +404,18 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-24"/>
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-35"/>
-        <tag k="z_order" v="-999999"/>
+    <way visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-49"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-60"/>
         <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Lecuna"/>
-        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
+        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2014-06-22T17:21:18.000Z;2019-01-17T19:50:06Z"/>
         <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
         <tag k="lanes" v="4"/>
         <tag k="maxspeed" v="40"/>
         <tag k="uuid" v="{7c809bd2-1b65-4e0e-9713-1e7ddc4f43a7};{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
@@ -409,11 +431,11 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-24"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
+    <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-49"/>
+        <nd ref="-56"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -430,11 +452,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-49"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -451,10 +473,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22"/>
-        <nd ref="-21"/>
-        <nd ref="-15"/>
+    <way visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-40"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -470,9 +492,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-46"/>
+        <nd ref="-39"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
@@ -486,11 +508,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-12"/>
-        <nd ref="-23"/>
-        <nd ref="-22"/>
-        <nd ref="-13"/>
+    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-38"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -514,10 +536,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-25"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -540,10 +562,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-42"/>
-        <nd ref="-43"/>
-        <nd ref="-10"/>
+    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-67"/>
+        <nd ref="-68"/>
+        <nd ref="-35"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -568,43 +590,32 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-8"/>
-        <nd ref="-51"/>
-        <nd ref="-28"/>
-        <nd ref="-50"/>
-        <nd ref="-49"/>
-        <nd ref="-45"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z;2014-05-19T20:08:16.000Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="2"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-        <tag k="destination" v="Centro"/>
-    </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-42"/>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33"/>
+        <nd ref="-76"/>
         <nd ref="-53"/>
-        <nd ref="-16"/>
-        <nd ref="-52"/>
-        <nd ref="-7"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-67"/>
+        <nd ref="-78"/>
+        <nd ref="-41"/>
+        <nd ref="-77"/>
+        <nd ref="-32"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -623,10 +634,10 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-56"/>
-        <nd ref="-21"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-81"/>
+        <nd ref="-46"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
@@ -640,14 +651,14 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-57"/>
-        <nd ref="-58"/>
-        <nd ref="-59"/>
-        <nd ref="-60"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-82"/>
+        <nd ref="-83"/>
+        <nd ref="-84"/>
+        <nd ref="-85"/>
+        <nd ref="-54"/>
+        <nd ref="-86"/>
         <nd ref="-29"/>
-        <nd ref="-61"/>
-        <nd ref="-4"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -664,12 +675,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3"/>
-        <nd ref="-65"/>
-        <nd ref="-66"/>
-        <nd ref="-67"/>
-        <nd ref="-57"/>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-90"/>
+        <nd ref="-91"/>
+        <nd ref="-92"/>
+        <nd ref="-82"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -686,19 +697,19 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-9"/>
-        <nd ref="-46"/>
-        <nd ref="-45"/>
-        <nd ref="-48"/>
-        <nd ref="-38"/>
-        <nd ref="-47"/>
-        <nd ref="-35"/>
-        <nd ref="-62"/>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-73"/>
         <nd ref="-63"/>
-        <nd ref="-64"/>
-        <nd ref="-66"/>
-        <nd ref="-2"/>
+        <nd ref="-72"/>
+        <nd ref="-60"/>
+        <nd ref="-87"/>
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <nd ref="-91"/>
+        <nd ref="-27"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>

--- a/test-files/cases/attribute/unifying/building-3022-duplicate-relation-member-ways-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/building-3022-duplicate-relation-member-ways-1/Expected.osm
@@ -1,91 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.0786640608" minlon="-69.31218968251" maxlat="10.07959649408" maxlon="-69.31059188491"/>
-    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795505612100005" lon="-69.3110665893500055">
+    <node visible="true" id="-13398293" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795505612100005" lon="-69.3110665893500055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0794337158899996" lon="-69.3110559440799960">
+    <node visible="true" id="-13398292" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0794337158899996" lon="-69.3110559440799960">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0794402179899976" lon="-69.3109832734599962">
+    <node visible="true" id="-13398291" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0794402179899976" lon="-69.3109832734599962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0793575145399998" lon="-69.3109757389400016">
+    <node visible="true" id="-13398290" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0793575145399998" lon="-69.3109757389400016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0792035595999998" lon="-69.3109617131099895">
+    <node visible="true" id="-13398289" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0792035595999998" lon="-69.3109617131099895">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0790375195699990" lon="-69.3109465865200036">
+    <node visible="true" id="-13398288" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0790375195699990" lon="-69.3109465865200036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0790310183699994" lon="-69.3110192571299990">
+    <node visible="true" id="-13398287" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0790310183699994" lon="-69.3110192571299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0787599285299994" lon="-69.3109945608500055">
+    <node visible="true" id="-13398286" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0787599285299994" lon="-69.3109945608500055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0786640607999995" lon="-69.3120660562999831">
+    <node visible="true" id="-13398285" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0786640607999995" lon="-69.3120660562999831">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0791569953999982" lon="-69.3121109657499943">
+    <node visible="true" id="-13398284" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0791569953999982" lon="-69.3121109657499943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0791524592199995" lon="-69.3121616614299825">
+    <node visible="true" id="-13398283" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0791524592199995" lon="-69.3121616614299825">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0794500763600006" lon="-69.3121896825099952">
+    <node visible="true" id="-13398282" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0794500763600006" lon="-69.3121896825099952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0793510133400002" lon="-69.3110484095600015">
+    <node visible="true" id="-13398281" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0793510133400002" lon="-69.3110484095600015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0791970575000001" lon="-69.3110343837300036">
+    <node visible="true" id="-13398280" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0791970575000001" lon="-69.3110343837300036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795948285399994" lon="-69.3107104101599987">
+    <node visible="true" id="-13398279" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795948285399994" lon="-69.3107104101599987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795964940800005" lon="-69.3105926889000017">
+    <node visible="true" id="-13398278" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795964940800005" lon="-69.3105926889000017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795407145299993" lon="-69.3105918849099965">
+    <node visible="true" id="-13398277" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795407145299993" lon="-69.3105918849099965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795390480900018" lon="-69.3107096061600032">
+    <node visible="true" id="-13398276" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0795390480900018" lon="-69.3107096061600032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-6"/>
-        <nd ref="-5"/>
-        <nd ref="-14"/>
-        <nd ref="-13"/>
-        <nd ref="-12"/>
-        <nd ref="-11"/>
-        <nd ref="-10"/>
-        <nd ref="-9"/>
-        <nd ref="-8"/>
-        <nd ref="-7"/>
-        <nd ref="-18"/>
-        <nd ref="-17"/>
-        <nd ref="-16"/>
-        <nd ref="-15"/>
-        <nd ref="-6"/>
+    <way visible="true" id="-13398292" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-13398281"/>
+        <nd ref="-13398280"/>
+        <nd ref="-13398289"/>
+        <nd ref="-13398288"/>
+        <nd ref="-13398287"/>
+        <nd ref="-13398286"/>
+        <nd ref="-13398285"/>
+        <nd ref="-13398284"/>
+        <nd ref="-13398283"/>
+        <nd ref="-13398282"/>
+        <nd ref="-13398293"/>
+        <nd ref="-13398292"/>
+        <nd ref="-13398291"/>
+        <nd ref="-13398290"/>
+        <nd ref="-13398281"/>
         <tag k="hoot:status" v="1"/>
         <tag k="building:part" v="yes"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-4"/>
-        <nd ref="-3"/>
-        <nd ref="-2"/>
-        <nd ref="-1"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-13398291" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-13398279"/>
+        <nd ref="-13398278"/>
+        <nd ref="-13398277"/>
+        <nd ref="-13398276"/>
+        <nd ref="-13398279"/>
         <tag k="hoot:status" v="1"/>
         <tag k="building:part" v="yes"/>
     </way>
     <relation visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-2" role="outer"/>
-        <member type="way" ref="-1" role="outer"/>
+        <member type="way" ref="-13398292" role="outer"/>
+        <member type="way" ref="-13398291" role="outer"/>
         <tag k="feature_area" v="23056.3"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="C.C. Arca"/>

--- a/test-files/cases/attribute/unifying/building-3136-many-to-many-auto-merge-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/building-3136-many-to-many-auto-merge-1/Expected.osm
@@ -126,22 +126,22 @@
     <relation visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2" role="outer"/>
         <member type="way" ref="-1" role="outer"/>
-        <tag k="feature_area" v="39128.8"/>
+        <tag k="feature_area" v="1602.1"/>
         <tag k="hoot:status" v="3"/>
         <tag k="amenity" v="fast_food"/>
         <tag k="addr:street" v="Avenida Libertador"/>
-        <tag k="name" v="Building 3"/>
-        <tag k="alt_types" v="shop=supermarket"/>
+        <tag k="name" v="Building 5"/>
+        <tag k="alt_types" v="shop=mall"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source:imagery" v="Unknown"/>
-        <tag k="shop" v="mall"/>
-        <tag k="alt_name" v="Building 1;Building 2;Building 4;Building 5"/>
+        <tag k="shop" v="supermarket"/>
+        <tag k="alt_name" v="Building 1;Building 2;Building 3;Building 4"/>
         <tag k="building" v="yes"/>
-        <tag k="source:datetime" v="2014-08-23T18:09:40Z;2015-06-30T21:43:19Z"/>
+        <tag k="source:datetime" v="2015-06-30T21:43:19Z;2014-08-23T18:09:40Z"/>
         <tag k="addr:city" v="Barquisimeto"/>
-        <tag k="width" v="160.1"/>
-        <tag k="angle" v="69.3"/>
-        <tag k="length" v="338.1"/>
+        <tag k="width" v="33.8"/>
+        <tag k="angle" v="359.4"/>
+        <tag k="length" v="63.2"/>
         <tag k="type" v="multipolygon"/>
     </relation>
 </osm>

--- a/test-files/cases/attribute/unifying/building-3184-completely-contained-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/building-3184-completely-contained-1/Expected.osm
@@ -232,7 +232,7 @@
     <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.0445596964999986" lon="-69.4084859930700020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-13"/>
         <nd ref="-12"/>
         <nd ref="-11"/>
@@ -242,7 +242,7 @@
         <nd ref="-13"/>
         <tag k="hoot:status" v="3"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19"/>
         <nd ref="-18"/>
         <nd ref="-17"/>
@@ -252,7 +252,7 @@
         <nd ref="-19"/>
         <tag k="hoot:status" v="3"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-57"/>
         <nd ref="-56"/>
         <nd ref="-55"/>
@@ -375,9 +375,9 @@
     <relation visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-7" role="outer"/>
         <member type="way" ref="-6" role="outer"/>
-        <member type="way" ref="-13" role="outer"/>
+        <member type="way" ref="-12" role="outer"/>
+        <member type="way" ref="-13" role="inner"/>
         <member type="way" ref="-14" role="inner"/>
-        <member type="way" ref="-15" role="inner"/>
         <tag k="feature_area" v="33731.4"/>
         <tag k="hoot:status" v="3"/>
         <tag k="addr:street" v="Avenida Florencio Jimenez"/>

--- a/test-files/cases/attribute/unifying/highway-2888/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2888/Expected.osm
@@ -3532,7 +3532,7 @@
     <node visible="true" id="-1" timestamp="2019-01-24T18:58:28Z" version="1" changeset="919" lat="4.1717205287399990" lon="73.5031247058399941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-979" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-813" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-840"/>
         <nd ref="-824"/>
         <nd ref="-823"/>
@@ -3550,26 +3550,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="300.2"/>
     </way>
-    <way visible="true" id="-947" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-1050"/>
-        <nd ref="-1022"/>
-        <nd ref="-1018"/>
-        <nd ref="-1024"/>
-        <tag k="source" v="DigitalGlobe"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Haveeree Hingun"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="DigitalGlobe"/>
-        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="1119"/>
-    </way>
-    <way visible="true" id="-917" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-796" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-976"/>
         <nd ref="-978"/>
         <nd ref="-979"/>
@@ -3594,7 +3575,26 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="1701.6"/>
     </way>
-    <way visible="true" id="-878" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-791" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-1050"/>
+        <nd ref="-1022"/>
+        <nd ref="-1018"/>
+        <nd ref="-1024"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Haveeree Hingun"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2015-10-22T17:25:22.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="1119"/>
+    </way>
+    <way visible="true" id="-768" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-930"/>
         <nd ref="-929"/>
         <nd ref="-928"/>
@@ -3648,26 +3648,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="30352.6"/>
     </way>
-    <way visible="true" id="-862" timestamp="2019-01-24T18:58:28Z" version="1">
-        <nd ref="-891"/>
-        <nd ref="-890"/>
-        <nd ref="-902"/>
-        <nd ref="-901"/>
-        <nd ref="-900"/>
-        <nd ref="-899"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
-        <tag k="name" v="Roashanee Magu"/>
-        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source:imagery" v="Unknown"/>
-        <tag k="source:datetime" v="2015-10-22T17:31:39.000Z;2019-01-24T18:58:28Z"/>
-        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
-        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
-        <tag k="length" v="141.5"/>
-    </way>
-    <way visible="true" id="-839" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-767" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-663"/>
         <nd ref="-665"/>
         <nd ref="-667"/>
@@ -3687,7 +3668,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="554.9"/>
     </way>
-    <way visible="true" id="-832" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-764" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-323"/>
         <nd ref="-673"/>
         <nd ref="-674"/>
@@ -3711,7 +3692,26 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="557.8"/>
     </way>
-    <way visible="true" id="-766" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-748" timestamp="2019-01-24T18:58:28Z" version="1">
+        <nd ref="-891"/>
+        <nd ref="-890"/>
+        <nd ref="-902"/>
+        <nd ref="-901"/>
+        <nd ref="-900"/>
+        <nd ref="-899"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:imagery:layerName" v="2019-01-04 - WV03_VNIR"/>
+        <tag k="name" v="Roashanee Magu"/>
+        <tag k="source:imagery:sensor" v="WV03_VNIR"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="Unknown"/>
+        <tag k="source:datetime" v="2015-10-22T17:31:39.000Z;2019-01-24T18:58:28Z"/>
+        <tag k="source:imagery:id" v="5ce2e89d91bbea89ecf6dbf5915a50e2"/>
+        <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
+        <tag k="length" v="141.5"/>
+    </way>
+    <way visible="true" id="-687" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-560"/>
         <nd ref="-559"/>
         <nd ref="-558"/>
@@ -3737,7 +3737,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="334.9"/>
     </way>
-    <way visible="true" id="-751" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-656" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-521"/>
         <nd ref="-517"/>
         <nd ref="-483"/>
@@ -3761,7 +3761,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="217.2"/>
     </way>
-    <way visible="true" id="-720" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-623" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-466"/>
         <nd ref="-465"/>
         <nd ref="-463"/>
@@ -3794,7 +3794,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="413.6"/>
     </way>
-    <way visible="true" id="-622" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-560" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-371"/>
         <nd ref="-372"/>
         <tag k="oneway" v="yes"/>
@@ -3811,7 +3811,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="134.4"/>
     </way>
-    <way visible="true" id="-500" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-420" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-219"/>
         <nd ref="-721"/>
         <nd ref="-199"/>
@@ -3836,7 +3836,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="761.4"/>
     </way>
-    <way visible="true" id="-481" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-408" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-167"/>
         <nd ref="-168"/>
         <nd ref="-169"/>
@@ -3868,7 +3868,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="412.4"/>
     </way>
-    <way visible="true" id="-442" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-351" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
         <nd ref="-764"/>
         <nd ref="-763"/>
@@ -3885,7 +3885,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="124.3"/>
     </way>
-    <way visible="true" id="-432" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-333" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-767"/>
         <nd ref="-768"/>
         <nd ref="-769"/>
@@ -3906,7 +3906,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="100.5"/>
     </way>
-    <way visible="true" id="-417" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-310" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1145"/>
         <nd ref="-1144"/>
         <tag k="hoot:status" v="3"/>
@@ -3921,7 +3921,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="125.9"/>
     </way>
-    <way visible="true" id="-408" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-292" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-368"/>
         <nd ref="-339"/>
         <nd ref="-340"/>
@@ -3945,7 +3945,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="559.2"/>
     </way>
-    <way visible="true" id="-370" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-209" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-1172"/>
         <nd ref="-321"/>
         <nd ref="-23"/>
@@ -3964,7 +3964,7 @@
         <tag k="source:imagery:datetime" v="2019-01-04 06:01:44"/>
         <tag k="length" v="156"/>
     </way>
-    <way visible="true" id="-363" timestamp="2019-01-24T18:58:28Z" version="1">
+    <way visible="true" id="-197" timestamp="2019-01-24T18:58:28Z" version="1">
         <nd ref="-31"/>
         <nd ref="-30"/>
         <nd ref="-29"/>

--- a/test-files/cases/attribute/unifying/highway-2927-bridge-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-bridge-1/Expected.osm
@@ -1,2869 +1,2869 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.5015" minlon="-66.92259999999999" maxlat="10.5099" maxlon="-66.9147"/>
-    <node visible="true" id="-5236" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082301450004501" lon="-66.9167206087748383">
+    <node visible="true" id="-4346" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082301450004501" lon="-66.9167206087748383">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5234" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5084235274567863" lon="-66.9177535677229969">
+    <node visible="true" id="-4344" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5084235274567863" lon="-66.9177535677229969">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5229" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5081656432906207" lon="-66.9167200335213863">
+    <node visible="true" id="-4339" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5081656432906207" lon="-66.9167200335213863">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5227" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5083481288326226" lon="-66.9177703591333710">
+    <node visible="true" id="-4337" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5083481288326226" lon="-66.9177703591333710">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5221" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5071969938525136" lon="-66.9219602198050580">
+    <node visible="true" id="-4331" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5071969938525136" lon="-66.9219602198050580">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5220" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060175046317461" lon="-66.9218696482961519">
+    <node visible="true" id="-4330" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060175046317461" lon="-66.9218696482961519">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5217" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062662208783522" lon="-66.9201004705132050">
+    <node visible="true" id="-4327" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062662208783522" lon="-66.9201004705132050">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-5216" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5081641872141720" lon="-66.9207106564285397">
+    <node visible="true" id="-4326" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5081641872141720" lon="-66.9207106564285397">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-945" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5067652497099981" lon="-66.9161491526400027">
+    <node visible="true" id="-999" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5067652497099981" lon="-66.9161491526400027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-944" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5066794441900004" lon="-66.9157311405100046">
+    <node visible="true" id="-998" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5066794441900004" lon="-66.9157311405100046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-943" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
+    <node visible="true" id="-997" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-942" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
+    <node visible="true" id="-996" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-941" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195200010" lon="-66.9148632606599989">
+    <node visible="true" id="-995" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195200010" lon="-66.9148632606599989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-940" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
+    <node visible="true" id="-994" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-939" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087822501599994" lon="-66.9205606987899984">
+    <node visible="true" id="-993" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087822501599994" lon="-66.9205606987899984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-938" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087881806399981" lon="-66.9206763885199933">
+    <node visible="true" id="-992" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087881806399981" lon="-66.9206763885199933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-937" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087818048099990" lon="-66.9207182430999978">
+    <node visible="true" id="-991" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087818048099990" lon="-66.9207182430999978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-936" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087784733100023" lon="-66.9207334703800001">
+    <node visible="true" id="-990" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087784733100023" lon="-66.9207334703800001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-935" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087736797900000" lon="-66.9207482940399956">
+    <node visible="true" id="-989" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087736797900000" lon="-66.9207482940399956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-934" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087674704699996" lon="-66.9207625711199938">
+    <node visible="true" id="-988" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087674704699996" lon="-66.9207625711199938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-933" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087599052400016" lon="-66.9207761639300003">
+    <node visible="true" id="-987" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087599052400016" lon="-66.9207761639300003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-932" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087510570599996" lon="-66.9207889413799961">
+    <node visible="true" id="-986" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087510570599996" lon="-66.9207889413799961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-931" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087410112599997" lon="-66.9208007802599951">
+    <node visible="true" id="-985" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087410112599997" lon="-66.9208007802599951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-930" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087298647100003" lon="-66.9208115663799958">
+    <node visible="true" id="-984" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087298647100003" lon="-66.9208115663799958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-929" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087177249299977" lon="-66.9208211957299994">
+    <node visible="true" id="-983" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087177249299977" lon="-66.9208211957299994">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-928" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087047089700008" lon="-66.9208295754399813">
+    <node visible="true" id="-982" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087047089700008" lon="-66.9208295754399813">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-927" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086909423700003" lon="-66.9208366246899971">
+    <node visible="true" id="-981" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086909423700003" lon="-66.9208366246899971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-926" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086765578999977" lon="-66.9208422755099974">
+    <node visible="true" id="-980" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086765578999977" lon="-66.9208422755099974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-925" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086616942699980" lon="-66.9208464733900001">
+    <node visible="true" id="-979" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086616942699980" lon="-66.9208464733900001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-924" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086464948299980" lon="-66.9208491778600063">
+    <node visible="true" id="-978" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086464948299980" lon="-66.9208491778600063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-923" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086311061700002" lon="-66.9208503628299951">
+    <node visible="true" id="-977" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086311061700002" lon="-66.9208503628299951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-922" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086156766800016" lon="-66.9208500168700056">
+    <node visible="true" id="-976" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086156766800016" lon="-66.9208500168700056">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-921" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085660942099999" lon="-66.9208384023600047">
+    <node visible="true" id="-975" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085660942099999" lon="-66.9208384023600047">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-920" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085304670599999" lon="-66.9208140015799984">
+    <node visible="true" id="-974" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085304670599999" lon="-66.9208140015799984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-919" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084577154699979" lon="-66.9207622234900015">
+    <node visible="true" id="-973" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084577154699979" lon="-66.9207622234900015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-918" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083707883800006" lon="-66.9206896343300031">
+    <node visible="true" id="-972" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083707883800006" lon="-66.9206896343300031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-917" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082939662099992" lon="-66.9206280372199984">
+    <node visible="true" id="-971" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082939662099992" lon="-66.9206280372199984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-916" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040445870400010" lon="-66.9224095164999966">
+    <node visible="true" id="-970" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040445870400010" lon="-66.9224095164999966">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-915" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039924044300008" lon="-66.9224174342899971">
+    <node visible="true" id="-969" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039924044300008" lon="-66.9224174342899971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-914" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039246767600005" lon="-66.9224388707999793">
+    <node visible="true" id="-968" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039246767600005" lon="-66.9224388707999793">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-913" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038634434600002" lon="-66.9224639132600032">
+    <node visible="true" id="-967" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038634434600002" lon="-66.9224639132600032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-912" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038539809200007" lon="-66.9224690241100006">
+    <node visible="true" id="-966" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038539809200007" lon="-66.9224690241100006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-911" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038447006600002" lon="-66.9224744655400059">
+    <node visible="true" id="-965" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038447006600002" lon="-66.9224744655400059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-910" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038356139899989" lon="-66.9224802309200015">
+    <node visible="true" id="-964" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038356139899989" lon="-66.9224802309200015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-909" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038267319799985" lon="-66.9224863132299959">
+    <node visible="true" id="-963" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038267319799985" lon="-66.9224863132299959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-908" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038180654499982" lon="-66.9224927050399998">
+    <node visible="true" id="-962" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038180654499982" lon="-66.9224927050399998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-907" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038096249699997" lon="-66.9224993985900056">
+    <node visible="true" id="-961" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038096249699997" lon="-66.9224993985900056">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-906" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038014208099995" lon="-66.9225063857099940">
+    <node visible="true" id="-960" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038014208099995" lon="-66.9225063857099940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-905" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037934629700018" lon="-66.9225136578799891">
+    <node visible="true" id="-959" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037934629700018" lon="-66.9225136578799891">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-904" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037857611399996" lon="-66.9225212062499963">
+    <node visible="true" id="-958" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037857611399996" lon="-66.9225212062499963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-903" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037783247199989" lon="-66.9225290216299982">
+    <node visible="true" id="-957" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037783247199989" lon="-66.9225290216299982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-902" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037711627500006" lon="-66.9225370944899964">
+    <node visible="true" id="-956" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037711627500006" lon="-66.9225370944899964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-901" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037642839700016" lon="-66.9225454149899832">
+    <node visible="true" id="-955" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037642839700016" lon="-66.9225454149899832">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-900" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037530185399994" lon="-66.9225604472100031">
+    <node visible="true" id="-954" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037530185399994" lon="-66.9225604472100031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-899" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034778550399999" lon="-66.9225942178100013">
+    <node visible="true" id="-953" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034778550399999" lon="-66.9225942178100013">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-898" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035613673300006" lon="-66.9225243217500037">
+    <node visible="true" id="-952" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035613673300006" lon="-66.9225243217500037">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-897" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036717385100005" lon="-66.9224195771400048">
+    <node visible="true" id="-951" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036717385100005" lon="-66.9224195771400048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-896" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037426883100000" lon="-66.9223616254000007">
+    <node visible="true" id="-950" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037426883100000" lon="-66.9223616254000007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-895" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037495744299996" lon="-66.9223520091900070">
+    <node visible="true" id="-949" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037495744299996" lon="-66.9223520091900070">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-894" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037569178000005" lon="-66.9223427448499990">
+    <node visible="true" id="-948" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037569178000005" lon="-66.9223427448499990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-893" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037647008500006" lon="-66.9223338545399997">
+    <node visible="true" id="-947" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037647008500006" lon="-66.9223338545399997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-892" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037729049399999" lon="-66.9223253595500012">
+    <node visible="true" id="-946" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037729049399999" lon="-66.9223253595500012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-891" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037815104199996" lon="-66.9223172802199855">
+    <node visible="true" id="-945" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037815104199996" lon="-66.9223172802199855">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-890" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037904967100015" lon="-66.9223096358900023">
+    <node visible="true" id="-944" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037904967100015" lon="-66.9223096358900023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-889" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037998422799976" lon="-66.9223024448599944">
+    <node visible="true" id="-943" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037998422799976" lon="-66.9223024448599944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-888" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038095247599994" lon="-66.9222957243499934">
+    <node visible="true" id="-942" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038095247599994" lon="-66.9222957243499934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-887" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038195209800005" lon="-66.9222894904399936">
+    <node visible="true" id="-941" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038195209800005" lon="-66.9222894904399936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-886" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038298070000025" lon="-66.9222837580600043">
+    <node visible="true" id="-940" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038298070000025" lon="-66.9222837580600043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-885" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038403581999980" lon="-66.9222785409299945">
+    <node visible="true" id="-939" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038403581999980" lon="-66.9222785409299945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-884" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038511493100017" lon="-66.9222738515399982">
+    <node visible="true" id="-938" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038511493100017" lon="-66.9222738515399982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-883" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038621545099993" lon="-66.9222697011200012">
+    <node visible="true" id="-937" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038621545099993" lon="-66.9222697011200012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-882" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038733474499999" lon="-66.9222660995999945">
+    <node visible="true" id="-936" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038733474499999" lon="-66.9222660995999945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-881" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038847013299996" lon="-66.9222630556100029">
+    <node visible="true" id="-935" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038847013299996" lon="-66.9222630556100029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-880" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039477880999996" lon="-66.9222452994700063">
+    <node visible="true" id="-934" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039477880999996" lon="-66.9222452994700063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-879" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040154011000002" lon="-66.9222293377499966">
+    <node visible="true" id="-933" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040154011000002" lon="-66.9222293377499966">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-878" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040839707099991" lon="-66.9222215807299960">
+    <node visible="true" id="-932" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040839707099991" lon="-66.9222215807299960">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-877" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041033650500015" lon="-66.9222148420499963">
+    <node visible="true" id="-931" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041033650500015" lon="-66.9222148420499963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-876" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041225148299979" lon="-66.9222074235500060">
+    <node visible="true" id="-930" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041225148299979" lon="-66.9222074235500060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-875" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041413967199961" lon="-66.9221993342499957">
+    <node visible="true" id="-929" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041413967199961" lon="-66.9221993342499957">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-874" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041599877199978" lon="-66.9221905840200009">
+    <node visible="true" id="-928" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041599877199978" lon="-66.9221905840200009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-873" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041782651800002" lon="-66.9221811835199958">
+    <node visible="true" id="-927" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041782651800002" lon="-66.9221811835199958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-872" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041962068300005" lon="-66.9221711441900027">
+    <node visible="true" id="-926" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041962068300005" lon="-66.9221711441900027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-871" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042137907999997" lon="-66.9221604782800057">
+    <node visible="true" id="-925" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042137907999997" lon="-66.9221604782800057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-870" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042309956800004" lon="-66.9221491987700006">
+    <node visible="true" id="-924" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042309956800004" lon="-66.9221491987700006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-869" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042478005100008" lon="-66.9221373193999796">
+    <node visible="true" id="-923" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042478005100008" lon="-66.9221373193999796">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-868" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042641848099976" lon="-66.9221248546599981">
+    <node visible="true" id="-922" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042641848099976" lon="-66.9221248546599981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-867" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042801286100005" lon="-66.9221118197300058">
+    <node visible="true" id="-921" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042801286100005" lon="-66.9221118197300058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-866" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042908581999992" lon="-66.9221025055600052">
+    <node visible="true" id="-920" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042908581999992" lon="-66.9221025055600052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-865" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043700411499987" lon="-66.9220609207900026">
+    <node visible="true" id="-919" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043700411499987" lon="-66.9220609207900026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-864" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044260032499999" lon="-66.9220255604799945">
+    <node visible="true" id="-918" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044260032499999" lon="-66.9220255604799945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-863" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044353490899987" lon="-66.9220069666800015">
+    <node visible="true" id="-917" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044353490899987" lon="-66.9220069666800015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-862" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044358143699998" lon="-66.9219929827600026">
+    <node visible="true" id="-916" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044358143699998" lon="-66.9219929827600026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-861" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044277255500020" lon="-66.9219737966800068">
+    <node visible="true" id="-915" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044277255500020" lon="-66.9219737966800068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-860" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044174232300005" lon="-66.9219644478399971">
+    <node visible="true" id="-914" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044174232300005" lon="-66.9219644478399971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-859" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044045778199990" lon="-66.9219592232600036">
+    <node visible="true" id="-913" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044045778199990" lon="-66.9219592232600036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-858" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043907386700024" lon="-66.9219587531199949">
+    <node visible="true" id="-912" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043907386700024" lon="-66.9219587531199949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-857" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043811273400003" lon="-66.9219614011000061">
+    <node visible="true" id="-911" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043811273400003" lon="-66.9219614011000061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-856" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042767598900006" lon="-66.9220177517400003">
+    <node visible="true" id="-910" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042767598900006" lon="-66.9220177517400003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-855" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042093141199988" lon="-66.9220592580499982">
+    <node visible="true" id="-909" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042093141199988" lon="-66.9220592580499982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-854" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041752622299978" lon="-66.9220987164499803">
+    <node visible="true" id="-908" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041752622299978" lon="-66.9220987164499803">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-853" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041652686300022" lon="-66.9221060618800010">
+    <node visible="true" id="-907" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041652686300022" lon="-66.9221060618800010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-852" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041549584699982" lon="-66.9221129461400039">
+    <node visible="true" id="-906" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041549584699982" lon="-66.9221129461400039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-851" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041443525900000" lon="-66.9221193553200067">
+    <node visible="true" id="-905" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041443525900000" lon="-66.9221193553200067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-850" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041334724100022" lon="-66.9221252764799885">
+    <node visible="true" id="-904" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041334724100022" lon="-66.9221252764799885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-849" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041223399099977" lon="-66.9221306976500045">
+    <node visible="true" id="-903" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041223399099977" lon="-66.9221306976500045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-848" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041109775899990" lon="-66.9221356078799943">
+    <node visible="true" id="-902" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041109775899990" lon="-66.9221356078799943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-847" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040994083899992" lon="-66.9221399972499995">
+    <node visible="true" id="-901" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040994083899992" lon="-66.9221399972499995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-846" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040876556799976" lon="-66.9221438568999787">
+    <node visible="true" id="-900" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040876556799976" lon="-66.9221438568999787">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-845" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040757432100005" lon="-66.9221471790299915">
+    <node visible="true" id="-899" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040757432100005" lon="-66.9221471790299915">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-844" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040636950300001" lon="-66.9221499569299993">
+    <node visible="true" id="-898" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040636950300001" lon="-66.9221499569299993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-843" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040515354999986" lon="-66.9221521849899972">
+    <node visible="true" id="-897" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040515354999986" lon="-66.9221521849899972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-842" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040392891700023" lon="-66.9221538586999998">
+    <node visible="true" id="-896" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040392891700023" lon="-66.9221538586999998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-841" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040269807800009" lon="-66.9221549746900024">
+    <node visible="true" id="-895" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040269807800009" lon="-66.9221549746900024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-840" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040146352000008" lon="-66.9221555306999960">
+    <node visible="true" id="-894" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040146352000008" lon="-66.9221555306999960">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-839" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040022773599979" lon="-66.9221555256000045">
+    <node visible="true" id="-893" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040022773599979" lon="-66.9221555256000045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-838" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039776066999977" lon="-66.9221556904900012">
+    <node visible="true" id="-892" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039776066999977" lon="-66.9221556904900012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-837" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039399799999984" lon="-66.9221559419599998">
+    <node visible="true" id="-891" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039399799999984" lon="-66.9221559419599998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-836" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038614669899992" lon="-66.9221619407600059">
+    <node visible="true" id="-890" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038614669899992" lon="-66.9221619407600059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-835" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038504334499976" lon="-66.9221632969399849">
+    <node visible="true" id="-889" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038504334499976" lon="-66.9221632969399849">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-834" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038394563500024" lon="-66.9221650596900020">
+    <node visible="true" id="-888" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038394563500024" lon="-66.9221650596900020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-833" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038285503300006" lon="-66.9221672266399850">
+    <node visible="true" id="-887" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038285503300006" lon="-66.9221672266399850">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-832" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038177299700024" lon="-66.9221697948899958">
+    <node visible="true" id="-886" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038177299700024" lon="-66.9221697948899958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-831" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038070097399991" lon="-66.9221727610299979">
+    <node visible="true" id="-885" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038070097399991" lon="-66.9221727610299979">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-830" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037964039500018" lon="-66.9221761210799997">
+    <node visible="true" id="-884" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037964039500018" lon="-66.9221761210799997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-829" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037859267799991" lon="-66.9221798705499964">
+    <node visible="true" id="-883" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037859267799991" lon="-66.9221798705499964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-828" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037755922200002" lon="-66.9221840044399983">
+    <node visible="true" id="-882" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037755922200002" lon="-66.9221840044399983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-827" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037654140800001" lon="-66.9221885172199933">
+    <node visible="true" id="-881" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037654140800001" lon="-66.9221885172199933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-826" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037554059700025" lon="-66.9221934028600032">
+    <node visible="true" id="-880" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037554059700025" lon="-66.9221934028600032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-825" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037455812600022" lon="-66.9221986548299981">
+    <node visible="true" id="-879" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037455812600022" lon="-66.9221986548299981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-824" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037359530599979" lon="-66.9222042661200049">
+    <node visible="true" id="-878" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037359530599979" lon="-66.9222042661200049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-823" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037265342599984" lon="-66.9222102292199992">
+    <node visible="true" id="-877" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037265342599984" lon="-66.9222102292199992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-822" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037173374300004" lon="-66.9222165361800023">
+    <node visible="true" id="-876" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037173374300004" lon="-66.9222165361800023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-821" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037083748600004" lon="-66.9222231785499986">
+    <node visible="true" id="-875" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037083748600004" lon="-66.9222231785499986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-820" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036284024499977" lon="-66.9222821029500068">
+    <node visible="true" id="-874" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036284024499977" lon="-66.9222821029500068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-819" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034863535799996" lon="-66.9223751988100020">
+    <node visible="true" id="-873" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034863535799996" lon="-66.9223751988100020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-818" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034198822499985" lon="-66.9224276465100019">
+    <node visible="true" id="-872" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034198822499985" lon="-66.9224276465100019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-817" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034092908300014" lon="-66.9224348799099999">
+    <node visible="true" id="-871" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034092908300014" lon="-66.9224348799099999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-816" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033984560300002" lon="-66.9224417353899952">
+    <node visible="true" id="-870" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033984560300002" lon="-66.9224417353899952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-815" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033873910600022" lon="-66.9224482046199967">
+    <node visible="true" id="-869" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033873910600022" lon="-66.9224482046199967">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-814" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033761093999995" lon="-66.9224542797000055">
+    <node visible="true" id="-868" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033761093999995" lon="-66.9224542797000055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-813" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033646247799979" lon="-66.9224599532399935">
+    <node visible="true" id="-867" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033646247799979" lon="-66.9224599532399935">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-812" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033529511999983" lon="-66.9224652183300037">
+    <node visible="true" id="-866" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033529511999983" lon="-66.9224652183300037">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-811" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033411028899994" lon="-66.9224700685499982">
+    <node visible="true" id="-865" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033411028899994" lon="-66.9224700685499982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-810" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033290942799997" lon="-66.9224744979800050">
+    <node visible="true" id="-864" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033290942799997" lon="-66.9224744979800050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-809" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033169399999995" lon="-66.9224785012399934">
+    <node visible="true" id="-863" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033169399999995" lon="-66.9224785012399934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-808" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033046548499982" lon="-66.9224820734499986">
+    <node visible="true" id="-862" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033046548499982" lon="-66.9224820734499986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-807" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032922538100006" lon="-66.9224852102500023">
+    <node visible="true" id="-861" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032922538100006" lon="-66.9224852102500023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-806" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032797519900019" lon="-66.9224879078300035">
+    <node visible="true" id="-860" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032797519900019" lon="-66.9224879078300035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-805" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032695045699995" lon="-66.9224897782600010">
+    <node visible="true" id="-859" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032695045699995" lon="-66.9224897782600010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-804" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030999160599965" lon="-66.9225137199599942">
+    <node visible="true" id="-858" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030999160599965" lon="-66.9225137199599942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-803" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028625950799999" lon="-66.9225353771399938">
+    <node visible="true" id="-857" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028625950799999" lon="-66.9225353771399938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-802" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027135201099977" lon="-66.9225486612599951">
+    <node visible="true" id="-856" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027135201099977" lon="-66.9225486612599951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-801" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026747243000003" lon="-66.9225573881300022">
+    <node visible="true" id="-855" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026747243000003" lon="-66.9225573881300022">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-800" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026624367999997" lon="-66.9225631163100019">
+    <node visible="true" id="-854" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026624367999997" lon="-66.9225631163100019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-799" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026503546299992" lon="-66.9225692743199971">
+    <node visible="true" id="-853" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026503546299992" lon="-66.9225692743199971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-798" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026384925099965" lon="-66.9225758546500060">
+    <node visible="true" id="-852" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026384925099965" lon="-66.9225758546500060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-797" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026268648900007" lon="-66.9225828492700003">
+    <node visible="true" id="-851" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026268648900007" lon="-66.9225828492700003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-796" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026154859399981" lon="-66.9225902496799989">
+    <node visible="true" id="-850" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026154859399981" lon="-66.9225902496799989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-795" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026043695099975" lon="-66.9225980468499984">
+    <node visible="true" id="-849" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026043695099975" lon="-66.9225980468499984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-794" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015288125800001" lon="-66.9159977800899952">
+    <node visible="true" id="-848" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015288125800001" lon="-66.9159977800899952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-793" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015120575399976" lon="-66.9213846762699944">
+    <node visible="true" id="-847" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015120575399976" lon="-66.9213846762699944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-792" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086139687800006" lon="-66.9216279922300004">
+    <node visible="true" id="-846" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086139687800006" lon="-66.9216279922300004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-791" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083126373100004" lon="-66.9217581592599942">
+    <node visible="true" id="-845" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083126373100004" lon="-66.9217581592599942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-790" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080393113399992" lon="-66.9218612427000039">
+    <node visible="true" id="-844" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080393113399992" lon="-66.9218612427000039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-789" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078613864699975" lon="-66.9219478668400001">
+    <node visible="true" id="-843" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078613864699975" lon="-66.9219478668400001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-788" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077941566699984" lon="-66.9219625554400039">
+    <node visible="true" id="-842" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077941566699984" lon="-66.9219625554400039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-787" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076501270299989" lon="-66.9219651006099951">
+    <node visible="true" id="-841" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076501270299989" lon="-66.9219651006099951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-786" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072132582499975" lon="-66.9219601110600024">
+    <node visible="true" id="-840" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072132582499975" lon="-66.9219601110600024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-785" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5068735117000003" lon="-66.9219623826299994">
+    <node visible="true" id="-839" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5068735117000003" lon="-66.9219623826299994">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-784" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062499974199994" lon="-66.9219036006099941">
+    <node visible="true" id="-838" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062499974199994" lon="-66.9219036006099941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-783" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060194185500002" lon="-66.9218706015399931">
+    <node visible="true" id="-837" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060194185500002" lon="-66.9218706015399931">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-782" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060079334399994" lon="-66.9218648812800012">
+    <node visible="true" id="-836" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060079334399994" lon="-66.9218648812800012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-781" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059970743199997" lon="-66.9218580253999988">
+    <node visible="true" id="-835" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059970743199997" lon="-66.9218580253999988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-780" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059869508200006" lon="-66.9218501030999988">
+    <node visible="true" id="-834" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059869508200006" lon="-66.9218501030999988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-779" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059776651000014" lon="-66.9218411943400042">
+    <node visible="true" id="-833" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059776651000014" lon="-66.9218411943400042">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-778" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059693109100003" lon="-66.9218313890499985">
+    <node visible="true" id="-832" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059693109100003" lon="-66.9218313890499985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-777" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059619725700006" lon="-66.9218207862000014">
+    <node visible="true" id="-831" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059619725700006" lon="-66.9218207862000014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-776" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059557241500006" lon="-66.9218094928200031">
+    <node visible="true" id="-830" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059557241500006" lon="-66.9218094928200031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-775" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059506287299982" lon="-66.9217976228899971">
+    <node visible="true" id="-829" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059506287299982" lon="-66.9217976228899971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-774" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059467377299978" lon="-66.9217852962400030">
+    <node visible="true" id="-828" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059467377299978" lon="-66.9217852962400030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-773" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059440904199999" lon="-66.9217726372899904">
+    <node visible="true" id="-827" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059440904199999" lon="-66.9217726372899904">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-772" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059427135399996" lon="-66.9217597738099812">
+    <node visible="true" id="-826" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059427135399996" lon="-66.9217597738099812">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-771" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059426209800009" lon="-66.9217468356499978">
+    <node visible="true" id="-825" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059426209800009" lon="-66.9217468356499978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-770" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059438136800001" lon="-66.9217339534099978">
+    <node visible="true" id="-824" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059438136800001" lon="-66.9217339534099978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-769" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059462795899989" lon="-66.9217212571000033">
+    <node visible="true" id="-823" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059462795899989" lon="-66.9217212571000033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-768" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059499938199981" lon="-66.9217088749000055">
+    <node visible="true" id="-822" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059499938199981" lon="-66.9217088749000055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-767" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059609192599979" lon="-66.9215616287399939">
+    <node visible="true" id="-821" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059609192599979" lon="-66.9215616287399939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-766" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059812237399992" lon="-66.9214849028799961">
+    <node visible="true" id="-820" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059812237399992" lon="-66.9214849028799961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-765" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060045791699999" lon="-66.9214201707499967">
+    <node visible="true" id="-819" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060045791699999" lon="-66.9214201707499967">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-764" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060426091799979" lon="-66.9213268069100025">
+    <node visible="true" id="-818" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060426091799979" lon="-66.9213268069100025">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-763" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060688680199998" lon="-66.9212515429699977">
+    <node visible="true" id="-817" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060688680199998" lon="-66.9212515429699977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-762" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060967998700008" lon="-66.9212048013999947">
+    <node visible="true" id="-816" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5060967998700008" lon="-66.9212048013999947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-761" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061453311899999" lon="-66.9211263849500000">
+    <node visible="true" id="-815" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061453311899999" lon="-66.9211263849500000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-760" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061630956900007" lon="-66.9211146599100033">
+    <node visible="true" id="-814" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061630956900007" lon="-66.9211146599100033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-759" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061787993800007" lon="-66.9211002411900040">
+    <node visible="true" id="-813" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061787993800007" lon="-66.9211002411900040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-758" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061920462600007" lon="-66.9210834924000011">
+    <node visible="true" id="-812" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061920462600007" lon="-66.9210834924000011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-757" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062025022900016" lon="-66.9210648358899931">
+    <node visible="true" id="-811" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062025022900016" lon="-66.9210648358899931">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-756" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062099038099994" lon="-66.9210447421200030">
+    <node visible="true" id="-810" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062099038099994" lon="-66.9210447421200030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-755" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062140641499990" lon="-66.9210237177999971">
+    <node visible="true" id="-809" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062140641499990" lon="-66.9210237177999971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-754" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062148784200016" lon="-66.9210022931000026">
+    <node visible="true" id="-808" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062148784200016" lon="-66.9210022931000026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-753" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062123260800000" lon="-66.9209810082899992">
+    <node visible="true" id="-807" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062123260800000" lon="-66.9209810082899992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-752" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062064714800005" lon="-66.9209604001100047">
+    <node visible="true" id="-806" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062064714800005" lon="-66.9209604001100047">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-751" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061974622800012" lon="-66.9209409882400053">
+    <node visible="true" id="-805" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061974622800012" lon="-66.9209409882400053">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-750" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061855256499985" lon="-66.9209232621799970">
+    <node visible="true" id="-804" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061855256499985" lon="-66.9209232621799970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-749" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061709625999988" lon="-66.9209076689400035">
+    <node visible="true" id="-803" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061709625999988" lon="-66.9209076689400035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-748" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061541403700005" lon="-66.9208946017299979">
+    <node visible="true" id="-802" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061541403700005" lon="-66.9208946017299979">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-747" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061354831599996" lon="-66.9208843900700003">
+    <node visible="true" id="-801" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061354831599996" lon="-66.9208843900700003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-746" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061154614499994" lon="-66.9208772914600019">
+    <node visible="true" id="-800" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061154614499994" lon="-66.9208772914600019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-745" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5058921756200014" lon="-66.9208232196699981">
+    <node visible="true" id="-799" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5058921756200014" lon="-66.9208232196699981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-744" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056540184999978" lon="-66.9207677456300019">
+    <node visible="true" id="-798" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056540184999978" lon="-66.9207677456300019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-743" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056384589299974" lon="-66.9207636844299998">
+    <node visible="true" id="-797" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056384589299974" lon="-66.9207636844299998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-742" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056239883000000" lon="-66.9207566216600043">
+    <node visible="true" id="-796" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056239883000000" lon="-66.9207566216600043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-741" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056111674899988" lon="-66.9207468310499962">
+    <node visible="true" id="-795" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056111674899988" lon="-66.9207468310499962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-740" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056004934200011" lon="-66.9207346920899937">
+    <node visible="true" id="-794" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5056004934200011" lon="-66.9207346920899937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-739" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055893856699996" lon="-66.9207131301400011">
+    <node visible="true" id="-793" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055893856699996" lon="-66.9207131301400011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-738" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055856679000001" lon="-66.9206973322000067">
+    <node visible="true" id="-792" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055856679000001" lon="-66.9206973322000067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-737" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055850852099990" lon="-66.9206811044199981">
+    <node visible="true" id="-791" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5055850852099990" lon="-66.9206811044199981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-736" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054844906600007" lon="-66.9202988277200035">
+    <node visible="true" id="-790" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054844906600007" lon="-66.9202988277200035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-735" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054158428399962" lon="-66.9200289697500068">
+    <node visible="true" id="-789" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054158428399962" lon="-66.9200289697500068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-734" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5053958635899995" lon="-66.9199284853699794">
+    <node visible="true" id="-788" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5053958635899995" lon="-66.9199284853699794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-733" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089287612799982" lon="-66.9217302900599975">
+    <node visible="true" id="-787" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089287612799982" lon="-66.9217302900599975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-732" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088875236000003" lon="-66.9216849471000046">
+    <node visible="true" id="-786" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088875236000003" lon="-66.9216849471000046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-731" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088478770700000" lon="-66.9216381775199949">
+    <node visible="true" id="-785" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088478770700000" lon="-66.9216381775199949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-730" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088098699899977" lon="-66.9215900382999962">
+    <node visible="true" id="-784" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088098699899977" lon="-66.9215900382999962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-729" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087771953400004" lon="-66.9215351826599942">
+    <node visible="true" id="-783" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087771953400004" lon="-66.9215351826599942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-728" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087302746899987" lon="-66.9214564102500020">
+    <node visible="true" id="-782" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087302746899987" lon="-66.9214564102500020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-727" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086553430300000" lon="-66.9213200567499911">
+    <node visible="true" id="-781" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086553430300000" lon="-66.9213200567499911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-726" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085851663100005" lon="-66.9211811438999860">
+    <node visible="true" id="-780" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085851663100005" lon="-66.9211811438999860">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-725" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085578297700000" lon="-66.9211235779699933">
+    <node visible="true" id="-779" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085578297700000" lon="-66.9211235779699933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-724" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085362564099984" lon="-66.9210856267999930">
+    <node visible="true" id="-778" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085362564099984" lon="-66.9210856267999930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-723" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085131987399976" lon="-66.9210485775199970">
+    <node visible="true" id="-777" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085131987399976" lon="-66.9210485775199970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-722" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084886936299977" lon="-66.9210124893599954">
+    <node visible="true" id="-776" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084886936299977" lon="-66.9210124893599954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-721" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084627802599986" lon="-66.9209774200299989">
+    <node visible="true" id="-775" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084627802599986" lon="-66.9209774200299989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-720" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084355000799974" lon="-66.9209434256100053">
+    <node visible="true" id="-774" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084355000799974" lon="-66.9209434256100053">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-719" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084068967099977" lon="-66.9209105604600012">
+    <node visible="true" id="-773" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084068967099977" lon="-66.9209105604600012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-718" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083770158800007" lon="-66.9208788771200034">
+    <node visible="true" id="-772" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083770158800007" lon="-66.9208788771200034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-717" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083459053699961" lon="-66.9208484262699983">
+    <node visible="true" id="-771" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083459053699961" lon="-66.9208484262699983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-716" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083136149299978" lon="-66.9208192565999838">
+    <node visible="true" id="-770" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083136149299978" lon="-66.9208192565999838">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-715" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082801961900003" lon="-66.9207914147399947">
+    <node visible="true" id="-769" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082801961900003" lon="-66.9207914147399947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-714" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082457025999982" lon="-66.9207649452099815">
+    <node visible="true" id="-768" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082457025999982" lon="-66.9207649452099815">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-713" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082101893100006" lon="-66.9207398903500064">
+    <node visible="true" id="-767" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082101893100006" lon="-66.9207398903500064">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-712" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081737131000015" lon="-66.9207162902099952">
+    <node visible="true" id="-766" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081737131000015" lon="-66.9207162902099952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-711" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081363322999977" lon="-66.9206941825299992">
+    <node visible="true" id="-765" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081363322999977" lon="-66.9206941825299992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-710" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080981066899977" lon="-66.9206736026599884">
+    <node visible="true" id="-764" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080981066899977" lon="-66.9206736026599884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-709" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080250690800003" lon="-66.9206415924600009">
+    <node visible="true" id="-763" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080250690800003" lon="-66.9206415924600009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-708" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079509703999996" lon="-66.9206121774400060">
+    <node visible="true" id="-762" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079509703999996" lon="-66.9206121774400060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-707" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078759009200002" lon="-66.9205853934300023">
+    <node visible="true" id="-761" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078759009200002" lon="-66.9205853934300023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-706" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077999521199974" lon="-66.9205612730799970">
+    <node visible="true" id="-760" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077999521199974" lon="-66.9205612730799970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-705" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077232165200023" lon="-66.9205398457600040">
+    <node visible="true" id="-759" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077232165200023" lon="-66.9205398457600040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-704" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076909209700009" lon="-66.9205316913599830">
+    <node visible="true" id="-758" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076909209700009" lon="-66.9205316913599830">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-703" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073682502200008" lon="-66.9204381356600067">
+    <node visible="true" id="-757" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073682502200008" lon="-66.9204381356600067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-702" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5070149405299986" lon="-66.9203267056799973">
+    <node visible="true" id="-756" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5070149405299986" lon="-66.9203267056799973">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-701" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065140467500004" lon="-66.9201790411700017">
+    <node visible="true" id="-755" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065140467500004" lon="-66.9201790411700017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-700" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5058274583899998" lon="-66.9199613656799954">
+    <node visible="true" id="-754" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5058274583899998" lon="-66.9199613656799954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-699" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054152416999997" lon="-66.9198466389700002">
+    <node visible="true" id="-753" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054152416999997" lon="-66.9198466389700002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-698" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5052043085500006" lon="-66.9197879328699798">
+    <node visible="true" id="-752" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5052043085500006" lon="-66.9197879328699798">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-697" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5049556215299997" lon="-66.9197417400799992">
+    <node visible="true" id="-751" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5049556215299997" lon="-66.9197417400799992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-696" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044982816499992" lon="-66.9196554676200037">
+    <node visible="true" id="-750" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5044982816499992" lon="-66.9196554676200037">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-695" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042886042300001" lon="-66.9196196487399959">
+    <node visible="true" id="-749" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042886042300001" lon="-66.9196196487399959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-694" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042590063100008" lon="-66.9196183788599797">
+    <node visible="true" id="-748" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042590063100008" lon="-66.9196183788599797">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-693" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042293825600002" lon="-66.9196181535100010">
+    <node visible="true" id="-747" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042293825600002" lon="-66.9196181535100010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-692" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041997690699986" lon="-66.9196189729699995">
+    <node visible="true" id="-746" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041997690699986" lon="-66.9196189729699995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-691" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041702019199992" lon="-66.9196208362299956">
+    <node visible="true" id="-745" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041702019199992" lon="-66.9196208362299956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-690" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041407171399968" lon="-66.9196237410299943">
+    <node visible="true" id="-744" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041407171399968" lon="-66.9196237410299943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-689" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041113506400006" lon="-66.9196276838300008">
+    <node visible="true" id="-743" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041113506400006" lon="-66.9196276838300008">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-688" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040821382099985" lon="-66.9196326598199818">
+    <node visible="true" id="-742" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040821382099985" lon="-66.9196326598199818">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-687" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040531154399996" lon="-66.9196386629400024">
+    <node visible="true" id="-741" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040531154399996" lon="-66.9196386629400024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-686" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040277550400010" lon="-66.9196447909200032">
+    <node visible="true" id="-740" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040277550400010" lon="-66.9196447909200032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-685" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036746892600004" lon="-66.9197311686099994">
+    <node visible="true" id="-739" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036746892600004" lon="-66.9197311686099994">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-684" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033531057099996" lon="-66.9198035101299951">
+    <node visible="true" id="-738" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033531057099996" lon="-66.9198035101299951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-683" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032744731199976" lon="-66.9198497659500049">
+    <node visible="true" id="-737" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032744731199976" lon="-66.9198497659500049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-682" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030926815000001" lon="-66.9198935214599970">
+    <node visible="true" id="-736" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030926815000001" lon="-66.9198935214599970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-681" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030075322399981" lon="-66.9199089798500069">
+    <node visible="true" id="-735" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030075322399981" lon="-66.9199089798500069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-680" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029916815999993" lon="-66.9199138512099978">
+    <node visible="true" id="-734" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029916815999993" lon="-66.9199138512099978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-679" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029762736299990" lon="-66.9199200040900024">
+    <node visible="true" id="-733" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029762736299990" lon="-66.9199200040900024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-678" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029614096000010" lon="-66.9199273980400022">
+    <node visible="true" id="-732" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029614096000010" lon="-66.9199273980400022">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-677" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029471872400020" lon="-66.9199359844500066">
+    <node visible="true" id="-731" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029471872400020" lon="-66.9199359844500066">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-676" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029337000299989" lon="-66.9199457068800001">
+    <node visible="true" id="-730" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029337000299989" lon="-66.9199457068800001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-675" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029210366400001" lon="-66.9199565014200033">
+    <node visible="true" id="-729" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029210366400001" lon="-66.9199565014200033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-674" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029037667199994" lon="-66.9199745463699998">
+    <node visible="true" id="-728" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029037667199994" lon="-66.9199745463699998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-673" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311726000010" lon="-66.9202954139200017">
+    <node visible="true" id="-727" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311726000010" lon="-66.9202954139200017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-672" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089963778199991" lon="-66.9216582198399976">
+    <node visible="true" id="-726" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089963778199991" lon="-66.9216582198399976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-671" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089658248599989" lon="-66.9216250456200044">
+    <node visible="true" id="-725" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089658248599989" lon="-66.9216250456200044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-670" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089356635200009" lon="-66.9215898807999992">
+    <node visible="true" id="-724" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089356635200009" lon="-66.9215898807999992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-669" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088680430700023" lon="-66.9215043898200008">
+    <node visible="true" id="-723" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088680430700023" lon="-66.9215043898200008">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-668" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087471214399990" lon="-66.9212721603000062">
+    <node visible="true" id="-722" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087471214399990" lon="-66.9212721603000062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-667" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087292921599982" lon="-66.9212284178200036">
+    <node visible="true" id="-721" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087292921599982" lon="-66.9212284178200036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-666" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087099629799994" lon="-66.9211853307299975">
+    <node visible="true" id="-720" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087099629799994" lon="-66.9211853307299975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-665" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086891574300001" lon="-66.9211429515499958">
+    <node visible="true" id="-719" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086891574300001" lon="-66.9211429515499958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-664" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086669008700007" lon="-66.9211013319099948">
+    <node visible="true" id="-718" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086669008700007" lon="-66.9211013319099948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-663" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086432204199998" lon="-66.9210605224999995">
+    <node visible="true" id="-717" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086432204199998" lon="-66.9210605224999995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-662" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086181449300007" lon="-66.9210205730500007">
+    <node visible="true" id="-716" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086181449300007" lon="-66.9210205730500007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-661" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085917049499979" lon="-66.9209815322300017">
+    <node visible="true" id="-715" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085917049499979" lon="-66.9209815322300017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-660" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085639326899987" lon="-66.9209434476100000">
+    <node visible="true" id="-714" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085639326899987" lon="-66.9209434476100000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-659" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084696773799990" lon="-66.9208421845400068">
+    <node visible="true" id="-713" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084696773799990" lon="-66.9208421845400068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-658" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083719820700008" lon="-66.9207443071399979">
+    <node visible="true" id="-712" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083719820700008" lon="-66.9207443071399979">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-657" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083461538699989" lon="-66.9207221068899969">
+    <node visible="true" id="-711" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083461538699989" lon="-66.9207221068899969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-656" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083195746500007" lon="-66.9207008309999907">
+    <node visible="true" id="-710" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083195746500007" lon="-66.9207008309999907">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-655" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082922767899998" lon="-66.9206805054000000">
+    <node visible="true" id="-709" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082922767899998" lon="-66.9206805054000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-654" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082642935699990" lon="-66.9206611548400048">
+    <node visible="true" id="-708" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082642935699990" lon="-66.9206611548400048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-653" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082356590699977" lon="-66.9206428029000051">
+    <node visible="true" id="-707" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082356590699977" lon="-66.9206428029000051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-652" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082064081699986" lon="-66.9206254719399993">
+    <node visible="true" id="-706" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082064081699986" lon="-66.9206254719399993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-651" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081765765199986" lon="-66.9206091830699989">
+    <node visible="true" id="-705" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081765765199986" lon="-66.9206091830699989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-650" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081462004699997" lon="-66.9205939561399958">
+    <node visible="true" id="-704" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081462004699997" lon="-66.9205939561399958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-649" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081153170100006" lon="-66.9205798096999871">
+    <node visible="true" id="-703" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081153170100006" lon="-66.9205798096999871">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-648" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080839637799990" lon="-66.9205667609899990">
+    <node visible="true" id="-702" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080839637799990" lon="-66.9205667609899990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-647" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080521789799999" lon="-66.9205548258999983">
+    <node visible="true" id="-701" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080521789799999" lon="-66.9205548258999983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-646" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080276005800002" lon="-66.9205464578599987">
+    <node visible="true" id="-700" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080276005800002" lon="-66.9205464578599987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-645" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078079281599983" lon="-66.9204702485599938">
+    <node visible="true" id="-699" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078079281599983" lon="-66.9204702485599938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-644" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075456556799995" lon="-66.9203827551699959">
+    <node visible="true" id="-698" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075456556799995" lon="-66.9203827551699959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-643" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073785157399993" lon="-66.9203359439400032">
+    <node visible="true" id="-697" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073785157399993" lon="-66.9203359439400032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-642" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5070572768999977" lon="-66.9202356233499955">
+    <node visible="true" id="-696" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5070572768999977" lon="-66.9202356233499955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-641" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064754877999995" lon="-66.9200610203400004">
+    <node visible="true" id="-695" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064754877999995" lon="-66.9200610203400004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-640" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059526758900024" lon="-66.9199008977499972">
+    <node visible="true" id="-694" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5059526758900024" lon="-66.9199008977499972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-639" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054544730200003" lon="-66.9197521800099793">
+    <node visible="true" id="-693" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054544730200003" lon="-66.9197521800099793">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-638" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5051235942399988" lon="-66.9196783685300005">
+    <node visible="true" id="-692" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5051235942399988" lon="-66.9196783685300005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-637" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5047224410899993" lon="-66.9196132910799975">
+    <node visible="true" id="-691" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5047224410899993" lon="-66.9196132910799975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-636" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043164138099989" lon="-66.9195532045099952">
+    <node visible="true" id="-690" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5043164138099989" lon="-66.9195532045099952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-635" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042312353800007" lon="-66.9195339417800028">
+    <node visible="true" id="-689" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042312353800007" lon="-66.9195339417800028">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-634" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042219293599999" lon="-66.9195290267799976">
+    <node visible="true" id="-688" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042219293599999" lon="-66.9195290267799976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-633" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042129804400002" lon="-66.9195234758200002">
+    <node visible="true" id="-687" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042129804400002" lon="-66.9195234758200002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-632" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042044311300007" lon="-66.9195173152500047">
+    <node visible="true" id="-686" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042044311300007" lon="-66.9195173152500047">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-631" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041963220200021" lon="-66.9195105743300047">
+    <node visible="true" id="-685" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041963220200021" lon="-66.9195105743300047">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-630" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041886916300005" lon="-66.9195032850699931">
+    <node visible="true" id="-684" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041886916300005" lon="-66.9195032850699931">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-629" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041815761899997" lon="-66.9194954821099799">
+    <node visible="true" id="-683" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041815761899997" lon="-66.9194954821099799">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-628" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041750095000026" lon="-66.9194872024799992">
+    <node visible="true" id="-682" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041750095000026" lon="-66.9194872024799992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-627" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041690227400029" lon="-66.9194784855200027">
+    <node visible="true" id="-681" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041690227400029" lon="-66.9194784855200027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-626" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041636443400002" lon="-66.9194693726099956">
+    <node visible="true" id="-680" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041636443400002" lon="-66.9194693726099956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-625" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041588998600002" lon="-66.9194599070399931">
+    <node visible="true" id="-679" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041588998600002" lon="-66.9194599070399931">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-624" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041548118099985" lon="-66.9194501337699990">
+    <node visible="true" id="-678" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041548118099985" lon="-66.9194501337699990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-623" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041513996099987" lon="-66.9194400992000027">
+    <node visible="true" id="-677" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041513996099987" lon="-66.9194400992000027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-622" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041486794699992" lon="-66.9194298510000039">
+    <node visible="true" id="-676" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041486794699992" lon="-66.9194298510000039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-621" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041466643099994" lon="-66.9194194378199967">
+    <node visible="true" id="-675" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041466643099994" lon="-66.9194194378199967">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-620" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041453636999993" lon="-66.9194089091299986">
+    <node visible="true" id="-674" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041453636999993" lon="-66.9194089091299986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-619" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040979867799980" lon="-66.9191679280099976">
+    <node visible="true" id="-673" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040979867799980" lon="-66.9191679280099976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-618" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039619644999984" lon="-66.9186283969700071">
+    <node visible="true" id="-672" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039619644999984" lon="-66.9186283969700071">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-617" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038227678499982" lon="-66.9181037623399817">
+    <node visible="true" id="-671" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038227678499982" lon="-66.9181037623399817">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-616" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037591646399999" lon="-66.9178827232099991">
+    <node visible="true" id="-670" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037591646399999" lon="-66.9178827232099991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-615" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036092753500032" lon="-66.9172242905600001">
+    <node visible="true" id="-669" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036092753500032" lon="-66.9172242905600001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-614" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034107391700005" lon="-66.9163810800500016">
+    <node visible="true" id="-668" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034107391700005" lon="-66.9163810800500016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-613" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084379255800009" lon="-66.9195653678700069">
+    <node visible="true" id="-667" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084379255800009" lon="-66.9195653678700069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-612" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078691862199989" lon="-66.9196609831000018">
+    <node visible="true" id="-666" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078691862199989" lon="-66.9196609831000018">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-611" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078541203400011" lon="-66.9196565428299976">
+    <node visible="true" id="-665" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078541203400011" lon="-66.9196565428299976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-610" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078401326099975" lon="-66.9196493525899996">
+    <node visible="true" id="-664" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078401326099975" lon="-66.9196493525899996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-609" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078222226300007" lon="-66.9196339823400024">
+    <node visible="true" id="-663" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078222226300007" lon="-66.9196339823400024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-608" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078092175899993" lon="-66.9196142067600022">
+    <node visible="true" id="-662" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078092175899993" lon="-66.9196142067600022">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-607" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078037918000007" lon="-66.9195993266800002">
+    <node visible="true" id="-661" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078037918000007" lon="-66.9195993266800002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-606" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078009899599998" lon="-66.9195757523300045">
+    <node visible="true" id="-660" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078009899599998" lon="-66.9195757523300045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-605" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077536309599981" lon="-66.9192812643999986">
+    <node visible="true" id="-659" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077536309599981" lon="-66.9192812643999986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-604" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086789080600003" lon="-66.9195209107899842">
+    <node visible="true" id="-658" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086789080600003" lon="-66.9195209107899842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-603" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085785455400007" lon="-66.9190457208599980">
+    <node visible="true" id="-657" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085785455400007" lon="-66.9190457208599980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-602" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084681434299974" lon="-66.9184233462000009">
+    <node visible="true" id="-656" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084681434299974" lon="-66.9184233462000009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-601" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089473686999995" lon="-66.9214125773400070">
+    <node visible="true" id="-655" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089473686999995" lon="-66.9214125773400070">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-600" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088439846499995" lon="-66.9207372628499968">
+    <node visible="true" id="-654" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088439846499995" lon="-66.9207372628499968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-599" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088207340199986" lon="-66.9205589132299963">
+    <node visible="true" id="-653" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088207340199986" lon="-66.9205589132299963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-598" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087870630100024" lon="-66.9204128634799957">
+    <node visible="true" id="-652" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087870630100024" lon="-66.9204128634799957">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-597" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087327784999989" lon="-66.9199917563800000">
+    <node visible="true" id="-651" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087327784999989" lon="-66.9199917563800000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-596" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086747186699991" lon="-66.9196186067100030">
+    <node visible="true" id="-650" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086747186699991" lon="-66.9196186067100030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-595" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086589365699989" lon="-66.9195245951899835">
+    <node visible="true" id="-649" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086589365699989" lon="-66.9195245951899835">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-594" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086676205600007" lon="-66.9190891815299977">
+    <node visible="true" id="-648" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5086676205600007" lon="-66.9190891815299977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-593" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085482689799985" lon="-66.9184074126199988">
+    <node visible="true" id="-647" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085482689799985" lon="-66.9184074126199988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-592" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092733841099992" lon="-66.9217712948999974">
+    <node visible="true" id="-646" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092733841099992" lon="-66.9217712948999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-591" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092539297700007" lon="-66.9217522853000020">
+    <node visible="true" id="-645" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092539297700007" lon="-66.9217522853000020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-590" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092351875700007" lon="-66.9217325587000005">
+    <node visible="true" id="-644" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092351875700007" lon="-66.9217325587000005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-589" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092171833699997" lon="-66.9217121423099996">
+    <node visible="true" id="-643" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092171833699997" lon="-66.9217121423099996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-588" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091999420200004" lon="-66.9216910643000062">
+    <node visible="true" id="-642" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091999420200004" lon="-66.9216910643000062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-587" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091834872999996" lon="-66.9216693537699996">
+    <node visible="true" id="-641" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091834872999996" lon="-66.9216693537699996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-586" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091678419299992" lon="-66.9216470406699955">
+    <node visible="true" id="-640" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091678419299992" lon="-66.9216470406699955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-585" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091530275000000" lon="-66.9216241557999894">
+    <node visible="true" id="-639" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091530275000000" lon="-66.9216241557999894">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-584" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091390644399976" lon="-66.9216007307300060">
+    <node visible="true" id="-638" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091390644399976" lon="-66.9216007307300060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-583" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091259720300005" lon="-66.9215767977799914">
+    <node visible="true" id="-637" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091259720300005" lon="-66.9215767977799914">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-582" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091137683400007" lon="-66.9215523899899978">
+    <node visible="true" id="-636" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091137683400007" lon="-66.9215523899899978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-581" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091024701899993" lon="-66.9215275410300023">
+    <node visible="true" id="-635" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5091024701899993" lon="-66.9215275410300023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-580" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090920931900005" lon="-66.9215022851999919">
+    <node visible="true" id="-634" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090920931900005" lon="-66.9215022851999919">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-579" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090826516500009" lon="-66.9214766573499986">
+    <node visible="true" id="-633" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090826516500009" lon="-66.9214766573499986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-578" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090741586000007" lon="-66.9214506928299926">
+    <node visible="true" id="-632" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090741586000007" lon="-66.9214506928299926">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-577" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090666257600009" lon="-66.9214244274899954">
+    <node visible="true" id="-631" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090666257600009" lon="-66.9214244274899954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-576" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090299118899999" lon="-66.9212563521799950">
+    <node visible="true" id="-630" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090299118899999" lon="-66.9212563521799950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-575" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089392300299984" lon="-66.9207415488900068">
+    <node visible="true" id="-629" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5089392300299984" lon="-66.9207415488900068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-574" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088121598500024" lon="-66.9199332990800002">
+    <node visible="true" id="-628" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5088121598500024" lon="-66.9199332990800002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-573" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096955576499997" lon="-66.9193774115800011">
+    <node visible="true" id="-627" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096955576499997" lon="-66.9193774115800011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-572" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093143124200008" lon="-66.9194309689600004">
+    <node visible="true" id="-626" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093143124200008" lon="-66.9194309689600004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-571" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087400640999995" lon="-66.9195122541500069">
+    <node visible="true" id="-625" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087400640999995" lon="-66.9195122541500069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-570" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083680347499993" lon="-66.9183853975000034">
+    <node visible="true" id="-624" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083680347499993" lon="-66.9183853975000034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-569" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079139132900004" lon="-66.9184551810299979">
+    <node visible="true" id="-623" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079139132900004" lon="-66.9184551810299979">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-568" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073803076899992" lon="-66.9185500339099946">
+    <node visible="true" id="-622" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5073803076899992" lon="-66.9185500339099946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-567" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072755510100002" lon="-66.9185723283499954">
+    <node visible="true" id="-621" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072755510100002" lon="-66.9185723283499954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-566" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071494636500020" lon="-66.9185673662299934">
+    <node visible="true" id="-620" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071494636500020" lon="-66.9185673662299934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-565" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071010608699975" lon="-66.9185676903900060">
+    <node visible="true" id="-619" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071010608699975" lon="-66.9185676903900060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-564" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065128829599974" lon="-66.9187169667000035">
+    <node visible="true" id="-618" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065128829599974" lon="-66.9187169667000035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-563" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084579523099979" lon="-66.9183691350099963">
+    <node visible="true" id="-617" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5084579523099979" lon="-66.9183691350099963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-562" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083689952900006" lon="-66.9178959340000006">
+    <node visible="true" id="-616" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083689952900006" lon="-66.9178959340000006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-561" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082540464100003" lon="-66.9172041726399982">
+    <node visible="true" id="-615" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082540464100003" lon="-66.9172041726399982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-560" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094156974900006" lon="-66.9181771718800036">
+    <node visible="true" id="-614" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094156974900006" lon="-66.9181771718800036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-559" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087512526700007" lon="-66.9183160886099984">
+    <node visible="true" id="-613" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5087512526700007" lon="-66.9183160886099984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-558" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085381975299992" lon="-66.9183546218499998">
+    <node visible="true" id="-612" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5085381975299992" lon="-66.9183546218499998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-557" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083567247499978" lon="-66.9174034179000046">
+    <node visible="true" id="-611" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083567247499978" lon="-66.9174034179000046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-556" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077948642800010" lon="-66.9172593429800031">
+    <node visible="true" id="-610" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077948642800010" lon="-66.9172593429800031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-555" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071945532900024" lon="-66.9173640398300051">
+    <node visible="true" id="-609" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5071945532900024" lon="-66.9173640398300051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-554" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082891319900007" lon="-66.9171569800300006">
+    <node visible="true" id="-608" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082891319900007" lon="-66.9171569800300006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-553" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082470243099984" lon="-66.9171657005500009">
+    <node visible="true" id="-607" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082470243099984" lon="-66.9171657005500009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-552" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081666657999975" lon="-66.9167254408300067">
+    <node visible="true" id="-606" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081666657999975" lon="-66.9167254408300067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-551" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080421179299996" lon="-66.9160668015299933">
+    <node visible="true" id="-605" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5080421179299996" lon="-66.9160668015299933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-550" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079896716799990" lon="-66.9158018761199997">
+    <node visible="true" id="-604" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079896716799990" lon="-66.9158018761199997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-549" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079668038400005" lon="-66.9156822002800027">
+    <node visible="true" id="-603" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079668038400005" lon="-66.9156822002800027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-548" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
+    <node visible="true" id="-602" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-547" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
+    <node visible="true" id="-601" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-546" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081273995000011" lon="-66.9170906772600063">
+    <node visible="true" id="-600" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081273995000011" lon="-66.9170906772600063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-545" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074340443699974" lon="-66.9172195429299990">
+    <node visible="true" id="-599" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074340443699974" lon="-66.9172195429299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-544" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5068586905599979" lon="-66.9173317852699938">
+    <node visible="true" id="-598" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5068586905599979" lon="-66.9173317852699938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-543" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061376644000006" lon="-66.9174681416800041">
+    <node visible="true" id="-597" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061376644000006" lon="-66.9174681416800041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-542" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082283234300000" lon="-66.9170632438499950">
+    <node visible="true" id="-596" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082283234300000" lon="-66.9170632438499950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-541" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082591445899975" lon="-66.9168886642300009">
+    <node visible="true" id="-595" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082591445899975" lon="-66.9168886642300009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-540" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081827136299992" lon="-66.9164457405200039">
+    <node visible="true" id="-594" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5081827136299992" lon="-66.9164457405200039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-539" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092129559499980" lon="-66.9168556654999804">
+    <node visible="true" id="-593" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092129559499980" lon="-66.9168556654999804">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-538" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083800427800025" lon="-66.9170220030599978">
+    <node visible="true" id="-592" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083800427800025" lon="-66.9170220030599978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-537" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093081230899994" lon="-66.9169406820499972">
+    <node visible="true" id="-591" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093081230899994" lon="-66.9169406820499972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-536" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090305066999985" lon="-66.9169993754299810">
+    <node visible="true" id="-590" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5090305066999985" lon="-66.9169993754299810">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-535" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054198110300003" lon="-66.9164128790300055">
+    <node visible="true" id="-589" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5054198110300003" lon="-66.9164128790300055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-534" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5051697971199989" lon="-66.9153252867399999">
+    <node visible="true" id="-588" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5051697971199989" lon="-66.9153252867399999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-533" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5017691462699982" lon="-66.9147128052199918">
+    <node visible="true" id="-587" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5017691462699982" lon="-66.9147128052199918">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-532" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000024" lon="-66.9179020508999969">
+    <node visible="true" id="-586" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000024" lon="-66.9179020508999969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-531" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699979" lon="-66.9171032446199803">
+    <node visible="true" id="-585" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699979" lon="-66.9171032446199803">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-530" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021944227699979" lon="-66.9165971720299950">
+    <node visible="true" id="-584" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021944227699979" lon="-66.9165971720299950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-529" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020857885299979" lon="-66.9160550627699990">
+    <node visible="true" id="-583" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020857885299979" lon="-66.9160550627699990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-528" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020058897099986" lon="-66.9156069727699929">
+    <node visible="true" id="-582" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020058897099986" lon="-66.9156069727699929">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-527" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018764962799995" lon="-66.9150590220200030">
+    <node visible="true" id="-581" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018764962799995" lon="-66.9150590220200030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-526" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018507009000004" lon="-66.9149758286500003">
+    <node visible="true" id="-580" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018507009000004" lon="-66.9149758286500003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-525" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
+    <node visible="true" id="-579" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-524" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800022" lon="-66.9191175683799884">
+    <node visible="true" id="-578" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800022" lon="-66.9191175683799884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-523" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579599985" lon="-66.9184036784899945">
+    <node visible="true" id="-577" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579599985" lon="-66.9184036784899945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-522" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768700005" lon="-66.9184060968199930">
+    <node visible="true" id="-576" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768700005" lon="-66.9184060968199930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-521" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611199996" lon="-66.9182588634100028">
+    <node visible="true" id="-575" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611199996" lon="-66.9182588634100028">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-520" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
+    <node visible="true" id="-574" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-519" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654499996" lon="-66.9182879955099850">
+    <node visible="true" id="-573" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654499996" lon="-66.9182879955099850">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-518" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032842497800019" lon="-66.9180571054100000">
+    <node visible="true" id="-572" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032842497800019" lon="-66.9180571054100000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-517" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
+    <node visible="true" id="-571" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-516" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
+    <node visible="true" id="-570" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-515" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439091999998" lon="-66.9179112165300012">
+    <node visible="true" id="-569" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439091999998" lon="-66.9179112165300012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-514" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799992" lon="-66.9172775671599993">
+    <node visible="true" id="-568" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799992" lon="-66.9172775671599993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-513" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
+    <node visible="true" id="-567" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-512" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328600000" lon="-66.9184260814800069">
+    <node visible="true" id="-566" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328600000" lon="-66.9184260814800069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-511" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905699970" lon="-66.9183505367499976">
+    <node visible="true" id="-565" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905699970" lon="-66.9183505367499976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-510" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083091997399993" lon="-66.9171527139500029">
+    <node visible="true" id="-564" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5083091997399993" lon="-66.9171527139500029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-509" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082891070699986" lon="-66.9170467214800055">
+    <node visible="true" id="-563" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5082891070699986" lon="-66.9170467214800055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-508" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
+    <node visible="true" id="-562" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-507" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099977" lon="-66.9194331024600046">
+    <node visible="true" id="-561" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099977" lon="-66.9194331024600046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-506" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226900015" lon="-66.9196067043800014">
+    <node visible="true" id="-560" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226900015" lon="-66.9196067043800014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-505" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930900002" lon="-66.9197283843299999">
+    <node visible="true" id="-559" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930900002" lon="-66.9197283843299999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-504" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019060823800015" lon="-66.9208505552000048">
+    <node visible="true" id="-558" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019060823800015" lon="-66.9208505552000048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-503" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800003" lon="-66.9199025736400017">
+    <node visible="true" id="-557" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800003" lon="-66.9199025736400017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-502" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
+    <node visible="true" id="-556" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-501" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021955604800024" lon="-66.9207009846099936">
+    <node visible="true" id="-555" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021955604800024" lon="-66.9207009846099936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-500" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
+    <node visible="true" id="-554" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-499" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029978296399999" lon="-66.9197189401899948">
+    <node visible="true" id="-553" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029978296399999" lon="-66.9197189401899948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-498" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030613326499989" lon="-66.9196450069299971">
+    <node visible="true" id="-552" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030613326499989" lon="-66.9196450069299971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-497" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031033764699995" lon="-66.9195962114999929">
+    <node visible="true" id="-551" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031033764699995" lon="-66.9195962114999929">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-496" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031072953599978" lon="-66.9195789741499993">
+    <node visible="true" id="-550" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031072953599978" lon="-66.9195789741499993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-495" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031121528699991" lon="-66.9195619825299985">
+    <node visible="true" id="-549" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031121528699991" lon="-66.9195619825299985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-494" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031179340899996" lon="-66.9195452887699958">
+    <node visible="true" id="-548" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031179340899996" lon="-66.9195452887699958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-493" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031246212799996" lon="-66.9195289440999943">
+    <node visible="true" id="-547" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031246212799996" lon="-66.9195289440999943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-492" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031321939200009" lon="-66.9195129986800055">
+    <node visible="true" id="-546" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031321939200009" lon="-66.9195129986800055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-491" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031406287699998" lon="-66.9194975014400057">
+    <node visible="true" id="-545" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031406287699998" lon="-66.9194975014400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-490" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031498999499977" lon="-66.9194824999400026">
+    <node visible="true" id="-544" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031498999499977" lon="-66.9194824999400026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-489" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031599789999994" lon="-66.9194680402100062">
+    <node visible="true" id="-543" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031599789999994" lon="-66.9194680402100062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-488" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031708349999988" lon="-66.9194541666199996">
+    <node visible="true" id="-542" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031708349999988" lon="-66.9194541666199996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-487" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031824346300002" lon="-66.9194409217499953">
+    <node visible="true" id="-541" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031824346300002" lon="-66.9194409217499953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-486" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031947422999981" lon="-66.9194283462399824">
+    <node visible="true" id="-540" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031947422999981" lon="-66.9194283462399824">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-485" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032077202499998" lon="-66.9194164786800059">
+    <node visible="true" id="-539" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032077202499998" lon="-66.9194164786800059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-484" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032213286299978" lon="-66.9194053554899995">
+    <node visible="true" id="-538" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032213286299978" lon="-66.9194053554899995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-483" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032355257100001" lon="-66.9193950108000024">
+    <node visible="true" id="-537" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032355257100001" lon="-66.9193950108000024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-482" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032502678999986" lon="-66.9193854763500013">
+    <node visible="true" id="-536" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032502678999986" lon="-66.9193854763500013">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-481" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032681428399997" lon="-66.9193782480000010">
+    <node visible="true" id="-535" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032681428399997" lon="-66.9193782480000010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-480" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032853857600017" lon="-66.9193695928999830">
+    <node visible="true" id="-534" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032853857600017" lon="-66.9193695928999830">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-479" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033018853499982" lon="-66.9193595669299981">
+    <node visible="true" id="-533" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033018853499982" lon="-66.9193595669299981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-478" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033175350799972" lon="-66.9193482348099877">
+    <node visible="true" id="-532" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033175350799972" lon="-66.9193482348099877">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-477" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033322339199984" lon="-66.9193356696999899">
+    <node visible="true" id="-531" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033322339199984" lon="-66.9193356696999899">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-476" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033458869699992" lon="-66.9193219527300016">
+    <node visible="true" id="-530" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033458869699992" lon="-66.9193219527300016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-475" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033584060999985" lon="-66.9193071724500044">
+    <node visible="true" id="-529" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033584060999985" lon="-66.9193071724500044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-474" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033697104599995" lon="-66.9192914242800043">
+    <node visible="true" id="-528" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033697104599995" lon="-66.9192914242800043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-473" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033797271000022" lon="-66.9192748098899983">
+    <node visible="true" id="-527" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033797271000022" lon="-66.9192748098899983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-472" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033883913299988" lon="-66.9192574365499979">
+    <node visible="true" id="-526" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033883913299988" lon="-66.9192574365499979">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-471" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033956472199996" lon="-66.9192394164099937">
+    <node visible="true" id="-525" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033956472199996" lon="-66.9192394164099937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-470" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034014479300009" lon="-66.9192208658100043">
+    <node visible="true" id="-524" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034014479300009" lon="-66.9192208658100043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-469" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034057560099985" lon="-66.9192019045199942">
+    <node visible="true" id="-523" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034057560099985" lon="-66.9192019045199942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-468" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034085436499982" lon="-66.9191826549500064">
+    <node visible="true" id="-522" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034085436499982" lon="-66.9191826549500064">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-467" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034097928399994" lon="-66.9191632413700006">
+    <node visible="true" id="-521" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034097928399994" lon="-66.9191632413700006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-466" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034004880899996" lon="-66.9190363107399975">
+    <node visible="true" id="-520" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034004880899996" lon="-66.9190363107399975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-465" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032390066199994" lon="-66.9182831560700038">
+    <node visible="true" id="-519" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032390066199994" lon="-66.9182831560700038">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-464" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031881615899980" lon="-66.9180781926399959">
+    <node visible="true" id="-518" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031881615899980" lon="-66.9180781926399959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-463" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015322329400007" lon="-66.9216200500300005">
+    <node visible="true" id="-517" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015322329400007" lon="-66.9216200500300005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-462" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016398406599993" lon="-66.9214481051500059">
+    <node visible="true" id="-516" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016398406599993" lon="-66.9214481051500059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-461" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094012735299991" lon="-66.9166840477899996">
+    <node visible="true" id="-515" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094012735299991" lon="-66.9166840477899996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-460" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093687881700042" lon="-66.9165144423500067">
+    <node visible="true" id="-514" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093687881700042" lon="-66.9165144423500067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-459" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093050151899980" lon="-66.9162439076399949">
+    <node visible="true" id="-513" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5093050151899980" lon="-66.9162439076399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-458" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092802416300000" lon="-66.9161112343300033">
+    <node visible="true" id="-512" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5092802416300000" lon="-66.9161112343300033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-457" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019902737699979" lon="-66.9209381544999928">
+    <node visible="true" id="-511" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019902737699979" lon="-66.9209381544999928">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-456" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
+    <node visible="true" id="-510" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-455" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022250648999957" lon="-66.9208000921599933">
+    <node visible="true" id="-509" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022250648999957" lon="-66.9208000921599933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-454" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020767294499997" lon="-66.9210000434199941">
+    <node visible="true" id="-508" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020767294499997" lon="-66.9210000434199941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-453" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020070219699999" lon="-66.9210940066599989">
+    <node visible="true" id="-507" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020070219699999" lon="-66.9210940066599989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-452" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018371189799993" lon="-66.9213461233500055">
+    <node visible="true" id="-506" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018371189799993" lon="-66.9213461233500055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-451" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016243236399998" lon="-66.9216378751199983">
+    <node visible="true" id="-505" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016243236399998" lon="-66.9216378751199983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-450" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022550139300002" lon="-66.9212592136399991">
+    <node visible="true" id="-504" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022550139300002" lon="-66.9212592136399991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-449" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025094695099988" lon="-66.9214422182599975">
+    <node visible="true" id="-503" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025094695099988" lon="-66.9214422182599975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-448" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026710715200000" lon="-66.9215527962399932">
+    <node visible="true" id="-502" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026710715200000" lon="-66.9215527962399932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-447" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026873578200011" lon="-66.9215595944299935">
+    <node visible="true" id="-501" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026873578200011" lon="-66.9215595944299935">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-446" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027044573800001" lon="-66.9215638947999878">
+    <node visible="true" id="-500" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027044573800001" lon="-66.9215638947999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-445" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027219972699992" lon="-66.9215656035700022">
+    <node visible="true" id="-499" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027219972699992" lon="-66.9215656035700022">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-444" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027395949499986" lon="-66.9215646834500006">
+    <node visible="true" id="-498" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027395949499986" lon="-66.9215646834500006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-443" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027568666200004" lon="-66.9215611545299964">
+    <node visible="true" id="-497" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027568666200004" lon="-66.9215611545299964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-442" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027889404999986" lon="-66.9215466333299958">
+    <node visible="true" id="-496" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027889404999986" lon="-66.9215466333299958">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-441" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031088263600001" lon="-66.9214289246800007">
+    <node visible="true" id="-495" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031088263600001" lon="-66.9214289246800007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-440" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035092954900016" lon="-66.9212972625499987">
+    <node visible="true" id="-494" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035092954900016" lon="-66.9212972625499987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-439" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037328937999987" lon="-66.9212212412599996">
+    <node visible="true" id="-493" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037328937999987" lon="-66.9212212412599996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-438" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037412539300004" lon="-66.9212154433400030">
+    <node visible="true" id="-492" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037412539300004" lon="-66.9212154433400030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-437" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037543837099996" lon="-66.9211999287299903">
+    <node visible="true" id="-491" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037543837099996" lon="-66.9211999287299903">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-436" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037587543100006" lon="-66.9211906835400043">
+    <node visible="true" id="-490" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037587543100006" lon="-66.9211906835400043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-435" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037614695400023" lon="-66.9211808118599976">
+    <node visible="true" id="-489" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037614695400023" lon="-66.9211808118599976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-434" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037624468599979" lon="-66.9211706137199798">
+    <node visible="true" id="-488" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037624468599979" lon="-66.9211706137199798">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-433" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037616565800001" lon="-66.9211603990400050">
+    <node visible="true" id="-487" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037616565800001" lon="-66.9211603990400050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-432" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019222646799957" lon="-66.9210167259899862">
+    <node visible="true" id="-486" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019222646799957" lon="-66.9210167259899862">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-431" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020144928000025" lon="-66.9210839362499996">
+    <node visible="true" id="-485" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020144928000025" lon="-66.9210839362499996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-430" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033851321600036" lon="-66.9213380837500011">
+    <node visible="true" id="-484" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033851321600036" lon="-66.9213380837500011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-429" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033517576899982" lon="-66.9212092518300068">
+    <node visible="true" id="-483" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033517576899982" lon="-66.9212092518300068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-428" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033330426800013" lon="-66.9211144764099970">
+    <node visible="true" id="-482" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033330426800013" lon="-66.9211144764099970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-427" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033265781800011" lon="-66.9210483504499933">
+    <node visible="true" id="-481" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033265781800011" lon="-66.9210483504499933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-426" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
+    <node visible="true" id="-480" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-425" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028420722499991" lon="-66.9208148481099983">
+    <node visible="true" id="-479" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028420722499991" lon="-66.9208148481099983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-424" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028790556900020" lon="-66.9208342641399980">
+    <node visible="true" id="-478" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028790556900020" lon="-66.9208342641399980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-423" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029166871999990" lon="-66.9208523641499937">
+    <node visible="true" id="-477" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029166871999990" lon="-66.9208523641499937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-422" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029549209299997" lon="-66.9208691260800066">
+    <node visible="true" id="-476" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029549209299997" lon="-66.9208691260800066">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-421" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029937103000002" lon="-66.9208845295100048">
+    <node visible="true" id="-475" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029937103000002" lon="-66.9208845295100048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-420" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030330080499983" lon="-66.9208985556699929">
+    <node visible="true" id="-474" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030330080499983" lon="-66.9208985556699929">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-419" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030727663099999" lon="-66.9209111874900060">
+    <node visible="true" id="-473" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030727663099999" lon="-66.9209111874900060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-418" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031129366199991" lon="-66.9209224095500019">
+    <node visible="true" id="-472" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031129366199991" lon="-66.9209224095500019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-417" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031534700499982" lon="-66.9209322082000000">
+    <node visible="true" id="-471" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031534700499982" lon="-66.9209322082000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-416" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031943172299975" lon="-66.9209405714899930">
+    <node visible="true" id="-470" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031943172299975" lon="-66.9209405714899930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-415" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032354283699991" lon="-66.9209474892400067">
+    <node visible="true" id="-469" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032354283699991" lon="-66.9209474892400067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-414" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032767533900007" lon="-66.9209529530100014">
+    <node visible="true" id="-468" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032767533900007" lon="-66.9209529530100014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-413" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033182419600006" lon="-66.9209569561499933">
+    <node visible="true" id="-467" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033182419600006" lon="-66.9209569561499933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-412" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033294982300021" lon="-66.9209576602799956">
+    <node visible="true" id="-466" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033294982300021" lon="-66.9209576602799956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-411" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033561824500001" lon="-66.9209593295099978">
+    <node visible="true" id="-465" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033561824500001" lon="-66.9209593295099978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-410" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035540927500008" lon="-66.9209661335400057">
+    <node visible="true" id="-464" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5035540927500008" lon="-66.9209661335400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-409" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037461854600025" lon="-66.9209917840099990">
+    <node visible="true" id="-463" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037461854600025" lon="-66.9209917840099990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-408" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037859432000023" lon="-66.9209970929299942">
+    <node visible="true" id="-462" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5037859432000023" lon="-66.9209970929299942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-407" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041341233999983" lon="-66.9211052980199952">
+    <node visible="true" id="-461" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041341233999983" lon="-66.9211052980199952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-406" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041460421099995" lon="-66.9211106936400029">
+    <node visible="true" id="-460" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041460421099995" lon="-66.9211106936400029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-405" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041573054799997" lon="-66.9211173738100058">
+    <node visible="true" id="-459" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041573054799997" lon="-66.9211173738100058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-404" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041677784100020" lon="-66.9211252584099867">
+    <node visible="true" id="-458" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041677784100020" lon="-66.9211252584099867">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-403" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041773353199979" lon="-66.9211342529000035">
+    <node visible="true" id="-457" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041773353199979" lon="-66.9211342529000035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-402" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041858615800017" lon="-66.9211442494000011">
+    <node visible="true" id="-456" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041858615800017" lon="-66.9211442494000011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-401" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041932549499961" lon="-66.9211551280200041">
+    <node visible="true" id="-455" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041932549499961" lon="-66.9211551280200041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-400" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041994267599996" lon="-66.9211667583199983">
+    <node visible="true" id="-454" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041994267599996" lon="-66.9211667583199983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-399" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042043029999999" lon="-66.9211790007900049">
+    <node visible="true" id="-453" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042043029999999" lon="-66.9211790007900049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-398" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042078251799982" lon="-66.9211917086399950">
+    <node visible="true" id="-452" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042078251799982" lon="-66.9211917086399950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-397" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042099510600000" lon="-66.9212047294600012">
+    <node visible="true" id="-451" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042099510600000" lon="-66.9212047294600012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-396" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042106551599996" lon="-66.9212179070800062">
+    <node visible="true" id="-450" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042106551599996" lon="-66.9212179070800062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-395" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042099290199982" lon="-66.9212310834899995">
+    <node visible="true" id="-449" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042099290199982" lon="-66.9212310834899995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-394" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042077813599981" lon="-66.9212441006500001">
+    <node visible="true" id="-448" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042077813599981" lon="-66.9212441006500001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-393" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042042379199980" lon="-66.9212568024699976">
+    <node visible="true" id="-447" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5042042379199980" lon="-66.9212568024699976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-392" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041993412100005" lon="-66.9212690365999947">
+    <node visible="true" id="-446" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041993412100005" lon="-66.9212690365999947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-391" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041014424600014" lon="-66.9214269575000031">
+    <node visible="true" id="-445" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5041014424600014" lon="-66.9214269575000031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-390" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040751560899999" lon="-66.9214661450500046">
+    <node visible="true" id="-444" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040751560899999" lon="-66.9214661450500046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-389" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040348473500007" lon="-66.9215749160899946">
+    <node visible="true" id="-443" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040348473500007" lon="-66.9215749160899946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-388" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040310464799997" lon="-66.9215908210099997">
+    <node visible="true" id="-442" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040310464799997" lon="-66.9215908210099997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-387" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040261854000008" lon="-66.9216064283800023">
+    <node visible="true" id="-441" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040261854000008" lon="-66.9216064283800023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-386" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040202865499985" lon="-66.9216216661299939">
+    <node visible="true" id="-440" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040202865499985" lon="-66.9216216661299939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-385" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040133771799997" lon="-66.9216364638899961">
+    <node visible="true" id="-439" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040133771799997" lon="-66.9216364638899961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-384" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040054891899981" lon="-66.9216507533400033">
+    <node visible="true" id="-438" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5040054891899981" lon="-66.9216507533400033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-383" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039966590099976" lon="-66.9216644684800031">
+    <node visible="true" id="-437" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039966590099976" lon="-66.9216644684800031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-382" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039869274000015" lon="-66.9216775459899935">
+    <node visible="true" id="-436" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039869274000015" lon="-66.9216775459899935">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-381" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039763393199994" lon="-66.9216899254900000">
+    <node visible="true" id="-435" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039763393199994" lon="-66.9216899254900000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-380" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039649436399980" lon="-66.9217015497999910">
+    <node visible="true" id="-434" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039649436399980" lon="-66.9217015497999910">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-379" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039527929900007" lon="-66.9217123652500021">
+    <node visible="true" id="-433" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039527929900007" lon="-66.9217123652500021">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-378" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039399434800025" lon="-66.9217223219000061">
+    <node visible="true" id="-432" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039399434800025" lon="-66.9217223219000061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-377" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039264544299975" lon="-66.9217313737800055">
+    <node visible="true" id="-431" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039264544299975" lon="-66.9217313737800055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-376" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039123881499989" lon="-66.9217394790800029">
+    <node visible="true" id="-430" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5039123881499989" lon="-66.9217394790800029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-375" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038978095799997" lon="-66.9217466003699997">
+    <node visible="true" id="-429" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038978095799997" lon="-66.9217466003699997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-374" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038827860400001" lon="-66.9217527047800047">
+    <node visible="true" id="-428" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5038827860400001" lon="-66.9217527047800047">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-373" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036867019599995" lon="-66.9218405728600061">
+    <node visible="true" id="-427" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5036867019599995" lon="-66.9218405728600061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-372" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034632047399974" lon="-66.9219798269299986">
+    <node visible="true" id="-426" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5034632047399974" lon="-66.9219798269299986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-371" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033276024599971" lon="-66.9220916728200024">
+    <node visible="true" id="-425" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5033276024599971" lon="-66.9220916728200024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-370" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032437496500002" lon="-66.9221836669100014">
+    <node visible="true" id="-424" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5032437496500002" lon="-66.9221836669100014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-369" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031693808300002" lon="-66.9222499961500006">
+    <node visible="true" id="-423" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031693808300002" lon="-66.9222499961500006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-368" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031612861799992" lon="-66.9222600471800035">
+    <node visible="true" id="-422" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031612861799992" lon="-66.9222600471800035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-367" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031527531099993" lon="-66.9222697208600010">
+    <node visible="true" id="-421" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031527531099993" lon="-66.9222697208600010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-366" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031437988499974" lon="-66.9222789976900003">
+    <node visible="true" id="-420" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031437988499974" lon="-66.9222789976900003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-365" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031344414499994" lon="-66.9222878589699945">
+    <node visible="true" id="-419" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031344414499994" lon="-66.9222878589699945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-364" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031246997800025" lon="-66.9222962868199858">
+    <node visible="true" id="-418" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031246997800025" lon="-66.9222962868199858">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-363" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031145934799977" lon="-66.9223042642499877">
+    <node visible="true" id="-417" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031145934799977" lon="-66.9223042642499877">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-362" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031041429299989" lon="-66.9223117751700016">
+    <node visible="true" id="-416" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5031041429299989" lon="-66.9223117751700016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-361" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030933692099993" lon="-66.9223188044500006">
+    <node visible="true" id="-415" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030933692099993" lon="-66.9223188044500006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-360" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030822940399968" lon="-66.9223253378899869">
+    <node visible="true" id="-414" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030822940399968" lon="-66.9223253378899869">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-359" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030709397500015" lon="-66.9223313623299987">
+    <node visible="true" id="-413" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030709397500015" lon="-66.9223313623299987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-358" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030593292500001" lon="-66.9223368656300011">
+    <node visible="true" id="-412" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030593292500001" lon="-66.9223368656300011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-357" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030474859399998" lon="-66.9223418366700002">
+    <node visible="true" id="-411" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030474859399998" lon="-66.9223418366700002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-356" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030354337100018" lon="-66.9223462654399981">
+    <node visible="true" id="-410" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030354337100018" lon="-66.9223462654399981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-355" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030231968699983" lon="-66.9223501430000027">
+    <node visible="true" id="-409" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030231968699983" lon="-66.9223501430000027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-354" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030108000800020" lon="-66.9223534615500029">
+    <node visible="true" id="-408" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5030108000800020" lon="-66.9223534615500029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-353" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029506452800003" lon="-66.9223794649199988">
+    <node visible="true" id="-407" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029506452800003" lon="-66.9223794649199988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-352" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029224121900011" lon="-66.9223895889199838">
+    <node visible="true" id="-406" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5029224121900011" lon="-66.9223895889199838">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-351" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028938466400010" lon="-66.9223987111300005">
+    <node visible="true" id="-405" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028938466400010" lon="-66.9223987111300005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-350" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028649834099994" lon="-66.9224068204299982">
+    <node visible="true" id="-404" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028649834099994" lon="-66.9224068204299982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-349" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028358576900001" lon="-66.9224139069499984">
+    <node visible="true" id="-403" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028358576900001" lon="-66.9224139069499984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-348" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028065049499979" lon="-66.9224199620500002">
+    <node visible="true" id="-402" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028065049499979" lon="-66.9224199620500002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-347" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027880542100007" lon="-66.9224232203499980">
+    <node visible="true" id="-401" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027880542100007" lon="-66.9224232203499980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-346" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027254067399962" lon="-66.9224370491999991">
+    <node visible="true" id="-400" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027254067399962" lon="-66.9224370491999991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-345" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026422018000005" lon="-66.9224437007199953">
+    <node visible="true" id="-399" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026422018000005" lon="-66.9224437007199953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-344" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026274663800017" lon="-66.9224488972599971">
+    <node visible="true" id="-398" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026274663800017" lon="-66.9224488972599971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-343" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026129194100033" lon="-66.9224546102699946">
+    <node visible="true" id="-397" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026129194100033" lon="-66.9224546102699946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-342" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025985786200007" lon="-66.9224608327899944">
+    <node visible="true" id="-396" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025985786200007" lon="-66.9224608327899944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-341" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025844614900024" lon="-66.9224675572399832">
+    <node visible="true" id="-395" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025844614900024" lon="-66.9224675572399832">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-340" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025705851999991" lon="-66.9224747754199996">
+    <node visible="true" id="-394" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025705851999991" lon="-66.9224747754199996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-339" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025569666800003" lon="-66.9224824785399903">
+    <node visible="true" id="-393" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025569666800003" lon="-66.9224824785399903">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-338" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025436224999975" lon="-66.9224906572199956">
+    <node visible="true" id="-392" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025436224999975" lon="-66.9224906572199956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-337" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025305689299984" lon="-66.9224993014900065">
+    <node visible="true" id="-391" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025305689299984" lon="-66.9224993014900065">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-336" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025178218600015" lon="-66.9225084008100026">
+    <node visible="true" id="-390" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025178218600015" lon="-66.9225084008100026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-335" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025087488999986" lon="-66.9225153009700051">
+    <node visible="true" id="-389" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025087488999986" lon="-66.9225153009700051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-334" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024702782100015" lon="-66.9225362829299968">
+    <node visible="true" id="-388" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024702782100015" lon="-66.9225362829299968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-333" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024439437900021" lon="-66.9225681558099978">
+    <node visible="true" id="-387" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024439437900021" lon="-66.9225681558099978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-332" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024223872799993" lon="-66.9225926820899986">
+    <node visible="true" id="-386" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024223872799993" lon="-66.9225926820899986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-331" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5097894898599993" lon="-66.9189306639899968">
+    <node visible="true" id="-385" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5097894898599993" lon="-66.9189306639899968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-330" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5097055605299978" lon="-66.9184338315699989">
+    <node visible="true" id="-384" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5097055605299978" lon="-66.9184338315699989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-329" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096711711800008" lon="-66.9182015923399973">
+    <node visible="true" id="-383" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096711711800008" lon="-66.9182015923399973">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-328" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096708096599993" lon="-66.9181464964500066">
+    <node visible="true" id="-382" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096708096599993" lon="-66.9181464964500066">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-327" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096727363800024" lon="-66.9181350198300038">
+    <node visible="true" id="-381" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096727363800024" lon="-66.9181350198300038">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-326" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096794358299999" lon="-66.9180951141999998">
+    <node visible="true" id="-380" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096794358299999" lon="-66.9180951141999998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-325" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096630176799977" lon="-66.9179835180599980">
+    <node visible="true" id="-379" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5096630176799977" lon="-66.9179835180599980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-324" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5095590491499991" lon="-66.9175064447099999">
+    <node visible="true" id="-378" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5095590491499991" lon="-66.9175064447099999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-323" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5095227850599979" lon="-66.9173300714100066">
+    <node visible="true" id="-377" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5095227850599979" lon="-66.9173300714100066">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-322" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094717696600011" lon="-66.9170685079999998">
+    <node visible="true" id="-376" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094717696600011" lon="-66.9170685079999998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-321" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094540852999998" lon="-66.9169916399700071">
+    <node visible="true" id="-375" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5094540852999998" lon="-66.9169916399700071">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-320" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020243295300020" lon="-66.9224822075899937">
+    <node visible="true" id="-374" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020243295300020" lon="-66.9224822075899937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-319" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020621497000004" lon="-66.9224162470899984">
+    <node visible="true" id="-373" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020621497000004" lon="-66.9224162470899984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-318" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020848911200009" lon="-66.9223842075199968">
+    <node visible="true" id="-372" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020848911200009" lon="-66.9223842075199968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-317" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020918695199992" lon="-66.9223783048300049">
+    <node visible="true" id="-371" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020918695199992" lon="-66.9223783048300049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-316" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020990587800007" lon="-66.9223726664299932">
+    <node visible="true" id="-370" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020990587800007" lon="-66.9223726664299932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-315" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021064491099967" lon="-66.9223673000099950">
+    <node visible="true" id="-369" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021064491099967" lon="-66.9223673000099950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-314" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021140304199996" lon="-66.9223622128800031">
+    <node visible="true" id="-368" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021140304199996" lon="-66.9223622128800031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-313" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021217924000005" lon="-66.9223574119699975">
+    <node visible="true" id="-367" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021217924000005" lon="-66.9223574119699975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-312" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021297244699987" lon="-66.9223529038300029">
+    <node visible="true" id="-366" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021297244699987" lon="-66.9223529038300029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-311" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021378158000012" lon="-66.9223486945899850">
+    <node visible="true" id="-365" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021378158000012" lon="-66.9223486945899850">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-310" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021460553799990" lon="-66.9223447899999968">
+    <node visible="true" id="-364" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021460553799990" lon="-66.9223447899999968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-309" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021544319700002" lon="-66.9223411953799996">
+    <node visible="true" id="-363" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021544319700002" lon="-66.9223411953799996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-308" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021629341599994" lon="-66.9223379156299814">
+    <node visible="true" id="-362" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021629341599994" lon="-66.9223379156299814">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-307" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021715503700008" lon="-66.9223349552199949">
+    <node visible="true" id="-361" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5021715503700008" lon="-66.9223349552199949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-306" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021802688399983" lon="-66.9223323181700067">
+    <node visible="true" id="-360" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021802688399983" lon="-66.9223323181700067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-305" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021890777000024" lon="-66.9223300080900003">
+    <node visible="true" id="-359" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021890777000024" lon="-66.9223300080900003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-304" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021979649400006" lon="-66.9223280281299964">
+    <node visible="true" id="-358" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5021979649400006" lon="-66.9223280281299964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-303" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5022069184499980" lon="-66.9223263809799960">
+    <node visible="true" id="-357" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5022069184499980" lon="-66.9223263809799960">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-302" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024514346900002" lon="-66.9222812640000058">
+    <node visible="true" id="-356" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024514346900002" lon="-66.9222812640000058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-301" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5025507142699990" lon="-66.9222545107000002">
+    <node visible="true" id="-355" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5025507142699990" lon="-66.9222545107000002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-300" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5025774197900006" lon="-66.9222437030300057">
+    <node visible="true" id="-354" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5025774197900006" lon="-66.9222437030300057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-299" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5026079945899991" lon="-66.9222396335400020">
+    <node visible="true" id="-353" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5026079945899991" lon="-66.9222396335400020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-298" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5027331878599988" lon="-66.9222272014399948">
+    <node visible="true" id="-352" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5027331878599988" lon="-66.9222272014399948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-297" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5029110445900002" lon="-66.9222250466300039">
+    <node visible="true" id="-351" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5029110445900002" lon="-66.9222250466300039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-296" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030515884900026" lon="-66.9222202422599963">
+    <node visible="true" id="-350" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030515884900026" lon="-66.9222202422599963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-295" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031031692299983" lon="-66.9222112009200032">
+    <node visible="true" id="-349" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031031692299983" lon="-66.9222112009200032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-294" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031547436499988" lon="-66.9222011933100021">
+    <node visible="true" id="-348" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031547436499988" lon="-66.9222011933100021">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-293" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031899114700025" lon="-66.9222316849699865">
+    <node visible="true" id="-347" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5031899114700025" lon="-66.9222316849699865">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-292" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060914807999985" lon="-66.9224291806099956">
+    <node visible="true" id="-346" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060914807999985" lon="-66.9224291806099956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-291" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060633816999971" lon="-66.9223179485600070">
+    <node visible="true" id="-345" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060633816999971" lon="-66.9223179485600070">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-290" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060590372099973" lon="-66.9222515998099965">
+    <node visible="true" id="-344" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060590372099973" lon="-66.9222515998099965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-289" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060511819099993" lon="-66.9221267988699964">
+    <node visible="true" id="-343" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060511819099993" lon="-66.9221267988699964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-288" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060503386299988" lon="-66.9219980000100065">
+    <node visible="true" id="-342" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060503386299988" lon="-66.9219980000100065">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-287" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060598688499987" lon="-66.9217814183299993">
+    <node visible="true" id="-341" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060598688499987" lon="-66.9217814183299993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-286" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062818944800007" lon="-66.9181573339999858">
+    <node visible="true" id="-340" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062818944800007" lon="-66.9181573339999858">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-285" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061648468000008" lon="-66.9176740356499948">
+    <node visible="true" id="-339" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061648468000008" lon="-66.9176740356499948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-284" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059300716599999" lon="-66.9188410517999870">
+    <node visible="true" id="-338" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059300716599999" lon="-66.9188410517999870">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-283" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055750874899996" lon="-66.9189091096399977">
+    <node visible="true" id="-337" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055750874899996" lon="-66.9189091096399977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-282" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051952928599981" lon="-66.9189899105600006">
+    <node visible="true" id="-336" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051952928599981" lon="-66.9189899105600006">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-281" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047918416500004" lon="-66.9190485100699988">
+    <node visible="true" id="-335" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047918416500004" lon="-66.9190485100699988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-280" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040953147699962" lon="-66.9191573294800008">
+    <node visible="true" id="-334" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040953147699962" lon="-66.9191573294800008">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-279" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040457241999974" lon="-66.9191555192399932">
+    <node visible="true" id="-333" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040457241999974" lon="-66.9191555192399932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-278" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039586815799986" lon="-66.9191686789999949">
+    <node visible="true" id="-332" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039586815799986" lon="-66.9191686789999949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-277" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038523144699987" lon="-66.9191875579400062">
+    <node visible="true" id="-331" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038523144699987" lon="-66.9191875579400062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-276" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037625517700004" lon="-66.9192077231899987">
+    <node visible="true" id="-330" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037625517700004" lon="-66.9192077231899987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-275" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063523938099994" lon="-66.9162722837800032">
+    <node visible="true" id="-329" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063523938099994" lon="-66.9162722837800032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-274" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059284661799985" lon="-66.9163486464699986">
+    <node visible="true" id="-328" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059284661799985" lon="-66.9163486464699986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-273" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069191310600001" lon="-66.9168471839300025">
+    <node visible="true" id="-327" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069191310600001" lon="-66.9168471839300025">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-272" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068529482000006" lon="-66.9165352802399980">
+    <node visible="true" id="-326" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068529482000006" lon="-66.9165352802399980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-271" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066023617799988" lon="-66.9174816718000045">
+    <node visible="true" id="-325" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066023617799988" lon="-66.9174816718000045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-270" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069967027600004" lon="-66.9173048613500043">
+    <node visible="true" id="-324" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069967027600004" lon="-66.9173048613500043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-269" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072214588500010" lon="-66.9185794613800056">
+    <node visible="true" id="-323" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072214588500010" lon="-66.9185794613800056">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-268" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071615708699984" lon="-66.9182477991100058">
+    <node visible="true" id="-322" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071615708699984" lon="-66.9182477991100058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-267" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070787627000009" lon="-66.9177817534199875">
+    <node visible="true" id="-321" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070787627000009" lon="-66.9177817534199875">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-266" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070130883199990" lon="-66.9174000858100015">
+    <node visible="true" id="-320" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070130883199990" lon="-66.9174000858100015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-265" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061359141099988" lon="-66.9175366525399795">
+    <node visible="true" id="-319" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061359141099988" lon="-66.9175366525399795">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-264" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061437431500000" lon="-66.9175738276800018">
+    <node visible="true" id="-318" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061437431500000" lon="-66.9175738276800018">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-263" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060422756899978" lon="-66.9175942167299951">
+    <node visible="true" id="-317" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060422756899978" lon="-66.9175942167299951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-262" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055432188300006" lon="-66.9177014809399964">
+    <node visible="true" id="-316" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055432188300006" lon="-66.9177014809399964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-261" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051692639099983" lon="-66.9177721839400022">
+    <node visible="true" id="-315" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051692639099983" lon="-66.9177721839400022">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-260" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059956875499978" lon="-66.9175044098199834">
+    <node visible="true" id="-314" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059956875499978" lon="-66.9175044098199834">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-259" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055515677300004" lon="-66.9175962862999967">
+    <node visible="true" id="-313" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055515677300004" lon="-66.9175962862999967">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-258" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049533554100023" lon="-66.9177147688200051">
+    <node visible="true" id="-312" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049533554100023" lon="-66.9177147688200051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-257" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061021202100005" lon="-66.9174772214900031">
+    <node visible="true" id="-311" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061021202100005" lon="-66.9174772214900031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-256" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060778466800002" lon="-66.9174345332900060">
+    <node visible="true" id="-310" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5060778466800002" lon="-66.9174345332900060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-255" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059951321099998" lon="-66.9170344960599834">
+    <node visible="true" id="-309" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059951321099998" lon="-66.9170344960599834">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-254" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059042314299980" lon="-66.9166075381699841">
+    <node visible="true" id="-308" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059042314299980" lon="-66.9166075381699841">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-253" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058777022099985" lon="-66.9164296754899937">
+    <node visible="true" id="-307" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058777022099985" lon="-66.9164296754899937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-252" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046685254200014" lon="-66.9178680922500035">
+    <node visible="true" id="-306" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046685254200014" lon="-66.9178680922500035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-251" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038070532700001" lon="-66.9180491496999963">
+    <node visible="true" id="-305" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038070532700001" lon="-66.9180491496999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-250" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053432219099996" lon="-66.9198265946899937">
+    <node visible="true" id="-304" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053432219099996" lon="-66.9198265946899937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-249" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053649547400010" lon="-66.9197322105199817">
+    <node visible="true" id="-303" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053649547400010" lon="-66.9197322105199817">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-248" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052494527399993" lon="-66.9191995371999866">
+    <node visible="true" id="-302" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052494527399993" lon="-66.9191995371999866">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-247" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5050732855399982" lon="-66.9183869069299817">
+    <node visible="true" id="-301" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5050732855399982" lon="-66.9183869069299817">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-246" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049342697800014" lon="-66.9178171933099861">
+    <node visible="true" id="-300" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049342697800014" lon="-66.9178171933099861">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-245" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045356450099998" lon="-66.9177906358799959">
+    <node visible="true" id="-299" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045356450099998" lon="-66.9177906358799959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-244" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037778407700024" lon="-66.9179476279900030">
+    <node visible="true" id="-298" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037778407700024" lon="-66.9179476279900030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-243" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049111476799997" lon="-66.9177224348500062">
+    <node visible="true" id="-297" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049111476799997" lon="-66.9177224348500062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-242" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048757827699983" lon="-66.9175775034800040">
+    <node visible="true" id="-296" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048757827699983" lon="-66.9175775034800040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-241" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047173406399974" lon="-66.9169096394799965">
+    <node visible="true" id="-295" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047173406399974" lon="-66.9169096394799965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-240" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058770043799985" lon="-66.9163602237699990">
+    <node visible="true" id="-294" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058770043799985" lon="-66.9163602237699990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-239" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058538840399986" lon="-66.9163143857499989">
+    <node visible="true" id="-293" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058538840399986" lon="-66.9163143857499989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-238" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058434388300004" lon="-66.9162936772499961">
+    <node visible="true" id="-292" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5058434388300004" lon="-66.9162936772499961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-237" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5057298551400002" lon="-66.9158682208299922">
+    <node visible="true" id="-291" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5057298551400002" lon="-66.9158682208299922">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-236" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
+    <node visible="true" id="-290" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-235" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
+    <node visible="true" id="-289" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-234" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
+    <node visible="true" id="-288" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-233" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299997" lon="-66.9151838086699939">
+    <node visible="true" id="-287" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299997" lon="-66.9151838086699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-232" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
+    <node visible="true" id="-286" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-231" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699999" lon="-66.9151444806499995">
+    <node visible="true" id="-285" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699999" lon="-66.9151444806499995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-230" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
+    <node visible="true" id="-284" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-229" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
+    <node visible="true" id="-283" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-228" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042815343599987" lon="-66.9147518508599859">
+    <node visible="true" id="-282" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042815343599987" lon="-66.9147518508599859">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-227" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032642808799981" lon="-66.9157474172099995">
+    <node visible="true" id="-281" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032642808799981" lon="-66.9157474172099995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-226" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030713079300000" lon="-66.9149294392900060">
+    <node visible="true" id="-280" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030713079300000" lon="-66.9149294392900060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-225" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042510361299986" lon="-66.9153836661400021">
+    <node visible="true" id="-279" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042510361299986" lon="-66.9153836661400021">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-224" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035492336900003" lon="-66.9155513811799949">
+    <node visible="true" id="-278" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035492336900003" lon="-66.9155513811799949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-223" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032438332300000" lon="-66.9156426956199937">
+    <node visible="true" id="-277" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032438332300000" lon="-66.9156426956199937">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-222" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546599987" lon="-66.9153896753699939">
+    <node visible="true" id="-276" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546599987" lon="-66.9153896753699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-221" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457500006" lon="-66.9149623942000034">
+    <node visible="true" id="-275" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457500006" lon="-66.9149623942000034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-220" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080860520500021" lon="-66.9158961567700032">
+    <node visible="true" id="-274" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080860520500021" lon="-66.9158961567700032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-219" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080252273599992" lon="-66.9156127823600002">
+    <node visible="true" id="-273" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080252273599992" lon="-66.9156127823600002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-218" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164700004" lon="-66.9153835618100032">
+    <node visible="true" id="-272" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164700004" lon="-66.9153835618100032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-217" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844299999" lon="-66.9148101529700057">
+    <node visible="true" id="-271" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844299999" lon="-66.9148101529700057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-216" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800037" lon="-66.9178452289699948">
+    <node visible="true" id="-270" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800037" lon="-66.9178452289699948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-215" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
+    <node visible="true" id="-269" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-214" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039194989899993" lon="-66.9196712758399883">
+    <node visible="true" id="-268" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039194989899993" lon="-66.9196712758399883">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-213" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039704792399995" lon="-66.9195592527499912">
+    <node visible="true" id="-267" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039704792399995" lon="-66.9195592527499912">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-212" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039802668399993" lon="-66.9195420380700057">
+    <node visible="true" id="-266" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039802668399993" lon="-66.9195420380700057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-211" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039880360800026" lon="-66.9195238027599970">
+    <node visible="true" id="-265" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039880360800026" lon="-66.9195238027599970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-210" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039936844599993" lon="-66.9195047874499949">
+    <node visible="true" id="-264" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039936844599993" lon="-66.9195047874499949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-209" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039971374299981" lon="-66.9194852430599951">
+    <node visible="true" id="-263" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039971374299981" lon="-66.9194852430599951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-208" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039983494300007" lon="-66.9194654274899960">
+    <node visible="true" id="-262" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039983494300007" lon="-66.9194654274899960">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-207" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039973044699995" lon="-66.9194456021999997">
+    <node visible="true" id="-261" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039973044699995" lon="-66.9194456021999997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-206" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039940163500010" lon="-66.9194260288099940">
+    <node visible="true" id="-260" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039940163500010" lon="-66.9194260288099940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-205" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039885284400007" lon="-66.9194069655899995">
+    <node visible="true" id="-259" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039885284400007" lon="-66.9194069655899995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-204" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039809131699986" lon="-66.9193886640899933">
+    <node visible="true" id="-258" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039809131699986" lon="-66.9193886640899933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039712710100002" lon="-66.9193713657999893">
+    <node visible="true" id="-257" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039712710100002" lon="-66.9193713657999893">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039597292100009" lon="-66.9193552990000029">
+    <node visible="true" id="-256" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039597292100009" lon="-66.9193552990000029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039464400600000" lon="-66.9193406756700000">
+    <node visible="true" id="-255" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039464400600000" lon="-66.9193406756700000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039315789199978" lon="-66.9193276887999957">
+    <node visible="true" id="-254" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039315789199978" lon="-66.9193276887999957">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039153418899982" lon="-66.9193165097299953">
+    <node visible="true" id="-253" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039153418899982" lon="-66.9193165097299953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038979432200001" lon="-66.9193072859900013">
+    <node visible="true" id="-252" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038979432200001" lon="-66.9193072859900013">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038711250799981" lon="-66.9192933751199917">
+    <node visible="true" id="-251" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038711250799981" lon="-66.9192933751199917">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038453873499993" lon="-66.9192935174699954">
+    <node visible="true" id="-250" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038453873499993" lon="-66.9192935174699954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038196887600002" lon="-66.9192920768799979">
+    <node visible="true" id="-249" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5038196887600002" lon="-66.9192920768799979">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037941245499997" lon="-66.9192890587199969">
+    <node visible="true" id="-248" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037941245499997" lon="-66.9192890587199969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037687894899996" lon="-66.9192844741500039">
+    <node visible="true" id="-247" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037687894899996" lon="-66.9192844741500039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037437775000004" lon="-66.9192783401800000">
+    <node visible="true" id="-246" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037437775000004" lon="-66.9192783401800000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037334723099995" lon="-66.9192751305700000">
+    <node visible="true" id="-245" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037334723099995" lon="-66.9192751305700000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037191812899984" lon="-66.9192706795400056">
+    <node visible="true" id="-244" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5037191812899984" lon="-66.9192706795400056">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036950920299983" lon="-66.9192615206400063">
+    <node visible="true" id="-243" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036950920299983" lon="-66.9192615206400063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036715990199987" lon="-66.9192508974099951">
+    <node visible="true" id="-242" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036715990199987" lon="-66.9192508974099951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036487893300023" lon="-66.9192388492499930">
+    <node visible="true" id="-241" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036487893300023" lon="-66.9192388492499930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036267475399985" lon="-66.9192254208099939">
+    <node visible="true" id="-240" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036267475399985" lon="-66.9192254208099939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036055553199983" lon="-66.9192106618699967">
+    <node visible="true" id="-239" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5036055553199983" lon="-66.9192106618699967">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035852912600003" lon="-66.9191946271400013">
+    <node visible="true" id="-238" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035852912600003" lon="-66.9191946271400013">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035660304499974" lon="-66.9191773760500013">
+    <node visible="true" id="-237" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035660304499974" lon="-66.9191773760500013">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035478442900008" lon="-66.9191589725499938">
+    <node visible="true" id="-236" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035478442900008" lon="-66.9191589725499938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035308001999983" lon="-66.9191394848599970">
+    <node visible="true" id="-235" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035308001999983" lon="-66.9191394848599970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035233190399993" lon="-66.9191289288099966">
+    <node visible="true" id="-234" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035233190399993" lon="-66.9191289288099966">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035162070299997" lon="-66.9191181153699972">
+    <node visible="true" id="-233" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035162070299997" lon="-66.9191181153699972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035094728299985" lon="-66.9191070577099936">
+    <node visible="true" id="-232" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035094728299985" lon="-66.9191070577099936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035031246399981" lon="-66.9190957693100046">
+    <node visible="true" id="-231" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5035031246399981" lon="-66.9190957693100046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034971702000011" lon="-66.9190842639199985">
+    <node visible="true" id="-230" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034971702000011" lon="-66.9190842639199985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034916167599999" lon="-66.9190725555699970">
+    <node visible="true" id="-229" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034916167599999" lon="-66.9190725555699970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034864711000004" lon="-66.9190606585000012">
+    <node visible="true" id="-228" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034864711000004" lon="-66.9190606585000012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034817394699989" lon="-66.9190485872299945">
+    <node visible="true" id="-227" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034817394699989" lon="-66.9190485872299945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034774276499991" lon="-66.9190363564499933">
+    <node visible="true" id="-226" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034774276499991" lon="-66.9190363564499933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034735408800017" lon="-66.9190239810599934">
+    <node visible="true" id="-225" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034735408800017" lon="-66.9190239810599934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034700839000017" lon="-66.9190114761599943">
+    <node visible="true" id="-224" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034700839000017" lon="-66.9190114761599943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034670609299976" lon="-66.9189988569600018">
+    <node visible="true" id="-223" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034670609299976" lon="-66.9189988569600018">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034644756399977" lon="-66.9189861388399976">
+    <node visible="true" id="-222" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034644756399977" lon="-66.9189861388399976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034623311899988" lon="-66.9189733373100069">
+    <node visible="true" id="-221" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034623311899988" lon="-66.9189733373100069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034268959599988" lon="-66.9188101090799989">
+    <node visible="true" id="-220" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5034268959599988" lon="-66.9188101090799989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5033042606499976" lon="-66.9182751022899964">
+    <node visible="true" id="-219" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5033042606499976" lon="-66.9182751022899964">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032568712999979" lon="-66.9180631138100068">
+    <node visible="true" id="-218" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5032568712999979" lon="-66.9180631138100068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030270432499986" lon="-66.9147251119999993">
+    <node visible="true" id="-217" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5030270432499986" lon="-66.9147251119999993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045740190299970" lon="-66.9165666487800053">
+    <node visible="true" id="-216" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045740190299970" lon="-66.9165666487800053">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045299362899964" lon="-66.9163211548700048">
+    <node visible="true" id="-215" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045299362899964" lon="-66.9163211548700048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044405943299974" lon="-66.9158470813899982">
+    <node visible="true" id="-214" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044405943299974" lon="-66.9158470813899982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043741888499991" lon="-66.9155341129499988">
+    <node visible="true" id="-213" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043741888499991" lon="-66.9155341129499988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043582842800021" lon="-66.9154639941399836">
+    <node visible="true" id="-212" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043582842800021" lon="-66.9154639941399836">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046516504500040" lon="-66.9166619300499974">
+    <node visible="true" id="-211" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046516504500040" lon="-66.9166619300499974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046769630700005" lon="-66.9165677409999944">
+    <node visible="true" id="-210" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046769630700005" lon="-66.9165677409999944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046011597699991" lon="-66.9161736758899934">
+    <node visible="true" id="-209" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046011597699991" lon="-66.9161736758899934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045687244099994" lon="-66.9159888408800043">
+    <node visible="true" id="-208" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045687244099994" lon="-66.9159888408800043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044906445499997" lon="-66.9155966217399936">
+    <node visible="true" id="-207" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044906445499997" lon="-66.9155966217399936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044716726299967" lon="-66.9154840413900018">
+    <node visible="true" id="-206" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044716726299967" lon="-66.9154840413900018">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044679569899984" lon="-66.9154575822200002">
+    <node visible="true" id="-205" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044679569899984" lon="-66.9154575822200002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044649218899977" lon="-66.9154359692000043">
+    <node visible="true" id="-204" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044649218899977" lon="-66.9154359692000043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043894673900002" lon="-66.9153129303799972">
+    <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043894673900002" lon="-66.9153129303799972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096322146500007" lon="-66.9155947246599965">
+    <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096322146500007" lon="-66.9155947246599965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092728589799975" lon="-66.9156553398100016">
+    <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092728589799975" lon="-66.9156553398100016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091801185500007" lon="-66.9156787637299999">
+    <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091801185500007" lon="-66.9156787637299999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090236679100002" lon="-66.9157182792099974">
+    <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090236679100002" lon="-66.9157182792099974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086644395900031" lon="-66.9157982945799858">
+    <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086644395900031" lon="-66.9157982945799858">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082264324199990" lon="-66.9158849647899956">
+    <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082264324199990" lon="-66.9158849647899956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079317687000007" lon="-66.9159482085800050">
+    <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079317687000007" lon="-66.9159482085800050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074756193199992" lon="-66.9160421477200060">
+    <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074756193199992" lon="-66.9160421477200060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067934462499988" lon="-66.9161876369699939">
+    <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067934462499988" lon="-66.9161876369699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067748030699999" lon="-66.9161912149800031">
+    <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067748030699999" lon="-66.9161912149800031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068154619499996" lon="-66.9221456928499947">
+    <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068154619499996" lon="-66.9221456928499947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067771756999999" lon="-66.9216615938599801">
+    <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067771756999999" lon="-66.9216615938599801">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067966759099995" lon="-66.9214219473199989">
+    <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067966759099995" lon="-66.9214219473199989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068400008000005" lon="-66.9210668188599982">
+    <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068400008000005" lon="-66.9210668188599982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068421848000000" lon="-66.9210163419700024">
+    <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068421848000000" lon="-66.9210163419700024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068426240999990" lon="-66.9209658187999992">
+    <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068426240999990" lon="-66.9209658187999992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068413181599993" lon="-66.9209153109299990">
+    <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068413181599993" lon="-66.9209153109299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068382685700001" lon="-66.9208648798799999">
+    <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068382685700001" lon="-66.9208648798799999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068334790499982" lon="-66.9208145870999971">
+    <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068334790499982" lon="-66.9208145870999971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068269554300002" lon="-66.9207644938600055">
+    <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068269554300002" lon="-66.9207644938600055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068187056600024" lon="-66.9207146611899901">
+    <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068187056600024" lon="-66.9207146611899901">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068087397899994" lon="-66.9206651498100058">
+    <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068087397899994" lon="-66.9206651498100058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067970699599993" lon="-66.9206160200500051">
+    <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067970699599993" lon="-66.9206160200500051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067876554299993" lon="-66.9205810401399930">
+    <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067876554299993" lon="-66.9205810401399930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066714401599999" lon="-66.9199945602299948">
+    <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066714401599999" lon="-66.9199945602299948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065514100199984" lon="-66.9193619775499968">
+    <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065514100199984" lon="-66.9193619775499968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064335067399970" lon="-66.9187861553899950">
+    <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064335067399970" lon="-66.9187861553899950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064215152299987" lon="-66.9187364196500027">
+    <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064215152299987" lon="-66.9187364196500027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039070353500037" lon="-66.9225971136300046">
+    <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039070353500037" lon="-66.9225971136300046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039205406799976" lon="-66.9225821776499998">
+    <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039205406799976" lon="-66.9225821776499998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039358283100039" lon="-66.9225691129399962">
+    <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039358283100039" lon="-66.9225691129399962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039526463099993" lon="-66.9225581347800045">
+    <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5039526463099993" lon="-66.9225581347800045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040592021299997" lon="-66.9224868957000041">
+    <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5040592021299997" lon="-66.9224868957000041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5041008246299992" lon="-66.9224478276699983">
+    <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5041008246299992" lon="-66.9224478276699983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5041377634199975" lon="-66.9224040891199934">
+    <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5041377634199975" lon="-66.9224040891199934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042506062499985" lon="-66.9223506049900010">
+    <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5042506062499985" lon="-66.9223506049900010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043546856499983" lon="-66.9222814760800020">
+    <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5043546856499983" lon="-66.9222814760800020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044485666299998" lon="-66.9222287797799993">
+    <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5044485666299998" lon="-66.9222287797799993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045394544799997" lon="-66.9221686650400045">
+    <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5045394544799997" lon="-66.9221686650400045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046303423099996" lon="-66.9221085502600062">
+    <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046303423099996" lon="-66.9221085502600062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046843760400002" lon="-66.9220412433700034">
+    <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5046843760400002" lon="-66.9220412433700034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047545067299986" lon="-66.9219589520299820">
+    <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047545067299986" lon="-66.9219589520299820">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047894308399989" lon="-66.9218962358799985">
+    <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047894308399989" lon="-66.9218962358799985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047986594700014" lon="-66.9218899126099984">
+    <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5047986594700014" lon="-66.9218899126099984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048083889299981" lon="-66.9218844090199951">
+    <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048083889299981" lon="-66.9218844090199951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048185480799976" lon="-66.9218797653599893">
+    <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048185480799976" lon="-66.9218797653599893">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048290626600025" lon="-66.9218760155700068">
+    <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048290626600025" lon="-66.9218760155700068">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048398558099976" lon="-66.9218731870599868">
+    <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048398558099976" lon="-66.9218731870599868">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048508486200021" lon="-66.9218713005100057">
+    <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048508486200021" lon="-66.9218713005100057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048619607399996" lon="-66.9218703697000024">
+    <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048619607399996" lon="-66.9218703697000024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048731109300011" lon="-66.9218704014499934">
+    <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048731109300011" lon="-66.9218704014499934">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048842176800008" lon="-66.9218713955300046">
+    <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048842176800008" lon="-66.9218713955300046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048951997900026" lon="-66.9218733446499954">
+    <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5048951997900026" lon="-66.9218733446499954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049059769899991" lon="-66.9218762345900018">
+    <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049059769899991" lon="-66.9218762345900018">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049164704900004" lon="-66.9218800442099990">
+    <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049164704900004" lon="-66.9218800442099990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049266035799977" lon="-66.9218847456500043">
+    <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049266035799977" lon="-66.9218847456500043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049363021800026" lon="-66.9218903045599944">
+    <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049363021800026" lon="-66.9218903045599944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049454953899986" lon="-66.9218966802999944">
+    <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5049454953899986" lon="-66.9218966802999944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5050997160699993" lon="-66.9220652454000060">
+    <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5050997160699993" lon="-66.9220652454000060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051591695399988" lon="-66.9221511337299972">
+    <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5051591695399988" lon="-66.9221511337299972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052266462600006" lon="-66.9223381310799965">
+    <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052266462600006" lon="-66.9223381310799965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052863431100025" lon="-66.9224612100299936">
+    <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5052863431100025" lon="-66.9224612100299936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053102880499996" lon="-66.9225205574399951">
+    <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053102880499996" lon="-66.9225205574399951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053327120799995" lon="-66.9225724765999956">
+    <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5053327120799995" lon="-66.9225724765999956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094299418899961" lon="-66.9169115387200009">
+    <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094299418899961" lon="-66.9169115387200009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098929898699982" lon="-66.9167171441300042">
+    <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098929898699982" lon="-66.9167171441300042">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094049278800004" lon="-66.9168165613399992">
+    <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094049278800004" lon="-66.9168165613399992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098801357199996" lon="-66.9194266970799987">
+    <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098801357199996" lon="-66.9194266970799987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096758779499986" lon="-66.9181163069000036">
+    <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096758779499986" lon="-66.9181163069000036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098666174000002" lon="-66.9193527216999939">
+    <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098666174000002" lon="-66.9193527216999939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094893116399977" lon="-66.9219630065600057">
+    <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094893116399977" lon="-66.9219630065600057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094511167099984" lon="-66.9219496928599966">
+    <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094511167099984" lon="-66.9219496928599966">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093171784799981" lon="-66.9219030056799795">
+    <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093171784799981" lon="-66.9219030056799795">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092779757799981" lon="-66.9218809953700031">
+    <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092779757799981" lon="-66.9218809953700031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092395571399990" lon="-66.9218576159800023">
+    <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092395571399990" lon="-66.9218576159800023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092019693799976" lon="-66.9218328959999980">
+    <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092019693799976" lon="-66.9218328959999980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091652582799995" lon="-66.9218068655400060">
+    <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091652582799995" lon="-66.9218068655400060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091294685799976" lon="-66.9217795563299944">
+    <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091294685799976" lon="-66.9217795563299944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090946438700001" lon="-66.9217510016299855">
+    <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090946438700001" lon="-66.9217510016299855">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090608265799990" lon="-66.9217212362400033">
+    <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090608265799990" lon="-66.9217212362400033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090221939399981" lon="-66.9216843590299959">
+    <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090221939399981" lon="-66.9216843590299959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096589336199990" lon="-66.9221201602099995">
+    <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096589336199990" lon="-66.9221201602099995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094775881599976" lon="-66.9220713881800009">
+    <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094775881599976" lon="-66.9220713881800009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094413869800007" lon="-66.9220612686000038">
+    <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094413869800007" lon="-66.9220612686000038">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094055573700000" lon="-66.9220498785399940">
+    <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094055573700000" lon="-66.9220498785399940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093701429599999" lon="-66.9220372318900019">
+    <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093701429599999" lon="-66.9220372318900019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093351869100005" lon="-66.9220233440500039">
+    <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093351869100005" lon="-66.9220233440500039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092668196299996" lon="-66.9219919139700039">
+    <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092668196299996" lon="-66.9219919139700039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092334916999999" lon="-66.9219744100399936">
+    <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092334916999999" lon="-66.9219744100399936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092007886100003" lon="-66.9219557414500059">
+    <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092007886100003" lon="-66.9219557414500059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091687502100015" lon="-66.9219359309600037">
+    <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091687502100015" lon="-66.9219359309600037">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091374155399979" lon="-66.9219150027000040">
+    <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091374155399979" lon="-66.9219150027000040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091068227700024" lon="-66.9218929821799975">
+    <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091068227700024" lon="-66.9218929821799975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090770091700030" lon="-66.9218698962099978">
+    <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090770091700030" lon="-66.9218698962099978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090615095499977" lon="-66.9218572159000047">
+    <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090615095499977" lon="-66.9218572159000047">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090158072899982" lon="-66.9218164769699797">
+    <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090158072899982" lon="-66.9218164769699797">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089715398900019" lon="-66.9217741511599939">
+    <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089715398900019" lon="-66.9217741511599939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089541299099984" lon="-66.9217563006399985">
+    <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089541299099984" lon="-66.9217563006399985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098610153999985" lon="-66.9223342548799991">
+    <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098610153999985" lon="-66.9223342548799991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097554013100005" lon="-66.9223270593700050">
+    <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097554013100005" lon="-66.9223270593700050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097071699200004" lon="-66.9223140055800059">
+    <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097071699200004" lon="-66.9223140055800059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096594187499992" lon="-66.9222992588500034">
+    <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096594187499992" lon="-66.9222992588500034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096122059799999" lon="-66.9222828371599832">
+    <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5096122059799999" lon="-66.9222828371599832">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095655891500002" lon="-66.9222647605100036">
+    <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095655891500002" lon="-66.9222647605100036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095196250300003" lon="-66.9222450509300018">
+    <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095196250300003" lon="-66.9222450509300018">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094743696300004" lon="-66.9222237324199938">
+    <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094743696300004" lon="-66.9222237324199938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094298780999988" lon="-66.9222008309699987">
+    <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5094298780999988" lon="-66.9222008309699987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093862046299975" lon="-66.9221763744699984">
+    <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093862046299975" lon="-66.9221763744699984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093397812800013" lon="-66.9221480991700020">
+    <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093397812800013" lon="-66.9221480991700020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092912423399998" lon="-66.9220996965700010">
+    <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092912423399998" lon="-66.9220996965700010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093086107700007" lon="-66.9220116876699791">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093086107700007" lon="-66.9220116876699791">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5030216030534156" lon="-66.9146999999999963">
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5030216030534156" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5042702357392166" lon="-66.9146999999999963">
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5042702357392166" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5055726487324517" lon="-66.9146999999999963">
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5055726487324517" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5061263174137789" lon="-66.9225999999999885">
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5061263174137789" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5019773254829722" lon="-66.9225999999999885">
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5019773254829722" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5024207826546370" lon="-66.9225999999999885">
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5024207826546370" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9218128281131044">
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9218128281131044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9216660902135345">
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9216660902135345">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9198273048406094">
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9198273048406094">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9191121238655313">
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9191121238655313">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9184432685039354">
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9184432685039354">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9172728837260422">
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9172728837260422">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9185233694162633">
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9185233694162633">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5017660737884562" lon="-66.9146999999999963">
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5017660737884562" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9150505735035637">
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9150505735035637">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5077664451104162" lon="-66.9146999999999963">
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5077664451104162" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9213871847514383">
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000001" lon="-66.9213871847514383">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9160029618147263">
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5015000000000018" lon="-66.9160029618147263">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5037296643490183" lon="-66.9225999999999885">
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5037296643490183" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5034735566289115" lon="-66.9225999999999885">
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5034735566289115" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5026017825486893" lon="-66.9225999999999885">
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5026017825486893" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5064658613273991" lon="-66.9146999999999963">
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5064658613273991" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9223373273507605">
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9223373273507605">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9221834345442232">
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9221834345442232">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9220751717364521">
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9220751717364521">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9193479034154564">
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9193479034154564">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9180924320168202">
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9180924320168202">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9195506086608987">
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9195506086608987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9167158545658367">
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9167158545658367">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9167990839550271">
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000018" lon="-66.9167990839550271">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5039050309753375" lon="-66.9225999999999885">
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5039050309753375" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5053410803396421" lon="-66.9225999999999885">
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5053410803396421" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5068735544789007" lon="-66.9225999999999885">
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5068735544789007" lon="-66.9225999999999885">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9155511759909132">
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5099000000000000" lon="-66.9155511759909132">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5031510625137052" lon="-66.9146999999999963">
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5031510625137052" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5078486207237187" lon="-66.9146999999999963">
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5078486207237187" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5089812841696180" lon="-66.9146999999999963">
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5089812841696180" lon="-66.9146999999999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-8019" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-220"/>
-        <nd ref="-540"/>
-        <nd ref="-5236"/>
+    <way visible="true" id="-7851" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-274"/>
+        <nd ref="-594"/>
+        <nd ref="-4346"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -2887,10 +2887,10 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8018" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5236"/>
-        <nd ref="-541"/>
-        <nd ref="-509"/>
+    <way visible="true" id="-7850" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4346"/>
+        <nd ref="-595"/>
+        <nd ref="-563"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -2917,9 +2917,9 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8015" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5234"/>
-        <nd ref="-558"/>
+    <way visible="true" id="-7847" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4344"/>
+        <nd ref="-612"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -2943,10 +2943,10 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8014" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-510"/>
-        <nd ref="-557"/>
-        <nd ref="-5234"/>
+    <way visible="true" id="-7846" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-564"/>
+        <nd ref="-611"/>
+        <nd ref="-4344"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -2973,9 +2973,9 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8008" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-509"/>
-        <nd ref="-510"/>
+    <way visible="true" id="-7840" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-563"/>
+        <nd ref="-564"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="layer" v="1"/>
@@ -3001,14 +3001,14 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8005" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5229"/>
-        <nd ref="-551"/>
-        <nd ref="-550"/>
-        <nd ref="-549"/>
-        <nd ref="-548"/>
-        <nd ref="-547"/>
-        <nd ref="-22"/>
+    <way visible="true" id="-7837" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-4339"/>
+        <nd ref="-605"/>
+        <nd ref="-604"/>
+        <nd ref="-603"/>
+        <nd ref="-602"/>
+        <nd ref="-601"/>
+        <nd ref="-76"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -3032,10 +3032,10 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8004" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-542"/>
-        <nd ref="-552"/>
-        <nd ref="-5229"/>
+    <way visible="true" id="-7836" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-596"/>
+        <nd ref="-606"/>
+        <nd ref="-4339"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -3062,10 +3062,10 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8001" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-563"/>
-        <nd ref="-562"/>
-        <nd ref="-5227"/>
+    <way visible="true" id="-7833" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-617"/>
+        <nd ref="-616"/>
+        <nd ref="-4337"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="layer" v="-1"/>
@@ -3090,10 +3090,10 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8000" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5227"/>
-        <nd ref="-561"/>
-        <nd ref="-553"/>
+    <way visible="true" id="-7832" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4337"/>
+        <nd ref="-615"/>
+        <nd ref="-607"/>
         <tag k="alt_name" v="Av. Urdaneta"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -3120,9 +3120,9 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-7994" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-553"/>
-        <nd ref="-542"/>
+    <way visible="true" id="-7826" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-607"/>
+        <nd ref="-596"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="layer" v="1"/>
@@ -3146,16 +3146,84 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-7990" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5221"/>
-        <nd ref="-786"/>
-        <nd ref="-787"/>
+    <way visible="true" id="-7822" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4331"/>
+        <nd ref="-840"/>
+        <nd ref="-841"/>
+        <nd ref="-842"/>
+        <nd ref="-843"/>
+        <nd ref="-844"/>
+        <nd ref="-845"/>
+        <nd ref="-846"/>
+        <nd ref="-783"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 4"/>
+        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
+        <tag k="source:datetime" v="2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-7821" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-753"/>
         <nd ref="-788"/>
         <nd ref="-789"/>
         <nd ref="-790"/>
         <nd ref="-791"/>
         <nd ref="-792"/>
-        <nd ref="-729"/>
+        <nd ref="-793"/>
+        <nd ref="-794"/>
+        <nd ref="-795"/>
+        <nd ref="-796"/>
+        <nd ref="-797"/>
+        <nd ref="-798"/>
+        <nd ref="-799"/>
+        <nd ref="-800"/>
+        <nd ref="-801"/>
+        <nd ref="-802"/>
+        <nd ref="-803"/>
+        <nd ref="-804"/>
+        <nd ref="-805"/>
+        <nd ref="-806"/>
+        <nd ref="-807"/>
+        <nd ref="-808"/>
+        <nd ref="-809"/>
+        <nd ref="-810"/>
+        <nd ref="-811"/>
+        <nd ref="-812"/>
+        <nd ref="-813"/>
+        <nd ref="-814"/>
+        <nd ref="-815"/>
+        <nd ref="-816"/>
+        <nd ref="-817"/>
+        <nd ref="-818"/>
+        <nd ref="-819"/>
+        <nd ref="-820"/>
+        <nd ref="-821"/>
+        <nd ref="-822"/>
+        <nd ref="-823"/>
+        <nd ref="-824"/>
+        <nd ref="-825"/>
+        <nd ref="-826"/>
+        <nd ref="-827"/>
+        <nd ref="-828"/>
+        <nd ref="-829"/>
+        <nd ref="-830"/>
+        <nd ref="-831"/>
+        <nd ref="-832"/>
+        <nd ref="-833"/>
+        <nd ref="-834"/>
+        <nd ref="-835"/>
+        <nd ref="-836"/>
+        <nd ref="-4330"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -3172,80 +3240,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-7989" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-699"/>
-        <nd ref="-734"/>
-        <nd ref="-735"/>
-        <nd ref="-736"/>
-        <nd ref="-737"/>
-        <nd ref="-738"/>
-        <nd ref="-739"/>
-        <nd ref="-740"/>
-        <nd ref="-741"/>
-        <nd ref="-742"/>
-        <nd ref="-743"/>
-        <nd ref="-744"/>
-        <nd ref="-745"/>
-        <nd ref="-746"/>
-        <nd ref="-747"/>
-        <nd ref="-748"/>
-        <nd ref="-749"/>
-        <nd ref="-750"/>
-        <nd ref="-751"/>
-        <nd ref="-752"/>
-        <nd ref="-753"/>
-        <nd ref="-754"/>
-        <nd ref="-755"/>
-        <nd ref="-756"/>
-        <nd ref="-757"/>
-        <nd ref="-758"/>
-        <nd ref="-759"/>
-        <nd ref="-760"/>
-        <nd ref="-761"/>
-        <nd ref="-762"/>
-        <nd ref="-763"/>
-        <nd ref="-764"/>
-        <nd ref="-765"/>
-        <nd ref="-766"/>
-        <nd ref="-767"/>
-        <nd ref="-768"/>
-        <nd ref="-769"/>
-        <nd ref="-770"/>
-        <nd ref="-771"/>
-        <nd ref="-772"/>
-        <nd ref="-773"/>
-        <nd ref="-774"/>
-        <nd ref="-775"/>
-        <nd ref="-776"/>
-        <nd ref="-777"/>
-        <nd ref="-778"/>
-        <nd ref="-779"/>
-        <nd ref="-780"/>
-        <nd ref="-781"/>
-        <nd ref="-782"/>
-        <nd ref="-5220"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 4"/>
-        <tag k="uuid" v="{83a0d5bc-776b-49a6-b6ad-023eea7b8490}"/>
-        <tag k="source:datetime" v="2015-04-23T16:51:25.000Z;2015-08-17T18:05:50.000Z;2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-7988" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5220"/>
-        <nd ref="-783"/>
-        <nd ref="-784"/>
-        <nd ref="-785"/>
-        <nd ref="-5221"/>
+    <way visible="true" id="-7820" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4330"/>
+        <nd ref="-837"/>
+        <nd ref="-838"/>
+        <nd ref="-839"/>
+        <nd ref="-4331"/>
         <tag k="alt_name" v="Av. Oeste 4"/>
         <tag k="z_order" v="-999999"/>
         <tag k="layer" v="1"/>
@@ -3265,20 +3265,62 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="tertiary"/>
     </way>
-    <way visible="true" id="-7983" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5216"/>
-        <nd ref="-711"/>
-        <nd ref="-710"/>
-        <nd ref="-709"/>
-        <nd ref="-708"/>
-        <nd ref="-707"/>
-        <nd ref="-706"/>
-        <nd ref="-705"/>
-        <nd ref="-704"/>
-        <nd ref="-703"/>
-        <nd ref="-702"/>
-        <nd ref="-701"/>
-        <nd ref="-5217"/>
+    <way visible="true" id="-7817" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4327"/>
+        <nd ref="-754"/>
+        <nd ref="-753"/>
+        <nd ref="-304"/>
+        <nd ref="-752"/>
+        <nd ref="-751"/>
+        <nd ref="-750"/>
+        <nd ref="-749"/>
+        <nd ref="-748"/>
+        <nd ref="-747"/>
+        <nd ref="-746"/>
+        <nd ref="-745"/>
+        <nd ref="-744"/>
+        <nd ref="-743"/>
+        <nd ref="-742"/>
+        <nd ref="-741"/>
+        <nd ref="-740"/>
+        <nd ref="-268"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z;2019-01-17T19:50:06Z;2014-04-25T15:37:21.000Z;2014-05-19T20:36:26.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-7815" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-4326"/>
+        <nd ref="-765"/>
+        <nd ref="-764"/>
+        <nd ref="-763"/>
+        <nd ref="-762"/>
+        <nd ref="-761"/>
+        <nd ref="-760"/>
+        <nd ref="-759"/>
+        <nd ref="-758"/>
+        <nd ref="-757"/>
+        <nd ref="-756"/>
+        <nd ref="-755"/>
+        <nd ref="-4327"/>
         <tag k="alt_name" v="Av. Sucre"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -3305,9 +3347,9 @@
         <tag k="motor_vehicle" v="permissive"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-404" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-26"/>
-        <nd ref="-513"/>
+    <way visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-80"/>
+        <nd ref="-567"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -3330,1949 +3372,8 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-394" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-37"/>
-        <nd ref="-163"/>
-        <nd ref="-226"/>
-        <nd ref="-223"/>
-        <nd ref="-227"/>
-        <nd ref="-614"/>
-        <nd ref="-615"/>
-        <nd ref="-616"/>
-        <nd ref="-244"/>
-        <nd ref="-251"/>
-        <nd ref="-617"/>
-        <nd ref="-618"/>
-        <nd ref="-280"/>
-        <nd ref="-619"/>
-        <nd ref="-620"/>
-        <nd ref="-621"/>
-        <nd ref="-622"/>
-        <nd ref="-623"/>
-        <nd ref="-624"/>
-        <nd ref="-625"/>
-        <nd ref="-626"/>
-        <nd ref="-627"/>
-        <nd ref="-628"/>
-        <nd ref="-629"/>
-        <nd ref="-630"/>
-        <nd ref="-631"/>
-        <nd ref="-632"/>
-        <nd ref="-633"/>
-        <nd ref="-634"/>
-        <nd ref="-635"/>
-        <nd ref="-636"/>
-        <nd ref="-637"/>
-        <nd ref="-638"/>
-        <nd ref="-249"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z;2019-01-17T19:50:05.676Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 6"/>
-        <tag k="uuid" v="{006de0c0-48c5-434f-8fdb-29c68cb4c649};{48532445-a733-416c-a55c-1fad8bf34ae1}"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2015-08-03T17:38:19.000Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-391" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-507"/>
-        <nd ref="-524"/>
-        <nd ref="-523"/>
-        <nd ref="-520"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="highway" v="primary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-372" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-214"/>
-        <nd ref="-685"/>
-        <nd ref="-684"/>
-        <nd ref="-683"/>
-        <nd ref="-682"/>
-        <nd ref="-681"/>
-        <nd ref="-680"/>
-        <nd ref="-679"/>
-        <nd ref="-678"/>
-        <nd ref="-677"/>
-        <nd ref="-676"/>
-        <nd ref="-675"/>
-        <nd ref="-674"/>
-        <nd ref="-673"/>
-        <nd ref="-426"/>
-        <nd ref="-456"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2015-10-15T16:12:12.000Z;2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454};{35fb46ac-4c0c-4d19-a3d2-94876d592c26}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z;2019-01-17T19:50:05.669Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-        <tag k="destination" v="San Martín;Centro"/>
-    </way>
-    <way visible="true" id="-365" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-5217"/>
-        <nd ref="-700"/>
-        <nd ref="-699"/>
-        <nd ref="-250"/>
-        <nd ref="-698"/>
-        <nd ref="-697"/>
-        <nd ref="-696"/>
-        <nd ref="-695"/>
-        <nd ref="-694"/>
-        <nd ref="-693"/>
-        <nd ref="-692"/>
-        <nd ref="-691"/>
-        <nd ref="-690"/>
-        <nd ref="-689"/>
-        <nd ref="-688"/>
-        <nd ref="-687"/>
-        <nd ref="-686"/>
-        <nd ref="-214"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="source:datetime" v="2014-04-25T15:37:21.000Z;2019-01-17T19:50:06Z;2014-05-19T20:36:26.000Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="motor_vehicle" v="permissive"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-314" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-293"/>
-        <nd ref="-369"/>
-        <nd ref="-368"/>
-        <nd ref="-367"/>
-        <nd ref="-366"/>
-        <nd ref="-365"/>
-        <nd ref="-364"/>
-        <nd ref="-363"/>
-        <nd ref="-362"/>
-        <nd ref="-361"/>
-        <nd ref="-360"/>
-        <nd ref="-359"/>
-        <nd ref="-358"/>
-        <nd ref="-357"/>
-        <nd ref="-356"/>
-        <nd ref="-355"/>
-        <nd ref="-354"/>
-        <nd ref="-353"/>
-        <nd ref="-352"/>
-        <nd ref="-351"/>
-        <nd ref="-350"/>
-        <nd ref="-349"/>
-        <nd ref="-348"/>
+    <way visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-347"/>
-        <nd ref="-346"/>
-        <nd ref="-345"/>
-        <nd ref="-344"/>
-        <nd ref="-343"/>
-        <nd ref="-342"/>
-        <nd ref="-341"/>
-        <nd ref="-340"/>
-        <nd ref="-339"/>
-        <nd ref="-338"/>
-        <nd ref="-337"/>
-        <nd ref="-336"/>
-        <nd ref="-335"/>
-        <nd ref="-334"/>
-        <nd ref="-333"/>
-        <nd ref="-332"/>
-        <nd ref="-32"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="El Calvario"/>
-        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c}"/>
-        <tag k="source:datetime" v="2015-09-15T22:49:24.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-311" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-191"/>
-        <nd ref="-276"/>
-        <nd ref="-277"/>
-        <nd ref="-278"/>
-        <nd ref="-279"/>
-        <nd ref="-280"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="secondary_link"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="uuid" v="{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-307" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-269"/>
-        <nd ref="-566"/>
-        <nd ref="-565"/>
-        <nd ref="-564"/>
-        <nd ref="-121"/>
-        <nd ref="-284"/>
-        <nd ref="-283"/>
-        <nd ref="-282"/>
-        <nd ref="-281"/>
-        <nd ref="-280"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z;2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c};{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
-        <tag k="source:datetime" v="2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z;2015-04-23T16:51:25.000Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-216"/>
-        <nd ref="-215"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
-        <tag k="highway" v="footway"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{a439f440-165f-401c-9395-166374e5bdd7}"/>
-        <tag k="source:datetime" v="2013-04-18T01:17:19.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-164"/>
-        <nd ref="-165"/>
-        <nd ref="-166"/>
-        <nd ref="-167"/>
-        <nd ref="-168"/>
-        <nd ref="-169"/>
-        <nd ref="-170"/>
-        <nd ref="-171"/>
-        <nd ref="-172"/>
-        <nd ref="-173"/>
-        <nd ref="-174"/>
-        <nd ref="-175"/>
-        <nd ref="-176"/>
-        <nd ref="-177"/>
-        <nd ref="-178"/>
-        <nd ref="-179"/>
-        <nd ref="-180"/>
-        <nd ref="-181"/>
-        <nd ref="-182"/>
-        <nd ref="-183"/>
-        <nd ref="-184"/>
-        <nd ref="-185"/>
-        <nd ref="-186"/>
-        <nd ref="-187"/>
-        <nd ref="-188"/>
-        <nd ref="-189"/>
-        <nd ref="-190"/>
-        <nd ref="-191"/>
-        <nd ref="-192"/>
-        <nd ref="-193"/>
-        <nd ref="-194"/>
-        <nd ref="-195"/>
-        <nd ref="-196"/>
-        <nd ref="-197"/>
-        <nd ref="-198"/>
-        <nd ref="-199"/>
-        <nd ref="-200"/>
-        <nd ref="-201"/>
-        <nd ref="-202"/>
-        <nd ref="-203"/>
-        <nd ref="-204"/>
-        <nd ref="-205"/>
-        <nd ref="-206"/>
-        <nd ref="-207"/>
-        <nd ref="-208"/>
-        <nd ref="-209"/>
-        <nd ref="-210"/>
-        <nd ref="-211"/>
-        <nd ref="-212"/>
-        <nd ref="-213"/>
-        <nd ref="-214"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2014-12-24T02:49:57.000Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="2"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="uuid" v="{aec76311-ef7c-458d-b5dc-495745461b2f}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="no"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="destination" v="San Martín"/>
-        <tag k="highway" v="primary_link"/>
-    </way>
-    <way visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-149"/>
-        <nd ref="-158"/>
-        <nd ref="-159"/>
-        <nd ref="-160"/>
-        <nd ref="-161"/>
-        <nd ref="-162"/>
-        <nd ref="-157"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="source:datetime" v="2013-12-19T16:34:21.000Z;2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="1"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{fb707a34-dd57-41b3-b236-7d7c6de3cd29}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-149"/>
-        <nd ref="-150"/>
-        <nd ref="-151"/>
-        <nd ref="-152"/>
-        <nd ref="-153"/>
-        <nd ref="-154"/>
-        <nd ref="-155"/>
-        <nd ref="-156"/>
-        <nd ref="-157"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z;2015-07-07T18:03:14.000Z;2013-12-19T16:34:22.000Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="1"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-653"/>
-        <nd ref="-917"/>
-        <nd ref="-918"/>
-        <nd ref="-919"/>
-        <nd ref="-920"/>
-        <nd ref="-921"/>
-        <nd ref="-922"/>
-        <nd ref="-923"/>
-        <nd ref="-924"/>
-        <nd ref="-925"/>
-        <nd ref="-926"/>
-        <nd ref="-927"/>
-        <nd ref="-928"/>
-        <nd ref="-929"/>
-        <nd ref="-930"/>
-        <nd ref="-931"/>
-        <nd ref="-932"/>
-        <nd ref="-933"/>
-        <nd ref="-934"/>
-        <nd ref="-935"/>
-        <nd ref="-936"/>
-        <nd ref="-937"/>
-        <nd ref="-938"/>
-        <nd ref="-939"/>
-        <nd ref="-598"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="source:datetime" v="2014-04-25T15:54:45.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="2"/>
-        <tag k="uuid" v="{f1a85717-8752-48b3-9d48-c8c5d3c1e99c}"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="no"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary_link"/>
-    </way>
-    <way visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-51"/>
-        <nd ref="-68"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{73768fac-23de-4ae6-b24f-a14cae4ab15b}"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-51"/>
-        <nd ref="-733"/>
-        <nd ref="-732"/>
-        <nd ref="-731"/>
-        <nd ref="-730"/>
-        <nd ref="-729"/>
-        <nd ref="-728"/>
-        <nd ref="-727"/>
-        <nd ref="-726"/>
-        <nd ref="-725"/>
-        <nd ref="-724"/>
-        <nd ref="-723"/>
-        <nd ref="-722"/>
-        <nd ref="-721"/>
-        <nd ref="-720"/>
-        <nd ref="-719"/>
-        <nd ref="-718"/>
-        <nd ref="-717"/>
-        <nd ref="-716"/>
-        <nd ref="-715"/>
-        <nd ref="-714"/>
-        <nd ref="-713"/>
-        <nd ref="-712"/>
-        <nd ref="-5216"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="source:datetime" v="2015-06-12T14:51:44.000Z;2019-01-17T19:50:06Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="motor_vehicle" v="permissive"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-595"/>
-        <nd ref="-613"/>
-        <nd ref="-612"/>
-        <nd ref="-611"/>
-        <nd ref="-610"/>
-        <nd ref="-609"/>
-        <nd ref="-608"/>
-        <nd ref="-607"/>
-        <nd ref="-606"/>
-        <nd ref="-605"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="no"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="highway" v="service"/>
-        <tag k="service" v="driveway"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{905a39fa-496f-4b2f-810f-663fd92c5565}"/>
-        <tag k="source:datetime" v="2014-06-24T05:28:45.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="paved"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="access" v="private"/>
-    </way>
-    <way visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-595"/>
-        <nd ref="-604"/>
-        <nd ref="-571"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Norte 10"/>
-        <tag k="uuid" v="{63dbcce4-3f71-4568-9c3c-36f0e8cb836d}"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:00.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-595"/>
-        <nd ref="-603"/>
-        <nd ref="-602"/>
-        <nd ref="-563"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="layer" v="-1"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{4fde3a77-aa34-4531-b770-6c3818311f8a}"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-601"/>
-        <nd ref="-600"/>
-        <nd ref="-599"/>
-        <nd ref="-598"/>
-        <nd ref="-597"/>
-        <nd ref="-596"/>
-        <nd ref="-595"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="layer" v="-1"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{ae210ee0-b440-4ebc-87d9-91e9d194b8ed}"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-558"/>
-        <nd ref="-593"/>
-        <nd ref="-594"/>
-        <nd ref="-571"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Urdaneta"/>
-        <tag k="source:datetime" v="2014-06-24T05:28:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{8bdee643-f6c6-4bcf-a2ab-662da78e442c}"/>
-        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-571"/>
-        <nd ref="-574"/>
-        <nd ref="-575"/>
-        <nd ref="-576"/>
-        <nd ref="-577"/>
-        <nd ref="-578"/>
-        <nd ref="-579"/>
-        <nd ref="-580"/>
-        <nd ref="-581"/>
-        <nd ref="-582"/>
-        <nd ref="-583"/>
-        <nd ref="-584"/>
-        <nd ref="-585"/>
-        <nd ref="-586"/>
-        <nd ref="-587"/>
-        <nd ref="-588"/>
-        <nd ref="-589"/>
-        <nd ref="-590"/>
-        <nd ref="-591"/>
-        <nd ref="-592"/>
-        <nd ref="-77"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Sucre"/>
-        <tag k="source:datetime" v="2014-12-10T04:55:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{c31794dc-aae1-41f8-9908-8475b8e999de}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-571"/>
-        <nd ref="-572"/>
-        <nd ref="-573"/>
-        <nd ref="-79"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Norte 10"/>
-        <tag k="uuid" v="{022fd160-a0bb-46ef-a78c-9eeadebe02b3}"/>
-        <tag k="source:datetime" v="2015-06-05T14:13:59.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-563"/>
-        <nd ref="-570"/>
-        <nd ref="-569"/>
-        <nd ref="-568"/>
-        <nd ref="-567"/>
-        <nd ref="-269"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c}"/>
-        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-558"/>
-        <nd ref="-563"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="uuid" v="{ac26def1-7e6e-4947-9322-20587353e9f1}"/>
-        <tag k="source:datetime" v="2014-04-28T19:27:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-327"/>
-        <nd ref="-560"/>
-        <nd ref="-559"/>
-        <nd ref="-558"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Norte 8"/>
-        <tag k="uuid" v="{9f87d03d-3b17-4360-a370-c5313fcc639f}"/>
-        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-553"/>
-        <nd ref="-556"/>
-        <nd ref="-555"/>
-        <nd ref="-266"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{569d7378-99ce-4e3e-8863-37c85ab179f9}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-553"/>
-        <nd ref="-554"/>
-        <nd ref="-510"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-257"/>
-        <nd ref="-543"/>
-        <nd ref="-544"/>
-        <nd ref="-270"/>
-        <nd ref="-545"/>
-        <nd ref="-546"/>
-        <nd ref="-542"/>
-        <nd ref="-509"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z;2014-12-26T14:05:26.000Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0};{91bd559b-809d-4cef-ae04-6103684ae9fb};{e2598c3b-e27d-4c8d-8283-1f589dfccac4}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-510"/>
-        <nd ref="-536"/>
-        <nd ref="-537"/>
-        <nd ref="-84"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-84"/>
-        <nd ref="-82"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380}"/>
-        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-156"/>
-        <nd ref="-535"/>
-        <nd ref="-239"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Sur 4"/>
-        <tag k="uuid" v="{3b13e0ef-5bb0-405c-b1cd-f960330ad854}"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="paving_stones"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="1"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-235"/>
-        <nd ref="-534"/>
-        <nd ref="-151"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Sur 2"/>
-        <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="uuid" v="{fdc60078-3a67-4381-9d4c-642c5ac1287f}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="motor_vehicle" v="no"/>
-        <tag k="highway" v="pedestrian"/>
-    </way>
-    <way visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-526"/>
-        <nd ref="-163"/>
-        <nd ref="-3"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="layer" v="-3"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Sur"/>
-        <tag k="source:datetime" v="2013-12-26T19:49:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="no"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="2"/>
-        <tag k="maxspeed" v="30"/>
-        <tag k="uuid" v="{d7de87ac-7197-42fe-b791-1a65a1a7974b};{5e7b547b-a9cf-4e4e-a649-360a6925911c};{391a3187-29a7-4217-8429-1e389cd586a5}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="no"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.666Z"/>
-        <tag k="tunnel" v="yes"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="motor_vehicle" v="yes"/>
-        <tag k="highway" v="tertiary"/>
-    </way>
-    <way visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-520"/>
-        <nd ref="-516"/>
-        <nd ref="-532"/>
-        <nd ref="-215"/>
-        <nd ref="-531"/>
-        <nd ref="-530"/>
-        <nd ref="-529"/>
-        <nd ref="-528"/>
-        <nd ref="-527"/>
-        <nd ref="-526"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980};{bdf0d568-d4fa-4c77-ad37-c4b60ea708f2}"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:45.000Z"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-499"/>
-        <nd ref="-525"/>
-        <nd ref="-507"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="highway" v="primary_link"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-251"/>
-        <nd ref="-521"/>
-        <nd ref="-520"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{0d03894e-5353-42d2-9f60-0316286dab1b}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-511"/>
-        <nd ref="-519"/>
-        <nd ref="-516"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{c7000abf-95fe-4c00-9be5-00533f4d7ef0}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-516"/>
-        <nd ref="-517"/>
-        <nd ref="-518"/>
-        <nd ref="-244"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{40a71cf9-24ff-42b7-af9f-a80a93b7a29e}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-512"/>
-        <nd ref="-511"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{7839e6b8-9f99-4b27-96f9-6342a40197de}"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-507"/>
-        <nd ref="-506"/>
-        <nd ref="-505"/>
-        <nd ref="-502"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Sur 8"/>
-        <tag k="uuid" v="{60cb34a4-b2a7-4427-baa6-7bfd0f871bc1}"/>
-        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-457"/>
-        <nd ref="-504"/>
-        <nd ref="-503"/>
-        <nd ref="-502"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="4"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{8bd0e392-a3b6-4f60-80ed-05254da2cb8e}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-30"/>
-        <nd ref="-463"/>
-        <nd ref="-462"/>
-        <nd ref="-432"/>
-        <nd ref="-457"/>
-        <nd ref="-501"/>
-        <nd ref="-456"/>
-        <nd ref="-500"/>
-        <nd ref="-499"/>
-        <nd ref="-498"/>
-        <nd ref="-497"/>
-        <nd ref="-496"/>
-        <nd ref="-495"/>
-        <nd ref="-494"/>
-        <nd ref="-493"/>
-        <nd ref="-492"/>
-        <nd ref="-491"/>
-        <nd ref="-490"/>
-        <nd ref="-489"/>
-        <nd ref="-488"/>
-        <nd ref="-487"/>
-        <nd ref="-486"/>
-        <nd ref="-485"/>
-        <nd ref="-484"/>
-        <nd ref="-483"/>
-        <nd ref="-482"/>
-        <nd ref="-481"/>
-        <nd ref="-480"/>
-        <nd ref="-479"/>
-        <nd ref="-478"/>
-        <nd ref="-477"/>
-        <nd ref="-476"/>
-        <nd ref="-475"/>
-        <nd ref="-474"/>
-        <nd ref="-473"/>
-        <nd ref="-472"/>
-        <nd ref="-471"/>
-        <nd ref="-470"/>
-        <nd ref="-469"/>
-        <nd ref="-468"/>
-        <nd ref="-467"/>
-        <nd ref="-466"/>
-        <nd ref="-465"/>
-        <nd ref="-464"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:11.000Z;2019-01-17T19:50:06Z;2014-04-21T23:52:41.000Z;2014-04-21T23:52:43.000Z;2014-12-24T02:39:20.000Z;2015-10-15T16:12:12.000Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="uuid" v="{6f44fd8f-d8fd-4e57-b362-afb57ca0c781};{78aeebde-818c-45c7-9246-3000f001c09a}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-82"/>
-        <nd ref="-461"/>
-        <nd ref="-460"/>
-        <nd ref="-459"/>
-        <nd ref="-458"/>
-        <nd ref="-146"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.669Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380};{8683446c-cd51-4173-953f-792506c2b133}"/>
-        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-454"/>
-        <nd ref="-457"/>
-        <tag k="source" v="Metroguía;osm:line"/>
-        <tag k="oneway" v="no"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Callejón Penichez"/>
-        <tag k="uuid" v="{d3cf6f64-8525-4139-b1ff-b351e3a4d999}"/>
-        <tag k="source:datetime" v="2014-04-21T23:52:41.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-426"/>
-        <nd ref="-455"/>
-        <nd ref="-454"/>
-        <nd ref="-431"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. San Martín"/>
-        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-432"/>
-        <nd ref="-431"/>
-        <nd ref="-450"/>
-        <nd ref="-449"/>
-        <nd ref="-448"/>
-        <nd ref="-447"/>
-        <nd ref="-446"/>
-        <nd ref="-445"/>
-        <nd ref="-444"/>
-        <nd ref="-443"/>
-        <nd ref="-442"/>
-        <nd ref="-441"/>
-        <nd ref="-430"/>
-        <nd ref="-440"/>
-        <nd ref="-439"/>
-        <nd ref="-438"/>
-        <nd ref="-437"/>
-        <nd ref="-436"/>
-        <nd ref="-435"/>
-        <nd ref="-434"/>
-        <nd ref="-433"/>
-        <nd ref="-409"/>
-        <tag k="source" v="Metroguía;osm:line"/>
-        <tag k="oneway" v="no"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Callejón Penichez"/>
-        <tag k="uuid" v="{8fed249a-1156-48df-88e7-3572ee880756};{9b1a6ca0-962e-447b-b3f9-686be3adb939}"/>
-        <tag k="source:datetime" v="2014-11-08T12:50:13.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-430"/>
-        <nd ref="-429"/>
-        <nd ref="-428"/>
-        <nd ref="-427"/>
-        <nd ref="-412"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{2c746cd5-7fed-451d-ab6b-99ecfd467865}"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-79"/>
-        <nd ref="-331"/>
-        <nd ref="-330"/>
-        <nd ref="-329"/>
-        <nd ref="-328"/>
-        <nd ref="-327"/>
-        <nd ref="-80"/>
-        <nd ref="-326"/>
-        <nd ref="-325"/>
-        <nd ref="-324"/>
-        <nd ref="-323"/>
-        <nd ref="-322"/>
-        <nd ref="-321"/>
-        <nd ref="-84"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="no"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 3"/>
-        <tag k="uuid" v="{49e61517-6b6d-4314-894b-9dbb2113bab8}"/>
-        <tag k="source:datetime" v="2013-11-12T18:40:59.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:44.000Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-121"/>
-        <nd ref="-286"/>
-        <nd ref="-285"/>
-        <nd ref="-264"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.672Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="uuid" v="{110c0fcd-4178-4061-8d4f-cfc665d2bcb4}"/>
-        <tag k="source:datetime" v="2014-04-16T18:24:48.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-240"/>
-        <nd ref="-274"/>
-        <nd ref="-275"/>
-        <nd ref="-139"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Sur 4"/>
-        <tag k="uuid" v="{993c8b95-a1be-4116-8186-22c5a2bc3b96}"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-139"/>
-        <nd ref="-272"/>
-        <nd ref="-273"/>
-        <nd ref="-270"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe};{6d3a27e4-a1f4-4584-8d5f-04d9295f29ad}"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="concrete"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-266"/>
-        <nd ref="-271"/>
-        <nd ref="-264"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2015-08-11T15:27:58.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{52b96f30-702b-4d97-92b4-7338515c81c0}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-270"/>
-        <nd ref="-266"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe}"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="concrete"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-269"/>
-        <nd ref="-268"/>
-        <nd ref="-267"/>
-        <nd ref="-266"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="no"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 0"/>
-        <tag k="uuid" v="{63630fad-74ee-4cd8-9eff-b0503d3b902b}"/>
-        <tag k="source:datetime" v="2014-06-22T21:12:18.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="concrete"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-264"/>
-        <nd ref="-265"/>
-        <nd ref="-257"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170}"/>
-        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="concrete"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="1"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-264"/>
-        <nd ref="-263"/>
-        <nd ref="-262"/>
-        <nd ref="-261"/>
-        <nd ref="-246"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{81d897e2-47a5-4f7f-a15b-017cf45d4912}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-243"/>
-        <nd ref="-258"/>
-        <nd ref="-259"/>
-        <nd ref="-260"/>
-        <nd ref="-257"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{bc0b107e-cb23-4e0d-9643-3d54ced6a3b7}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-257"/>
-        <nd ref="-256"/>
-        <nd ref="-255"/>
-        <nd ref="-254"/>
-        <nd ref="-253"/>
-        <nd ref="-240"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z;2019-01-17T19:50:05.674Z"/>
-        <tag k="highway" v="tertiary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170};{26d294f7-6565-4b94-80c4-2c7bcb34380a}"/>
-        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="surface" v="concrete"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="1"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-246"/>
-        <nd ref="-252"/>
-        <nd ref="-251"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="lit" v="yes"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{a99d148f-6883-4595-9543-c7d2cdff4acd}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="sidewalk" v="right"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-243"/>
-        <nd ref="-246"/>
-        <tag k="alt_name" v="Av. Oeste 4"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="source:datetime" v="2015-08-17T18:05:50.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="lanes" v="4"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{7c94360d-c347-492f-a2c4-6edce5cab2f7}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-246"/>
-        <nd ref="-247"/>
-        <nd ref="-248"/>
-        <nd ref="-249"/>
-        <nd ref="-250"/>
-        <tag k="alt_name" v="Av. Oeste 4"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="source:datetime" v="2014-06-10T02:45:38.000Z;2019-01-17T19:50:06Z;2015-08-17T18:05:50.000Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="4"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{cbee07c1-c63c-4fa0-908c-effbd7e8e7f2}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-244"/>
-        <nd ref="-245"/>
-        <nd ref="-243"/>
-        <tag k="alt_name" v="Avenida Norte 6"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Baralt"/>
-        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{d5b69c9e-fde6-4cf7-9af6-5c2a363f055e}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-157"/>
-        <nd ref="-241"/>
-        <nd ref="-242"/>
-        <nd ref="-243"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="4"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{9ad6953d-3ec1-4845-a58a-948133832973}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-149"/>
-        <nd ref="-225"/>
-        <nd ref="-224"/>
-        <nd ref="-223"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
-        <tag k="highway" v="footway"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Sur 2"/>
-        <tag k="uuid" v="{1c605363-8a32-4bb4-b559-ea1c6b1133c6}"/>
-        <tag k="source:datetime" v="2013-11-13T13:38:12.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-36"/>
-        <nd ref="-228"/>
-        <nd ref="-149"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Universidad"/>
-        <tag k="source:datetime" v="2015-07-07T18:03:14.000Z;2013-12-19T16:34:22.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="old_name" v="Avenida Este 4"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-240"/>
-        <nd ref="-239"/>
-        <nd ref="-238"/>
-        <nd ref="-237"/>
-        <nd ref="-236"/>
-        <nd ref="-235"/>
-        <nd ref="-234"/>
-        <nd ref="-233"/>
-        <nd ref="-232"/>
-        <nd ref="-231"/>
-        <nd ref="-230"/>
-        <nd ref="-229"/>
-        <nd ref="-35"/>
-        <tag k="surface" v="paving_stones"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Oeste 2"/>
-        <tag k="source:datetime" v="2013-12-19T16:36:19.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="2"/>
-        <tag k="uuid" v="{82fc4cc9-b0a0-42e9-a811-c99032648c0d}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="no"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.675Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="horse" v="no"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="motor_vehicle" v="no"/>
-        <tag k="highway" v="pedestrian"/>
-    </way>
-    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34"/>
-        <nd ref="-292"/>
-        <nd ref="-291"/>
-        <nd ref="-290"/>
-        <nd ref="-289"/>
-        <nd ref="-288"/>
-        <nd ref="-287"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{d87ac22e-5556-4eef-a1c4-3c4e8dcbfabf}"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-33"/>
-        <nd ref="-320"/>
-        <nd ref="-319"/>
-        <nd ref="-318"/>
-        <nd ref="-317"/>
-        <nd ref="-316"/>
-        <nd ref="-315"/>
-        <nd ref="-314"/>
-        <nd ref="-313"/>
-        <nd ref="-312"/>
-        <nd ref="-311"/>
-        <nd ref="-310"/>
-        <nd ref="-309"/>
-        <nd ref="-308"/>
-        <nd ref="-307"/>
-        <nd ref="-306"/>
-        <nd ref="-305"/>
-        <nd ref="-304"/>
-        <nd ref="-303"/>
-        <nd ref="-302"/>
-        <nd ref="-301"/>
-        <nd ref="-300"/>
-        <nd ref="-299"/>
-        <nd ref="-298"/>
-        <nd ref="-297"/>
-        <nd ref="-296"/>
-        <nd ref="-295"/>
-        <nd ref="-294"/>
-        <nd ref="-293"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="no"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
-        <tag k="highway" v="residential"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="La Amargura"/>
-        <tag k="uuid" v="{05262cb4-489f-42bc-a67c-e519b12512a3}"/>
-        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-426"/>
-        <nd ref="-425"/>
-        <nd ref="-424"/>
         <nd ref="-423"/>
         <nd ref="-422"/>
         <nd ref="-421"/>
@@ -5311,23 +3412,1922 @@
         <nd ref="-388"/>
         <nd ref="-387"/>
         <nd ref="-386"/>
+        <nd ref="-86"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="unclassified"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="El Calvario"/>
+        <tag k="uuid" v="{028399af-be6d-43cb-b3c3-3a32f9dae08c}"/>
+        <tag k="source:datetime" v="2015-09-15T22:49:24.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-187" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-245"/>
+        <nd ref="-330"/>
+        <nd ref="-331"/>
+        <nd ref="-332"/>
+        <nd ref="-333"/>
+        <nd ref="-334"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="secondary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-182" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-323"/>
+        <nd ref="-620"/>
+        <nd ref="-619"/>
+        <nd ref="-618"/>
+        <nd ref="-175"/>
+        <nd ref="-338"/>
+        <nd ref="-337"/>
+        <nd ref="-336"/>
+        <nd ref="-335"/>
+        <nd ref="-334"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z;2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c};{b9eeb22d-02a0-41c2-8894-f5e74271f979}"/>
+        <tag k="source:datetime" v="2015-04-23T16:51:23.000Z;2019-01-17T19:50:06Z;2015-04-23T16:51:25.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-176" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-561"/>
+        <nd ref="-578"/>
+        <nd ref="-577"/>
+        <nd ref="-574"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-91"/>
+        <nd ref="-217"/>
+        <nd ref="-280"/>
+        <nd ref="-277"/>
+        <nd ref="-281"/>
+        <nd ref="-668"/>
+        <nd ref="-669"/>
+        <nd ref="-670"/>
+        <nd ref="-298"/>
+        <nd ref="-305"/>
+        <nd ref="-671"/>
+        <nd ref="-672"/>
+        <nd ref="-334"/>
+        <nd ref="-673"/>
+        <nd ref="-674"/>
+        <nd ref="-675"/>
+        <nd ref="-676"/>
+        <nd ref="-677"/>
+        <nd ref="-678"/>
+        <nd ref="-679"/>
+        <nd ref="-680"/>
+        <nd ref="-681"/>
+        <nd ref="-682"/>
+        <nd ref="-683"/>
+        <nd ref="-684"/>
+        <nd ref="-685"/>
+        <nd ref="-686"/>
+        <nd ref="-687"/>
+        <nd ref="-688"/>
+        <nd ref="-689"/>
+        <nd ref="-690"/>
+        <nd ref="-691"/>
+        <nd ref="-692"/>
+        <nd ref="-303"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z;2019-01-17T19:50:05.662Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 6"/>
+        <tag k="uuid" v="{48532445-a733-416c-a55c-1fad8bf34ae1};{006de0c0-48c5-434f-8fdb-29c68cb4c649}"/>
+        <tag k="source:datetime" v="2015-08-03T17:38:19.000Z;2019-01-17T19:50:06Z;2014-09-04T14:24:34.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-155" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-268"/>
+        <nd ref="-739"/>
+        <nd ref="-738"/>
+        <nd ref="-737"/>
+        <nd ref="-736"/>
+        <nd ref="-735"/>
+        <nd ref="-734"/>
+        <nd ref="-733"/>
+        <nd ref="-732"/>
+        <nd ref="-731"/>
+        <nd ref="-730"/>
+        <nd ref="-729"/>
+        <nd ref="-728"/>
+        <nd ref="-727"/>
+        <nd ref="-480"/>
+        <nd ref="-510"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2015-10-15T16:12:12.000Z;2014-09-04T14:24:35.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454};{35fb46ac-4c0c-4d19-a3d2-94876d592c26}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z;2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+        <tag k="destination" v="San Martín;Centro"/>
+    </way>
+    <way visible="true" id="-153" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-270"/>
+        <nd ref="-269"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{a439f440-165f-401c-9395-166374e5bdd7}"/>
+        <tag k="source:datetime" v="2013-04-18T01:17:19.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-152" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-218"/>
+        <nd ref="-219"/>
+        <nd ref="-220"/>
+        <nd ref="-221"/>
+        <nd ref="-222"/>
+        <nd ref="-223"/>
+        <nd ref="-224"/>
+        <nd ref="-225"/>
+        <nd ref="-226"/>
+        <nd ref="-227"/>
+        <nd ref="-228"/>
+        <nd ref="-229"/>
+        <nd ref="-230"/>
+        <nd ref="-231"/>
+        <nd ref="-232"/>
+        <nd ref="-233"/>
+        <nd ref="-234"/>
+        <nd ref="-235"/>
+        <nd ref="-236"/>
+        <nd ref="-237"/>
+        <nd ref="-238"/>
+        <nd ref="-239"/>
+        <nd ref="-240"/>
+        <nd ref="-241"/>
+        <nd ref="-242"/>
+        <nd ref="-243"/>
+        <nd ref="-244"/>
+        <nd ref="-245"/>
+        <nd ref="-246"/>
+        <nd ref="-247"/>
+        <nd ref="-248"/>
+        <nd ref="-249"/>
+        <nd ref="-250"/>
+        <nd ref="-251"/>
+        <nd ref="-252"/>
+        <nd ref="-253"/>
+        <nd ref="-254"/>
+        <nd ref="-255"/>
+        <nd ref="-256"/>
+        <nd ref="-257"/>
+        <nd ref="-258"/>
+        <nd ref="-259"/>
+        <nd ref="-260"/>
+        <nd ref="-261"/>
+        <nd ref="-262"/>
+        <nd ref="-263"/>
+        <nd ref="-264"/>
+        <nd ref="-265"/>
+        <nd ref="-266"/>
+        <nd ref="-267"/>
+        <nd ref="-268"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:34.000Z;2019-01-17T19:50:06Z;2014-12-24T02:49:57.000Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="uuid" v="{aec76311-ef7c-458d-b5dc-495745461b2f}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="destination" v="San Martín"/>
+        <tag k="highway" v="primary_link"/>
+    </way>
+    <way visible="true" id="-151" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-203"/>
+        <nd ref="-212"/>
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <nd ref="-211"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2013-12-19T16:34:21.000Z;2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="1"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{fb707a34-dd57-41b3-b236-7d7c6de3cd29}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-150" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-205"/>
+        <nd ref="-206"/>
+        <nd ref="-207"/>
+        <nd ref="-208"/>
+        <nd ref="-209"/>
+        <nd ref="-210"/>
+        <nd ref="-211"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z;2013-12-19T16:34:22.000Z;2015-07-07T18:03:14.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="1"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-149" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-707"/>
+        <nd ref="-971"/>
+        <nd ref="-972"/>
+        <nd ref="-973"/>
+        <nd ref="-974"/>
+        <nd ref="-975"/>
+        <nd ref="-976"/>
+        <nd ref="-977"/>
+        <nd ref="-978"/>
+        <nd ref="-979"/>
+        <nd ref="-980"/>
+        <nd ref="-981"/>
+        <nd ref="-982"/>
+        <nd ref="-983"/>
+        <nd ref="-984"/>
+        <nd ref="-985"/>
+        <nd ref="-986"/>
+        <nd ref="-987"/>
+        <nd ref="-988"/>
+        <nd ref="-989"/>
+        <nd ref="-990"/>
+        <nd ref="-991"/>
+        <nd ref="-992"/>
+        <nd ref="-993"/>
+        <nd ref="-652"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2014-04-25T15:54:45.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{f1a85717-8752-48b3-9d48-c8c5d3c1e99c}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.659Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary_link"/>
+    </way>
+    <way visible="true" id="-147" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-105"/>
+        <nd ref="-122"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{73768fac-23de-4ae6-b24f-a14cae4ab15b}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-146" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-105"/>
+        <nd ref="-787"/>
+        <nd ref="-786"/>
+        <nd ref="-785"/>
+        <nd ref="-784"/>
+        <nd ref="-783"/>
+        <nd ref="-782"/>
+        <nd ref="-781"/>
+        <nd ref="-780"/>
+        <nd ref="-779"/>
+        <nd ref="-778"/>
+        <nd ref="-777"/>
+        <nd ref="-776"/>
+        <nd ref="-775"/>
+        <nd ref="-774"/>
+        <nd ref="-773"/>
+        <nd ref="-772"/>
+        <nd ref="-771"/>
+        <nd ref="-770"/>
+        <nd ref="-769"/>
+        <nd ref="-768"/>
+        <nd ref="-767"/>
+        <nd ref="-766"/>
+        <nd ref="-4326"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2015-06-12T14:51:44.000Z;2019-01-17T19:50:06Z;2015-06-12T14:51:52.000Z;2014-04-25T15:54:46.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{74701b58-570f-40d1-9230-e682fd5f7454}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.661Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="permissive"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-144" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-649"/>
+        <nd ref="-667"/>
+        <nd ref="-666"/>
+        <nd ref="-665"/>
+        <nd ref="-664"/>
+        <nd ref="-663"/>
+        <nd ref="-662"/>
+        <nd ref="-661"/>
+        <nd ref="-660"/>
+        <nd ref="-659"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="service" v="driveway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{905a39fa-496f-4b2f-810f-663fd92c5565}"/>
+        <tag k="source:datetime" v="2014-06-24T05:28:45.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="access" v="private"/>
+    </way>
+    <way visible="true" id="-143" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-649"/>
+        <nd ref="-658"/>
+        <nd ref="-625"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 10"/>
+        <tag k="uuid" v="{63dbcce4-3f71-4568-9c3c-36f0e8cb836d}"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:00.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-142" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-649"/>
+        <nd ref="-657"/>
+        <nd ref="-656"/>
+        <nd ref="-617"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="layer" v="-1"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{4fde3a77-aa34-4531-b770-6c3818311f8a}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-141" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-655"/>
+        <nd ref="-654"/>
+        <nd ref="-653"/>
+        <nd ref="-652"/>
+        <nd ref="-651"/>
+        <nd ref="-650"/>
+        <nd ref="-649"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="layer" v="-1"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2015-06-12T14:47:33.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{ae210ee0-b440-4ebc-87d9-91e9d194b8ed}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-140" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-612"/>
+        <nd ref="-647"/>
+        <nd ref="-648"/>
+        <nd ref="-625"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Urdaneta"/>
+        <tag k="source:datetime" v="2014-06-24T05:28:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8bdee643-f6c6-4bcf-a2ab-662da78e442c}"/>
+        <tag k="motor_vehicle:conditional" v="no @ (21:00-05:59)"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.662Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-139" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-625"/>
+        <nd ref="-628"/>
+        <nd ref="-629"/>
+        <nd ref="-630"/>
+        <nd ref="-631"/>
+        <nd ref="-632"/>
+        <nd ref="-633"/>
+        <nd ref="-634"/>
+        <nd ref="-635"/>
+        <nd ref="-636"/>
+        <nd ref="-637"/>
+        <nd ref="-638"/>
+        <nd ref="-639"/>
+        <nd ref="-640"/>
+        <nd ref="-641"/>
+        <nd ref="-642"/>
+        <nd ref="-643"/>
+        <nd ref="-644"/>
+        <nd ref="-645"/>
+        <nd ref="-646"/>
+        <nd ref="-131"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Sucre"/>
+        <tag k="source:datetime" v="2014-12-10T04:55:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{c31794dc-aae1-41f8-9908-8475b8e999de}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-138" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-625"/>
+        <nd ref="-626"/>
+        <nd ref="-627"/>
+        <nd ref="-133"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 10"/>
+        <tag k="uuid" v="{022fd160-a0bb-46ef-a78c-9eeadebe02b3}"/>
+        <tag k="source:datetime" v="2015-06-05T14:13:59.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-137" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-617"/>
+        <nd ref="-624"/>
+        <nd ref="-623"/>
+        <nd ref="-622"/>
+        <nd ref="-621"/>
+        <nd ref="-323"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{6ae5e672-3459-44ea-bb95-acdf2c18404c}"/>
+        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-136" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-612"/>
+        <nd ref="-617"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{ac26def1-7e6e-4947-9322-20587353e9f1}"/>
+        <tag k="source:datetime" v="2014-04-28T19:27:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-134" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-381"/>
+        <nd ref="-614"/>
+        <nd ref="-613"/>
+        <nd ref="-612"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.663Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Norte 8"/>
+        <tag k="uuid" v="{9f87d03d-3b17-4360-a370-c5313fcc639f}"/>
+        <tag k="source:datetime" v="2014-05-07T19:27:28.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-131" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-607"/>
+        <nd ref="-610"/>
+        <nd ref="-609"/>
+        <nd ref="-320"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{569d7378-99ce-4e3e-8863-37c85ab179f9}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-130" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-607"/>
+        <nd ref="-608"/>
+        <nd ref="-564"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-129" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-311"/>
+        <nd ref="-597"/>
+        <nd ref="-598"/>
+        <nd ref="-324"/>
+        <nd ref="-599"/>
+        <nd ref="-600"/>
+        <nd ref="-596"/>
+        <nd ref="-563"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z;2014-12-26T14:05:26.000Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0};{91bd559b-809d-4cef-ae04-6103684ae9fb};{e2598c3b-e27d-4c8d-8283-1f589dfccac4}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-125" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-564"/>
+        <nd ref="-590"/>
+        <nd ref="-591"/>
+        <nd ref="-138"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:27.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{47e09d13-6779-4128-a7d3-fe28fa5c59bc};{84d2390d-b38b-488e-acff-390e1ccfeef0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.664Z;2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-124" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-138"/>
+        <nd ref="-136"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380}"/>
+        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-123" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-210"/>
+        <nd ref="-589"/>
+        <nd ref="-293"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 4"/>
+        <tag k="uuid" v="{3b13e0ef-5bb0-405c-b1cd-f960330ad854}"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="paving_stones"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="1"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-122" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-289"/>
+        <nd ref="-588"/>
+        <nd ref="-205"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Sur 2"/>
+        <tag k="source:datetime" v="2014-02-08T15:54:54.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="uuid" v="{fdc60078-3a67-4381-9d4c-642c5ac1287f}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="no"/>
+        <tag k="highway" v="pedestrian"/>
+    </way>
+    <way visible="true" id="-121" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-580"/>
+        <nd ref="-217"/>
+        <nd ref="-57"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="layer" v="-3"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Sur"/>
+        <tag k="source:datetime" v="2013-12-26T19:49:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="30"/>
+        <tag k="uuid" v="{d7de87ac-7197-42fe-b791-1a65a1a7974b};{5e7b547b-a9cf-4e4e-a649-360a6925911c};{391a3187-29a7-4217-8429-1e389cd586a5}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="no"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.666Z"/>
+        <tag k="tunnel" v="yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="motor_vehicle" v="yes"/>
+        <tag k="highway" v="tertiary"/>
+    </way>
+    <way visible="true" id="-120" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-574"/>
+        <nd ref="-570"/>
+        <nd ref="-586"/>
+        <nd ref="-269"/>
+        <nd ref="-585"/>
+        <nd ref="-584"/>
+        <nd ref="-583"/>
+        <nd ref="-582"/>
+        <nd ref="-581"/>
+        <nd ref="-580"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.666Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{9999fb82-3240-4c16-83c4-777553acb980};{bdf0d568-d4fa-4c77-ad37-c4b60ea708f2}"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:45.000Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-118" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-553"/>
+        <nd ref="-579"/>
+        <nd ref="-561"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary_link"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-12-24T02:49:57.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-117" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-305"/>
+        <nd ref="-575"/>
+        <nd ref="-574"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{0d03894e-5353-42d2-9f60-0316286dab1b}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-116" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-565"/>
+        <nd ref="-573"/>
+        <nd ref="-570"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-04-16T16:03:47.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{c7000abf-95fe-4c00-9be5-00533f4d7ef0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-115" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-570"/>
+        <nd ref="-571"/>
+        <nd ref="-572"/>
+        <nd ref="-298"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{40a71cf9-24ff-42b7-af9f-a80a93b7a29e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-114" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-566"/>
+        <nd ref="-565"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{7839e6b8-9f99-4b27-96f9-6342a40197de}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-112" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-561"/>
+        <nd ref="-560"/>
+        <nd ref="-559"/>
+        <nd ref="-556"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 8"/>
+        <tag k="uuid" v="{60cb34a4-b2a7-4427-baa6-7bfd0f871bc1}"/>
+        <tag k="source:datetime" v="2013-11-07T21:45:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-111" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-511"/>
+        <nd ref="-558"/>
+        <nd ref="-557"/>
+        <nd ref="-556"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2014-06-22T17:21:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8bd0e392-a3b6-4f60-80ed-05254da2cb8e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-110" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-84"/>
+        <nd ref="-517"/>
+        <nd ref="-516"/>
+        <nd ref="-486"/>
+        <nd ref="-511"/>
+        <nd ref="-555"/>
+        <nd ref="-510"/>
+        <nd ref="-554"/>
+        <nd ref="-553"/>
+        <nd ref="-552"/>
+        <nd ref="-551"/>
+        <nd ref="-550"/>
+        <nd ref="-549"/>
+        <nd ref="-548"/>
+        <nd ref="-547"/>
+        <nd ref="-546"/>
+        <nd ref="-545"/>
+        <nd ref="-544"/>
+        <nd ref="-543"/>
+        <nd ref="-542"/>
+        <nd ref="-541"/>
+        <nd ref="-540"/>
+        <nd ref="-539"/>
+        <nd ref="-538"/>
+        <nd ref="-537"/>
+        <nd ref="-536"/>
+        <nd ref="-535"/>
+        <nd ref="-534"/>
+        <nd ref="-533"/>
+        <nd ref="-532"/>
+        <nd ref="-531"/>
+        <nd ref="-530"/>
+        <nd ref="-529"/>
+        <nd ref="-528"/>
+        <nd ref="-527"/>
+        <nd ref="-526"/>
+        <nd ref="-525"/>
+        <nd ref="-524"/>
+        <nd ref="-523"/>
+        <nd ref="-522"/>
+        <nd ref="-521"/>
+        <nd ref="-520"/>
+        <nd ref="-519"/>
+        <nd ref="-518"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:11.000Z;2019-01-17T19:50:06Z;2014-04-21T23:52:41.000Z;2014-04-21T23:52:43.000Z;2014-12-24T02:39:20.000Z;2015-10-15T16:12:12.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{6f44fd8f-d8fd-4e57-b362-afb57ca0c781};{78aeebde-818c-45c7-9246-3000f001c09a}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-109" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-136"/>
+        <nd ref="-515"/>
+        <nd ref="-514"/>
+        <nd ref="-513"/>
+        <nd ref="-512"/>
+        <nd ref="-200"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.669Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{cbab7620-b752-45fd-aace-620f28ca0380};{8683446c-cd51-4173-953f-792506c2b133}"/>
+        <tag k="source:datetime" v="2014-04-16T15:31:08.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-108" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-508"/>
+        <nd ref="-511"/>
+        <tag k="source" v="Metroguía;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Callejón Penichez"/>
+        <tag k="uuid" v="{d3cf6f64-8525-4139-b1ff-b351e3a4d999}"/>
+        <tag k="source:datetime" v="2014-04-21T23:52:41.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-106" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-480"/>
+        <nd ref="-509"/>
+        <nd ref="-508"/>
+        <nd ref="-485"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. San Martín"/>
+        <tag k="source:datetime" v="2015-10-15T16:12:12.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="uuid" v="{4344bc96-c83e-43b2-bb65-7f0d8ab650c2}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.669Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-105" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-486"/>
+        <nd ref="-485"/>
+        <nd ref="-504"/>
+        <nd ref="-503"/>
+        <nd ref="-502"/>
+        <nd ref="-501"/>
+        <nd ref="-500"/>
+        <nd ref="-499"/>
+        <nd ref="-498"/>
+        <nd ref="-497"/>
+        <nd ref="-496"/>
+        <nd ref="-495"/>
+        <nd ref="-484"/>
+        <nd ref="-494"/>
+        <nd ref="-493"/>
+        <nd ref="-492"/>
+        <nd ref="-491"/>
+        <nd ref="-490"/>
+        <nd ref="-489"/>
+        <nd ref="-488"/>
+        <nd ref="-487"/>
+        <nd ref="-463"/>
+        <tag k="source" v="Metroguía;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Callejón Penichez"/>
+        <tag k="uuid" v="{8fed249a-1156-48df-88e7-3572ee880756};{9b1a6ca0-962e-447b-b3f9-686be3adb939}"/>
+        <tag k="source:datetime" v="2014-11-08T12:50:13.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-484"/>
+        <nd ref="-483"/>
+        <nd ref="-482"/>
+        <nd ref="-481"/>
+        <nd ref="-466"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{2c746cd5-7fed-451d-ab6b-99ecfd467865}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-133"/>
         <nd ref="-385"/>
         <nd ref="-384"/>
         <nd ref="-383"/>
         <nd ref="-382"/>
         <nd ref="-381"/>
+        <nd ref="-134"/>
         <nd ref="-380"/>
         <nd ref="-379"/>
         <nd ref="-378"/>
         <nd ref="-377"/>
         <nd ref="-376"/>
         <nd ref="-375"/>
+        <nd ref="-138"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.670Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 3"/>
+        <tag k="uuid" v="{49e61517-6b6d-4314-894b-9dbb2113bab8}"/>
+        <tag k="source:datetime" v="2013-11-12T18:40:59.000Z;2019-01-17T19:50:06Z;2014-04-16T18:24:44.000Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-175"/>
+        <nd ref="-340"/>
+        <nd ref="-339"/>
+        <nd ref="-318"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.672Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="uuid" v="{110c0fcd-4178-4061-8d4f-cfc665d2bcb4}"/>
+        <tag k="source:datetime" v="2014-04-16T18:24:48.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-294"/>
+        <nd ref="-328"/>
+        <nd ref="-329"/>
+        <nd ref="-193"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 4"/>
+        <tag k="uuid" v="{993c8b95-a1be-4116-8186-22c5a2bc3b96}"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:55.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-193"/>
+        <nd ref="-326"/>
+        <nd ref="-327"/>
+        <nd ref="-324"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe};{6d3a27e4-a1f4-4584-8d5f-04d9295f29ad}"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-320"/>
+        <nd ref="-325"/>
+        <nd ref="-318"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2015-08-11T15:27:58.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{52b96f30-702b-4d97-92b4-7338515c81c0}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-96" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-324"/>
+        <nd ref="-320"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{39b610a3-6ab2-4ac8-bca7-692fcb501cbe}"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-323"/>
+        <nd ref="-322"/>
+        <nd ref="-321"/>
+        <nd ref="-320"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 0"/>
+        <tag k="uuid" v="{63630fad-74ee-4cd8-9eff-b0503d3b902b}"/>
+        <tag k="source:datetime" v="2014-06-22T21:12:18.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-318"/>
+        <nd ref="-319"/>
+        <nd ref="-311"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170}"/>
+        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="1"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-318"/>
+        <nd ref="-317"/>
+        <nd ref="-316"/>
+        <nd ref="-315"/>
+        <nd ref="-300"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{81d897e2-47a5-4f7f-a15b-017cf45d4912}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-297"/>
+        <nd ref="-312"/>
+        <nd ref="-313"/>
+        <nd ref="-314"/>
+        <nd ref="-311"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{bc0b107e-cb23-4e0d-9643-3d54ced6a3b7}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-311"/>
+        <nd ref="-310"/>
+        <nd ref="-309"/>
+        <nd ref="-308"/>
+        <nd ref="-307"/>
+        <nd ref="-294"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.673Z;2019-01-17T19:50:05.674Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="uuid" v="{e6f52adf-7647-4986-9ed6-8773b54e5170};{26d294f7-6565-4b94-80c4-2c7bcb34380a}"/>
+        <tag k="source:datetime" v="2014-09-03T20:00:44.000Z;2014-04-16T18:24:44.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="surface" v="concrete"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="1"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-300"/>
+        <nd ref="-306"/>
+        <nd ref="-305"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="lit" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2016-01-14T14:25:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{a99d148f-6883-4595-9543-c7d2cdff4acd}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="right"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-297"/>
+        <nd ref="-300"/>
+        <tag k="alt_name" v="Av. Oeste 4"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2015-08-17T18:05:50.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{7c94360d-c347-492f-a2c4-6edce5cab2f7}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-300"/>
+        <nd ref="-301"/>
+        <nd ref="-302"/>
+        <nd ref="-303"/>
+        <nd ref="-304"/>
+        <tag k="alt_name" v="Av. Oeste 4"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2014-06-10T02:45:38.000Z;2019-01-17T19:50:06Z;2015-08-17T18:05:50.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{cbee07c1-c63c-4fa0-908c-effbd7e8e7f2}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-298"/>
+        <nd ref="-299"/>
+        <nd ref="-297"/>
+        <tag k="alt_name" v="Avenida Norte 6"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Baralt"/>
+        <tag k="source:datetime" v="2014-12-26T14:05:26.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{d5b69c9e-fde6-4cf7-9af6-5c2a363f055e}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.674Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-211"/>
+        <nd ref="-295"/>
+        <nd ref="-296"/>
+        <nd ref="-297"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2014-09-04T14:24:37.000Z;2014-09-04T14:24:29.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{9ad6953d-3ec1-4845-a58a-948133832973}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-203"/>
+        <nd ref="-279"/>
+        <nd ref="-278"/>
+        <nd ref="-277"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
+        <tag k="highway" v="footway"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Sur 2"/>
+        <tag k="uuid" v="{1c605363-8a32-4bb4-b559-ea1c6b1133c6}"/>
+        <tag k="source:datetime" v="2013-11-13T13:38:12.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-90"/>
+        <nd ref="-282"/>
+        <nd ref="-203"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Universidad"/>
+        <tag k="source:datetime" v="2013-12-19T16:34:22.000Z;2015-07-07T18:03:14.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="1"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{8f5055d4-6eec-4a91-b638-8f642986e4fc};{b1e399a0-311a-4562-a0ae-4c87d1a1cfe1}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.677Z;2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="old_name" v="Avenida Este 4"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-294"/>
+        <nd ref="-293"/>
+        <nd ref="-292"/>
+        <nd ref="-291"/>
+        <nd ref="-290"/>
+        <nd ref="-289"/>
+        <nd ref="-288"/>
+        <nd ref="-287"/>
+        <nd ref="-286"/>
+        <nd ref="-285"/>
+        <nd ref="-284"/>
+        <nd ref="-283"/>
+        <nd ref="-89"/>
+        <tag k="surface" v="paving_stones"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Oeste 2"/>
+        <tag k="source:datetime" v="2013-12-19T16:36:19.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="2"/>
+        <tag k="uuid" v="{82fc4cc9-b0a0-42e9-a811-c99032648c0d}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.675Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="horse" v="no"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="motor_vehicle" v="no"/>
+        <tag k="highway" v="pedestrian"/>
+    </way>
+    <way visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-88"/>
+        <nd ref="-346"/>
+        <nd ref="-345"/>
+        <nd ref="-344"/>
+        <nd ref="-343"/>
+        <nd ref="-342"/>
+        <nd ref="-341"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{d87ac22e-5556-4eef-a1c4-3c4e8dcbfabf}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-87"/>
         <nd ref="-374"/>
         <nd ref="-373"/>
         <nd ref="-372"/>
         <nd ref="-371"/>
         <nd ref="-370"/>
-        <nd ref="-293"/>
+        <nd ref="-369"/>
+        <nd ref="-368"/>
+        <nd ref="-367"/>
+        <nd ref="-366"/>
+        <nd ref="-365"/>
+        <nd ref="-364"/>
+        <nd ref="-363"/>
+        <nd ref="-362"/>
+        <nd ref="-361"/>
+        <nd ref="-360"/>
+        <nd ref="-359"/>
+        <nd ref="-358"/>
+        <nd ref="-357"/>
+        <nd ref="-356"/>
+        <nd ref="-355"/>
+        <nd ref="-354"/>
+        <nd ref="-353"/>
+        <nd ref="-352"/>
+        <nd ref="-351"/>
+        <nd ref="-350"/>
+        <nd ref="-349"/>
+        <nd ref="-348"/>
+        <nd ref="-347"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.671Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="La Amargura"/>
+        <tag k="uuid" v="{05262cb4-489f-42bc-a67c-e519b12512a3}"/>
+        <tag k="source:datetime" v="2014-11-08T12:50:42.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-480"/>
+        <nd ref="-479"/>
+        <nd ref="-478"/>
+        <nd ref="-477"/>
+        <nd ref="-476"/>
+        <nd ref="-475"/>
+        <nd ref="-474"/>
+        <nd ref="-473"/>
+        <nd ref="-472"/>
+        <nd ref="-471"/>
+        <nd ref="-470"/>
+        <nd ref="-469"/>
+        <nd ref="-468"/>
+        <nd ref="-467"/>
+        <nd ref="-466"/>
+        <nd ref="-465"/>
+        <nd ref="-464"/>
+        <nd ref="-463"/>
+        <nd ref="-462"/>
+        <nd ref="-461"/>
+        <nd ref="-460"/>
+        <nd ref="-459"/>
+        <nd ref="-458"/>
+        <nd ref="-457"/>
+        <nd ref="-456"/>
+        <nd ref="-455"/>
+        <nd ref="-454"/>
+        <nd ref="-453"/>
+        <nd ref="-452"/>
+        <nd ref="-451"/>
+        <nd ref="-450"/>
+        <nd ref="-449"/>
+        <nd ref="-448"/>
+        <nd ref="-447"/>
+        <nd ref="-446"/>
+        <nd ref="-445"/>
+        <nd ref="-444"/>
+        <nd ref="-443"/>
+        <nd ref="-442"/>
+        <nd ref="-441"/>
+        <nd ref="-440"/>
+        <nd ref="-439"/>
+        <nd ref="-438"/>
+        <nd ref="-437"/>
+        <nd ref="-436"/>
+        <nd ref="-435"/>
+        <nd ref="-434"/>
+        <nd ref="-433"/>
+        <nd ref="-432"/>
+        <nd ref="-431"/>
+        <nd ref="-430"/>
+        <nd ref="-429"/>
+        <nd ref="-428"/>
+        <nd ref="-427"/>
+        <nd ref="-426"/>
+        <nd ref="-425"/>
+        <nd ref="-424"/>
+        <nd ref="-347"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -5343,12 +5343,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-431"/>
-        <nd ref="-453"/>
-        <nd ref="-452"/>
-        <nd ref="-451"/>
-        <nd ref="-31"/>
+    <way visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-485"/>
+        <nd ref="-507"/>
+        <nd ref="-506"/>
+        <nd ref="-505"/>
+        <nd ref="-85"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -5372,10 +5372,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-502"/>
-        <nd ref="-508"/>
-        <nd ref="-29"/>
+    <way visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-556"/>
+        <nd ref="-562"/>
+        <nd ref="-83"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -5392,9 +5392,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-502"/>
-        <nd ref="-28"/>
+    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-556"/>
+        <nd ref="-82"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -5417,9 +5417,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-27"/>
-        <nd ref="-511"/>
+    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-81"/>
+        <nd ref="-565"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -5444,12 +5444,12 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-513"/>
-        <nd ref="-514"/>
-        <nd ref="-216"/>
-        <nd ref="-515"/>
-        <nd ref="-511"/>
+    <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-567"/>
+        <nd ref="-568"/>
+        <nd ref="-270"/>
+        <nd ref="-569"/>
+        <nd ref="-565"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
@@ -5463,11 +5463,11 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-520"/>
-        <nd ref="-522"/>
-        <nd ref="-512"/>
-        <nd ref="-25"/>
+    <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-574"/>
+        <nd ref="-576"/>
+        <nd ref="-566"/>
+        <nd ref="-79"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -5492,10 +5492,10 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-526"/>
-        <nd ref="-533"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-580"/>
+        <nd ref="-587"/>
+        <nd ref="-78"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -5513,9 +5513,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-23"/>
-        <nd ref="-526"/>
+    <way visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-77"/>
+        <nd ref="-580"/>
         <tag k="z_order" v="-999999"/>
         <tag k="layer" v="-3"/>
         <tag k="hoot:status" v="3"/>
@@ -5538,10 +5538,10 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="tertiary"/>
     </way>
-    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-462"/>
-        <nd ref="-793"/>
-        <nd ref="-21"/>
+    <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-516"/>
+        <nd ref="-847"/>
+        <nd ref="-75"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -5558,9 +5558,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-20"/>
-        <nd ref="-794"/>
+    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-74"/>
+        <nd ref="-848"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur 2"/>
@@ -5580,8 +5580,78 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-114"/>
+    <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-168"/>
+        <nd ref="-970"/>
+        <nd ref="-969"/>
+        <nd ref="-968"/>
+        <nd ref="-967"/>
+        <nd ref="-966"/>
+        <nd ref="-965"/>
+        <nd ref="-964"/>
+        <nd ref="-963"/>
+        <nd ref="-962"/>
+        <nd ref="-961"/>
+        <nd ref="-960"/>
+        <nd ref="-959"/>
+        <nd ref="-958"/>
+        <nd ref="-957"/>
+        <nd ref="-956"/>
+        <nd ref="-955"/>
+        <nd ref="-954"/>
+        <nd ref="-73"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{52f3c8c5-203c-4ec0-b9cd-70b2a0826c2f}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:55:34Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-72"/>
+        <nd ref="-953"/>
+        <nd ref="-952"/>
+        <nd ref="-951"/>
+        <nd ref="-950"/>
+        <nd ref="-949"/>
+        <nd ref="-948"/>
+        <nd ref="-947"/>
+        <nd ref="-946"/>
+        <nd ref="-945"/>
+        <nd ref="-944"/>
+        <nd ref="-943"/>
+        <nd ref="-942"/>
+        <nd ref="-941"/>
+        <nd ref="-940"/>
+        <nd ref="-939"/>
+        <nd ref="-938"/>
+        <nd ref="-937"/>
+        <nd ref="-936"/>
+        <nd ref="-935"/>
+        <nd ref="-934"/>
+        <nd ref="-933"/>
+        <nd ref="-932"/>
+        <nd ref="-931"/>
+        <nd ref="-930"/>
+        <nd ref="-929"/>
+        <nd ref="-928"/>
+        <nd ref="-927"/>
+        <nd ref="-926"/>
+        <nd ref="-925"/>
+        <nd ref="-924"/>
+        <nd ref="-923"/>
+        <nd ref="-922"/>
+        <nd ref="-921"/>
+        <nd ref="-920"/>
+        <nd ref="-919"/>
+        <nd ref="-918"/>
+        <nd ref="-917"/>
         <nd ref="-916"/>
         <nd ref="-915"/>
         <nd ref="-914"/>
@@ -5599,22 +5669,6 @@
         <nd ref="-902"/>
         <nd ref="-901"/>
         <nd ref="-900"/>
-        <nd ref="-19"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{52f3c8c5-203c-4ec0-b9cd-70b2a0826c2f}"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:55:34Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18"/>
         <nd ref="-899"/>
         <nd ref="-898"/>
         <nd ref="-897"/>
@@ -5666,61 +5720,7 @@
         <nd ref="-851"/>
         <nd ref="-850"/>
         <nd ref="-849"/>
-        <nd ref="-848"/>
-        <nd ref="-847"/>
-        <nd ref="-846"/>
-        <nd ref="-845"/>
-        <nd ref="-844"/>
-        <nd ref="-843"/>
-        <nd ref="-842"/>
-        <nd ref="-841"/>
-        <nd ref="-840"/>
-        <nd ref="-839"/>
-        <nd ref="-838"/>
-        <nd ref="-837"/>
-        <nd ref="-836"/>
-        <nd ref="-835"/>
-        <nd ref="-834"/>
-        <nd ref="-833"/>
-        <nd ref="-832"/>
-        <nd ref="-831"/>
-        <nd ref="-830"/>
-        <nd ref="-829"/>
-        <nd ref="-828"/>
-        <nd ref="-827"/>
-        <nd ref="-826"/>
-        <nd ref="-825"/>
-        <nd ref="-824"/>
-        <nd ref="-823"/>
-        <nd ref="-822"/>
-        <nd ref="-821"/>
-        <nd ref="-820"/>
-        <nd ref="-819"/>
-        <nd ref="-818"/>
-        <nd ref="-817"/>
-        <nd ref="-816"/>
-        <nd ref="-815"/>
-        <nd ref="-814"/>
-        <nd ref="-813"/>
-        <nd ref="-812"/>
-        <nd ref="-811"/>
-        <nd ref="-810"/>
-        <nd ref="-809"/>
-        <nd ref="-808"/>
-        <nd ref="-807"/>
-        <nd ref="-806"/>
-        <nd ref="-805"/>
-        <nd ref="-804"/>
-        <nd ref="-803"/>
-        <nd ref="-802"/>
-        <nd ref="-801"/>
-        <nd ref="-800"/>
-        <nd ref="-799"/>
-        <nd ref="-798"/>
-        <nd ref="-797"/>
-        <nd ref="-796"/>
-        <nd ref="-795"/>
-        <nd ref="-17"/>
+        <nd ref="-71"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.660Z"/>
@@ -5734,15 +5734,15 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-139"/>
-        <nd ref="-945"/>
-        <nd ref="-944"/>
-        <nd ref="-943"/>
-        <nd ref="-942"/>
-        <nd ref="-941"/>
-        <nd ref="-940"/>
-        <nd ref="-16"/>
+    <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-193"/>
+        <nd ref="-999"/>
+        <nd ref="-998"/>
+        <nd ref="-997"/>
+        <nd ref="-996"/>
+        <nd ref="-995"/>
+        <nd ref="-994"/>
+        <nd ref="-70"/>
         <tag k="surface" v="concrete"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -5762,21 +5762,21 @@
         <tag k="motor_vehicle" v="permissive"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-50"/>
-        <nd ref="-49"/>
-        <nd ref="-48"/>
-        <nd ref="-47"/>
-        <nd ref="-46"/>
-        <nd ref="-45"/>
-        <nd ref="-44"/>
-        <nd ref="-43"/>
-        <nd ref="-42"/>
-        <nd ref="-41"/>
-        <nd ref="-40"/>
-        <nd ref="-39"/>
-        <nd ref="-38"/>
+    <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-69"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-99"/>
+        <nd ref="-98"/>
+        <nd ref="-97"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-93"/>
+        <nd ref="-92"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Urdaneta"/>
@@ -5798,26 +5798,26 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary_link"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-14"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-64"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-38"/>
-        <nd ref="-61"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-55"/>
-        <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-51"/>
+    <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-68"/>
+        <nd ref="-121"/>
+        <nd ref="-120"/>
+        <nd ref="-119"/>
+        <nd ref="-118"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-92"/>
+        <nd ref="-115"/>
+        <nd ref="-114"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-110"/>
+        <nd ref="-109"/>
+        <nd ref="-108"/>
+        <nd ref="-107"/>
+        <nd ref="-106"/>
+        <nd ref="-105"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -5840,54 +5840,54 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-249"/>
-        <nd ref="-639"/>
-        <nd ref="-640"/>
-        <nd ref="-641"/>
-        <nd ref="-642"/>
-        <nd ref="-643"/>
-        <nd ref="-644"/>
-        <nd ref="-645"/>
-        <nd ref="-646"/>
-        <nd ref="-647"/>
-        <nd ref="-648"/>
-        <nd ref="-649"/>
-        <nd ref="-650"/>
-        <nd ref="-651"/>
-        <nd ref="-652"/>
-        <nd ref="-653"/>
-        <nd ref="-654"/>
-        <nd ref="-655"/>
-        <nd ref="-656"/>
-        <nd ref="-657"/>
-        <nd ref="-658"/>
-        <nd ref="-659"/>
-        <nd ref="-660"/>
-        <nd ref="-661"/>
-        <nd ref="-662"/>
-        <nd ref="-663"/>
-        <nd ref="-664"/>
-        <nd ref="-665"/>
-        <nd ref="-666"/>
-        <nd ref="-667"/>
-        <nd ref="-668"/>
-        <nd ref="-669"/>
-        <nd ref="-670"/>
-        <nd ref="-671"/>
-        <nd ref="-672"/>
-        <nd ref="-68"/>
-        <nd ref="-69"/>
-        <nd ref="-70"/>
-        <nd ref="-71"/>
-        <nd ref="-72"/>
-        <nd ref="-73"/>
-        <nd ref="-74"/>
-        <nd ref="-75"/>
-        <nd ref="-76"/>
-        <nd ref="-77"/>
-        <nd ref="-78"/>
-        <nd ref="-13"/>
+    <way visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-303"/>
+        <nd ref="-693"/>
+        <nd ref="-694"/>
+        <nd ref="-695"/>
+        <nd ref="-696"/>
+        <nd ref="-697"/>
+        <nd ref="-698"/>
+        <nd ref="-699"/>
+        <nd ref="-700"/>
+        <nd ref="-701"/>
+        <nd ref="-702"/>
+        <nd ref="-703"/>
+        <nd ref="-704"/>
+        <nd ref="-705"/>
+        <nd ref="-706"/>
+        <nd ref="-707"/>
+        <nd ref="-708"/>
+        <nd ref="-709"/>
+        <nd ref="-710"/>
+        <nd ref="-711"/>
+        <nd ref="-712"/>
+        <nd ref="-713"/>
+        <nd ref="-714"/>
+        <nd ref="-715"/>
+        <nd ref="-716"/>
+        <nd ref="-717"/>
+        <nd ref="-718"/>
+        <nd ref="-719"/>
+        <nd ref="-720"/>
+        <nd ref="-721"/>
+        <nd ref="-722"/>
+        <nd ref="-723"/>
+        <nd ref="-724"/>
+        <nd ref="-725"/>
+        <nd ref="-726"/>
+        <nd ref="-122"/>
+        <nd ref="-123"/>
+        <nd ref="-124"/>
+        <nd ref="-125"/>
+        <nd ref="-126"/>
+        <nd ref="-127"/>
+        <nd ref="-128"/>
+        <nd ref="-129"/>
+        <nd ref="-130"/>
+        <nd ref="-131"/>
+        <nd ref="-132"/>
+        <nd ref="-67"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -5910,9 +5910,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-79"/>
-        <nd ref="-12"/>
+    <way visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-133"/>
+        <nd ref="-66"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -5928,9 +5928,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-80"/>
+    <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-65"/>
+        <nd ref="-134"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -5946,10 +5946,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-79"/>
-        <nd ref="-81"/>
-        <nd ref="-10"/>
+    <way visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-133"/>
+        <nd ref="-135"/>
+        <nd ref="-64"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -5965,13 +5965,13 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-509"/>
-        <nd ref="-538"/>
-        <nd ref="-539"/>
-        <nd ref="-82"/>
-        <nd ref="-83"/>
-        <nd ref="-9"/>
+    <way visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-563"/>
+        <nd ref="-592"/>
+        <nd ref="-593"/>
+        <nd ref="-136"/>
+        <nd ref="-137"/>
+        <nd ref="-63"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -5993,9 +5993,9 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-8"/>
-        <nd ref="-84"/>
+    <way visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-62"/>
+        <nd ref="-138"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -6020,45 +6020,45 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7"/>
-        <nd ref="-120"/>
-        <nd ref="-119"/>
-        <nd ref="-118"/>
-        <nd ref="-117"/>
-        <nd ref="-116"/>
-        <nd ref="-115"/>
-        <nd ref="-114"/>
-        <nd ref="-113"/>
-        <nd ref="-112"/>
-        <nd ref="-111"/>
-        <nd ref="-110"/>
-        <nd ref="-109"/>
-        <nd ref="-108"/>
-        <nd ref="-107"/>
-        <nd ref="-106"/>
-        <nd ref="-105"/>
-        <nd ref="-104"/>
-        <nd ref="-103"/>
-        <nd ref="-102"/>
-        <nd ref="-101"/>
-        <nd ref="-100"/>
-        <nd ref="-99"/>
-        <nd ref="-98"/>
-        <nd ref="-97"/>
-        <nd ref="-96"/>
-        <nd ref="-95"/>
-        <nd ref="-94"/>
-        <nd ref="-93"/>
-        <nd ref="-92"/>
-        <nd ref="-91"/>
-        <nd ref="-90"/>
-        <nd ref="-89"/>
-        <nd ref="-88"/>
-        <nd ref="-87"/>
-        <nd ref="-86"/>
-        <nd ref="-85"/>
-        <nd ref="-6"/>
+    <way visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-61"/>
+        <nd ref="-174"/>
+        <nd ref="-173"/>
+        <nd ref="-172"/>
+        <nd ref="-171"/>
+        <nd ref="-170"/>
+        <nd ref="-169"/>
+        <nd ref="-168"/>
+        <nd ref="-167"/>
+        <nd ref="-166"/>
+        <nd ref="-165"/>
+        <nd ref="-164"/>
+        <nd ref="-163"/>
+        <nd ref="-162"/>
+        <nd ref="-161"/>
+        <nd ref="-160"/>
+        <nd ref="-159"/>
+        <nd ref="-158"/>
+        <nd ref="-157"/>
+        <nd ref="-156"/>
+        <nd ref="-155"/>
+        <nd ref="-154"/>
+        <nd ref="-153"/>
+        <nd ref="-152"/>
+        <nd ref="-151"/>
+        <nd ref="-150"/>
+        <nd ref="-149"/>
+        <nd ref="-148"/>
+        <nd ref="-147"/>
+        <nd ref="-146"/>
+        <nd ref="-145"/>
+        <nd ref="-144"/>
+        <nd ref="-143"/>
+        <nd ref="-142"/>
+        <nd ref="-141"/>
+        <nd ref="-140"/>
+        <nd ref="-139"/>
+        <nd ref="-60"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.708Z"/>
@@ -6072,26 +6072,26 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-138"/>
-        <nd ref="-137"/>
-        <nd ref="-136"/>
-        <nd ref="-135"/>
-        <nd ref="-134"/>
-        <nd ref="-133"/>
-        <nd ref="-132"/>
-        <nd ref="-131"/>
-        <nd ref="-130"/>
-        <nd ref="-129"/>
-        <nd ref="-128"/>
-        <nd ref="-127"/>
-        <nd ref="-126"/>
-        <nd ref="-125"/>
-        <nd ref="-124"/>
-        <nd ref="-123"/>
-        <nd ref="-122"/>
-        <nd ref="-121"/>
+    <way visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-59"/>
+        <nd ref="-192"/>
+        <nd ref="-191"/>
+        <nd ref="-190"/>
+        <nd ref="-189"/>
+        <nd ref="-188"/>
+        <nd ref="-187"/>
+        <nd ref="-186"/>
+        <nd ref="-185"/>
+        <nd ref="-184"/>
+        <nd ref="-183"/>
+        <nd ref="-182"/>
+        <nd ref="-181"/>
+        <nd ref="-180"/>
+        <nd ref="-179"/>
+        <nd ref="-178"/>
+        <nd ref="-177"/>
+        <nd ref="-176"/>
+        <nd ref="-175"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -6108,18 +6108,18 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-139"/>
-        <nd ref="-140"/>
-        <nd ref="-141"/>
-        <nd ref="-142"/>
-        <nd ref="-143"/>
-        <nd ref="-144"/>
-        <nd ref="-145"/>
-        <nd ref="-146"/>
-        <nd ref="-147"/>
-        <nd ref="-148"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-193"/>
+        <nd ref="-194"/>
+        <nd ref="-195"/>
+        <nd ref="-196"/>
+        <nd ref="-197"/>
+        <nd ref="-198"/>
+        <nd ref="-199"/>
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-202"/>
+        <nd ref="-58"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -6138,12 +6138,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-217"/>
-        <nd ref="-218"/>
-        <nd ref="-219"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-56"/>
+        <nd ref="-271"/>
+        <nd ref="-272"/>
+        <nd ref="-273"/>
+        <nd ref="-274"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -6167,11 +6167,11 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-146"/>
-        <nd ref="-222"/>
-        <nd ref="-221"/>
-        <nd ref="-1"/>
+    <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-200"/>
+        <nd ref="-276"/>
+        <nd ref="-275"/>
+        <nd ref="-55"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>

--- a/test-files/cases/attribute/unifying/highway-2927-bridge-2/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-bridge-2/Expected.osm
@@ -1,1098 +1,1098 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="7.6988" minlon="-72.36539999999999" maxlat="7.703000000000001" maxlon="-72.3584"/>
-    <node visible="true" id="-880" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012553812881999" lon="-72.3611678554792235">
+    <node visible="true" id="-792" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012553812881999" lon="-72.3611678554792235">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-879" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013901482034317" lon="-72.3616783782998283">
+    <node visible="true" id="-791" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013901482034317" lon="-72.3616783782998283">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-876" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007844373138692" lon="-72.3608138875766400">
+    <node visible="true" id="-788" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007844373138692" lon="-72.3608138875766400">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-875" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006221644488200" lon="-72.3616555431526365">
+    <node visible="true" id="-787" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006221644488200" lon="-72.3616555431526365">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-872" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996465494859683" lon="-72.3620384038982110">
+    <node visible="true" id="-784" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996465494859683" lon="-72.3620384038982110">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-871" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998374847308737" lon="-72.3619818040271099">
+    <node visible="true" id="-783" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998374847308737" lon="-72.3619818040271099">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-268" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000125445999998" lon="-72.3589731062100014">
+    <node visible="true" id="-290" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000125445999998" lon="-72.3589731062100014">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{982630d9-e726-433a-bcd7-a33ef723c34f}"/>
     </node>
-    <node visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998995600399986" lon="-72.3589844938999960">
+    <node visible="true" id="-289" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998995600399986" lon="-72.3589844938999960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee7f5868-82c8-4f17-b42c-7ce7c75afca2}"/>
     </node>
-    <node visible="true" id="-266" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998106361499987" lon="-72.3589917918399976">
+    <node visible="true" id="-288" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998106361499987" lon="-72.3589917918399976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{af37fca5-b78d-4cda-a388-95b1ddc59266}"/>
     </node>
-    <node visible="true" id="-265" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993994747499999" lon="-72.3590126697099976">
+    <node visible="true" id="-287" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993994747499999" lon="-72.3590126697099976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{960765e7-e8e7-424b-bb72-93a6897bb679}"/>
     </node>
-    <node visible="true" id="-264" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993151479199993" lon="-72.3590223339899978">
+    <node visible="true" id="-286" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993151479199993" lon="-72.3590223339899978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b34ba694-1b12-433b-85a2-120cfe899e15}"/>
     </node>
-    <node visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992909182700000" lon="-72.3590288738100043">
+    <node visible="true" id="-285" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992909182700000" lon="-72.3590288738100043">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{398ad070-2704-4c96-9344-0d30bd3aeea5}"/>
     </node>
-    <node visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992585774999984" lon="-72.3590461502100055">
+    <node visible="true" id="-284" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992585774999984" lon="-72.3590461502100055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1a6777ee-9fa9-4ac4-915b-98ee76819e3d}"/>
     </node>
-    <node visible="true" id="-261" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992385942999970" lon="-72.3590730195799807">
+    <node visible="true" id="-283" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992385942999970" lon="-72.3590730195799807">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{09df298a-2d0b-401c-9907-eb8dc9e19397}"/>
     </node>
-    <node visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992321979699989" lon="-72.3590979001800036">
+    <node visible="true" id="-282" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992321979699989" lon="-72.3590979001800036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{616e8c64-a870-4dba-94b4-e98da5cf92d1}"/>
     </node>
-    <node visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992300854399973" lon="-72.3591403953499821">
+    <node visible="true" id="-281" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992300854399973" lon="-72.3591403953499821">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a30fc37c-8163-4d47-ac10-a8e469983153}"/>
     </node>
-    <node visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992334148500019" lon="-72.3592847030199948">
+    <node visible="true" id="-280" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992334148500019" lon="-72.3592847030199948">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c57bf62d-ad47-4dc7-86f6-693e6617d0dc}"/>
     </node>
-    <node visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026718036500013" lon="-72.3587359608799972">
+    <node visible="true" id="-279" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026718036500013" lon="-72.3587359608799972">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f337b438-01a8-4916-98a0-8a020ef93866}"/>
     </node>
-    <node visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024847145999997" lon="-72.3587602470999940">
+    <node visible="true" id="-278" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024847145999997" lon="-72.3587602470999940">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ecbb75b5-d097-4d8f-b9ac-aa4c466078cb}"/>
     </node>
-    <node visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013714084200000" lon="-72.3587790233400057">
+    <node visible="true" id="-277" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013714084200000" lon="-72.3587790233400057">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8c4823d6-673d-4fc6-8cb2-2c7f7c7065b4}"/>
     </node>
-    <node visible="true" id="-254" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013424454900008" lon="-72.3588624947000056">
+    <node visible="true" id="-276" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013424454900008" lon="-72.3588624947000056">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{95d2cd0d-d83b-426c-9b37-ca2f145adcf2}"/>
     </node>
-    <node visible="true" id="-253" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008197799199980" lon="-72.3597623706800022">
+    <node visible="true" id="-275" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008197799199980" lon="-72.3597623706800022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{41ee920a-d2ed-432d-b3c9-163eac3b363b}"/>
     </node>
-    <node visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008092709699989" lon="-72.3595223599700006">
+    <node visible="true" id="-274" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008092709699989" lon="-72.3595223599700006">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c9817e93-2182-4fc8-8a78-f81830bca66d}"/>
     </node>
-    <node visible="true" id="-251" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007744741800002" lon="-72.3589044947500071">
+    <node visible="true" id="-273" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007744741800002" lon="-72.3589044947500071">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c753f0f7-9ac3-4325-a21d-790d48100f62}"/>
     </node>
-    <node visible="true" id="-250" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012598976399991" lon="-72.3597289086799975">
+    <node visible="true" id="-272" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012598976399991" lon="-72.3597289086799975">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6b071116-3bdb-4a14-b0c9-4bf96b96d606}"/>
     </node>
-    <node visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012764845499984" lon="-72.3593171985600065">
+    <node visible="true" id="-271" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012764845499984" lon="-72.3593171985600065">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{981feaca-838d-4552-ac59-a3e1d3d37557}"/>
     </node>
-    <node visible="true" id="-248" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012955818400020" lon="-72.3590066044900055">
+    <node visible="true" id="-270" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012955818400020" lon="-72.3590066044900055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ea76cb0d-0e1b-4a77-87ab-3c3b89b6bc3f}"/>
     </node>
-    <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013077781100003" lon="-72.3589521360100036">
+    <node visible="true" id="-269" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013077781100003" lon="-72.3589521360100036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dc8d2fd1-3c53-4243-8404-cbc639cdf774}"/>
     </node>
-    <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999971438299974" lon="-72.3587579203200022">
+    <node visible="true" id="-268" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999971438299974" lon="-72.3587579203200022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5b351244-e61f-4d90-8a3f-2976296fa5ad}"/>
     </node>
-    <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000668045399996" lon="-72.3598254307700017">
+    <node visible="true" id="-267" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000668045399996" lon="-72.3598254307700017">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{395dc79e-32f0-49da-873f-d02e840a4e85}"/>
     </node>
-    <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000550239600019" lon="-72.3596615684899973">
+    <node visible="true" id="-266" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000550239600019" lon="-72.3596615684899973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{41cda987-2dcd-4cec-979d-e87cd45307d6}"/>
     </node>
-    <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024430316399988" lon="-72.3587628416200062">
+    <node visible="true" id="-265" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024430316399988" lon="-72.3587628416200062">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0d532bc7-5901-49fb-9af5-7ac26f155bfe}"/>
     </node>
-    <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022753596499989" lon="-72.3587660034399960">
+    <node visible="true" id="-264" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022753596499989" lon="-72.3587660034399960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b87fd95b-9069-4b25-9acd-8bfd2e7b30f4}"/>
     </node>
-    <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019420064599977" lon="-72.3587949213199835">
+    <node visible="true" id="-263" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019420064599977" lon="-72.3587949213199835">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8f039b12-3202-400f-8ad6-c1fb64585b9a}"/>
     </node>
-    <node visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017087688199979" lon="-72.3588288453800033">
+    <node visible="true" id="-262" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017087688199979" lon="-72.3588288453800033">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a3014fe8-999a-4e77-b0ed-3b1300b319bf}"/>
     </node>
-    <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011678514400019" lon="-72.3588790485100048">
+    <node visible="true" id="-261" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011678514400019" lon="-72.3588790485100048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{85c81f2a-f885-4316-8bf4-ab29e166b691}"/>
     </node>
-    <node visible="true" id="-238" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007611580700006" lon="-72.3586901564100060">
+    <node visible="true" id="-260" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007611580700006" lon="-72.3586901564100060">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5b1dbf2f-e2b5-4f49-8a5b-2b5f78982efb}"/>
     </node>
-    <node visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024746729499984" lon="-72.3585429223900007">
+    <node visible="true" id="-259" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024746729499984" lon="-72.3585429223900007">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{018aab14-7edd-44c8-9742-cc31146db1e6}"/>
     </node>
-    <node visible="true" id="-236" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025112673000011" lon="-72.3596282107299942">
+    <node visible="true" id="-258" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025112673000011" lon="-72.3596282107299942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{89d1fec9-de0d-4d6f-97ef-e76e45e3dd77}"/>
     </node>
-    <node visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025058843299998" lon="-72.3593829638100061">
+    <node visible="true" id="-257" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025058843299998" lon="-72.3593829638100061">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee9280ea-54c9-41bc-a529-72f3cb065e4c}"/>
     </node>
-    <node visible="true" id="-234" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002443052199983" lon="-72.3589490580299923">
+    <node visible="true" id="-256" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002443052199983" lon="-72.3589490580299923">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{24e16643-fab4-4920-b770-536a667b00ad}"/>
     </node>
-    <node visible="true" id="-233" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006631927900013" lon="-72.3622576000999942">
+    <node visible="true" id="-255" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006631927900013" lon="-72.3622576000999942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{abb89eaa-f7e1-48ef-a20d-daccb382e6dc}"/>
     </node>
-    <node visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006467123899993" lon="-72.3621917521900002">
+    <node visible="true" id="-254" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006467123899993" lon="-72.3621917521900002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e822a229-32f9-49bf-8259-92e7209883c7}"/>
     </node>
-    <node visible="true" id="-231" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006359377100004" lon="-72.3621451826700053">
+    <node visible="true" id="-253" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006359377100004" lon="-72.3621451826700053">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{45a42602-0a92-4eaa-baff-690cf431b96e}"/>
     </node>
-    <node visible="true" id="-230" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026271959599999" lon="-72.3630450196699968">
+    <node visible="true" id="-252" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026271959599999" lon="-72.3630450196699968">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{118a81bb-a69f-4d92-bbfd-bb1495693a02}"/>
     </node>
-    <node visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024136314199989" lon="-72.3631098588599997">
+    <node visible="true" id="-251" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024136314199989" lon="-72.3631098588599997">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{06556a1e-4599-48a4-9954-80c574157f42}"/>
     </node>
-    <node visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018343149700002" lon="-72.3632777502100026">
+    <node visible="true" id="-250" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018343149700002" lon="-72.3632777502100026">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{78838ae7-12eb-4638-87ae-9d20c4a63f20}"/>
     </node>
-    <node visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023457846799985" lon="-72.3620573045100031">
+    <node visible="true" id="-249" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023457846799985" lon="-72.3620573045100031">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6185f7cc-d893-4348-9535-873732391681}"/>
     </node>
-    <node visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021065329700003" lon="-72.3621256362999929">
+    <node visible="true" id="-248" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021065329700003" lon="-72.3621256362999929">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3731555f-5c69-4a2f-a2a2-19c139166164}"/>
     </node>
-    <node visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015651482700020" lon="-72.3622890368200018">
+    <node visible="true" id="-247" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015651482700020" lon="-72.3622890368200018">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{81f5baf5-2787-49b8-90d4-2e796f47325d}"/>
     </node>
-    <node visible="true" id="-224" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012623905600011" lon="-72.3606986641199939">
+    <node visible="true" id="-246" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012623905600011" lon="-72.3606986641199939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c989a443-e7b0-4ec3-a5d4-a1d8d467b90d}"/>
     </node>
-    <node visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012264768899996" lon="-72.3606929453199967">
+    <node visible="true" id="-245" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012264768899996" lon="-72.3606929453199967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{03691619-b190-44e5-af12-0b718693aec9}"/>
     </node>
-    <node visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011946802500004" lon="-72.3606873789299954">
+    <node visible="true" id="-244" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011946802500004" lon="-72.3606873789299954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{367c6198-a706-4f2c-aadd-a40ae8bd028f}"/>
     </node>
-    <node visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005899704199976" lon="-72.3597828621900021">
+    <node visible="true" id="-243" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005899704199976" lon="-72.3597828621900021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d6ff1f49-845e-4e4c-85dd-c807cb229f24}"/>
     </node>
-    <node visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004508032499999" lon="-72.3645342810900019">
+    <node visible="true" id="-242" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004508032499999" lon="-72.3645342810900019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cb9f5bc1-0820-48e2-b355-32c68cd4a795}"/>
     </node>
-    <node visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003871811100009" lon="-72.3643266931999989">
+    <node visible="true" id="-241" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003871811100009" lon="-72.3643266931999989">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{08681d5f-a5b7-4611-8ea3-c77d6be244b9}"/>
     </node>
-    <node visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002798132799999" lon="-72.3639517346500014">
+    <node visible="true" id="-240" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002798132799999" lon="-72.3639517346500014">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7e1534df-0a76-4e7d-8e5c-796c313781c8}"/>
     </node>
-    <node visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002040256299988" lon="-72.3637306485599936">
+    <node visible="true" id="-239" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002040256299988" lon="-72.3637306485599936">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6207ef23-ff4b-4311-84d3-74d3590cb32c}"/>
     </node>
-    <node visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008287735000005" lon="-72.3605437910899951">
+    <node visible="true" id="-238" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008287735000005" lon="-72.3605437910899951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb318626-0651-4678-a706-d458a0f7b740}"/>
     </node>
-    <node visible="true" id="-215" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008253843899990" lon="-72.3605705059400037">
+    <node visible="true" id="-237" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008253843899990" lon="-72.3605705059400037">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5acf5d01-cea8-4d8c-b07e-c72cd816b073}"/>
     </node>
-    <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007972569599996" lon="-72.3607473959300052">
+    <node visible="true" id="-236" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007972569599996" lon="-72.3607473959300052">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f14d1506-471f-4379-bef7-6d82fd126994}"/>
     </node>
-    <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029913144300020" lon="-72.3643388391599842">
+    <node visible="true" id="-235" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029913144300020" lon="-72.3643388391599842">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2dd1952f-5b09-4c08-b7a7-5950135e532a}"/>
     </node>
-    <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029451957799990" lon="-72.3642402141099979">
+    <node visible="true" id="-234" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029451957799990" lon="-72.3642402141099979">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{572b05ea-e0fe-4344-bd1a-79aba66e0e23}"/>
     </node>
-    <node visible="true" id="-211" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029194344199992" lon="-72.3641647013199929">
+    <node visible="true" id="-233" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029194344199992" lon="-72.3641647013199929">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{15646cdf-f8f5-454a-93c9-f60c215d85a6}"/>
     </node>
-    <node visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029000823099993" lon="-72.3640872884299995">
+    <node visible="true" id="-232" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029000823099993" lon="-72.3640872884299995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cd4862c7-97ce-4b2f-a312-0a4c70ac5bd2}"/>
     </node>
-    <node visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028743568799989" lon="-72.3639080177500063">
+    <node visible="true" id="-231" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028743568799989" lon="-72.3639080177500063">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6014bb75-2061-4041-9614-32caeff0fc5e}"/>
     </node>
-    <node visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028559585300016" lon="-72.3638136811500061">
+    <node visible="true" id="-230" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028559585300016" lon="-72.3638136811500061">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{294a16bf-825f-4ab1-9c0f-1092f547b442}"/>
     </node>
-    <node visible="true" id="-207" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029272476499990" lon="-72.3629551069300021">
+    <node visible="true" id="-229" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029272476499990" lon="-72.3629551069300021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d3544fd0-7f36-4db6-9b3c-8d55a20ede05}"/>
     </node>
-    <node visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028236705099973" lon="-72.3629831259799943">
+    <node visible="true" id="-228" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028236705099973" lon="-72.3629831259799943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8b69cf3d-0c67-4afe-b55e-3484e5a211bc}"/>
     </node>
-    <node visible="true" id="-205" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027090382500001" lon="-72.3651492070899991">
+    <node visible="true" id="-227" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027090382500001" lon="-72.3651492070899991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6cb57a87-35bb-4b55-b541-8d3f38dcd8c5}"/>
     </node>
-    <node visible="true" id="-204" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026454572700009" lon="-72.3650829173700032">
+    <node visible="true" id="-226" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026454572700009" lon="-72.3650829173700032">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9ba2c828-3cb0-4e23-978e-175a5f9c0a1a}"/>
     </node>
-    <node visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015378418000013" lon="-72.3622036787599967">
+    <node visible="true" id="-225" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015378418000013" lon="-72.3622036787599967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0622996b-12af-4779-8f5b-e824949ed7be}"/>
     </node>
-    <node visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014912199299994" lon="-72.3620477259700010">
+    <node visible="true" id="-224" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014912199299994" lon="-72.3620477259700010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{63b9dec9-ca0b-4526-bc31-f702d4954e13}"/>
     </node>
-    <node visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6990490502900002" lon="-72.3592864234800004">
+    <node visible="true" id="-223" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6990490502900002" lon="-72.3592864234800004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fe3e54f6-c119-410b-9817-24a70ed71ab2}"/>
     </node>
-    <node visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023333015699986" lon="-72.3620129969399954">
+    <node visible="true" id="-222" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023333015699986" lon="-72.3620129969399954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8702c164-0903-496a-9f7e-740ab9d4a563}"/>
     </node>
-    <node visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021926759499992" lon="-72.3616215999099950">
+    <node visible="true" id="-221" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021926759499992" lon="-72.3616215999099950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4c39a9b8-0abd-466f-9c60-14f8c579e90d}"/>
     </node>
-    <node visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021745098799972" lon="-72.3615513291699841">
+    <node visible="true" id="-220" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021745098799972" lon="-72.3615513291699841">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{83013c28-fe21-4143-8c06-afe4273fdddd}"/>
     </node>
-    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017758671699976" lon="-72.3630599810399957">
+    <node visible="true" id="-219" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017758671699976" lon="-72.3630599810399957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5bd7ddcc-49c6-469a-93b5-c427377cdbff}"/>
     </node>
-    <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016327996199978" lon="-72.3625044378700011">
+    <node visible="true" id="-218" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016327996199978" lon="-72.3625044378700011">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{250c22dd-780b-44a5-aec3-5840c98bc7af}"/>
     </node>
-    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012088752899990" lon="-72.3643351878800019">
+    <node visible="true" id="-217" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012088752899990" lon="-72.3643351878800019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3e643060-ed6a-432f-a653-e20e3752bc77}"/>
     </node>
-    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011570231600031" lon="-72.3641177542399987">
+    <node visible="true" id="-216" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011570231600031" lon="-72.3641177542399987">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cfcd1c0a-050e-451a-a572-2ee9d49b3056}"/>
     </node>
-    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009986579199978" lon="-72.3635211022599805">
+    <node visible="true" id="-215" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009986579199978" lon="-72.3635211022599805">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3ba124af-3a0a-4357-9ec0-5daabdd54dbc}"/>
     </node>
-    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014475595599965" lon="-72.3618958642800010">
+    <node visible="true" id="-214" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014475595599965" lon="-72.3618958642800010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e47c790e-aaa7-4699-85b1-9b13c9e0afeb}"/>
     </node>
-    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012185099100012" lon="-72.3610281801099973">
+    <node visible="true" id="-213" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012185099100012" lon="-72.3610281801099973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b58dd51-6a6c-4991-85d8-8310d90aee65}"/>
     </node>
-    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012058795200025" lon="-72.3609601674999965">
+    <node visible="true" id="-212" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012058795200025" lon="-72.3609601674999965">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2bfac72f-c5eb-4eda-bccb-39ae86bd1547}"/>
     </node>
-    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011854733399998" lon="-72.3607682998599984">
+    <node visible="true" id="-211" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011854733399998" lon="-72.3607682998599984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7a8e8f48-a3ad-43f4-bf37-a7bfffa4fd47}"/>
     </node>
-    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011867500899989" lon="-72.3607269335499979">
+    <node visible="true" id="-210" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011867500899989" lon="-72.3607269335499979">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2517d848-fc83-4184-bcb5-145f8998d9fa}"/>
     </node>
-    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024978803100019" lon="-72.3653636431100011">
+    <node visible="true" id="-209" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024978803100019" lon="-72.3653636431100011">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{19a73972-2edb-44b8-93d7-dd70ec0ba05a}"/>
     </node>
-    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029593477100011" lon="-72.3653755295199943">
+    <node visible="true" id="-208" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029593477100011" lon="-72.3653755295199943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{24bd8d78-8ac7-40b4-bf34-f2f1e0e9d174}"/>
     </node>
-    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028953822399995" lon="-72.3653253606699991">
+    <node visible="true" id="-207" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028953822399995" lon="-72.3653253606699991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bfe364dd-a50a-4f35-9324-8004397ffda9}"/>
     </node>
-    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028264479300015" lon="-72.3652641111099939">
+    <node visible="true" id="-206" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028264479300015" lon="-72.3652641111099939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fad979c8-3563-4e4d-b0f2-0922deb597f3}"/>
     </node>
-    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027073002500011" lon="-72.3609297702300012">
+    <node visible="true" id="-205" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027073002500011" lon="-72.3609297702300012">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c00c4d6e-18cf-4014-b189-c7a024821a61}"/>
     </node>
-    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024966756600008" lon="-72.3608927498199961">
+    <node visible="true" id="-204" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024966756600008" lon="-72.3608927498199961">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ac868205-8c68-42e5-8503-34adf8ed90ef}"/>
     </node>
-    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016897398499991" lon="-72.3648851958499932">
+    <node visible="true" id="-203" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016897398499991" lon="-72.3648851958499932">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{aaa495db-bb2c-4d14-b6f1-852d77945dd2}"/>
     </node>
-    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016640244399994" lon="-72.3648701313099991">
+    <node visible="true" id="-202" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016640244399994" lon="-72.3648701313099991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d5d0a69d-76e9-4e17-8b74-0e4b84b56812}"/>
     </node>
-    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016019476799995" lon="-72.3648422017000001">
+    <node visible="true" id="-201" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016019476799995" lon="-72.3648422017000001">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7b21e8df-b452-4ed2-a820-a45834862a9c}"/>
     </node>
-    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015621251499988" lon="-72.3648169241400012">
+    <node visible="true" id="-200" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015621251499988" lon="-72.3648169241400012">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{52359d05-ecca-42e8-9d49-0f9dc18d7e03}"/>
     </node>
-    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015320594699999" lon="-72.3648214196999930">
+    <node visible="true" id="-199" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015320594699999" lon="-72.3648214196999930">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{048ace9f-5506-4de2-bdd3-9523b46c6c6a}"/>
     </node>
-    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015020998500017" lon="-72.3648431532299838">
+    <node visible="true" id="-198" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015020998500017" lon="-72.3648431532299838">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b54181d4-a211-41c1-984f-3812a57be74d}"/>
     </node>
-    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013769878999989" lon="-72.3649754676700070">
+    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013769878999989" lon="-72.3649754676700070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2cb73e9b-5dc9-4d46-aeae-75de34976546}"/>
     </node>
-    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013116965700004" lon="-72.3650257533199976">
+    <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013116965700004" lon="-72.3650257533199976">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{39f5b7b6-9133-4b66-8695-b27845493733}"/>
     </node>
-    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011985683099997" lon="-72.3651106152599937">
+    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011985683099997" lon="-72.3651106152599937">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a3f0b378-1bf3-4e44-8e81-3b81b47a55b6}"/>
     </node>
-    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006126074400001" lon="-72.3621489709500025">
+    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006126074400001" lon="-72.3621489709500025">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4aa38a15-1d1a-496d-a6ac-c11d125801f3}"/>
     </node>
-    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005910945099982" lon="-72.3621499434400022">
+    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005910945099982" lon="-72.3621499434400022">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7db3022e-6731-4b4e-8f6d-da72dced98aa}"/>
     </node>
-    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005495876499994" lon="-72.3621442957399950">
+    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005495876499994" lon="-72.3621442957399950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6a4cec9f-62ae-4a45-bd74-fc3b5336cc88}"/>
     </node>
-    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003910035800018" lon="-72.3620746576300036">
+    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003910035800018" lon="-72.3620746576300036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb1529f2-de86-427b-b4fb-cda4954c891d}"/>
     </node>
-    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002851133800005" lon="-72.3620377767099825">
+    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002851133800005" lon="-72.3620377767099825">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ab8bb983-17c8-4cc2-8d8a-50cdb7f5b830}"/>
     </node>
-    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001765405099993" lon="-72.3620098119699833">
+    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001765405099993" lon="-72.3620098119699833">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a43e29c7-5c4b-49ec-a12e-3fb954ce9b1e}"/>
     </node>
-    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000151722999997" lon="-72.3619831066999950">
+    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000151722999997" lon="-72.3619831066999950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{607c8fb3-2d66-428a-8421-ca69d4fd6b36}"/>
     </node>
-    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998794510700019" lon="-72.3619774456099947">
+    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998794510700019" lon="-72.3619774456099947">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0813dba4-e3d7-4fdb-a9a6-eb05878ba17c}"/>
     </node>
-    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998032185799987" lon="-72.3619853627400005">
+    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998032185799987" lon="-72.3619853627400005">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a8c1b1d5-6513-4514-ab87-8cf7b65c72b7}"/>
     </node>
-    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997383847400007" lon="-72.3620026328199941">
+    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997383847400007" lon="-72.3620026328199941">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{64c29c0a-72de-4ae5-982e-675d405758a0}"/>
     </node>
-    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995928115399996" lon="-72.3620593355500006">
+    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995928115399996" lon="-72.3620593355500006">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{44c82af0-db6a-470f-90c0-69a4450fa828}"/>
     </node>
-    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013270798199986" lon="-72.3648078769700049">
+    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013270798199986" lon="-72.3648078769700049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5c313c81-5777-4a62-9640-7d07b261562b}"/>
     </node>
-    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013010982400001" lon="-72.3646917833000032">
+    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013010982400001" lon="-72.3646917833000032">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{49a05c15-a62c-4777-9905-b53a030e1b2c}"/>
     </node>
-    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012490775000018" lon="-72.3645015987799951">
+    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012490775000018" lon="-72.3645015987799951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{18fe3d45-f033-4b11-beb4-2979965f70dc}"/>
     </node>
-    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018812826899969" lon="-72.3645933403099946">
+    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018812826899969" lon="-72.3645933403099946">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2ac6ec6d-b9b4-42f3-b016-843d4db288c8}"/>
     </node>
-    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018605171900001" lon="-72.3645600612099855">
+    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018605171900001" lon="-72.3645600612099855">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cbf15011-67eb-4a89-855a-e2ab76c6cf69}"/>
     </node>
-    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018431562299989" lon="-72.3645263168699984">
+    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018431562299989" lon="-72.3645263168699984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9232806a-aae7-4c76-b722-c73c118779cd}"/>
     </node>
-    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018131116899982" lon="-72.3644459178999995">
+    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018131116899982" lon="-72.3644459178999995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a4804903-408d-443e-b664-1640d62563ff}"/>
     </node>
-    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017914866500004" lon="-72.3643983965900048">
+    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017914866500004" lon="-72.3643983965900048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b9d5b900-227f-45d6-b75f-91d3f7d503b0}"/>
     </node>
-    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016739074900000" lon="-72.3641703957000004">
+    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016739074900000" lon="-72.3641703957000004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{44a846b4-3b66-4ef8-8469-38289351ef3b}"/>
     </node>
-    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999122416799990" lon="-72.3598398665299953">
+    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999122416799990" lon="-72.3598398665299953">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{97da5ee2-a050-49e1-9ee1-1c25fb1d5df0}"/>
     </node>
-    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997171014199992" lon="-72.3598605828299952">
+    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997171014199992" lon="-72.3598605828299952">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{547715c1-5fd7-4c84-83e9-07a34d33e514}"/>
     </node>
-    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996722981099985" lon="-72.3598742513199937">
+    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996722981099985" lon="-72.3598742513199937">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fce33577-9e74-4dcb-bc0d-ee698213e37a}"/>
     </node>
-    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996323785100005" lon="-72.3598990515200029">
+    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996323785100005" lon="-72.3598990515200029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a8fbb3ef-0ecc-4426-b7a3-ef431231e0b5}"/>
     </node>
-    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008073074299999" lon="-72.3635727247900036">
+    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008073074299999" lon="-72.3635727247900036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7bc2131a-998c-4eb2-8327-308a3fc6230b}"/>
     </node>
-    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004169135099989" lon="-72.3636700057400049">
+    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004169135099989" lon="-72.3636700057400049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c1643b44-18b1-4a64-aad9-6987e1964038}"/>
     </node>
-    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025105688900011" lon="-72.3604663040100036">
+    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025105688900011" lon="-72.3604663040100036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ef317431-bd4b-4aae-9cbb-efec060dbbba}"/>
     </node>
-    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025134469500003" lon="-72.3602217308899895">
+    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025134469500003" lon="-72.3602217308899895">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4449e8a9-e837-44f4-93de-a2d440f3c7c5}"/>
     </node>
-    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009705876999988" lon="-72.3634189647799957">
+    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009705876999988" lon="-72.3634189647799957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bb8d560b-afba-41f3-a550-e4782b5e6a0c}"/>
     </node>
-    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009115960299992" lon="-72.3632323317799973">
+    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009115960299992" lon="-72.3632323317799973">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f02672bc-5098-44cc-8aae-7d17fab617bf}"/>
     </node>
-    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008676288800002" lon="-72.3630775018600048">
+    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008676288800002" lon="-72.3630775018600048">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{763e8292-46a2-4045-b10a-601f81a4f3e3}"/>
     </node>
-    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028380173500004" lon="-72.3637438608899970">
+    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7028380173500004" lon="-72.3637438608899970">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c1b24ce7-377f-46f7-8fbe-d64e60a15d3c}"/>
     </node>
-    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027048353199978" lon="-72.3632830014399957">
+    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027048353199978" lon="-72.3632830014399957">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9f9d7e20-ae6a-4b64-8731-6efbe69b7694}"/>
     </node>
-    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026376565999994" lon="-72.3638784585599950">
+    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026376565999994" lon="-72.3638784585599950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8aff790a-de78-4972-a6c7-8256771bcd55}"/>
     </node>
-    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021681667799973" lon="-72.3640271775699944">
+    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021681667799973" lon="-72.3640271775699944">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0749bc5-4981-4e42-a91f-cd65c6101338}"/>
     </node>
-    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020382077799994" lon="-72.3640629748000066">
+    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020382077799994" lon="-72.3640629748000066">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a02de9d0-d7c1-4d80-82a5-f52744f735dc}"/>
     </node>
-    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019855596399998" lon="-72.3638471517800070">
+    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019855596399998" lon="-72.3638471517800070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c01ea5a7-6169-48b2-a547-8e3cf0c6d9d0}"/>
     </node>
-    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017943246200025" lon="-72.3646545002600021">
+    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017943246200025" lon="-72.3646545002600021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e75e3182-39f4-4a2e-9000-b3da70366cc8}"/>
     </node>
-    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017613183100000" lon="-72.3646789551700067">
+    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017613183100000" lon="-72.3646789551700067">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9d2e75b8-7b3e-4212-a6d3-13ffce9bd5b5}"/>
     </node>
-    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016925778499994" lon="-72.3647298860600046">
+    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7016925778499994" lon="-72.3647298860600046">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{43170a0b-5530-4103-a1db-21ce1da0f13b}"/>
     </node>
-    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015033074300012" lon="-72.3647676287800010">
+    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7015033074300012" lon="-72.3647676287800010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{47cef29e-8cb0-4bcb-bd96-f32e89861003}"/>
     </node>
-    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019125718900012" lon="-72.3653594478400066">
+    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019125718900012" lon="-72.3653594478400066">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{53fe45e8-12b6-4cd8-a776-1b0f38d075aa}"/>
     </node>
-    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019170361199976" lon="-72.3652935094499981">
+    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019170361199976" lon="-72.3652935094499981">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{953fa01d-77bb-40e9-b414-c9276745c00a}"/>
     </node>
-    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019098487599980" lon="-72.3652112486099952">
+    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019098487599980" lon="-72.3652112486099952">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{65abc668-4648-4d8f-8f0e-0ff31c7651b3}"/>
     </node>
-    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018988007800004" lon="-72.3651629165800045">
+    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018988007800004" lon="-72.3651629165800045">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00eae29a-18ee-4083-9d9b-6ce3beb4ebcb}"/>
     </node>
-    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018695400000006" lon="-72.3650857263500029">
+    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018695400000006" lon="-72.3650857263500029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1ebc0ac8-8992-4d6b-8c91-b6bc962193b5}"/>
     </node>
-    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018368800699992" lon="-72.3650283159600036">
+    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7018368800699992" lon="-72.3650283159600036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0a8b03e8-8cf1-4cb4-a6c6-743c9423e16f}"/>
     </node>
-    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017855075299995" lon="-72.3649637669900017">
+    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017855075299995" lon="-72.3649637669900017">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{73f1a3d4-f061-477d-aa78-0167bc45d078}"/>
     </node>
-    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017530332899975" lon="-72.3649325465199951">
+    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017530332899975" lon="-72.3649325465199951">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7f41aff8-101a-456d-85b7-4d65109fab2c}"/>
     </node>
-    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012823693799994" lon="-72.3648179282999990">
+    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012823693799994" lon="-72.3648179282999990">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{aa207c4c-6123-4b19-9124-f867b4665a24}"/>
     </node>
-    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012374695599979" lon="-72.3648322397200019">
+    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012374695599979" lon="-72.3648322397200019">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f567cdc7-60ea-4580-85d9-914239eddac4}"/>
     </node>
-    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006060287499993" lon="-72.3650699608899970">
+    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006060287499993" lon="-72.3650699608899970">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ee9ae638-b3fc-41a5-886d-82cc4f355eb9}"/>
     </node>
-    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008923923800001" lon="-72.3607497208700039">
+    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008923923800001" lon="-72.3607497208700039">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00282eb6-07d9-4490-a60e-d8541a07ec51}"/>
     </node>
-    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008460567700006" lon="-72.3607534871499922">
+    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008460567700006" lon="-72.3607534871499922">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{27b64afd-85ec-4d9e-889c-96f38249e170}"/>
     </node>
-    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017029639099981" lon="-72.3648606462199950">
+    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017029639099981" lon="-72.3648606462199950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e813d633-c35d-4d36-af1b-170d39b085e7}"/>
     </node>
-    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017121249399993" lon="-72.3648359878300056">
+    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017121249399993" lon="-72.3648359878300056">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e7e8ea7e-62f1-461a-9f9e-cdb3307f77dd}"/>
     </node>
-    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017322410099993" lon="-72.3647497908099950">
+    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7017322410099993" lon="-72.3647497908099950">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{52724a1d-a920-4605-b298-1cd4bca5d8e5}"/>
     </node>
-    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005652468600010" lon="-72.3649338501799946">
+    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005652468600010" lon="-72.3649338501799946">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ce494fa3-d0a3-4cd6-9cca-b5bef17f4acc}"/>
     </node>
-    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005029935499989" lon="-72.3647064545199896">
+    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005029935499989" lon="-72.3647064545199896">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{efbcf4d1-45de-4f80-a7f3-200b90b4f26b}"/>
     </node>
-    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023699280499995" lon="-72.3596330036399991">
+    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7023699280499995" lon="-72.3596330036399991">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f8906d8b-524d-4fc9-a16b-2f3c32d399d8}"/>
     </node>
-    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014893720299993" lon="-72.3597033407099985">
+    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014893720299993" lon="-72.3597033407099985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f32070c6-9028-4e04-b9b2-6e6a295d1ee3}"/>
     </node>
-    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012677290700005" lon="-72.3606008227500013">
+    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012677290700005" lon="-72.3606008227500013">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e4fbe1ff-f723-431b-96fb-40f240a591ea}"/>
     </node>
-    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012565179399992" lon="-72.3599581959600044">
+    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7012565179399992" lon="-72.3599581959600044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{10a8a646-89e4-4325-a1c0-0bba91edd235}"/>
     </node>
-    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006222338299990" lon="-72.3620713771800013">
+    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006222338299990" lon="-72.3620713771800013">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{29b4e035-bf6f-4c0a-8ea4-3d453ca11958}"/>
     </node>
-    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006166110400009" lon="-72.3620127005400064">
+    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006166110400009" lon="-72.3620127005400064">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3236cbd6-48d9-454d-a8c4-1371a982eaf6}"/>
     </node>
-    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006200294399987" lon="-72.3618202711599992">
+    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006200294399987" lon="-72.3618202711599992">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f5a74281-96eb-4f5e-b481-651edb664c2b}"/>
     </node>
-    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006146626000005" lon="-72.3617239950699940">
+    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006146626000005" lon="-72.3617239950699940">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{65842328-7e41-408d-a5ae-934a30e075e0}"/>
     </node>
-    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006174317799978" lon="-72.3616800897999894">
+    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7006174317799978" lon="-72.3616800897999894">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0dccbbc-e9eb-46d7-b79b-120abe29eded}"/>
     </node>
-    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021432854499992" lon="-72.3644346259099933">
+    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021432854499992" lon="-72.3644346259099933">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ff09ca3d-4dc3-47a8-8646-aa0fa7e82936}"/>
     </node>
-    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021206720000004" lon="-72.3643814086800035">
+    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021206720000004" lon="-72.3643814086800035">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4d5d8d79-a11f-4de2-b6dc-15547a6d7cbd}"/>
     </node>
-    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021015211100012" lon="-72.3643231872499939">
+    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021015211100012" lon="-72.3643231872499939">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{5a9206d5-800f-4011-965d-f301a8d427eb}"/>
     </node>
-    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026129862400001" lon="-72.3604632380500021">
+    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026129862400001" lon="-72.3604632380500021">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{824ffa86-73f5-400e-849e-67fa91014a0f}"/>
     </node>
-    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020204485399999" lon="-72.3645026282299995">
+    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7020204485399999" lon="-72.3645026282299995">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{6d7b17e4-660a-4bad-bd27-3f9ac8c26f45}"/>
     </node>
-    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008388564899990" lon="-72.3604372371499949">
+    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008388564899990" lon="-72.3604372371499949">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{83b1e61c-ba23-4c55-968d-955604dab858}"/>
     </node>
-    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008414641999989" lon="-72.3603488479899966">
+    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008414641999989" lon="-72.3603488479899966">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f58efa1d-1534-4d88-a24a-65f0e8a8b94c}"/>
     </node>
-    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014684370100017" lon="-72.3607199184299930">
+    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014684370100017" lon="-72.3607199184299930">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d24f3529-f6f0-414e-8d8e-60da4d196983}"/>
     </node>
-    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011480890199993" lon="-72.3597396552600003">
+    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011480890199993" lon="-72.3597396552600003">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1f08e79d-65f6-4645-9193-d71b5f53fc5d}"/>
     </node>
-    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011314008299978" lon="-72.3606690550100069">
+    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7011314008299978" lon="-72.3606690550100069">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0fdb3dcf-8b32-41f0-90be-c389007acb55}"/>
     </node>
-    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7010350738799991" lon="-72.3606303437099996">
+    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7010350738799991" lon="-72.3606303437099996">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c3670158-c9c6-4ff0-8a58-c1b76a1ec4e5}"/>
     </node>
-    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008914643399997" lon="-72.3605619019399882">
+    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008914643399997" lon="-72.3605619019399882">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d8cb4c59-7766-4836-be2c-e8c19fba607f}"/>
     </node>
-    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027208787900010" lon="-72.3596191073200004">
+    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7027208787900010" lon="-72.3596191073200004">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3eeb7ede-2b3d-4c29-9e44-9d07960fa336}"/>
     </node>
-    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009478563300000" lon="-72.3643993500499931">
+    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7009478563300000" lon="-72.3643993500499931">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0c5f531f-dc9d-4838-be76-22f347450aa0}"/>
     </node>
-    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007024150600003" lon="-72.3644763970700069">
+    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007024150600003" lon="-72.3644763970700069">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3f4b8bd2-df1c-4138-b4fd-3260d8fe0ec3}"/>
     </node>
-    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005803708500009" lon="-72.3645073528099942">
+    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005803708500009" lon="-72.3645073528099942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{eb14e619-d0c3-4d9a-979f-ccbb797c6951}"/>
     </node>
-    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008241934799990" lon="-72.3605447727200044">
+    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008241934799990" lon="-72.3605447727200044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9967ecd7-f1a3-4fc8-914e-e2f78db509fc}"/>
     </node>
-    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007832027999976" lon="-72.3605486476500062">
+    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007832027999976" lon="-72.3605486476500062">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{138c095d-54fd-445b-90c5-923650b541e3}"/>
     </node>
-    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007356230099999" lon="-72.3605422724999983">
+    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007356230099999" lon="-72.3605422724999983">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{22806f5a-e73a-4ba9-af2e-160f454900fe}"/>
     </node>
-    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004424406699998" lon="-72.3603875287600005">
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004424406699998" lon="-72.3603875287600005">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{00d30ebe-52c8-45c5-bc86-5b1dc30bbe06}"/>
     </node>
-    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999463079099986" lon="-72.3601460936800009">
+    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999463079099986" lon="-72.3601460936800009">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{caee4c3f-bf77-40c2-b541-e49caf11c2fe}"/>
     </node>
-    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998361407499969" lon="-72.3600846000900049">
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6998361407499969" lon="-72.3600846000900049">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{af319fcf-ad29-45dc-8031-c484298dc8ab}"/>
     </node>
-    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997747674000001" lon="-72.3600422314799943">
+    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997747674000001" lon="-72.3600422314799943">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{59ba072e-e835-424e-9638-3a46a515d8f3}"/>
     </node>
-    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996897282199992" lon="-72.3599654490699891">
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996897282199992" lon="-72.3599654490699891">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{e030d272-c409-4fc0-9339-9554f98ca67d}"/>
     </node>
-    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000669276699982" lon="-72.3637773729799960">
+    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000669276699982" lon="-72.3637773729799960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{698ee339-549a-4414-833d-70c41bf96aa3}"/>
     </node>
-    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997781354999999" lon="-72.3638605285700010">
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997781354999999" lon="-72.3638605285700010">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{119ff15b-1a2e-4924-a6b3-d30e2cf7f7a0}"/>
     </node>
-    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997060737399972" lon="-72.3638749536899866">
+    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997060737399972" lon="-72.3638749536899866">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{249b4a4c-a063-4402-a9c1-dc9b0daf2923}"/>
     </node>
-    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996463546499987" lon="-72.3638948664100070">
+    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996463546499987" lon="-72.3638948664100070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{022159b5-d615-40cd-8e0b-7e15a2f3fffd}"/>
     </node>
-    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025429482899987" lon="-72.3619990111400000">
+    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025429482899987" lon="-72.3619990111400000">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{628254ce-ddf5-4a6d-8e2b-604d49b8740c}"/>
     </node>
-    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025063127400015" lon="-72.3607880166299964">
+    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025063127400015" lon="-72.3607880166299964">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0f9afdde-b63b-4bc1-9563-1baa4b85e28c}"/>
     </node>
-    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005030098099985" lon="-72.3651013186299963">
+    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005030098099985" lon="-72.3651013186299963">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b42fe56c-6b69-4eb8-9dc8-4cc15abf7100}"/>
     </node>
-    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003987303299999" lon="-72.3651280253599936">
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003987303299999" lon="-72.3651280253599936">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{de968008-487e-45f7-b75d-cc6a7e3c3b02}"/>
     </node>
-    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996794169599996" lon="-72.3652826818200055">
+    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996794169599996" lon="-72.3652826818200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{12b490fd-a953-4a29-858b-871368ccd8ba}"/>
     </node>
-    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994617584999991" lon="-72.3653356666000036">
+    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994617584999991" lon="-72.3653356666000036">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b6be1c87-29d1-4959-9da4-9d17d7e664b8}"/>
     </node>
-    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005950625799988" lon="-72.3622759602600070">
+    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7005950625799988" lon="-72.3622759602600070">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dbc43ee4-a923-4289-afe8-1459523ab536}"/>
     </node>
-    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004419767799988" lon="-72.3623265571600029">
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7004419767799988" lon="-72.3623265571600029">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2e997e60-15a4-40d4-b464-f033b5e1e192}"/>
     </node>
-    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002421877699998" lon="-72.3623841271899977">
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002421877699998" lon="-72.3623841271899977">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0489272e-8d70-46b9-b3a7-bc232913d425}"/>
     </node>
-    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001300551699998" lon="-72.3624071531999959">
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001300551699998" lon="-72.3624071531999959">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c64c8768-ce14-47a8-9c38-8ace6941987b}"/>
     </node>
-    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263536499997" lon="-72.3629389733599879">
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263536499997" lon="-72.3629389733599879">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c626b399-6782-461d-917a-0cf0996b1fdb}"/>
     </node>
-    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002326456700017" lon="-72.3629951913199960">
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002326456700017" lon="-72.3629951913199960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{90fcd827-fbd0-48ae-a4d6-09673f960de9}"/>
     </node>
-    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263687200001" lon="-72.3630515204099964">
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7002263687200001" lon="-72.3630515204099964">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{7931c590-92d0-45e3-9827-de3955aed059}"/>
     </node>
-    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001738660599983" lon="-72.3633648031100023">
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001738660599983" lon="-72.3633648031100023">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{0767e414-fe2f-4e87-86b1-83c5065f4304}"/>
     </node>
-    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001659247899985" lon="-72.3634536496399789">
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001659247899985" lon="-72.3634536496399789">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{39843252-90f8-4328-a1f2-80fab8e6b8b6}"/>
     </node>
-    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001675363100013" lon="-72.3635159822700018">
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001675363100013" lon="-72.3635159822700018">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{105fc6d8-94f1-4ef4-ba69-3046dff39d16}"/>
     </node>
-    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001798178699969" lon="-72.3636234875299920">
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7001798178699969" lon="-72.3636234875299920">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ec320852-50a3-4e2c-aeda-0fd3e6195a7c}"/>
     </node>
-    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025861574699990" lon="-72.3629225343800044">
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025861574699990" lon="-72.3629225343800044">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{cc54749b-a8ec-4890-85c3-09a892963506}"/>
     </node>
-    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024048346499994" lon="-72.3623002673199949">
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024048346499994" lon="-72.3623002673199949">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{1b331fd7-7f67-4919-90e4-05086bf62cbf}"/>
     </node>
-    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013730528799984" lon="-72.3620810506499907">
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013730528799984" lon="-72.3620810506499907">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a7735e22-4c30-4d65-a692-ff1ed1f9376f}"/>
     </node>
-    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008919916799989" lon="-72.3622094409199974">
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7008919916799989" lon="-72.3622094409199974">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{85994d76-029a-4614-9df7-7b500fa1d7f1}"/>
     </node>
-    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025805898900002" lon="-72.3650112703899993">
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025805898900002" lon="-72.3650112703899993">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{12c8cfe5-2c80-4416-a6c6-7dd032a41850}"/>
     </node>
-    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025182392699998" lon="-72.3649374931300002">
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7025182392699998" lon="-72.3649374931300002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f6efc0ea-6a32-4bce-b27b-56022d012add}"/>
     </node>
-    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022252799000022" lon="-72.3645673879100002">
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7022252799000022" lon="-72.3645673879100002">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{133a2d8b-e32e-4e50-ad73-c4854fcc925b}"/>
     </node>
-    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021796015300001" lon="-72.3645015413899984">
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7021796015300001" lon="-72.3645015413899984">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{8746ed36-9f0b-4eb7-9558-3fae339f6750}"/>
     </node>
-    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026958136299992" lon="-72.3650447362499989">
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7026958136299992" lon="-72.3650447362499989">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{ddd4701d-ab0c-42dc-8c75-900e0dc3af5e}"/>
     </node>
-    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992193064799999" lon="-72.3588999086399838">
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992193064799999" lon="-72.3588999086399838">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{bbac7ebe-6c98-42a8-ae6e-b09b73364b98}"/>
     </node>
-    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991501087799987" lon="-72.3586803331299961">
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991501087799987" lon="-72.3586803331299961">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3e41468b-4ec7-41ce-a48d-39b762301e90}"/>
     </node>
-    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013292813500005" lon="-72.3648242249600031">
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013292813500005" lon="-72.3648242249600031">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{98c4d4ed-44cc-405e-972f-de5696f366be}"/>
     </node>
-    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013324558299985" lon="-72.3648735912399985">
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013324558299985" lon="-72.3648735912399985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9d22553e-4320-44c6-a1b3-e20179af825f}"/>
     </node>
-    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013304654399999" lon="-72.3649230197300000">
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7013304654399999" lon="-72.3649230197300000">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{dd91b33a-be42-4891-bc91-2be90c51b853}"/>
     </node>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992473837099986" lon="-72.3588367156799990">
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992473837099986" lon="-72.3588367156799990">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{d51893a6-3df0-4d94-ae99-a0291cf1f8b2}"/>
     </node>
-    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991559975199992" lon="-72.3588277695599942">
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991559975199992" lon="-72.3588277695599942">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a05ed439-4959-4ec7-a534-1e3cb1be92fc}"/>
     </node>
-    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995335028499996" lon="-72.3597741646800046">
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995335028499996" lon="-72.3597741646800046">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{26a7a9c4-a267-4a2a-8720-d176d5fa1034}"/>
     </node>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993052853000004" lon="-72.3595089049200055">
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993052853000004" lon="-72.3595089049200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9893a976-8d41-4fa8-8b7f-7784f22cb53f}"/>
     </node>
-    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992779188700000" lon="-72.3594700869700063">
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992779188700000" lon="-72.3594700869700063">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{de4ac387-e204-40b6-a872-bac62a736235}"/>
     </node>
-    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992564190600010" lon="-72.3594277203900020">
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992564190600010" lon="-72.3594277203900020">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{a0f095b9-7fbc-4361-b994-d85f4e67855b}"/>
     </node>
-    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992412347999988" lon="-72.3593826898599985">
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992412347999988" lon="-72.3593826898599985">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{66fa7879-ad20-47e4-9140-c3c7de8a9f52}"/>
     </node>
-    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988183784600013" lon="-72.3644868463200055">
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988183784600013" lon="-72.3644868463200055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{347874d6-7887-4085-9a1a-24efd90a2479}"/>
     </node>
-    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988550299999998" lon="-72.3644932968399814">
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988550299999998" lon="-72.3644932968399814">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{62350f3f-463b-42fb-8b9e-e32eb8a3b174}"/>
     </node>
-    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988897343599980" lon="-72.3645093670400001">
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988897343599980" lon="-72.3645093670400001">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{517b3307-09b5-4b3a-b497-e5bf7adf0d64}"/>
     </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994340143300004" lon="-72.3648455978899960">
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994340143300004" lon="-72.3648455978899960">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{f354a4b8-acc1-4762-bfe4-1cdc0422cb72}"/>
     </node>
-    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994883816500002" lon="-72.3648748282899987">
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6994883816500002" lon="-72.3648748282899987">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{b778ee8d-262a-40b4-aa1d-4e2b3ff58d14}"/>
     </node>
-    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995300524399983" lon="-72.3648891177899998">
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995300524399983" lon="-72.3648891177899998">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{083899ed-ba61-47ce-8baf-6616ec0677ec}"/>
     </node>
-    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995468363599979" lon="-72.3648901012099941">
+    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995468363599979" lon="-72.3648901012099941">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{4132d23d-4212-4639-a6b3-e5b6935de61c}"/>
     </node>
-    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995612977999981" lon="-72.3648866791999978">
+    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995612977999981" lon="-72.3648866791999978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{06bf1610-0e90-49fc-9114-36b379c4660a}"/>
     </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995737206600010" lon="-72.3648786283799978">
+    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6995737206600010" lon="-72.3648786283799978">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{575d3611-dc51-40ab-b2d8-c2561e00890b}"/>
     </node>
-    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996182300299996" lon="-72.3648208084500055">
+    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996182300299996" lon="-72.3648208084500055">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{fd69d246-ec48-48f9-9317-26fae1eae0fe}"/>
     </node>
-    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996632180000013" lon="-72.3647774958599967">
+    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996632180000013" lon="-72.3647774958599967">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{9058c10d-26e0-4c35-ad74-e9aaed0ea42b}"/>
     </node>
-    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996960073499991" lon="-72.3647552536900065">
+    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6996960073499991" lon="-72.3647552536900065">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{15f50f45-3907-4fb8-907a-bc3bc30b02ee}"/>
     </node>
-    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997367568100019" lon="-72.3647365293199982">
+    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6997367568100019" lon="-72.3647365293199982">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3bafbefa-9894-45a8-a7cb-69912c23d12c}"/>
     </node>
-    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999384750299988" lon="-72.3646676866299856">
+    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999384750299988" lon="-72.3646676866299856">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{c4a1cf21-416f-414f-b333-94cc84807c1c}"/>
     </node>
-    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000524529499996" lon="-72.3646327131999954">
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7000524529499996" lon="-72.3646327131999954">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{3d83ceeb-0418-4a95-b4ab-5fc7705850f7}"/>
     </node>
-    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003252868600010" lon="-72.3645614283999947">
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7003252868600010" lon="-72.3645614283999947">
         <tag k="hoot:status" v="1"/>
         <tag k="bdw-id" v="{2b1399b5-2753-4066-bc56-b8e3aefe90e7}"/>
     </node>
-    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3644779235235234">
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3644779235235234">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991389118199240" lon="-72.3584000000000032">
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6991389118199240" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992284381644600" lon="-72.3584000000000032">
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6992284381644600" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3587000267866642">
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3587000267866642">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3648749865446348">
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3648749865446348">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993110867921271" lon="-72.3653999999999940">
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6993110867921271" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3595948439905925">
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3595948439905925">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3604333847607819">
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3604333847607819">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019046245402620" lon="-72.3653999999999940">
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7019046245402620" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3637694387719250">
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3637694387719250">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007915076878293" lon="-72.3653999999999940">
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007915076878293" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999976" lon="-72.3609894875373385">
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999976" lon="-72.3609894875373385">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029956433356528" lon="-72.3653999999999940">
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029956433356528" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024584100726941" lon="-72.3653999999999940">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024584100726941" lon="-72.3653999999999940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3592806677495304">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6988000000000003" lon="-72.3592806677495304">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3629401351312538">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3629401351312538">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3643537384355255">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7030000000000012" lon="-72.3643537384355255">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024697672642928" lon="-72.3584000000000032">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7024697672642928" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007453994198976" lon="-72.3584000000000032">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7007453994198976" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999766979966902" lon="-72.3584000000000032">
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.6999766979966902" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014734418771242" lon="-72.3584000000000032">
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7014734418771242" lon="-72.3584000000000032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3587182734695205">
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="7.7029999999999994" lon="-72.3587182734695205">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-1426" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-880"/>
-        <nd ref="-191"/>
-        <nd ref="-190"/>
-        <nd ref="-189"/>
-        <nd ref="-188"/>
-        <nd ref="-222"/>
+    <way visible="true" id="-143451" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-792"/>
+        <nd ref="-213"/>
+        <nd ref="-212"/>
+        <nd ref="-211"/>
+        <nd ref="-210"/>
+        <nd ref="-244"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-1425" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-202"/>
-        <nd ref="-192"/>
-        <nd ref="-879"/>
+    <way visible="true" id="-143450" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-224"/>
+        <nd ref="-214"/>
+        <nd ref="-791"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-1424" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-879"/>
-        <nd ref="-880"/>
+    <way visible="true" id="-143449" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-791"/>
+        <nd ref="-792"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="bridge" v="yes"/>
@@ -1100,30 +1100,30 @@
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2012-07-10T16:22:23Z;2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{40ea34f9-03b9-46b5-b9ad-7e71a1b00175}"/>
     </way>
-    <way visible="true" id="-1421" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-876"/>
-        <nd ref="-214"/>
+    <way visible="true" id="-143446" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-788"/>
+        <nd ref="-236"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-1420" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-231"/>
-        <nd ref="-109"/>
-        <nd ref="-108"/>
-        <nd ref="-107"/>
-        <nd ref="-106"/>
-        <nd ref="-105"/>
-        <nd ref="-875"/>
+    <way visible="true" id="-143445" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-253"/>
+        <nd ref="-131"/>
+        <nd ref="-130"/>
+        <nd ref="-129"/>
+        <nd ref="-128"/>
+        <nd ref="-127"/>
+        <nd ref="-787"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-1419" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-875"/>
-        <nd ref="-876"/>
+    <way visible="true" id="-143444" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-787"/>
+        <nd ref="-788"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="bridge" v="yes"/>
@@ -1131,491 +1131,539 @@
         <tag k="source:datetime" v="2018-05-22T21:24:39Z;2013-10-26T16:12:18Z;2013-10-26T16:12:16Z"/>
         <tag k="bdw-id" v="{206c3cb6-55ad-4745-95a6-7b713f797b58}"/>
     </way>
-    <way visible="true" id="-1416" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-872"/>
-        <nd ref="-162"/>
+    <way visible="true" id="-143441" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-784"/>
+        <nd ref="-184"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:16Z"/>
         <tag k="bdw-id" v="{7a909337-b6e1-43dc-bd38-80f089cc6bbb}"/>
     </way>
-    <way visible="true" id="-1415" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-231"/>
-        <nd ref="-172"/>
-        <nd ref="-171"/>
-        <nd ref="-170"/>
-        <nd ref="-169"/>
-        <nd ref="-168"/>
-        <nd ref="-167"/>
-        <nd ref="-166"/>
-        <nd ref="-165"/>
-        <nd ref="-871"/>
+    <way visible="true" id="-143440" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-253"/>
+        <nd ref="-194"/>
+        <nd ref="-193"/>
+        <nd ref="-192"/>
+        <nd ref="-191"/>
+        <nd ref="-190"/>
+        <nd ref="-189"/>
+        <nd ref="-188"/>
+        <nd ref="-187"/>
+        <nd ref="-783"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:16Z"/>
         <tag k="bdw-id" v="{7a909337-b6e1-43dc-bd38-80f089cc6bbb}"/>
     </way>
-    <way visible="true" id="-1414" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-871"/>
-        <nd ref="-164"/>
-        <nd ref="-163"/>
-        <nd ref="-872"/>
+    <way visible="true" id="-143439" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-783"/>
+        <nd ref="-186"/>
+        <nd ref="-185"/>
+        <nd ref="-784"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="bridge" v="yes"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{607c2a36-d410-462c-bcfe-cf528efb36d2}"/>
     </way>
-    <way visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-260"/>
-        <nd ref="-259"/>
-        <nd ref="-258"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="name" v="Avenida Los Leones"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
-        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
-    </way>
-    <way visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-174"/>
-        <nd ref="-173"/>
-        <nd ref="-12"/>
+    <way visible="true" id="-142169" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-196"/>
+        <nd ref="-195"/>
+        <nd ref="-34"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
         <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
     </way>
-    <way visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-268"/>
-        <nd ref="-267"/>
-        <nd ref="-266"/>
-        <nd ref="-265"/>
-        <nd ref="-264"/>
-        <nd ref="-263"/>
-        <nd ref="-262"/>
-        <nd ref="-261"/>
-        <nd ref="-260"/>
+    <way visible="true" id="-142153" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-282"/>
+        <nd ref="-281"/>
+        <nd ref="-280"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida Los Leones"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
+        <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
+    </way>
+    <way visible="true" id="-142142" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-290"/>
+        <nd ref="-289"/>
+        <nd ref="-288"/>
+        <nd ref="-287"/>
+        <nd ref="-286"/>
+        <nd ref="-285"/>
+        <nd ref="-284"/>
+        <nd ref="-283"/>
+        <nd ref="-282"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-253"/>
-        <nd ref="-252"/>
-        <nd ref="-251"/>
+    <way visible="true" id="-142141" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-275"/>
+        <nd ref="-274"/>
+        <nd ref="-273"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
-    <way visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-250"/>
-        <nd ref="-249"/>
-        <nd ref="-248"/>
-        <nd ref="-247"/>
-        <nd ref="-254"/>
+    <way visible="true" id="-142140" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-272"/>
+        <nd ref="-271"/>
+        <nd ref="-270"/>
+        <nd ref="-269"/>
+        <nd ref="-276"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-245"/>
-        <nd ref="-244"/>
-        <nd ref="-268"/>
+    <way visible="true" id="-142139" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-267"/>
+        <nd ref="-266"/>
+        <nd ref="-290"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
     </way>
-    <way visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-256"/>
-        <nd ref="-243"/>
-        <nd ref="-242"/>
-        <nd ref="-241"/>
-        <nd ref="-240"/>
-        <nd ref="-254"/>
+    <way visible="true" id="-142138" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-278"/>
+        <nd ref="-265"/>
+        <nd ref="-264"/>
+        <nd ref="-263"/>
+        <nd ref="-262"/>
+        <nd ref="-276"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-254"/>
-        <nd ref="-239"/>
-        <nd ref="-251"/>
+    <way visible="true" id="-142137" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-276"/>
+        <nd ref="-261"/>
+        <nd ref="-273"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-236"/>
-        <nd ref="-235"/>
-        <nd ref="-256"/>
+    <way visible="true" id="-142136" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-258"/>
+        <nd ref="-257"/>
+        <nd ref="-278"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
-    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-251"/>
-        <nd ref="-234"/>
-        <nd ref="-268"/>
+    <way visible="true" id="-142135" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-273"/>
+        <nd ref="-256"/>
+        <nd ref="-290"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>
         <tag k="source:datetime" v="2012-07-10T17:03:24Z"/>
         <tag k="bdw-id" v="{8d570128-1cda-4e73-ae68-a45e8ea56df2}"/>
     </way>
-    <way visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-233"/>
-        <nd ref="-232"/>
-        <nd ref="-231"/>
+    <way visible="true" id="-142134" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-255"/>
+        <nd ref="-254"/>
+        <nd ref="-253"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-230"/>
-        <nd ref="-229"/>
-        <nd ref="-228"/>
+    <way visible="true" id="-142133" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-252"/>
+        <nd ref="-251"/>
+        <nd ref="-250"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-227"/>
-        <nd ref="-226"/>
-        <nd ref="-225"/>
+    <way visible="true" id="-142132" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-249"/>
+        <nd ref="-248"/>
+        <nd ref="-247"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{9cbc6adc-20c7-4565-a103-a9cc523d8c95}"/>
     </way>
-    <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-253"/>
-        <nd ref="-221"/>
-        <nd ref="-245"/>
+    <way visible="true" id="-142130" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-275"/>
+        <nd ref="-243"/>
+        <nd ref="-267"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-220"/>
-        <nd ref="-219"/>
-        <nd ref="-218"/>
-        <nd ref="-217"/>
+    <way visible="true" id="-142129" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-242"/>
+        <nd ref="-241"/>
+        <nd ref="-240"/>
+        <nd ref="-239"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
     </way>
-    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
-        <nd ref="-215"/>
-        <nd ref="-214"/>
+    <way visible="true" id="-142128" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-238"/>
+        <nd ref="-237"/>
+        <nd ref="-236"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:16Z"/>
         <tag k="bdw-id" v="{ce5ed05b-ab6e-4533-becd-513a7bbb445a}"/>
     </way>
-    <way visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-205"/>
-        <nd ref="-204"/>
+    <way visible="true" id="-142127" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-227"/>
+        <nd ref="-226"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
-    <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142126" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-247"/>
         <nd ref="-225"/>
-        <nd ref="-203"/>
-        <nd ref="-202"/>
+        <nd ref="-224"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-227"/>
-        <nd ref="-200"/>
-        <nd ref="-199"/>
-        <nd ref="-198"/>
+    <way visible="true" id="-142125" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-249"/>
+        <nd ref="-222"/>
+        <nd ref="-221"/>
+        <nd ref="-220"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-228"/>
-        <nd ref="-197"/>
-        <nd ref="-196"/>
-        <nd ref="-225"/>
+    <way visible="true" id="-142124" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-250"/>
+        <nd ref="-219"/>
+        <nd ref="-218"/>
+        <nd ref="-247"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-195"/>
-        <nd ref="-194"/>
-        <nd ref="-193"/>
+    <way visible="true" id="-142123" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-217"/>
+        <nd ref="-216"/>
+        <nd ref="-215"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-161"/>
-        <nd ref="-160"/>
-        <nd ref="-159"/>
-        <nd ref="-195"/>
+    <way visible="true" id="-142120" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-183"/>
+        <nd ref="-182"/>
+        <nd ref="-181"/>
+        <nd ref="-217"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-158"/>
-        <nd ref="-157"/>
-        <nd ref="-156"/>
-        <nd ref="-155"/>
-        <nd ref="-154"/>
-        <nd ref="-153"/>
+    <way visible="true" id="-142119" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-180"/>
+        <nd ref="-179"/>
+        <nd ref="-178"/>
+        <nd ref="-177"/>
+        <nd ref="-176"/>
+        <nd ref="-175"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{6aa81513-dca3-45e8-9132-c60073bb31b1}"/>
     </way>
-    <way visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-245"/>
-        <nd ref="-152"/>
-        <nd ref="-151"/>
-        <nd ref="-150"/>
-        <nd ref="-149"/>
+    <way visible="true" id="-142118" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-267"/>
+        <nd ref="-174"/>
+        <nd ref="-173"/>
+        <nd ref="-172"/>
+        <nd ref="-171"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-193"/>
-        <nd ref="-148"/>
-        <nd ref="-147"/>
-        <nd ref="-217"/>
+    <way visible="true" id="-142117" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-215"/>
+        <nd ref="-170"/>
+        <nd ref="-169"/>
+        <nd ref="-239"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-146"/>
-        <nd ref="-145"/>
-        <nd ref="-236"/>
+    <way visible="true" id="-142116" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-168"/>
+        <nd ref="-167"/>
+        <nd ref="-258"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
         <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
     </way>
-    <way visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-193"/>
-        <nd ref="-144"/>
-        <nd ref="-143"/>
-        <nd ref="-142"/>
-        <nd ref="-233"/>
+    <way visible="true" id="-142115" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-215"/>
+        <nd ref="-166"/>
+        <nd ref="-165"/>
+        <nd ref="-164"/>
+        <nd ref="-255"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-10-26T16:12:18Z"/>
         <tag k="bdw-id" v="{23973f69-7830-4ee2-be77-9592a2c17bf3}"/>
     </way>
-    <way visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-228"/>
-        <nd ref="-193"/>
+    <way visible="true" id="-142114" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-250"/>
+        <nd ref="-215"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-208"/>
-        <nd ref="-141"/>
-        <nd ref="-140"/>
+    <way visible="true" id="-142113" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-230"/>
+        <nd ref="-163"/>
+        <nd ref="-162"/>
+        <nd ref="-252"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-208"/>
-        <nd ref="-139"/>
-        <nd ref="-138"/>
-        <nd ref="-137"/>
+    <way visible="true" id="-142112" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-230"/>
+        <nd ref="-161"/>
+        <nd ref="-160"/>
+        <nd ref="-159"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
     </way>
-    <way visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-137"/>
-        <nd ref="-136"/>
-        <nd ref="-228"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
-    </way>
-    <way visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142111" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-159"/>
         <nd ref="-158"/>
-        <nd ref="-135"/>
-        <nd ref="-134"/>
-        <nd ref="-133"/>
-        <nd ref="-132"/>
-        <nd ref="-161"/>
+        <nd ref="-250"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-161"/>
-        <nd ref="-123"/>
-        <nd ref="-122"/>
-        <nd ref="-121"/>
+    <way visible="true" id="-142110" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-180"/>
+        <nd ref="-157"/>
+        <nd ref="-156"/>
+        <nd ref="-155"/>
+        <nd ref="-154"/>
+        <nd ref="-183"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
+    </way>
+    <way visible="true" id="-142109" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-183"/>
+        <nd ref="-145"/>
+        <nd ref="-144"/>
+        <nd ref="-143"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
     </way>
-    <way visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-181"/>
-        <nd ref="-118"/>
-        <nd ref="-117"/>
-        <nd ref="-116"/>
-        <nd ref="-134"/>
+    <way visible="true" id="-142107" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-203"/>
+        <nd ref="-140"/>
+        <nd ref="-139"/>
+        <nd ref="-138"/>
+        <nd ref="-156"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{06fdfdf2-6ac0-45a9-8895-42ee0c3a20d1}"/>
     </way>
-    <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-121"/>
-        <nd ref="-115"/>
-        <nd ref="-114"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-142106" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-143"/>
+        <nd ref="-137"/>
+        <nd ref="-136"/>
+        <nd ref="-242"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{0e4a3555-a203-4f60-930f-2453ea55da17}"/>
     </way>
-    <way visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-236"/>
-        <nd ref="-113"/>
-        <nd ref="-112"/>
-        <nd ref="-250"/>
+    <way visible="true" id="-142105" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-258"/>
+        <nd ref="-135"/>
+        <nd ref="-134"/>
+        <nd ref="-272"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-224"/>
-        <nd ref="-111"/>
-        <nd ref="-110"/>
-        <nd ref="-250"/>
+    <way visible="true" id="-142104" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-246"/>
+        <nd ref="-133"/>
+        <nd ref="-132"/>
+        <nd ref="-272"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-104"/>
-        <nd ref="-103"/>
-        <nd ref="-102"/>
-        <nd ref="-137"/>
+    <way visible="true" id="-142102" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-159"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-104"/>
-        <nd ref="-100"/>
-        <nd ref="-158"/>
+    <way visible="true" id="-142101" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-126"/>
+        <nd ref="-122"/>
+        <nd ref="-180"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
-        <nd ref="-99"/>
-        <nd ref="-98"/>
-        <nd ref="-253"/>
+    <way visible="true" id="-142100" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-238"/>
+        <nd ref="-121"/>
+        <nd ref="-120"/>
+        <nd ref="-275"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
-    <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-182"/>
-        <nd ref="-97"/>
-        <nd ref="-224"/>
-        <nd ref="-223"/>
-        <nd ref="-222"/>
-        <nd ref="-120"/>
+    <way visible="true" id="-142099" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-204"/>
         <nd ref="-119"/>
-        <nd ref="-214"/>
+        <nd ref="-246"/>
+        <nd ref="-245"/>
+        <nd ref="-244"/>
+        <nd ref="-142"/>
+        <nd ref="-141"/>
+        <nd ref="-236"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-250"/>
-        <nd ref="-96"/>
-        <nd ref="-253"/>
+    <way visible="true" id="-142098" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-272"/>
+        <nd ref="-118"/>
+        <nd ref="-275"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-222"/>
-        <nd ref="-95"/>
-        <nd ref="-94"/>
-        <nd ref="-93"/>
-        <nd ref="-216"/>
+    <way visible="true" id="-142097" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-244"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-115"/>
+        <nd ref="-238"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-195"/>
-        <nd ref="-91"/>
-        <nd ref="-90"/>
-        <nd ref="-89"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-142096" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-217"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-242"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{b63b8bca-9850-40b8-a253-3bbd2aca3dd2}"/>
     </way>
-    <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
+    <way visible="true" id="-142095" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-238"/>
+        <nd ref="-110"/>
+        <nd ref="-109"/>
+        <nd ref="-108"/>
+        <nd ref="-107"/>
+        <nd ref="-106"/>
+        <nd ref="-105"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-171"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="name" v="Avenida 12"/>
+        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
+        <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
+    </way>
+    <way visible="true" id="-142094" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-239"/>
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-99"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
+        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
+    </way>
+    <way visible="true" id="-142093" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-98"/>
+        <nd ref="-249"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
+    </way>
+    <way visible="true" id="-142092" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-204"/>
+        <nd ref="-97"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
+        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
+    </way>
+    <way visible="true" id="-142091" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-255"/>
+        <nd ref="-92"/>
+        <nd ref="-91"/>
+        <nd ref="-90"/>
+        <nd ref="-89"/>
         <nd ref="-88"/>
         <nd ref="-87"/>
         <nd ref="-86"/>
@@ -1623,359 +1671,311 @@
         <nd ref="-84"/>
         <nd ref="-83"/>
         <nd ref="-82"/>
-        <nd ref="-81"/>
-        <nd ref="-149"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="name" v="Avenida 12"/>
-        <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
-        <tag k="bdw-id" v="{8986acfd-bf44-4e51-9398-980476ee46f3}"/>
-    </way>
-    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-217"/>
-        <nd ref="-80"/>
-        <nd ref="-79"/>
-        <nd ref="-78"/>
-        <nd ref="-77"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
-        <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
-    </way>
-    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-76"/>
-        <nd ref="-227"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="bdw-id" v="{0960eee7-2323-45b4-9d55-ff8c611e36ad}"/>
-    </way>
-    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-182"/>
-        <nd ref="-75"/>
-        <nd ref="-146"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="highway" v="residential"/>
-        <tag k="source:datetime" v="2012-07-10T15:32:23Z"/>
-        <tag k="bdw-id" v="{e7159cc3-10a3-4162-bd74-91a42efcf54a}"/>
-    </way>
-    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-233"/>
-        <nd ref="-70"/>
-        <nd ref="-69"/>
-        <nd ref="-68"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-64"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-61"/>
-        <nd ref="-60"/>
-        <nd ref="-217"/>
+        <nd ref="-239"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z;2012-07-12T16:14:18Z"/>
         <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
     </way>
-    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-230"/>
-        <nd ref="-59"/>
-        <nd ref="-58"/>
-        <nd ref="-227"/>
+    <way visible="true" id="-142090" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-252"/>
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-249"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-202"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-233"/>
+    <way visible="true" id="-142089" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-224"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-255"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{60de46a5-bb9b-48ea-b3b9-abdd7e0438d5}"/>
     </way>
-    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-204"/>
-        <nd ref="-55"/>
-        <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-104"/>
+    <way visible="true" id="-142088" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-226"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-126"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
-    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-161"/>
-        <nd ref="-48"/>
-        <nd ref="-47"/>
-        <nd ref="-46"/>
-        <nd ref="-174"/>
+    <way visible="true" id="-142086" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-183"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-196"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="source:datetime" v="2013-12-04T07:47:26Z"/>
         <tag k="bdw-id" v="{d1b83733-2e73-430d-a3c0-1327c4352912}"/>
     </way>
-    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-149"/>
-        <nd ref="-43"/>
-        <nd ref="-42"/>
-        <nd ref="-41"/>
-        <nd ref="-40"/>
-        <nd ref="-39"/>
-        <nd ref="-258"/>
+    <way visible="true" id="-142085" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-171"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-280"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
-    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-178"/>
-        <nd ref="-132"/>
+    <way visible="true" id="-142084" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-200"/>
+        <nd ref="-154"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{94c9cf4a-94e3-4fc4-9d48-0d3b7c7055e3}"/>
     </way>
-    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22"/>
-        <nd ref="-38"/>
-        <nd ref="-37"/>
-        <nd ref="-36"/>
-        <nd ref="-35"/>
-        <nd ref="-34"/>
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-25"/>
-        <nd ref="-24"/>
-        <nd ref="-23"/>
-        <nd ref="-220"/>
+    <way visible="true" id="-142083" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-44"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-242"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:24:57Z;2012-07-12T16:14:19Z;2012-07-12T16:24:56Z"/>
         <tag k="bdw-id" v="{d6bb5ef0-cba5-4f65-bb54-309479757568}"/>
     </way>
-    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21"/>
-        <nd ref="-49"/>
-        <nd ref="-44"/>
-        <nd ref="-50"/>
+    <way visible="true" id="-142082" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-43"/>
+        <nd ref="-71"/>
+        <nd ref="-66"/>
+        <nd ref="-72"/>
         <tag k="hoot:status" v="1"/>
         <tag k="highway" v="road"/>
         <tag k="bdw-id" v="{97de30bd-cf94-4781-9242-24a38ad7d345}"/>
     </way>
-    <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-260"/>
-        <nd ref="-50"/>
-        <nd ref="-45"/>
-        <nd ref="-20"/>
+    <way visible="true" id="-142081" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-282"/>
+        <nd ref="-72"/>
+        <nd ref="-67"/>
+        <nd ref="-42"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida Los Leones"/>
         <tag k="source:datetime" v="2013-10-26T16:12:11Z"/>
         <tag k="bdw-id" v="{be45bbff-72c6-44ab-865d-da9ccb9aeb14}"/>
     </way>
-    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-19"/>
-        <nd ref="-49"/>
+    <way visible="true" id="-142080" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-41"/>
+        <nd ref="-71"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{6e1509b9-a960-4bd6-845e-6ac143dc8d18}"/>
     </way>
-    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-18"/>
-        <nd ref="-51"/>
-        <nd ref="-204"/>
+    <way visible="true" id="-142079" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-40"/>
+        <nd ref="-73"/>
+        <nd ref="-226"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{efc93331-7a05-42f4-a7fc-78ab5793d04d}"/>
     </way>
-    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-121"/>
-        <nd ref="-74"/>
-        <nd ref="-73"/>
-        <nd ref="-72"/>
-        <nd ref="-71"/>
-        <nd ref="-17"/>
+    <way visible="true" id="-142078" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-143"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-93"/>
+        <nd ref="-39"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z;2012-07-12T16:24:57Z"/>
         <tag k="bdw-id" v="{5e17d515-6288-4493-9e60-c6039b5fce66}"/>
     </way>
-    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-16"/>
-        <nd ref="-92"/>
-        <nd ref="-236"/>
+    <way visible="true" id="-142077" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38"/>
+        <nd ref="-114"/>
+        <nd ref="-258"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 10"/>
         <tag k="source:datetime" v="2013-11-11T14:00:58Z"/>
         <tag k="bdw-id" v="{efdc47f0-b9fa-48e7-b7a1-d5bee0cd35d8}"/>
     </way>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-101"/>
-        <nd ref="-146"/>
+    <way visible="true" id="-142076" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-37"/>
+        <nd ref="-123"/>
+        <nd ref="-168"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 11"/>
         <tag k="source:datetime" v="2012-07-10T17:03:23Z"/>
         <tag k="bdw-id" v="{d3f5dac4-74c6-42fe-b0bf-bad11de41657}"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-14"/>
-        <nd ref="-131"/>
-        <nd ref="-130"/>
-        <nd ref="-129"/>
-        <nd ref="-128"/>
-        <nd ref="-127"/>
-        <nd ref="-126"/>
-        <nd ref="-125"/>
-        <nd ref="-124"/>
-        <nd ref="-181"/>
+    <way visible="true" id="-142075" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36"/>
+        <nd ref="-153"/>
+        <nd ref="-152"/>
+        <nd ref="-151"/>
+        <nd ref="-150"/>
+        <nd ref="-149"/>
+        <nd ref="-148"/>
+        <nd ref="-147"/>
+        <nd ref="-146"/>
+        <nd ref="-203"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{6cdcf24d-4846-4e30-9360-c782f3239ee5}"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-208"/>
+    <way visible="true" id="-142074" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-35"/>
+        <nd ref="-230"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:19Z"/>
         <tag k="bdw-id" v="{260cc32c-6acc-4c50-b63e-6eeec120615b}"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-181"/>
-        <nd ref="-180"/>
-        <nd ref="-179"/>
-        <nd ref="-178"/>
-        <nd ref="-177"/>
-        <nd ref="-176"/>
-        <nd ref="-175"/>
-        <nd ref="-174"/>
+    <way visible="true" id="-142073" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-203"/>
+        <nd ref="-202"/>
+        <nd ref="-201"/>
+        <nd ref="-200"/>
+        <nd ref="-199"/>
+        <nd ref="-198"/>
+        <nd ref="-197"/>
+        <nd ref="-196"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{b467cee0-609e-473f-8127-a9f37fd29840}"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-183"/>
-        <nd ref="-182"/>
+    <way visible="true" id="-142072" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33"/>
+        <nd ref="-205"/>
+        <nd ref="-204"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="secondary"/>
         <tag k="name" v="Avenida 12"/>
         <tag k="source:datetime" v="2013-10-26T16:12:21Z"/>
         <tag k="bdw-id" v="{8a1fd2bd-e512-4b92-9a5c-37688bf5241b}"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-186"/>
-        <nd ref="-185"/>
-        <nd ref="-184"/>
-        <nd ref="-205"/>
+    <way visible="true" id="-142071" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32"/>
+        <nd ref="-208"/>
+        <nd ref="-207"/>
+        <nd ref="-206"/>
+        <nd ref="-227"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{45f42e2c-f3f1-4fbe-a174-6cb6857349fe}"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-205"/>
-        <nd ref="-187"/>
-        <nd ref="-9"/>
+    <way visible="true" id="-142070" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-227"/>
+        <nd ref="-209"/>
+        <nd ref="-31"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:17Z"/>
         <tag k="bdw-id" v="{e1882670-308b-4243-9802-b0f59e00fcd8}"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-258"/>
-        <nd ref="-201"/>
-        <nd ref="-8"/>
+    <way visible="true" id="-142069" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-280"/>
+        <nd ref="-223"/>
+        <nd ref="-30"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:30:24Z"/>
         <tag k="bdw-id" v="{841e511f-12b8-465b-8dcf-3f2e88245c4f}"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-7"/>
-        <nd ref="-207"/>
-        <nd ref="-206"/>
-        <nd ref="-230"/>
+    <way visible="true" id="-142068" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="-229"/>
+        <nd ref="-228"/>
+        <nd ref="-252"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-12T16:14:21Z"/>
         <tag k="bdw-id" v="{f91dbab1-668f-46c8-9e15-8682f41aa02f}"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-6"/>
-        <nd ref="-213"/>
-        <nd ref="-212"/>
-        <nd ref="-211"/>
-        <nd ref="-210"/>
-        <nd ref="-209"/>
-        <nd ref="-208"/>
+    <way visible="true" id="-142067" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-235"/>
+        <nd ref="-234"/>
+        <nd ref="-233"/>
+        <nd ref="-232"/>
+        <nd ref="-231"/>
+        <nd ref="-230"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:20Z"/>
         <tag k="bdw-id" v="{3c7f6574-477c-46c6-89b0-71e0ed7944b8}"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-256"/>
-        <nd ref="-237"/>
-        <nd ref="-5"/>
+    <way visible="true" id="-142066" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-278"/>
+        <nd ref="-259"/>
+        <nd ref="-27"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Calle 16"/>
         <tag k="source:datetime" v="2012-07-10T17:03:25Z"/>
         <tag k="bdw-id" v="{7b9e474f-b2b4-4427-bae9-a57622382722}"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-251"/>
-        <nd ref="-238"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-142065" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-273"/>
+        <nd ref="-260"/>
+        <nd ref="-26"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-13T01:28:03Z"/>
         <tag k="bdw-id" v="{28cdb02b-9f22-4d16-93ea-7bcf3230d333}"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-142064" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-290"/>
         <nd ref="-268"/>
-        <nd ref="-246"/>
-        <nd ref="-3"/>
+        <nd ref="-25"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T15:32:21Z"/>
         <tag k="bdw-id" v="{2809ebbe-7b86-4049-a8dc-d5f32d26d181}"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-255"/>
-        <nd ref="-254"/>
+    <way visible="true" id="-142063" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24"/>
+        <nd ref="-277"/>
+        <nd ref="-276"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="source:datetime" v="2012-07-10T16:22:23Z"/>
         <tag k="bdw-id" v="{ef7b4cf9-7bd7-4c8b-af43-343bb12118f2}"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-257"/>
-        <nd ref="-256"/>
+    <way visible="true" id="-142062" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23"/>
+        <nd ref="-279"/>
+        <nd ref="-278"/>
         <tag k="hoot:status" v="3"/>
         <tag k="highway" v="residential"/>
         <tag k="name" v="Avenida 9"/>

--- a/test-files/cases/attribute/unifying/highway-2927-multiple-types-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-multiple-types-1/Expected.osm
@@ -1,651 +1,627 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.5063" minlon="-66.90266" maxlat="10.50933" maxlon="-66.89794699999999"/>
-    <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075377200199984" lon="-66.8999424799399947">
+    <node visible="true" id="-220" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075377200199984" lon="-66.8999424799399947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073352537799973" lon="-66.8990133738400061">
+    <node visible="true" id="-219" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073352537799973" lon="-66.8990133738400061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072683640099989" lon="-66.8990233080599950">
+    <node visible="true" id="-218" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072683640099989" lon="-66.8990233080599950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072011718899994" lon="-66.8990308773600049">
+    <node visible="true" id="-217" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072011718899994" lon="-66.8990308773600049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071682123500008" lon="-66.8990337162099991">
+    <node visible="true" id="-216" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071682123500008" lon="-66.8990337162099991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071000859000012" lon="-66.8990379307799969">
+    <node visible="true" id="-215" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5071000859000012" lon="-66.8990379307799969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070321465099976" lon="-66.8990445452599971">
+    <node visible="true" id="-214" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5070321465099976" lon="-66.8990445452599971">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069644769599986" lon="-66.8990535515700060">
+    <node visible="true" id="-213" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069644769599986" lon="-66.8990535515700060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068971596799976" lon="-66.8990649387500014">
+    <node visible="true" id="-212" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068971596799976" lon="-66.8990649387500014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068302767099979" lon="-66.8990786929099954">
+    <node visible="true" id="-211" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068302767099979" lon="-66.8990786929099954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067639095099956" lon="-66.8990947973099992">
+    <node visible="true" id="-210" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067639095099956" lon="-66.8990947973099992">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066981389500000" lon="-66.8991132323200048">
+    <node visible="true" id="-209" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066981389500000" lon="-66.8991132323200048">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066330451599992" lon="-66.8991339754799839">
+    <node visible="true" id="-208" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066330451599992" lon="-66.8991339754799839">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065991354400001" lon="-66.8991457931099944">
+    <node visible="true" id="-207" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065991354400001" lon="-66.8991457931099944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065369998999980" lon="-66.8991808702199791">
+    <node visible="true" id="-206" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065369998999980" lon="-66.8991808702199791">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064761136999998" lon="-66.8992181171399949">
+    <node visible="true" id="-205" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064761136999998" lon="-66.8992181171399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064165510099983" lon="-66.8992574884999840">
+    <node visible="true" id="-204" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064165510099983" lon="-66.8992574884999840">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063583844000004" lon="-66.8992989363299984">
+    <node visible="true" id="-203" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063583844000004" lon="-66.8992989363299984">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063016847399968" lon="-66.8993424101299894">
+    <node visible="true" id="-202" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063016847399968" lon="-66.8993424101299894">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080110682999983" lon="-66.9023204815299977">
+    <node visible="true" id="-201" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080110682999983" lon="-66.9023204815299977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080157422199978" lon="-66.9023084269200012">
+    <node visible="true" id="-200" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080157422199978" lon="-66.9023084269200012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080198679799981" lon="-66.9022961697200031">
+    <node visible="true" id="-199" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080198679799981" lon="-66.9022961697200031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080234370099976" lon="-66.9022837353600011">
+    <node visible="true" id="-198" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080234370099976" lon="-66.9022837353600011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080264419200002" lon="-66.9022711496699998">
+    <node visible="true" id="-197" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080264419200002" lon="-66.9022711496699998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080288764500001" lon="-66.9022584387400059">
+    <node visible="true" id="-196" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080288764500001" lon="-66.9022584387400059">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080307355600002" lon="-66.9022456289699790">
+    <node visible="true" id="-195" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080307355600002" lon="-66.9022456289699790">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080320153899986" lon="-66.9022327469400011">
+    <node visible="true" id="-194" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080320153899986" lon="-66.9022327469400011">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080327132899995" lon="-66.9022198193700035">
+    <node visible="true" id="-193" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080327132899995" lon="-66.9022198193700035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080328278100001" lon="-66.9022068730999990">
+    <node visible="true" id="-192" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080328278100001" lon="-66.9022068730999990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080323586999977" lon="-66.9021939349899952">
+    <node visible="true" id="-191" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080323586999977" lon="-66.9021939349899952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080313069499987" lon="-66.9021810318999997">
+    <node visible="true" id="-190" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080313069499987" lon="-66.9021810318999997">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080296747399977" lon="-66.9021681905900039">
+    <node visible="true" id="-189" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080296747399977" lon="-66.9021681905900039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080274654399997" lon="-66.9021554377300021">
+    <node visible="true" id="-188" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080274654399997" lon="-66.9021554377300021">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077602018099991" lon="-66.9019608399800063">
+    <node visible="true" id="-187" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077602018099991" lon="-66.9019608399800063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072674942200024" lon="-66.9016812216199952">
+    <node visible="true" id="-186" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072674942200024" lon="-66.9016812216199952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067556583899986" lon="-66.9013769333299990">
+    <node visible="true" id="-185" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067556583899986" lon="-66.9013769333299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073261783799996" lon="-66.8987263520100015">
+    <node visible="true" id="-184" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073261783799996" lon="-66.8987263520100015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072803441799998" lon="-66.8984187934499914">
+    <node visible="true" id="-183" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072803441799998" lon="-66.8984187934499914">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066152618600004" lon="-66.8984401191300009">
+    <node visible="true" id="-182" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066152618600004" lon="-66.8984401191300009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089760357599982" lon="-66.9011001908299932">
+    <node visible="true" id="-181" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089760357599982" lon="-66.9011001908299932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084638829199992" lon="-66.9006832217600049">
+    <node visible="true" id="-180" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084638829199992" lon="-66.9006832217600049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084490193099978" lon="-66.9006774795900014">
+    <node visible="true" id="-179" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084490193099978" lon="-66.9006774795900014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084339664399984" lon="-66.9006722650899945">
+    <node visible="true" id="-178" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084339664399984" lon="-66.9006722650899945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084187426400000" lon="-66.9006675846000007">
+    <node visible="true" id="-177" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084187426400000" lon="-66.9006675846000007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084033664499987" lon="-66.9006634438400027">
+    <node visible="true" id="-176" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084033664499987" lon="-66.9006634438400027">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083878566299962" lon="-66.9006598478399894">
+    <node visible="true" id="-175" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083878566299962" lon="-66.9006598478399894">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083722320499984" lon="-66.9006568009799878">
+    <node visible="true" id="-174" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083722320499984" lon="-66.9006568009799878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083565117600006" lon="-66.9006543069800017">
+    <node visible="true" id="-173" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083565117600006" lon="-66.9006543069800017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083407149099983" lon="-66.9006523688800030">
+    <node visible="true" id="-172" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083407149099983" lon="-66.9006523688800030">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083248607400002" lon="-66.9006509890400025">
+    <node visible="true" id="-171" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083248607400002" lon="-66.9006509890400025">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083089685799980" lon="-66.9006501691300031">
+    <node visible="true" id="-170" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083089685799980" lon="-66.9006501691300031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082930577799978" lon="-66.9006499101599985">
+    <node visible="true" id="-169" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082930577799978" lon="-66.9006499101599985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082771477199994" lon="-66.9006502124399987">
+    <node visible="true" id="-168" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082771477199994" lon="-66.9006502124399987">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082595245399979" lon="-66.9006512038099999">
+    <node visible="true" id="-167" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082595245399979" lon="-66.9006512038099999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074846600500003" lon="-66.9007861025600050">
+    <node visible="true" id="-166" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074846600500003" lon="-66.9007861025600050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067216292700003" lon="-66.9009464602499975">
+    <node visible="true" id="-165" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067216292700003" lon="-66.9009464602499975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066933640299993" lon="-66.9009582118199972">
+    <node visible="true" id="-164" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066933640299993" lon="-66.9009582118199972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066655218899978" lon="-66.9009709529899936">
+    <node visible="true" id="-163" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066655218899978" lon="-66.9009709529899936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066381367599977" lon="-66.9009846682399996">
+    <node visible="true" id="-162" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066381367599977" lon="-66.9009846682399996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066112420100026" lon="-66.9009993408800057">
+    <node visible="true" id="-161" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066112420100026" lon="-66.9009993408800057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065848703999976" lon="-66.9010149530000007">
+    <node visible="true" id="-160" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065848703999976" lon="-66.9010149530000007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065590540699976" lon="-66.9010314856100052">
+    <node visible="true" id="-159" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065590540699976" lon="-66.9010314856100052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065338244599982" lon="-66.9010489185500035">
+    <node visible="true" id="-158" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065338244599982" lon="-66.9010489185500035">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065092123199975" lon="-66.9010672305900016">
+    <node visible="true" id="-157" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065092123199975" lon="-66.9010672305900016">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064852476399988" lon="-66.9010863994100049">
+    <node visible="true" id="-156" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064852476399988" lon="-66.9010863994100049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064619595999975" lon="-66.9011064016600017">
+    <node visible="true" id="-155" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064619595999975" lon="-66.9011064016600017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064393765799995" lon="-66.9011272129699961">
+    <node visible="true" id="-154" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064393765799995" lon="-66.9011272129699961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064175260899990" lon="-66.9011488079799932">
+    <node visible="true" id="-153" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064175260899990" lon="-66.9011488079799932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064042021799988" lon="-66.9011627459599936">
+    <node visible="true" id="-152" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064042021799988" lon="-66.9011627459599936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063870420499974" lon="-66.9012000042399961">
+    <node visible="true" id="-151" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063870420499974" lon="-66.9012000042399961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063726633800005" lon="-66.9012384457499962">
+    <node visible="true" id="-150" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063726633800005" lon="-66.9012384457499962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063611453199997" lon="-66.9012778588000003">
+    <node visible="true" id="-149" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063611453199997" lon="-66.9012778588000003">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063525512999991" lon="-66.9013180263899869">
+    <node visible="true" id="-148" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063525512999991" lon="-66.9013180263899869">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063469286300002" lon="-66.9013587273300061">
+    <node visible="true" id="-147" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063469286300002" lon="-66.9013587273300061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063443082899983" lon="-66.9013997375199949">
+    <node visible="true" id="-146" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063443082899983" lon="-66.9013997375199949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063447046999983" lon="-66.9014408311499977">
+    <node visible="true" id="-145" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063447046999983" lon="-66.9014408311499977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063481156700007" lon="-66.9014817819400065">
+    <node visible="true" id="-144" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063481156700007" lon="-66.9014817819400065">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063545224200006" lon="-66.9015223644099990">
+    <node visible="true" id="-143" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063545224200006" lon="-66.9015223644099990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063638896899985" lon="-66.9015623550899932">
+    <node visible="true" id="-142" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063638896899985" lon="-66.9015623550899932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063761658800008" lon="-66.9016015337900001">
+    <node visible="true" id="-141" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063761658800008" lon="-66.9016015337900001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063912833999993" lon="-66.9016396847899983">
+    <node visible="true" id="-140" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5063912833999993" lon="-66.9016396847899983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064091590199986" lon="-66.9016765979999946">
+    <node visible="true" id="-139" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064091590199986" lon="-66.9016765979999946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064296942999995" lon="-66.9017120701799968">
+    <node visible="true" id="-138" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064296942999995" lon="-66.9017120701799968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064527761799980" lon="-66.9017459059999879">
+    <node visible="true" id="-137" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064527761799980" lon="-66.9017459059999879">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069241426099982" lon="-66.9024637357100005">
+    <node visible="true" id="-136" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069241426099982" lon="-66.9024637357100005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069578427000003" lon="-66.9025617388099789">
+    <node visible="true" id="-135" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069578427000003" lon="-66.9025617388099789">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085585902499989" lon="-66.9016759834800041">
+    <node visible="true" id="-134" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085585902499989" lon="-66.9016759834800041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075739353999982" lon="-66.9000768396799970">
+    <node visible="true" id="-133" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075739353999982" lon="-66.9000768396799970">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082147958999990" lon="-66.9025298977699805">
+    <node visible="true" id="-132" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082147958999990" lon="-66.9025298977699805">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080246836499995" lon="-66.9021427997700044">
+    <node visible="true" id="-131" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080246836499995" lon="-66.9021427997700044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081916148999976" lon="-66.9021967271600033">
+    <node visible="true" id="-130" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081916148999976" lon="-66.9021967271600033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082880034400006" lon="-66.9022063841899950">
+    <node visible="true" id="-129" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082880034400006" lon="-66.9022063841899950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080058559099996" lon="-66.9023323085500010">
+    <node visible="true" id="-128" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080058559099996" lon="-66.9023323085500010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082208136300004" lon="-66.9023667924499961">
+    <node visible="true" id="-127" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082208136300004" lon="-66.9023667924499961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078633333099969" lon="-66.9023475808800043">
+    <node visible="true" id="-126" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078633333099969" lon="-66.9023475808800043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069272716599986" lon="-66.9024728352599993">
+    <node visible="true" id="-125" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5069272716599986" lon="-66.9024728352599993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068978317999964" lon="-66.9024770390499839">
+    <node visible="true" id="-124" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068978317999964" lon="-66.9024770390499839">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068682494899992" lon="-66.9024800535400033">
+    <node visible="true" id="-123" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068682494899992" lon="-66.9024800535400033">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068385717700004" lon="-66.9024818739499807">
+    <node visible="true" id="-122" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068385717700004" lon="-66.9024818739499807">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068088458200002" lon="-66.9024824973800065">
+    <node visible="true" id="-121" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5068088458200002" lon="-66.9024824973800065">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067791188999990" lon="-66.9024819228500007">
+    <node visible="true" id="-120" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067791188999990" lon="-66.9024819228500007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067494382799982" lon="-66.9024801512699980">
+    <node visible="true" id="-119" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067494382799982" lon="-66.9024801512699980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067198511599980" lon="-66.9024771854400058">
+    <node visible="true" id="-118" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067198511599980" lon="-66.9024771854400058">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066904045599987" lon="-66.9024730300999977">
+    <node visible="true" id="-117" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066904045599987" lon="-66.9024730300999977">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066611453200007" lon="-66.9024676918500063">
+    <node visible="true" id="-116" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066611453200007" lon="-66.9024676918500063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066321199499981" lon="-66.9024611791700039">
+    <node visible="true" id="-115" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066321199499981" lon="-66.9024611791700039">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066033745999992" lon="-66.9024535024200020">
+    <node visible="true" id="-114" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5066033745999992" lon="-66.9024535024200020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065749549799996" lon="-66.9024446738000051">
+    <node visible="true" id="-113" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065749549799996" lon="-66.9024446738000051">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065469062699979" lon="-66.9024347073599870">
+    <node visible="true" id="-112" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065469062699979" lon="-66.9024347073599870">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065192730599986" lon="-66.9024236189400057">
+    <node visible="true" id="-111" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5065192730599986" lon="-66.9024236189400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064920992999991" lon="-66.9024114261700049">
+    <node visible="true" id="-110" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064920992999991" lon="-66.9024114261700049">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079992294599975" lon="-66.8988626414400045">
+    <node visible="true" id="-109" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079992294599975" lon="-66.8988626414400045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077623694300009" lon="-66.8989987836200015">
+    <node visible="true" id="-108" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077623694300009" lon="-66.8989987836200015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076509287499977" lon="-66.8990451847499941">
+    <node visible="true" id="-107" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076509287499977" lon="-66.8990451847499941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076327100599993" lon="-66.8990532784499976">
+    <node visible="true" id="-106" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076327100599993" lon="-66.8990532784499976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076153222500022" lon="-66.8990630618999944">
+    <node visible="true" id="-105" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076153222500022" lon="-66.8990630618999944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075989183999976" lon="-66.8990744489599933">
+    <node visible="true" id="-104" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075989183999976" lon="-66.8990744489599933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075836429000002" lon="-66.8990873393999976">
+    <node visible="true" id="-103" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075836429000002" lon="-66.8990873393999976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075696302299981" lon="-66.8991016197300041">
+    <node visible="true" id="-102" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075696302299981" lon="-66.8991016197300041">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075570037400006" lon="-66.8991171642500007">
+    <node visible="true" id="-101" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075570037400006" lon="-66.8991171642500007">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075458745900008" lon="-66.8991338361200008">
+    <node visible="true" id="-100" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075458745900008" lon="-66.8991338361200008">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075363407599998" lon="-66.8991514885699985">
+    <node visible="true" id="-99" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075363407599998" lon="-66.8991514885699985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075284861499991" lon="-66.8991699662099961">
+    <node visible="true" id="-98" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075284861499991" lon="-66.8991699662099961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075223799299984" lon="-66.8991891063699882">
+    <node visible="true" id="-97" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075223799299984" lon="-66.8991891063699882">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075180758400002" lon="-66.8992087405599989">
+    <node visible="true" id="-96" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075180758400002" lon="-66.8992087405599989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075156117800006" lon="-66.8992286959399962">
+    <node visible="true" id="-95" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075156117800006" lon="-66.8992286959399962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075150094399987" lon="-66.8992487968399985">
+    <node visible="true" id="-94" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075150094399987" lon="-66.8992487968399985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075162741099994" lon="-66.8992688663099955">
+    <node visible="true" id="-93" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075162741099994" lon="-66.8992688663099955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075193946700001" lon="-66.8992887276699975">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075193946700001" lon="-66.8992887276699975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075177010099985" lon="-66.8993920471500019">
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075177010099985" lon="-66.8993920471500019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076342153300022" lon="-66.8999983574800012">
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076342153300022" lon="-66.8999983574800012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078674621299974" lon="-66.9008672305400012">
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078674621299974" lon="-66.9008672305400012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081310488200010" lon="-66.9019488675299954">
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081310488200010" lon="-66.9019488675299954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076487450999974" lon="-66.9000524823700005">
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076487450999974" lon="-66.9000524823700005">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077129303400003" lon="-66.9000381607200012">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077129303400003" lon="-66.9000381607200012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085709374999983" lon="-66.8998653134499932">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085709374999983" lon="-66.8998653134499932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076185124599988" lon="-66.8999166434399939">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076185124599988" lon="-66.8999166434399939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076767757899994" lon="-66.8998738871599983">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076767757899994" lon="-66.8998738871599983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085450696200002" lon="-66.8997414667800001">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085450696200002" lon="-66.8997414667800001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091091437099990" lon="-66.9021158291200067">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091091437099990" lon="-66.9021158291200067">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088988646400008" lon="-66.9021110002500023">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088988646400008" lon="-66.9021110002500023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086704276400003" lon="-66.9021656548400045">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086704276400003" lon="-66.9021656548400045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083125509399959" lon="-66.9022836681899804">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083125509399959" lon="-66.9022836681899804">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088045681099977" lon="-66.9026277258600004">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088045681099977" lon="-66.9026277258600004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082851248800004" lon="-66.9023496594799951">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5082851248800004" lon="-66.9023496594799951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088878673099977" lon="-66.9000970889999991">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088878673099977" lon="-66.9000970889999991">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088469021400002" lon="-66.9000703169800062">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088469021400002" lon="-66.9000703169800062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088091845399987" lon="-66.9000390495800019">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088091845399987" lon="-66.9000390495800019">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087751952799984" lon="-66.9000036853699811">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087751952799984" lon="-66.9000036853699811">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087453675999960" lon="-66.8999646751099988">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087453675999960" lon="-66.8999646751099988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087200817199982" lon="-66.8999225160499975">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087200817199982" lon="-66.8999225160499975">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086996599300004" lon="-66.8998777455900040">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086996599300004" lon="-66.8998777455900040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086843625499977" lon="-66.8998309343899962">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086843625499977" lon="-66.8998309343899962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086771310000007" lon="-66.8997959613599846">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086771310000007" lon="-66.8997959613599846">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086743845699999" lon="-66.8997826791299985">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086743845699999" lon="-66.8997826791299985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086698531699980" lon="-66.8997335949199936">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086698531699980" lon="-66.8997335949199936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086708260999977" lon="-66.8996843073999941">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086708260999977" lon="-66.8996843073999941">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086772909799997" lon="-66.8996354448299968">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086772909799997" lon="-66.8996354448299968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086891653900025" lon="-66.8995876300299983">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086891653900025" lon="-66.8995876300299983">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087062979699990" lon="-66.8995414724900002">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087062979699990" lon="-66.8995414724900002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087284703399977" lon="-66.8994975605500031">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087284703399977" lon="-66.8994975605500031">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087553998799983" lon="-66.8994564539499947">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087553998799983" lon="-66.8994564539499947">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092547383599975" lon="-66.8988241885100052">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092547383599975" lon="-66.8988241885100052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091938274399990" lon="-66.9008290948000024">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091938274399990" lon="-66.9008290948000024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089872306800007" lon="-66.9011045272900020">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089872306800007" lon="-66.9011045272900020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078442156499978" lon="-66.8979469999999878">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078442156499978" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080166959699994" lon="-66.8979469999999878">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080166959699994" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079621843600020" lon="-66.8980172303800060">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079621843600020" lon="-66.8980172303800060">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073355844799998" lon="-66.8983959509299950">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073355844799998" lon="-66.8983959509299950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072800635700006" lon="-66.8983993553400040">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072800635700006" lon="-66.8983993553400040">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072735327399993" lon="-66.8979469999999878">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072735327399993" lon="-66.8979469999999878">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092991859399962" lon="-66.8979525441699963">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092991859399962" lon="-66.8979525441699963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092608681199984" lon="-66.8979827626999963">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092608681199984" lon="-66.8979827626999963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092215299599978" lon="-66.8980116115399994">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5092215299599978" lon="-66.8980116115399994">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091812193800003" lon="-66.8980390555200017">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091812193800003" lon="-66.8980390555200017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091399855100001" lon="-66.8980650612299996">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091399855100001" lon="-66.8980650612299996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091240928199969" lon="-66.8980745550099982">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091240928199969" lon="-66.8980745550099982">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084822232099988" lon="-66.8985161486299944">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084822232099988" lon="-66.8985161486299944">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083496723199996" lon="-66.8985560080299990">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5083496723199996" lon="-66.8985560080299990">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079699015599992" lon="-66.8987880248100026">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079699015599992" lon="-66.8987880248100026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079104082800008" lon="-66.8988204772399939">
+    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079104082800008" lon="-66.8988204772399939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078498304099988" lon="-66.8988508118599867">
+    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078498304099988" lon="-66.8988508118599867">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077882417299975" lon="-66.8988789917100064">
+    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077882417299975" lon="-66.8988789917100064">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077257173099987" lon="-66.8989049824500057">
+    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077257173099987" lon="-66.8989049824500057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076623333000008" lon="-66.8989287524299954">
+    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076623333000008" lon="-66.8989287524299954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075981669399976" lon="-66.8989502726900014">
+    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075981669399976" lon="-66.8989502726900014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075332963999983" lon="-66.8989695169999976">
+    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075332963999983" lon="-66.8989695169999976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074678007199971" lon="-66.8989864619200034">
+    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074678007199971" lon="-66.8989864619200034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074017596899996" lon="-66.8990010867999985">
+    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074017596899996" lon="-66.8990010867999985">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9012373024223024">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9012373024223024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9006735384839999">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9006735384839999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093300000000003" lon="-66.9003953972457026">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093300000000003" lon="-66.9003953972457026">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.8987901743431763">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.8987901743431763">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5088619095409896" lon="-66.9026599999999974">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5088619095409896" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9021468873523020">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5093299999999985" lon="-66.9021468873523020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9023145890520965">
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9023145890520965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082281497036991" lon="-66.9026599999999974">
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5082281497036991" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9003284747380604">
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9003284747380604">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5069729286564915" lon="-66.9026599999999974">
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5069729286564915" lon="-66.9026599999999974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999995" lon="-66.8984462481496678">
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999995" lon="-66.8984462481496678">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9011125992666820">
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.9011125992666820">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.8993437981101806">
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999978" lon="-66.8993437981101806">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999960" lon="-66.9001776895871814">
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5062999999999960" lon="-66.9001776895871814">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-113"/>
-        <nd ref="-71"/>
-        <nd ref="-72"/>
-        <nd ref="-70"/>
-        <nd ref="-73"/>
+    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-58"/>
+        <nd ref="-59"/>
+        <nd ref="-60"/>
+        <nd ref="-61"/>
+        <nd ref="-62"/>
+        <nd ref="-63"/>
+        <nd ref="-64"/>
+        <nd ref="-65"/>
+        <nd ref="-66"/>
         <nd ref="-67"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z;2019-01-17T19:50:05.698Z"/>
-        <tag k="highway" v="secondary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Caracas"/>
-        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e};{a7d782db-4c62-48d0-bf4c-962db1dd717d}"/>
-        <tag k="source:datetime" v="2015-06-03T13:47:09.000Z;2019-01-17T19:50:06Z;2013-09-16T04:28:30.000Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="3"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-41"/>
-        <nd ref="-42"/>
-        <nd ref="-43"/>
-        <nd ref="-44"/>
-        <nd ref="-45"/>
-        <nd ref="-46"/>
-        <nd ref="-47"/>
-        <nd ref="-48"/>
-        <nd ref="-49"/>
-        <nd ref="-50"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="30"/>
@@ -663,16 +639,15 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3"/>
-        <nd ref="-168"/>
-        <nd ref="-169"/>
-        <nd ref="-170"/>
-        <nd ref="-114"/>
-        <nd ref="-113"/>
-        <nd ref="-112"/>
-        <nd ref="-61"/>
-        <nd ref="-59"/>
+    <way visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20"/>
+        <nd ref="-185"/>
+        <nd ref="-186"/>
+        <nd ref="-187"/>
+        <nd ref="-131"/>
+        <nd ref="-130"/>
+        <nd ref="-129"/>
+        <nd ref="-78"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. La Estrella"/>
@@ -681,7 +656,7 @@
         <tag k="way_area" v="-999999"/>
         <tag k="lanes" v="3"/>
         <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{aacc4e7a-d622-499b-86c7-837fdbc1409e};{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{97c786e4-418b-41f2-95e9-de855060fd96};{bbd46957-74bf-4942-8ce7-cc9763ce1c89}"/>
+        <tag k="uuid" v="{aacc4e7a-d622-499b-86c7-837fdbc1409e};{5ee48c4d-213f-4ef9-84c5-9de9189b059d};{97c786e4-418b-41f2-95e9-de855060fd96}"/>
         <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="attribution" v="osm"/>
         <tag k="cycleway" v="no"/>
@@ -694,23 +669,23 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-114"/>
-        <nd ref="-171"/>
-        <nd ref="-172"/>
-        <nd ref="-173"/>
-        <nd ref="-174"/>
-        <nd ref="-175"/>
-        <nd ref="-176"/>
-        <nd ref="-177"/>
-        <nd ref="-178"/>
-        <nd ref="-179"/>
-        <nd ref="-180"/>
-        <nd ref="-181"/>
-        <nd ref="-182"/>
-        <nd ref="-183"/>
-        <nd ref="-184"/>
-        <nd ref="-111"/>
+    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-131"/>
+        <nd ref="-188"/>
+        <nd ref="-189"/>
+        <nd ref="-190"/>
+        <nd ref="-191"/>
+        <nd ref="-192"/>
+        <nd ref="-193"/>
+        <nd ref="-194"/>
+        <nd ref="-195"/>
+        <nd ref="-196"/>
+        <nd ref="-197"/>
+        <nd ref="-198"/>
+        <nd ref="-199"/>
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-128"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. del Parque"/>
@@ -732,10 +707,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-118"/>
-        <nd ref="-108"/>
+    <way visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22"/>
+        <nd ref="-135"/>
+        <nd ref="-125"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -752,10 +727,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-67"/>
-        <nd ref="-74"/>
-        <nd ref="-15"/>
+    <way visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-84"/>
+        <nd ref="-91"/>
+        <nd ref="-32"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -771,11 +746,34 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-15"/>
-        <nd ref="-167"/>
-        <nd ref="-166"/>
-        <nd ref="-34"/>
+    <way visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <nd ref="-87"/>
+        <nd ref="-90"/>
+        <nd ref="-84"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.702Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Caracas"/>
+        <tag k="uuid" v="{c3ebab6b-1ff5-4824-98c7-e1cb35e68b6e}"/>
+        <tag k="source:datetime" v="2015-06-03T13:47:09.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="3"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-32"/>
+        <nd ref="-184"/>
+        <nd ref="-183"/>
+        <nd ref="-51"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -791,10 +789,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-39"/>
-        <nd ref="-117"/>
-        <nd ref="-112"/>
+    <way visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-56"/>
+        <nd ref="-134"/>
+        <nd ref="-129"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Gamboa"/>
@@ -816,27 +814,63 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="residential"/>
     </way>
-    <way visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-74"/>
-        <nd ref="-75"/>
-        <nd ref="-76"/>
-        <nd ref="-77"/>
-        <nd ref="-78"/>
-        <nd ref="-79"/>
-        <nd ref="-80"/>
-        <nd ref="-81"/>
-        <nd ref="-82"/>
-        <nd ref="-83"/>
-        <nd ref="-84"/>
-        <nd ref="-85"/>
-        <nd ref="-86"/>
-        <nd ref="-87"/>
+    <way visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-130"/>
         <nd ref="-88"/>
-        <nd ref="-89"/>
-        <nd ref="-90"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z"/>
+        <tag k="highway" v="secondary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Caracas"/>
+        <tag k="uuid" v="{a7d782db-4c62-48d0-bf4c-962db1dd717d}"/>
+        <tag k="source:datetime" v="2013-09-16T04:28:30.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-76"/>
+        <nd ref="-78"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.698Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{bbd46957-74bf-4942-8ce7-cc9763ce1c89}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-91"/>
         <nd ref="-92"/>
-        <nd ref="-26"/>
+        <nd ref="-93"/>
+        <nd ref="-94"/>
+        <nd ref="-95"/>
+        <nd ref="-96"/>
+        <nd ref="-97"/>
+        <nd ref="-98"/>
+        <nd ref="-99"/>
+        <nd ref="-100"/>
+        <nd ref="-101"/>
+        <nd ref="-102"/>
+        <nd ref="-103"/>
+        <nd ref="-104"/>
+        <nd ref="-105"/>
+        <nd ref="-106"/>
+        <nd ref="-107"/>
+        <nd ref="-108"/>
+        <nd ref="-109"/>
+        <nd ref="-43"/>
         <tag k="maxspeed:conditional" v="110 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -870,11 +904,11 @@
         <tag k="destination" v="Cota Mil"/>
         <tag k="highway" v="motorway_link"/>
     </way>
-    <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-50"/>
-        <nd ref="-68"/>
-        <nd ref="-69"/>
-        <nd ref="-70"/>
+    <way visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-67"/>
+        <nd ref="-85"/>
+        <nd ref="-86"/>
+        <nd ref="-87"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -897,11 +931,11 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+    <way visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
         <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-50"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -924,9 +958,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-38"/>
-        <nd ref="-36"/>
+    <way visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-55"/>
+        <nd ref="-53"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -943,11 +977,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-37"/>
-        <nd ref="-36"/>
-        <nd ref="-35"/>
-        <nd ref="-34"/>
+    <way visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-54"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -964,9 +998,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-15" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-34"/>
-        <nd ref="-33"/>
+    <way visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-51"/>
+        <nd ref="-50"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -983,25 +1017,25 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-16"/>
-        <nd ref="-17"/>
-        <nd ref="-18"/>
-        <nd ref="-19"/>
-        <nd ref="-20"/>
-        <nd ref="-21"/>
-        <nd ref="-22"/>
-        <nd ref="-23"/>
-        <nd ref="-24"/>
-        <nd ref="-25"/>
-        <nd ref="-26"/>
-        <nd ref="-27"/>
-        <nd ref="-28"/>
-        <nd ref="-29"/>
-        <nd ref="-30"/>
-        <nd ref="-31"/>
+    <way visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1">
         <nd ref="-32"/>
+        <nd ref="-33"/>
+        <nd ref="-34"/>
+        <nd ref="-35"/>
+        <nd ref="-36"/>
+        <nd ref="-37"/>
+        <nd ref="-38"/>
+        <nd ref="-39"/>
+        <nd ref="-40"/>
+        <nd ref="-41"/>
+        <nd ref="-42"/>
+        <nd ref="-43"/>
+        <nd ref="-44"/>
+        <nd ref="-45"/>
+        <nd ref="-46"/>
+        <nd ref="-47"/>
+        <nd ref="-48"/>
+        <nd ref="-49"/>
         <tag k="maxspeed:conditional" v="110 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -1035,9 +1069,9 @@
         <tag k="destination" v="Cota Mil"/>
         <tag k="highway" v="motorway_link"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-39"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-56"/>
+        <nd ref="-31"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -1055,10 +1089,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-40"/>
-        <nd ref="-39"/>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Gamboa"/>
@@ -1080,17 +1114,17 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="residential"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-12"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-55"/>
-        <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-51"/>
-        <nd ref="-50"/>
+    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="30"/>
@@ -1108,11 +1142,11 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
-        <nd ref="-110"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-127"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Anauco"/>
@@ -1134,12 +1168,12 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-61"/>
-        <nd ref="-62"/>
-        <nd ref="-63"/>
-        <nd ref="-64"/>
-        <nd ref="-9"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-78"/>
+        <nd ref="-79"/>
+        <nd ref="-80"/>
+        <nd ref="-81"/>
+        <nd ref="-26"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1156,25 +1190,25 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-109"/>
-        <nd ref="-108"/>
-        <nd ref="-107"/>
-        <nd ref="-106"/>
-        <nd ref="-105"/>
-        <nd ref="-104"/>
-        <nd ref="-103"/>
-        <nd ref="-102"/>
-        <nd ref="-101"/>
-        <nd ref="-100"/>
-        <nd ref="-99"/>
-        <nd ref="-98"/>
-        <nd ref="-97"/>
-        <nd ref="-96"/>
-        <nd ref="-95"/>
-        <nd ref="-94"/>
-        <nd ref="-93"/>
-        <nd ref="-8"/>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-123"/>
+        <nd ref="-122"/>
+        <nd ref="-121"/>
+        <nd ref="-120"/>
+        <nd ref="-119"/>
+        <nd ref="-118"/>
+        <nd ref="-117"/>
+        <nd ref="-116"/>
+        <nd ref="-115"/>
+        <nd ref="-114"/>
+        <nd ref="-113"/>
+        <nd ref="-112"/>
+        <nd ref="-111"/>
+        <nd ref="-110"/>
+        <nd ref="-25"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1191,10 +1225,10 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-110"/>
-        <nd ref="-115"/>
-        <nd ref="-7"/>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-127"/>
+        <nd ref="-132"/>
+        <nd ref="-24"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="30"/>
@@ -1212,10 +1246,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-70"/>
-        <nd ref="-116"/>
-        <nd ref="-6"/>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-87"/>
+        <nd ref="-133"/>
+        <nd ref="-23"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -1238,25 +1272,8 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-108"/>
-        <nd ref="-119"/>
-        <nd ref="-120"/>
-        <nd ref="-121"/>
-        <nd ref="-122"/>
-        <nd ref="-123"/>
-        <nd ref="-124"/>
+    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-125"/>
-        <nd ref="-126"/>
-        <nd ref="-127"/>
-        <nd ref="-128"/>
-        <nd ref="-129"/>
-        <nd ref="-130"/>
-        <nd ref="-131"/>
-        <nd ref="-132"/>
-        <nd ref="-133"/>
-        <nd ref="-134"/>
-        <nd ref="-135"/>
         <nd ref="-136"/>
         <nd ref="-137"/>
         <nd ref="-138"/>
@@ -1286,7 +1303,24 @@
         <nd ref="-162"/>
         <nd ref="-163"/>
         <nd ref="-164"/>
-        <nd ref="-39"/>
+        <nd ref="-165"/>
+        <nd ref="-166"/>
+        <nd ref="-167"/>
+        <nd ref="-168"/>
+        <nd ref="-169"/>
+        <nd ref="-170"/>
+        <nd ref="-171"/>
+        <nd ref="-172"/>
+        <nd ref="-173"/>
+        <nd ref="-174"/>
+        <nd ref="-175"/>
+        <nd ref="-176"/>
+        <nd ref="-177"/>
+        <nd ref="-178"/>
+        <nd ref="-179"/>
+        <nd ref="-180"/>
+        <nd ref="-181"/>
+        <nd ref="-56"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1303,10 +1337,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-34"/>
-        <nd ref="-165"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-51"/>
+        <nd ref="-182"/>
+        <nd ref="-21"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1322,10 +1356,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-110"/>
-        <nd ref="-111"/>
-        <nd ref="-109"/>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-127"/>
+        <nd ref="-128"/>
+        <nd ref="-126"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1342,27 +1376,27 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-185"/>
-        <nd ref="-186"/>
-        <nd ref="-187"/>
-        <nd ref="-188"/>
-        <nd ref="-189"/>
-        <nd ref="-190"/>
-        <nd ref="-191"/>
-        <nd ref="-192"/>
-        <nd ref="-193"/>
-        <nd ref="-194"/>
-        <nd ref="-195"/>
-        <nd ref="-196"/>
-        <nd ref="-197"/>
-        <nd ref="-198"/>
-        <nd ref="-199"/>
-        <nd ref="-200"/>
-        <nd ref="-201"/>
+    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19"/>
         <nd ref="-202"/>
-        <nd ref="-15"/>
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-205"/>
+        <nd ref="-206"/>
+        <nd ref="-207"/>
+        <nd ref="-208"/>
+        <nd ref="-209"/>
+        <nd ref="-210"/>
+        <nd ref="-211"/>
+        <nd ref="-212"/>
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <nd ref="-217"/>
+        <nd ref="-218"/>
+        <nd ref="-219"/>
+        <nd ref="-32"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1379,10 +1413,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-203"/>
-        <nd ref="-67"/>
+    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18"/>
+        <nd ref="-220"/>
+        <nd ref="-84"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>

--- a/test-files/cases/attribute/unifying/highway-2927-name-preservation-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-name-preservation-1/Expected.osm
@@ -1,272 +1,272 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.5053" minlon="-66.91539999999999" maxlat="10.509974" maxlon="-66.9121"/>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
+    <node visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065750463800001" lon="-66.9152038258099822">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
+    <node visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065369230400005" lon="-66.9150022248399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195199992" lon="-66.9148632606599989">
+    <node visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5065055195199992" lon="-66.9148632606599989">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
+    <node visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5064764559700006" lon="-66.9147604025199882">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063683161199997" lon="-66.9141438720999986">
+    <node visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063683161199997" lon="-66.9141438720999986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063046214299991" lon="-66.9137310251299908">
+    <node visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5063046214299991" lon="-66.9137310251299908">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062701718099962" lon="-66.9134486574999841">
+    <node visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5062701718099962" lon="-66.9134486574999841">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061558192900009" lon="-66.9128470437499914">
+    <node visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5061558192900009" lon="-66.9128470437499914">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
+    <node visible="true" id="-96" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5079109666299999" lon="-66.9153991168199980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
+    <node visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5078136666400024" lon="-66.9149047513499795">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077143307200007" lon="-66.9144740333299808">
+    <node visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5077143307200007" lon="-66.9144740333299808">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076331381000010" lon="-66.9140663332899948">
+    <node visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5076331381000010" lon="-66.9140663332899948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075232974400006" lon="-66.9135307329499938">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5075232974400006" lon="-66.9135307329499938">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074059489500016" lon="-66.9129728706199955">
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5074059489500016" lon="-66.9129728706199955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072912215099983" lon="-66.9124406098300000">
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5072912215099983" lon="-66.9124406098300000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055976876700008" lon="-66.9152554077300010">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056033822400003" lon="-66.9152220781300002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056066854899992" lon="-66.9152027445999948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299979" lon="-66.9151838086699939">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056145700299979" lon="-66.9151838086699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056264854200005" lon="-66.9151688920699996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699981" lon="-66.9151444806499995">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056463473699981" lon="-66.9151444806499995">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056635309399997" lon="-66.9151187383999968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056125587799993" lon="-66.9148776470100017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054585547299997" lon="-66.9141921468900023">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054585547299997" lon="-66.9141921468900023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090706364099997" lon="-66.9122308439799980">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090706364099997" lon="-66.9122308439799980">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086560423599984" lon="-66.9123156418699949">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086560423599984" lon="-66.9123156418699949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084297682300001" lon="-66.9123656226399959">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5084297682300001" lon="-66.9123656226399959">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080861369300003" lon="-66.9124369873999996">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5080861369300003" lon="-66.9124369873999996">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073236140899997" lon="-66.9126214131100028">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073236140899997" lon="-66.9126214131100028">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067621643700004" lon="-66.9127523923900043">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5067621643700004" lon="-66.9127523923900043">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062531555899987" lon="-66.9128357700700036">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5062531555899987" lon="-66.9128357700700036">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059741293800002" lon="-66.9128861039500009">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5059741293800002" lon="-66.9128861039500009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055539111399998" lon="-66.9129797883599906">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5055539111399998" lon="-66.9129797883599906">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546600005" lon="-66.9153896753699939">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091229546600005" lon="-66.9153896753699939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457499988" lon="-66.9149623942000034">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5090320457499988" lon="-66.9149623942000034">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089687944999994" lon="-66.9146354390299933">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089687944999994" lon="-66.9146354390299933">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088704779800004" lon="-66.9141622602300004">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5088704779800004" lon="-66.9141622602300004">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087785479200004" lon="-66.9135799125899950">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087785479200004" lon="-66.9135799125899950">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087181938499974" lon="-66.9132615540100062">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087181938499974" lon="-66.9132615540100062">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086206540999996" lon="-66.9126907318800050">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5086206540999996" lon="-66.9126907318800050">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164699986" lon="-66.9153835618100032">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5079911164699986" lon="-66.9153835618100032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844300016" lon="-66.9148101529700057">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5078714844300016" lon="-66.9148101529700057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077674644700014" lon="-66.9143090046700024">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5077674644700014" lon="-66.9143090046700024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076714456500007" lon="-66.9138736961400014">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5076714456500007" lon="-66.9138736961400014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075811864599995" lon="-66.9134289360400061">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075811864599995" lon="-66.9134289360400061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074946056699989" lon="-66.9130123914499961">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074946056699989" lon="-66.9130123914499961">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074074731200007" lon="-66.9126005575199940">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5074074731200007" lon="-66.9126005575199940">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054666680699977" lon="-66.9142282606800052">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054666680699977" lon="-66.9142282606800052">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073260069600014" lon="-66.9122176839899936">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5073260069600014" lon="-66.9122176839899936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072371582699979" lon="-66.9122143048799956">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5072371582699979" lon="-66.9122143048799956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085595781700007" lon="-66.9122740378600014">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5085595781700007" lon="-66.9122740378600014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091017258699981" lon="-66.9122257277799974">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5091017258699981" lon="-66.9122257277799974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061393139499994" lon="-66.9127610980299892">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5061393139499994" lon="-66.9127610980299892">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097398742500001" lon="-66.9121124348600063">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097398742500001" lon="-66.9121124348600063">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9133403110199936">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9133403110199936">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099533721900009" lon="-66.9133447353499946">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099533721900009" lon="-66.9133447353499946">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095799554799996" lon="-66.9134116472999949">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5095799554799996" lon="-66.9134116472999949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087610510700014" lon="-66.9135981024499955">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5087610510700014" lon="-66.9135981024499955">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081582664799988" lon="-66.9137211045599969">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5081582664799988" lon="-66.9137211045599969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075320805299999" lon="-66.9138658912099942">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5075320805299999" lon="-66.9138658912099942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064590959299995" lon="-66.9140936995999880">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5064590959299995" lon="-66.9140936995999880">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056531235300028" lon="-66.9142396904399988">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5056531235300028" lon="-66.9142396904399988">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054783852299991" lon="-66.9142804157000057">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5054783852299991" lon="-66.9142804157000057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089406039699984" lon="-66.9144997629800002">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5089406039699984" lon="-66.9144997629800002">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093437194699995" lon="-66.9144127489399949">
+    <node visible="true" id="-40" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5093437194699995" lon="-66.9144127489399949">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097353135099976" lon="-66.9143263374599968">
+    <node visible="true" id="-39" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097353135099976" lon="-66.9143263374599968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099296585699999" lon="-66.9142859718599965">
+    <node visible="true" id="-38" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099296585699999" lon="-66.9142859718599965">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9142793794799928">
+    <node visible="true" id="-37" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099739999999997" lon="-66.9142793794799928">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099738187200042" lon="-66.9132791853800057">
+    <node visible="true" id="-36" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5099738187200042" lon="-66.9132791853800057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098883177500007" lon="-66.9128676939699858">
+    <node visible="true" id="-35" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5098883177500007" lon="-66.9128676939699858">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097656522800023" lon="-66.9122512857699974">
+    <node visible="true" id="-34" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5097656522800023" lon="-66.9122512857699974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9130318683858576">
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9130318683858576">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5056288723729843" lon="-66.9153999999999911">
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5056288723729843" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9134683360734925">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9134683360734925">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9152942938446245">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9152942938446245">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079111408341266" lon="-66.9153999999999911">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079111408341266" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5066138849631390" lon="-66.9153999999999911">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5066138849631390" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097897933941198" lon="-66.9120999999999952">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097897933941198" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060273581464099" lon="-66.9120999999999952">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5060273581464099" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5096175760148949" lon="-66.9120999999999952">
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5096175760148949" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5085220341878234" lon="-66.9120999999999952">
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5085220341878234" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097376145495947" lon="-66.9120999999999952">
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5097376145495947" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5072142058022049" lon="-66.9120999999999952">
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5072142058022049" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5073020421552741" lon="-66.9120999999999952">
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5073020421552741" lon="-66.9120999999999952">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9142674929639298">
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5052999999999983" lon="-66.9142674929639298">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079935626786458" lon="-66.9153999999999911">
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5079935626786458" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5091249962365421" lon="-66.9153999999999911">
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5091249962365421" lon="-66.9153999999999911">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-25"/>
-        <nd ref="-40"/>
-        <nd ref="-64"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-42"/>
+        <nd ref="-57"/>
+        <nd ref="-81"/>
+        <nd ref="-31"/>
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -290,14 +290,14 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-41"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
+        <nd ref="-54"/>
         <nd ref="-24"/>
-        <nd ref="-51"/>
-        <nd ref="-50"/>
-        <nd ref="-49"/>
-        <nd ref="-48"/>
-        <nd ref="-37"/>
-        <nd ref="-7"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -313,10 +313,10 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-6"/>
+    <way visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-23"/>
+        <nd ref="-51"/>
         <nd ref="-34"/>
-        <nd ref="-17"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -332,16 +332,16 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-25"/>
+    <way visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-44"/>
+        <nd ref="-43"/>
+        <nd ref="-42"/>
         <tag k="alt_name" v="Av. Norte;Avenida Norte"/>
         <tag k="surface" v="paved"/>
         <tag k="z_order" v="-999999"/>
@@ -365,12 +365,12 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-20"/>
-        <nd ref="-21"/>
-        <nd ref="-22"/>
-        <nd ref="-23"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-37"/>
+        <nd ref="-38"/>
+        <nd ref="-39"/>
+        <nd ref="-40"/>
+        <nd ref="-41"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -386,10 +386,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-16" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-17"/>
-        <nd ref="-18"/>
-        <nd ref="-19"/>
+    <way visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-34"/>
+        <nd ref="-35"/>
+        <nd ref="-36"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -405,19 +405,19 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-8"/>
-        <nd ref="-36"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-61"/>
-        <nd ref="-60"/>
-        <nd ref="-59"/>
-        <nd ref="-58"/>
-        <nd ref="-57"/>
-        <nd ref="-56"/>
-        <nd ref="-55"/>
-        <nd ref="-16"/>
+    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-25"/>
+        <nd ref="-53"/>
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-33"/>
         <tag k="sidewalk" v="both"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
@@ -434,17 +434,17 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-15"/>
-        <nd ref="-72"/>
-        <nd ref="-71"/>
-        <nd ref="-70"/>
-        <nd ref="-69"/>
-        <nd ref="-68"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-25"/>
+    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-32"/>
+        <nd ref="-89"/>
+        <nd ref="-88"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-42"/>
         <tag k="surface" v="paving_stones"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -468,9 +468,9 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-71"/>
-        <nd ref="-13"/>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-88"/>
+        <nd ref="-30"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur 2"/>
@@ -490,17 +490,17 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-12"/>
-        <nd ref="-79"/>
-        <nd ref="-78"/>
-        <nd ref="-77"/>
-        <nd ref="-76"/>
-        <nd ref="-75"/>
-        <nd ref="-74"/>
-        <nd ref="-73"/>
-        <nd ref="-38"/>
-        <nd ref="-5"/>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-93"/>
+        <nd ref="-92"/>
+        <nd ref="-91"/>
+        <nd ref="-90"/>
+        <nd ref="-55"/>
+        <nd ref="-22"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -524,17 +524,17 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-87"/>
-        <nd ref="-86"/>
-        <nd ref="-85"/>
-        <nd ref="-84"/>
-        <nd ref="-83"/>
-        <nd ref="-82"/>
-        <nd ref="-81"/>
-        <nd ref="-80"/>
-        <nd ref="-35"/>
+    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-99"/>
+        <nd ref="-98"/>
+        <nd ref="-97"/>
+        <nd ref="-52"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -553,9 +553,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-34"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27"/>
+        <nd ref="-51"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.704Z"/>
@@ -569,9 +569,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-35"/>
-        <nd ref="-9"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-52"/>
+        <nd ref="-26"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -588,9 +588,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-40"/>
-        <nd ref="-3"/>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-57"/>
+        <nd ref="-20"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Av. Sur"/>
@@ -613,17 +613,17 @@
         <tag k="motor_vehicle" v="no"/>
         <tag k="highway" v="pedestrian"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-4"/>
-        <nd ref="-39"/>
-        <nd ref="-41"/>
-        <nd ref="-42"/>
-        <nd ref="-43"/>
-        <nd ref="-44"/>
-        <nd ref="-45"/>
-        <nd ref="-46"/>
-        <nd ref="-47"/>
-        <nd ref="-2"/>
+    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21"/>
+        <nd ref="-56"/>
+        <nd ref="-58"/>
+        <nd ref="-59"/>
+        <nd ref="-60"/>
+        <nd ref="-61"/>
+        <nd ref="-62"/>
+        <nd ref="-63"/>
+        <nd ref="-64"/>
+        <nd ref="-19"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -648,12 +648,12 @@
         <tag k="motor_vehicle" v="yes"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-54"/>
-        <nd ref="-53"/>
-        <nd ref="-52"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-41"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>

--- a/test-files/cases/attribute/unifying/highway-2927-unmarked-ref-divided-road-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-unmarked-ref-divided-road-1/Expected.osm
@@ -1,213 +1,213 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.4997" minlon="-66.92059999999999" maxlat="10.5029" maxlon="-66.91669999999999"/>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998810231100013" lon="-66.9189074321199939">
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998810231100013" lon="-66.9189074321199939">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998604597799989" lon="-66.9188191467099927">
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4998604597799989" lon="-66.9188191467099927">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4997972783799991" lon="-66.9185478879700071">
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4997972783799991" lon="-66.9185478879700071">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000853238699996" lon="-66.9187692859299972">
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000853238699996" lon="-66.9187692859299972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5004951816999998" lon="-66.9186780643999981">
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5004951816999998" lon="-66.9186780643999981">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011153773500006" lon="-66.9185667172800009">
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011153773500006" lon="-66.9185667172800009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002144495099987" lon="-66.9203518304800014">
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002144495099987" lon="-66.9203518304800014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001903106799990" lon="-66.9201516782899972">
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001903106799990" lon="-66.9201516782899972">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001468854300004" lon="-66.9199419429599942">
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5001468854300004" lon="-66.9199419429599942">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000569472900001" lon="-66.9196014045700025">
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000569472900001" lon="-66.9196014045700025">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000239723099984" lon="-66.9194572242199968">
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5000239723099984" lon="-66.9194572242199968">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311725999975" lon="-66.9202954139200017">
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026311725999975" lon="-66.9202954139200017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011785931099979" lon="-66.9176940783000020">
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5011785931099979" lon="-66.9176940783000020">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5009767157099994" lon="-66.9167081692999943">
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5009767157099994" lon="-66.9167081692999943">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000006" lon="-66.9179020508999969">
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025108126000006" lon="-66.9179020508999969">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699997" lon="-66.9171032446199803">
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023250189699997" lon="-66.9171032446199803">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028723977399974" lon="-66.9195550650800044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800004" lon="-66.9191175683799884">
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027733335800004" lon="-66.9191175683799884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579600003" lon="-66.9184036784899945">
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026354579600003" lon="-66.9184036784899945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768699987" lon="-66.9184060968199930">
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5020512768699987" lon="-66.9184060968199930">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014790620700023" lon="-66.9185278235199945">
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014790620700023" lon="-66.9185278235199945">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611200013" lon="-66.9182588634100028">
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5027782611200013" lon="-66.9182588634100028">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5026080403400002" lon="-66.9182933376900024">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654500014" lon="-66.9182879955099850">
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022517654500014" lon="-66.9182879955099850">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028019984899998" lon="-66.9181629386299903">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025877388799991" lon="-66.9182116356000023">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439092000015" lon="-66.9179112165300012">
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018439092000015" lon="-66.9179112165300012">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799974" lon="-66.9172775671599993">
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016984065799974" lon="-66.9172775671599993">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016887457600010" lon="-66.9172277782199956">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328599982" lon="-66.9184260814800069">
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019573328599982" lon="-66.9184260814800069">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905700006" lon="-66.9183505367499976">
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5019406905700006" lon="-66.9183505367499976">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014555671500016" lon="-66.9184526182300061">
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014555671500016" lon="-66.9184526182300061">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013612691200020" lon="-66.9185075180800055">
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013612691200020" lon="-66.9185075180800055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013524818399997" lon="-66.9184683888800009">
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013524818399997" lon="-66.9184683888800009">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014334137999992" lon="-66.9188287745400032">
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5014334137999992" lon="-66.9188287745400032">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013709919200000" lon="-66.9185508130999978">
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5013709919200000" lon="-66.9185508130999978">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5015229450700005" lon="-66.9198194749599935">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5008864321500006" lon="-66.9200366815399974">
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5008864321500006" lon="-66.9200366815399974">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002040527599974" lon="-66.9202656235199953">
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5002040527599974" lon="-66.9202656235199953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099994" lon="-66.9194331024600046">
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5028447813099994" lon="-66.9194331024600046">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226899997" lon="-66.9196067043800014">
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5022131226899997" lon="-66.9196067043800014">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930899984" lon="-66.9197283843299999">
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5018042930899984" lon="-66.9197283843299999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800021" lon="-66.9199025736400017">
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016857529800021" lon="-66.9199025736400017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5016560947599995" lon="-66.9197763657799953">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5025904524500007" lon="-66.9201932269999986">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5023933489200019" lon="-66.9204466658000001">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.5024632862199994" lon="-66.9205040500300044">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5011113656299990" lon="-66.9173657575999954">
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5011113656299990" lon="-66.9173657575999954">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5008601733099987" lon="-66.9174064675100055">
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5008601733099987" lon="-66.9174064675100055">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5000216885800004" lon="-66.9176102020399810">
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5000216885800004" lon="-66.9176102020399810">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800002" lon="-66.9178452289699948">
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5018287567800002" lon="-66.9178452289699948">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-16" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:05Z" version="1" changeset="841" lat="10.5024595645600023" lon="-66.9176817127400057">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5025802255145120" lon="-66.9205999999999932">
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5025802255145120" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5023860765049317" lon="-66.9205999999999932">
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5023860765049317" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022740980780522" lon="-66.9205999999999932">
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022740980780522" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9198328378480340">
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9198328378480340">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5018478484657400" lon="-66.9205999999999932">
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5018478484657400" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9181414315535363">
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9181414315535363">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9182340475983892">
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9182340475983892">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5028999999999986" lon="-66.9195911270657859">
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5028999999999986" lon="-66.9195911270657859">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022209583745791" lon="-66.9166999999999916">
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5022209583745791" lon="-66.9166999999999916">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5009748792788962" lon="-66.9166999999999916">
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5009748792788962" lon="-66.9166999999999916">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9199789801348146">
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5029000000000003" lon="-66.9199789801348146">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5002515743978755" lon="-66.9205999999999932">
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.5002515743978755" lon="-66.9205999999999932">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9181243895426690">
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9181243895426690">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4996999999999989" lon="-66.9188525813828505">
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4996999999999989" lon="-66.9188525813828505">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9176873631122788">
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4997000000000007" lon="-66.9176873631122788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-18"/>
-        <nd ref="-19"/>
-        <nd ref="-20"/>
-        <nd ref="-39"/>
+    <way visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-43"/>
+        <nd ref="-44"/>
+        <nd ref="-45"/>
+        <nd ref="-64"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -230,9 +230,63 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-66"/>
-        <nd ref="-2"/>
+    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-53"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-70"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="name" v="Av. Oeste 8"/>
+        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
+        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="lanes" v="2"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-49"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-80"/>
+        <nd ref="-45"/>
+        <nd ref="-79"/>
+        <nd ref="-31"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Av. Lecuna"/>
+        <tag k="source:datetime" v="2015-05-11T03:32:46.000Z;2019-01-17T19:50:06Z;2014-06-22T17:21:17.000Z;2014-06-22T17:21:18.000Z"/>
+        <tag k="bicycle" v="yes"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="4"/>
+        <tag k="maxspeed" v="40"/>
+        <tag k="uuid" v="{d420f044-9a4d-4dae-8ab3-3dec2959e07c};{7c809bd2-1b65-4e0e-9713-1e7ddc4f43a7};{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="yes"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.668Z"/>
+        <tag k="sidewalk" v="both"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="Yahoo;osm:line"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-91"/>
+        <nd ref="-27"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -257,63 +311,9 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28"/>
-        <nd ref="-50"/>
-        <nd ref="-49"/>
-        <nd ref="-45"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
-        <tag k="highway" v="primary"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="name" v="Av. Oeste 8"/>
-        <tag k="uuid" v="{8ab02c28-530a-43e4-84a8-ac2e44037da9}"/>
-        <tag k="source:datetime" v="2014-05-19T20:08:16.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="lanes" v="2"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="z_order" v="-999999"/>
-    </way>
-    <way visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-24"/>
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-35"/>
-        <nd ref="-34"/>
-        <nd ref="-55"/>
-        <nd ref="-20"/>
-        <nd ref="-54"/>
-        <nd ref="-6"/>
-        <tag k="surface" v="asphalt"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Av. Lecuna"/>
-        <tag k="source:datetime" v="2015-05-11T03:32:46.000Z;2019-01-17T19:50:06Z;2014-06-22T17:21:17.000Z;2014-06-22T17:21:18.000Z"/>
-        <tag k="bicycle" v="yes"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="4"/>
-        <tag k="maxspeed" v="40"/>
-        <tag k="uuid" v="{d420f044-9a4d-4dae-8ab3-3dec2959e07c};{7c809bd2-1b65-4e0e-9713-1e7ddc4f43a7};{95fc9085-85fa-4657-a06e-41cc9b5868db}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="yes"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.665Z;2019-01-17T19:50:05.668Z"/>
-        <tag k="sidewalk" v="both"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="Yahoo;osm:line"/>
-        <tag k="highway" v="primary"/>
-    </way>
-    <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-17"/>
-        <nd ref="-16"/>
+    <way visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-42"/>
+        <nd ref="-41"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.676Z"/>
@@ -327,11 +327,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-64"/>
-        <nd ref="-63"/>
-        <nd ref="-62"/>
-        <nd ref="-35"/>
+    <way visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-89"/>
+        <nd ref="-88"/>
+        <nd ref="-87"/>
+        <nd ref="-60"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -356,12 +356,12 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-45"/>
-        <nd ref="-48"/>
-        <nd ref="-38"/>
-        <nd ref="-47"/>
-        <nd ref="-35"/>
+    <way visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-70"/>
+        <nd ref="-73"/>
+        <nd ref="-63"/>
+        <nd ref="-72"/>
+        <nd ref="-60"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -386,10 +386,10 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-37"/>
-        <nd ref="-44"/>
-        <nd ref="-42"/>
+    <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-62"/>
+        <nd ref="-69"/>
+        <nd ref="-67"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -414,12 +414,12 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-39"/>
-        <nd ref="-40"/>
-        <nd ref="-17"/>
-        <nd ref="-41"/>
-        <nd ref="-37"/>
+    <way visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-64"/>
+        <nd ref="-65"/>
+        <nd ref="-42"/>
+        <nd ref="-66"/>
+        <nd ref="-62"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
@@ -433,9 +433,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-38"/>
-        <nd ref="-37"/>
+    <way visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-63"/>
+        <nd ref="-62"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.667Z"/>
@@ -449,10 +449,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-35"/>
-        <nd ref="-36"/>
-        <nd ref="-37"/>
+    <way visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-60"/>
+        <nd ref="-61"/>
+        <nd ref="-62"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -477,11 +477,11 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-24"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
+    <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-49"/>
+        <nd ref="-56"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -498,11 +498,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-49"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -519,10 +519,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-22"/>
-        <nd ref="-21"/>
-        <nd ref="-15"/>
+    <way visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-40"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -538,9 +538,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-21"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-46"/>
+        <nd ref="-39"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="lit" v="yes"/>
@@ -564,11 +564,11 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-13"/>
-        <nd ref="-22"/>
-        <nd ref="-23"/>
-        <nd ref="-12"/>
+    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-38"/>
+        <nd ref="-47"/>
+        <nd ref="-48"/>
+        <nd ref="-37"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -592,10 +592,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-25"/>
-        <nd ref="-24"/>
+    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -618,10 +618,10 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-42"/>
-        <nd ref="-43"/>
-        <nd ref="-10"/>
+    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-67"/>
+        <nd ref="-68"/>
+        <nd ref="-35"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -646,10 +646,10 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-9"/>
-        <nd ref="-46"/>
-        <nd ref="-45"/>
+    <way visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
@@ -674,10 +674,10 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-8"/>
-        <nd ref="-51"/>
-        <nd ref="-28"/>
+    <way visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-33"/>
+        <nd ref="-76"/>
+        <nd ref="-53"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -694,13 +694,13 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-45"/>
-        <nd ref="-42"/>
-        <nd ref="-53"/>
-        <nd ref="-16"/>
-        <nd ref="-52"/>
-        <nd ref="-7"/>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-70"/>
+        <nd ref="-67"/>
+        <nd ref="-78"/>
+        <nd ref="-41"/>
+        <nd ref="-77"/>
+        <nd ref="-32"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="40"/>
@@ -719,10 +719,10 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-56"/>
-        <nd ref="-21"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-81"/>
+        <nd ref="-46"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -747,14 +747,14 @@
         <tag k="highway" v="primary"/>
         <tag k="destination" v="San Martín"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-57"/>
-        <nd ref="-58"/>
-        <nd ref="-59"/>
-        <nd ref="-60"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-82"/>
+        <nd ref="-83"/>
+        <nd ref="-84"/>
+        <nd ref="-85"/>
+        <nd ref="-54"/>
+        <nd ref="-86"/>
         <nd ref="-29"/>
-        <nd ref="-61"/>
-        <nd ref="-4"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -771,12 +771,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-3"/>
-        <nd ref="-65"/>
-        <nd ref="-66"/>
-        <nd ref="-67"/>
-        <nd ref="-57"/>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-90"/>
+        <nd ref="-91"/>
+        <nd ref="-92"/>
+        <nd ref="-82"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -793,9 +793,9 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-66"/>
-        <nd ref="-64"/>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-91"/>
+        <nd ref="-89"/>
         <tag k="alt_name" v="Avenida Norte 6"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>

--- a/test-files/cases/attribute/unifying/highway-2927-way-member-tags-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-2927-way-member-tags-1/Expected.osm
@@ -1,936 +1,970 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="10.4953" minlon="-66.90266" maxlat="10.4986" maxlon="-66.89794699999999"/>
-    <node visible="true" id="-1809" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4970356391966728" lon="-66.9015098172667422">
+    <node visible="true" id="-1707" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4969606967081628" lon="-66.8980858001478538">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1705" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4974491016364286" lon="-66.8981350034610642">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1703" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4966018270344055" lon="-66.8989322499832042">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1702" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4966684789968543" lon="-66.8999130454100310">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1698" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4970356391966728" lon="-66.9015098172667422">
         <tag k="hoot:status" v="3"/>
     </node>
-    <node visible="true" id="-1807" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4960253697085815" lon="-66.9010837897166226">
+    <node visible="true" id="-1696" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4960253697085815" lon="-66.9010837897166226">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1805" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4966018270344055" lon="-66.8989322499832042">
+    <node visible="true" id="-294" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965255552600016" lon="-66.9022163124700029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1804" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4966684789968543" lon="-66.8999130454100310">
+    <node visible="true" id="-293" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966321991699996" lon="-66.9016561960600029">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1801" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4969606967081628" lon="-66.8980858001478538">
+    <node visible="true" id="-292" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966905865199998" lon="-66.9012790260800045">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1799" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4974491016364286" lon="-66.8981350034610642">
+    <node visible="true" id="-291" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967194419199998" lon="-66.9008953271499962">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-342" timestamp="2019-01-10T17:16:05Z" version="1" changeset="749" lat="10.4963607999999979" lon="-66.8996161999999970">
+    <node visible="true" id="-290" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967125643799974" lon="-66.9005743449900052">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-289" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966920457700006" lon="-66.9002044356600010">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-288" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966671838199996" lon="-66.8998970313599983">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-287" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966261936399974" lon="-66.8994522898200046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-286" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966029409599990" lon="-66.8991006614599968">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-285" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966009892599992" lon="-66.8988055979099983">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-284" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966118733300000" lon="-66.8985815736800049">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-283" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966216231299985" lon="-66.8984517497899986">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-282" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966358509199988" lon="-66.8983223487999936">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-281" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966545393799997" lon="-66.8981935283599967">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-280" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966776657499974" lon="-66.8980654453999932">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-279" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966806536599986" lon="-66.8980505477599934">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-278" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966990112899996" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-277" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4961183409699998" lon="-66.9022581171700068">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-276" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4961861367399987" lon="-66.9018063572100061">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-275" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962462924499995" lon="-66.9013065590699938">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-274" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962758852199975" lon="-66.9009832957400050">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-273" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962849855000027" lon="-66.9006983957699930">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-272" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963099247099994" lon="-66.9004096897500062">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-271" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963460312199981" lon="-66.8999643088399978">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-270" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963674937399976" lon="-66.8995190268099975">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-269" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964042595200002" lon="-66.8991735198899988">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-268" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964342904600016" lon="-66.8989168392400018">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-267" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964691859899997" lon="-66.8986576595900004">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-266" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965177537999974" lon="-66.8982516526500035">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-265" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965645345300000" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-264" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972940122799994" lon="-66.8990818915400069">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-263" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972619845899970" lon="-66.8988943461300067">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-262" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971868237599999" lon="-66.8985026652599970">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-261" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971740993299978" lon="-66.8984207946800069">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-260" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971642103599976" lon="-66.8983385252700060">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-259" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971571688999994" lon="-66.8982559572600053">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-258" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971529835200013" lon="-66.8981731912499953">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-257" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971516593299992" lon="-66.8980903280699977">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-256" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971531979399995" lon="-66.8980074686800066">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-255" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971537632699992" lon="-66.8979929326399940">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-254" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971585263300007" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-253" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985650466399978" lon="-66.8986611001000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-252" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985223443700004" lon="-66.8986437803999934">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-251" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984803225899999" lon="-66.8986248374099972">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-250" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984390417300002" lon="-66.8986042983499942">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-249" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983985611399984" lon="-66.8985821927699931">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-248" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983589390100001" lon="-66.8985585524399937">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-247" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983202322999993" lon="-66.8985334113500016">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-246" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982824966700026" lon="-66.8985068056500012">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-245" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982457863600001" lon="-66.8984787735799813">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-244" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982101541599988" lon="-66.8984493554499977">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-243" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981756512799986" lon="-66.8984185935500051">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-242" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981423273400001" lon="-66.8983865321200000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-241" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981102302499991" lon="-66.8983532172299959">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-240" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980794061400022" lon="-66.8983186968000041">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-239" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980561794799989" lon="-66.8982908470299975">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-238" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980091004699965" lon="-66.8982382300000040">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-237" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979638674700002" lon="-66.8981839848499931">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-236" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979205355899978" lon="-66.8981281776799932">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-235" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978791576099990" lon="-66.8980708764700012">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-234" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978397839499991" lon="-66.8980121510300023">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-233" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977995503699990" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-232" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973441388099999" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-231" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973472980199993" lon="-66.8979612051699917">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-230" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973568530499985" lon="-66.8979980984800022">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-229" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973676765100024" lon="-66.8980346323699990">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-228" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973797552199990" lon="-66.8980707623299935">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-227" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973930744599979" lon="-66.8981064443500060">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-226" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974076180099978" lon="-66.8981416349499938">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-225" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974233681299989" lon="-66.8981762912499960">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-224" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974403056599996" lon="-66.8982103710399940">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-223" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974584099400019" lon="-66.8982438327900013">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-222" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974776589300003" lon="-66.8982766357299994">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-221" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974980291699982" lon="-66.8983087399099929">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-220" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975194958399989" lon="-66.8983401061999956">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-219" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975420327900011" lon="-66.8983706963900033">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-218" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975656125700016" lon="-66.8984004732100033">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-217" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975725955900003" lon="-66.8984088960999941">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-216" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977151716199977" lon="-66.8985644712499976">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-215" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983789342400016" lon="-66.8987121958899991">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-214" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980557712199989" lon="-66.8983983944699929">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-213" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980061847199977" lon="-66.8983495882200003">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-212" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979583141299990" lon="-66.8982990631200067">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-211" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979122177900006" lon="-66.8982468807000004">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-210" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978679518399982" lon="-66.8981931045599936">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-209" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978255702199998" lon="-66.8981378001999900">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-208" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977851245599982" lon="-66.8980810350099944">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-207" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977466641499984" lon="-66.8980228781500017">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-206" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977278161999976" lon="-66.8979926842300046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-205" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977014156699990" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-204" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979060636200003" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-203" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979235978800016" lon="-66.8979751215899938">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-202" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979665330799961" lon="-66.8980389297399967">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-201" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980116459900010" lon="-66.8981011849700025">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-200" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980588816299996" lon="-66.8981618114499952">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-199" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981081824599993" lon="-66.8982207353000007">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-198" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981277215599995" lon="-66.8982429745800005">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-197" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982180172900001" lon="-66.8983219769200019">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-196" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983109866599982" lon="-66.8983977470099944">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-195" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984065163999993" lon="-66.8984701925199943">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-194" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985044901200020" lon="-66.8985392251900066">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-193" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985655291700013" lon="-66.8985797046599941">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-192" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985894030699978" lon="-66.8985925448899934">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-191" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982779118200007" lon="-66.8987583619200024">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-190" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982200921499995" lon="-66.8986946857999811">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-189" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981601083800005" lon="-66.8986330874400039">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-188" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980980336199998" lon="-66.8985736418899961">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-187" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980339434700003" lon="-66.8985164215600037">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-186" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979924468799979" lon="-66.8984814478599930">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-185" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979338934099982" lon="-66.8984224753200039">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-184" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978774124499985" lon="-66.8983614739200050">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-183" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978230728199975" lon="-66.8982985179600007">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-182" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977709406999988" lon="-66.8982336841500000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-181" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977210796299989" lon="-66.8981670514800015">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-180" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976702019799966" lon="-66.8980936891099986">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-179" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976396325099994" lon="-66.8980441594499950">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-178" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976107923500006" lon="-66.8979935819800033">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-177" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975863325000009" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-176" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979886416799975" lon="-66.8986379866099981">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-175" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979398743499992" lon="-66.8985984505400069">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-174" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975203752300015" lon="-66.8982062276299985">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-173" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972609674800008" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-172" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969159754600021" lon="-66.8979469999999878">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-171" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969668168800006" lon="-66.8981047951799894">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-170" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970539977099975" lon="-66.8984253776999935">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-169" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972046468099975" lon="-66.8990350387600046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-168" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979138786000004" lon="-66.8987390725000068">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-167" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980115386599984" lon="-66.8988506781099943">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-166" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978145000900014" lon="-66.8986508031099874">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-165" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983787414899989" lon="-66.8990110065399932">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-164" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982239350800004" lon="-66.8988287410700053">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-163" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984569345600001" lon="-66.8988036110699937">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-162" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983334969600026" lon="-66.8988240382300035">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-161" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955907653199993" lon="-66.9021525317999988">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-160" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955716818199996" lon="-66.9021487105000006">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-159" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955524082200000" lon="-66.9021460350499808">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-158" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955330118599974" lon="-66.9021445148199803">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-157" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955135604899983" lon="-66.9021441551000038">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-156" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954941220699975" lon="-66.9021449571600044">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-155" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954747644899999" lon="-66.9021469181899988">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-154" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954555553799977" lon="-66.9021500313399997">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-153" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954365618499992" lon="-66.9021542857399965">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-152" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954178502299964" lon="-66.9021596665199922">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-151" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953994859099975" lon="-66.9021661548899971">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-150" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953815330300007" lon="-66.9021737281800029">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-149" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953640543100004" lon="-66.9021823599299950">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-148" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953471108099983" lon="-66.9021920200000011">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-147" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953307617000018" lon="-66.9022026746300043">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-146" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953150641199997" lon="-66.9022142865999996">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-145" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959739620200008" lon="-66.9009545499399962">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-144" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959280306299974" lon="-66.9009321611899992">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-143" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958813539300007" lon="-66.9009114058000023">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-142" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958339887999976" lon="-66.9008923090400032">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-141" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4957859929299993" lon="-66.9008748941899967">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-140" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4957374247999997" lon="-66.9008591824500058">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-139" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4956883435900004" lon="-66.9008451929699959">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-138" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4956388091000008" lon="-66.9008329427999939">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-137" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955276566999984" lon="-66.9008007124700015">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-136" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954583077499990" lon="-66.9007799777599956">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-135" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953882848899980" lon="-66.9007617011800022">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-134" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953176734299998" lon="-66.9007459049900035">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-133" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962700263799977" lon="-66.9010472963699954">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-132" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958056912499984" lon="-66.9025679482599855">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-131" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958359980800005" lon="-66.9024133217100001">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-130" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958652051300003" lon="-66.9022966327299997">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-129" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958832425599979" lon="-66.9022122862100019">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-128" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958903640100001" lon="-66.9021789848799955">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-127" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959114440500016" lon="-66.9020605215000046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-126" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959284195800020" lon="-66.9019413869200008">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-125" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959412699199994" lon="-66.9018217262899952">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-124" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959432879799994" lon="-66.9017984121000069">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-123" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4960279313800005" lon="-66.9011267369299958">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-122" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4960190921399974" lon="-66.9009785447500036">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-121" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979196457599997" lon="-66.9025488747499963">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-120" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977696920400021" lon="-66.9017350473800008">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-119" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977218078700005" lon="-66.9014588562699970">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-118" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977064766999995" lon="-66.9013704279399803">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-117" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975172582699994" lon="-66.9003151283900053">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-116" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979151350299986" lon="-66.9025243939500029">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-115" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972461277600004" lon="-66.9026599894099974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-114" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971623784400023" lon="-66.9022121940199952">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-113" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970543100399976" lon="-66.9016132887300046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-112" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970123355900000" lon="-66.9013806718899957">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-111" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969015647500008" lon="-66.9007254838600005">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-110" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968865948899985" lon="-66.9006477751899951">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-109" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968689501500005" lon="-66.9005706417599981">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-108" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968486520300015" lon="-66.9004941775500015">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-107" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968257252499981" lon="-66.9004184757300067">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-106" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968001977600007" lon="-66.9003436285199911">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-105" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967953031299999" lon="-66.9003301835499968">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967135008600021" lon="-66.9000319800299934">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966736602000008" lon="-66.8999771078400016">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977457145699979" lon="-66.9015967475500020">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979862840700005" lon="-66.9015477735400026">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977592115799983" lon="-66.9016745969899915">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980731694399996" lon="-66.8989307704899971">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982483097799975" lon="-66.8989086649000058">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972986925499985" lon="-66.8992315182200059">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-96" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973390934099999" lon="-66.8991661363299954">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973478783399976" lon="-66.8991494384300012">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973577867000003" lon="-66.8991333953999998">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973687708999979" lon="-66.8991180842899951">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973807782000002" lon="-66.8991035786399948">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973937509399988" lon="-66.8990899481100030">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974076267900003" lon="-66.8990772581699957">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974223391400017" lon="-66.8990655697400030">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974378173199980" lon="-66.8990549389800009">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974539870000001" lon="-66.8990454169299937">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974707705299988" lon="-66.8990370493200004">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974880872899963" lon="-66.8990298763399949">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975058541300008" lon="-66.8990239324400022">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975239857199956" lon="-66.8990192461599946">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975423949800017" lon="-66.8990158400099943">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975609935100014" lon="-66.8990137303500063">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977432723199993" lon="-66.8986003190399998">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977239683400008" lon="-66.8985883402699955">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977039965199985" lon="-66.8985775370200031">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976834268800001" lon="-66.8985679471799983">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976623315499982" lon="-66.8985596043700070">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976407844999997" lon="-66.8985525378400041">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976188612799994" lon="-66.8985467723800014">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975966387699984" lon="-66.8985423281900040">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975741948899977" lon="-66.8985392208600018">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975516083400020" lon="-66.8985374612900046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-70" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975289583099975" lon="-66.8985370556499959">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975063242399980" lon="-66.8985380053599812">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974837854799983" lon="-66.8985403070799975">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974614210599988" lon="-66.8985439527599794">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974393094099998" lon="-66.8985489295900067">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974175280600015" lon="-66.8985552201399969">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973997838400006" lon="-66.8985664589399960">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973831906699981" lon="-66.8985793687899957">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973679021499979" lon="-66.8985938301700003">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973540598100001" lon="-66.8986097092199969">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973417917899976" lon="-66.8986268589300010">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973312116699979" lon="-66.8986451205699808">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973224173700004" lon="-66.8986643250599968">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973154903199983" lon="-66.8986842946400060">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973104946299998" lon="-66.8987048444499948">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973074765499987" lon="-66.8987257842500043">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973064640199976" lon="-66.8987469201999971">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973074664100015" lon="-66.8987680566499989">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973104744399990" lon="-66.8987889979199934">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973154602699985" lon="-66.8988095501800046">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973223777499989" lon="-66.8988295231499990">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973309210999997" lon="-66.8988466650699820">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973408521400007" lon="-66.8988630257099999">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973521014100015" lon="-66.8988784906400014">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973645902299975" lon="-66.8988929517099820">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973782312399972" lon="-66.8989063077499964">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973929290399965" lon="-66.8989184653599978">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974085808299993" lon="-66.8989293394899960">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974250771200008" lon="-66.8989388540999954">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974423025500023" lon="-66.8989469426300047">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974601366199991" lon="-66.8989535485099935">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974784545999977" lon="-66.8989586255299997">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974971283699983" lon="-66.8989621381799964">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975160273199979" lon="-66.8989640618899983">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975350192499981" lon="-66.8989643832200045">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975539713399986" lon="-66.8989630999000013">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976622110699989" lon="-66.8989826400199945">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8988753224482480">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.9015157811893317">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.9014250645420958">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4972461297405815" lon="-66.9026599999999974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4972460760916597" lon="-66.9026599999999974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4979393027591037" lon="-66.9026599999999974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4957905455867380" lon="-66.9026599999999974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4953000000000003" lon="-66.9007426004998393">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4953000000000003" lon="-66.9022314112524441">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8989876058872994">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8989771105911757">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8992280761345768">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8985977731945383">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8986737444705426">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4960415504698421" lon="-66.9026599999999974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4964387863919075" lon="-66.9026599999999974">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="724" timestamp="2019-01-10T17:16:05Z" version="1" changeset="749" lat="10.4960977000000018" lon="-66.9008881000000031">
         <tag k="hoot:status" v="2"/>
     </node>
-    <node visible="true" id="-341" timestamp="2019-01-10T17:16:05Z" version="1" changeset="749" lat="10.4960977000000018" lon="-66.9008881000000031">
+    <node visible="true" id="725" timestamp="2019-01-10T17:16:05Z" version="1" changeset="749" lat="10.4963607999999979" lon="-66.8996161999999970">
         <tag k="hoot:status" v="2"/>
     </node>
-    <node visible="true" id="-277" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965255552600016" lon="-66.9022163124700029">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-276" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966321991699996" lon="-66.9016561960600029">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-275" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966905865199998" lon="-66.9012790260800045">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-274" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967194419199998" lon="-66.9008953271499962">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-273" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967125643799974" lon="-66.9005743449900052">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-272" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966920457700006" lon="-66.9002044356600010">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-271" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966671838199996" lon="-66.8998970313599983">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-270" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966261936399974" lon="-66.8994522898200046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-269" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966029409599990" lon="-66.8991006614599968">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-268" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966009892599992" lon="-66.8988055979099983">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-267" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966118733300000" lon="-66.8985815736800049">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-266" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966216231299985" lon="-66.8984517497899986">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-265" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966358509199988" lon="-66.8983223487999936">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-264" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966545393799997" lon="-66.8981935283599967">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-263" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966776657499974" lon="-66.8980654453999932">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-262" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966806536599986" lon="-66.8980505477599934">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-261" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966990112899996" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-260" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4961183409699998" lon="-66.9022581171700068">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-259" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4961861367399987" lon="-66.9018063572100061">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-258" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962462924499995" lon="-66.9013065590699938">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-257" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962758852199975" lon="-66.9009832957400050">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-256" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962849855000027" lon="-66.9006983957699930">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-255" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963099247099994" lon="-66.9004096897500062">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-254" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963460312199981" lon="-66.8999643088399978">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-253" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4963674937399976" lon="-66.8995190268099975">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-252" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964042595200002" lon="-66.8991735198899988">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-251" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964342904600016" lon="-66.8989168392400018">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-250" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4964691859899997" lon="-66.8986576595900004">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-249" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965177537999974" lon="-66.8982516526500035">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-248" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4965645345300000" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-247" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972940122799994" lon="-66.8990818915400069">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-246" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972619845899970" lon="-66.8988943461300067">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-245" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971868237599999" lon="-66.8985026652599970">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-244" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971740993299978" lon="-66.8984207946800069">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-243" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971642103599976" lon="-66.8983385252700060">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-242" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971571688999994" lon="-66.8982559572600053">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-241" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971529835200013" lon="-66.8981731912499953">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-240" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971516593299992" lon="-66.8980903280699977">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-239" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971531979399995" lon="-66.8980074686800066">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-238" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971537632699992" lon="-66.8979929326399940">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-237" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971585263300007" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-236" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985650466399978" lon="-66.8986611001000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-235" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985223443700004" lon="-66.8986437803999934">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-234" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984803225899999" lon="-66.8986248374099972">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-233" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984390417300002" lon="-66.8986042983499942">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-232" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983985611399984" lon="-66.8985821927699931">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-231" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983589390100001" lon="-66.8985585524399937">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-230" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983202322999993" lon="-66.8985334113500016">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-229" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982824966700026" lon="-66.8985068056500012">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-228" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982457863600001" lon="-66.8984787735799813">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-227" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982101541599988" lon="-66.8984493554499977">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-226" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981756512799986" lon="-66.8984185935500051">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-225" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981423273400001" lon="-66.8983865321200000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-224" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981102302499991" lon="-66.8983532172299959">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-223" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980794061400022" lon="-66.8983186968000041">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-222" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980561794799989" lon="-66.8982908470299975">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-221" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980091004699965" lon="-66.8982382300000040">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-220" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979638674700002" lon="-66.8981839848499931">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-219" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979205355899978" lon="-66.8981281776799932">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-218" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978791576099990" lon="-66.8980708764700012">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-217" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978397839499991" lon="-66.8980121510300023">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-216" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977995503699990" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-215" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973441388099999" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-214" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973472980199993" lon="-66.8979612051699917">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-213" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973568530499985" lon="-66.8979980984800022">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-212" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973676765100024" lon="-66.8980346323699990">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-211" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973797552199990" lon="-66.8980707623299935">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-210" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973930744599979" lon="-66.8981064443500060">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-209" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974076180099978" lon="-66.8981416349499938">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-208" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974233681299989" lon="-66.8981762912499960">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-207" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974403056599996" lon="-66.8982103710399940">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-206" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974584099400019" lon="-66.8982438327900013">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-205" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974776589300003" lon="-66.8982766357299994">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-204" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974980291699982" lon="-66.8983087399099929">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-203" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975194958399989" lon="-66.8983401061999956">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-202" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975420327900011" lon="-66.8983706963900033">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-201" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975656125700016" lon="-66.8984004732100033">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-200" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975725955900003" lon="-66.8984088960999941">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-199" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977151716199977" lon="-66.8985644712499976">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-198" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983789342400016" lon="-66.8987121958899991">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-197" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980557712199989" lon="-66.8983983944699929">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-196" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980061847199977" lon="-66.8983495882200003">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-195" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979583141299990" lon="-66.8982990631200067">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-194" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979122177900006" lon="-66.8982468807000004">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-193" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978679518399982" lon="-66.8981931045599936">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-192" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978255702199998" lon="-66.8981378001999900">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-191" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977851245599982" lon="-66.8980810350099944">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-190" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977466641499984" lon="-66.8980228781500017">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-189" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977278161999976" lon="-66.8979926842300046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-188" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977014156699990" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-187" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979060636200003" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-186" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979235978800016" lon="-66.8979751215899938">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-185" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979665330799961" lon="-66.8980389297399967">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-184" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980116459900010" lon="-66.8981011849700025">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-183" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980588816299996" lon="-66.8981618114499952">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-182" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981081824599993" lon="-66.8982207353000007">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-181" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981277215599995" lon="-66.8982429745800005">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-180" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982180172900001" lon="-66.8983219769200019">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-179" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983109866599982" lon="-66.8983977470099944">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-178" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984065163999993" lon="-66.8984701925199943">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-177" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985044901200020" lon="-66.8985392251900066">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-176" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985655291700013" lon="-66.8985797046599941">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-175" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4985894030699978" lon="-66.8985925448899934">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-174" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982779118200007" lon="-66.8987583619200024">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-173" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982200921499995" lon="-66.8986946857999811">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-172" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4981601083800005" lon="-66.8986330874400039">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-171" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980980336199998" lon="-66.8985736418899961">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-170" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980339434700003" lon="-66.8985164215600037">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-169" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979924468799979" lon="-66.8984814478599930">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-168" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979338934099982" lon="-66.8984224753200039">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-167" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978774124499985" lon="-66.8983614739200050">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-166" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978230728199975" lon="-66.8982985179600007">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-165" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977709406999988" lon="-66.8982336841500000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-164" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977210796299989" lon="-66.8981670514800015">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-163" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976702019799966" lon="-66.8980936891099986">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-162" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976396325099994" lon="-66.8980441594499950">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-161" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976107923500006" lon="-66.8979935819800033">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-160" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975863325000009" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-159" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979886416799975" lon="-66.8986379866099981">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-158" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979398743499992" lon="-66.8985984505400069">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-157" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975203752300015" lon="-66.8982062276299985">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-156" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972609674800008" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-155" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969159754600021" lon="-66.8979469999999878">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-154" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969668168800006" lon="-66.8981047951799894">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-153" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970539977099975" lon="-66.8984253776999935">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-152" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972046468099975" lon="-66.8990350387600046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-151" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979138786000004" lon="-66.8987390725000068">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-150" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980115386599984" lon="-66.8988506781099943">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-149" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4978145000900014" lon="-66.8986508031099874">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-148" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983787414899989" lon="-66.8990110065399932">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-147" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982239350800004" lon="-66.8988287410700053">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-146" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4984569345600001" lon="-66.8988036110699937">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-145" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4983334969600026" lon="-66.8988240382300035">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-144" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955907653199993" lon="-66.9021525317999988">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-143" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955716818199996" lon="-66.9021487105000006">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-142" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955524082200000" lon="-66.9021460350499808">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-141" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955330118599974" lon="-66.9021445148199803">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-140" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955135604899983" lon="-66.9021441551000038">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-139" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954941220699975" lon="-66.9021449571600044">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-138" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954747644899999" lon="-66.9021469181899988">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-137" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954555553799977" lon="-66.9021500313399997">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-136" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954365618499992" lon="-66.9021542857399965">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-135" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954178502299964" lon="-66.9021596665199922">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-134" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953994859099975" lon="-66.9021661548899971">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-133" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953815330300007" lon="-66.9021737281800029">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-132" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953640543100004" lon="-66.9021823599299950">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-131" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953471108099983" lon="-66.9021920200000011">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-130" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953307617000018" lon="-66.9022026746300043">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-129" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953150641199997" lon="-66.9022142865999996">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-128" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959739620200008" lon="-66.9009545499399962">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-127" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959280306299974" lon="-66.9009321611899992">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-126" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958813539300007" lon="-66.9009114058000023">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-125" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958339887999976" lon="-66.9008923090400032">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-124" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4957859929299993" lon="-66.9008748941899967">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-123" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4957374247999997" lon="-66.9008591824500058">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-122" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4956883435900004" lon="-66.9008451929699959">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-121" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4956388091000008" lon="-66.9008329427999939">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-120" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4955276566999984" lon="-66.9008007124700015">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-119" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4954583077499990" lon="-66.9007799777599956">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-118" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953882848899980" lon="-66.9007617011800022">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-117" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4953176734299998" lon="-66.9007459049900035">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-116" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4962700263799977" lon="-66.9010472963699954">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-115" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958056912499984" lon="-66.9025679482599855">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-114" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958359980800005" lon="-66.9024133217100001">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-113" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958652051300003" lon="-66.9022966327299997">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-112" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958832425599979" lon="-66.9022122862100019">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-111" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4958903640100001" lon="-66.9021789848799955">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-110" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959114440500016" lon="-66.9020605215000046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-109" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959284195800020" lon="-66.9019413869200008">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-108" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959412699199994" lon="-66.9018217262899952">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-107" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4959432879799994" lon="-66.9017984121000069">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-106" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4960279313800005" lon="-66.9011267369299958">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-105" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4960190921399974" lon="-66.9009785447500036">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-104" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979196457599997" lon="-66.9025488747499963">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-103" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977696920400021" lon="-66.9017350473800008">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-102" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977218078700005" lon="-66.9014588562699970">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-101" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977064766999995" lon="-66.9013704279399803">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-100" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975172582699994" lon="-66.9003151283900053">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-99" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979151350299986" lon="-66.9025243939500029">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-98" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972461277600004" lon="-66.9026599894099974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-97" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4971623784400023" lon="-66.9022121940199952">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-96" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970543100399976" lon="-66.9016132887300046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-95" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4970123355900000" lon="-66.9013806718899957">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-94" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4969015647500008" lon="-66.9007254838600005">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-93" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968865948899985" lon="-66.9006477751899951">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968689501500005" lon="-66.9005706417599981">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-91" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968486520300015" lon="-66.9004941775500015">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-90" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968257252499981" lon="-66.9004184757300067">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-89" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4968001977600007" lon="-66.9003436285199911">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-88" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967953031299999" lon="-66.9003301835499968">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-87" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4967135008600021" lon="-66.9000319800299934">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-86" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4966736602000008" lon="-66.8999771078400016">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-85" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977457145699979" lon="-66.9015967475500020">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-84" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4979862840700005" lon="-66.9015477735400026">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-83" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977592115799983" lon="-66.9016745969899915">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-82" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4980731694399996" lon="-66.8989307704899971">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-81" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4982483097799975" lon="-66.8989086649000058">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-80" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4972986925499985" lon="-66.8992315182200059">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-79" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973390934099999" lon="-66.8991661363299954">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-78" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973478783399976" lon="-66.8991494384300012">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-77" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973577867000003" lon="-66.8991333953999998">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-76" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973687708999979" lon="-66.8991180842899951">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-75" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973807782000002" lon="-66.8991035786399948">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-74" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973937509399988" lon="-66.8990899481100030">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-73" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974076267900003" lon="-66.8990772581699957">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-72" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974223391400017" lon="-66.8990655697400030">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-71" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974378173199980" lon="-66.8990549389800009">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-70" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974539870000001" lon="-66.8990454169299937">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-69" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974707705299988" lon="-66.8990370493200004">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-68" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974880872899963" lon="-66.8990298763399949">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-67" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975058541300008" lon="-66.8990239324400022">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-66" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975239857199956" lon="-66.8990192461599946">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-65" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975423949800017" lon="-66.8990158400099943">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-64" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975609935100014" lon="-66.8990137303500063">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-63" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977432723199993" lon="-66.8986003190399998">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977239683400008" lon="-66.8985883402699955">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-61" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4977039965199985" lon="-66.8985775370200031">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-60" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976834268800001" lon="-66.8985679471799983">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-59" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976623315499982" lon="-66.8985596043700070">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-58" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976407844999997" lon="-66.8985525378400041">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-57" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976188612799994" lon="-66.8985467723800014">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-56" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975966387699984" lon="-66.8985423281900040">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-55" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975741948899977" lon="-66.8985392208600018">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-54" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975516083400020" lon="-66.8985374612900046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-53" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975289583099975" lon="-66.8985370556499959">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-52" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975063242399980" lon="-66.8985380053599812">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-51" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974837854799983" lon="-66.8985403070799975">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-50" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974614210599988" lon="-66.8985439527599794">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-49" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974393094099998" lon="-66.8985489295900067">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974175280600015" lon="-66.8985552201399969">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973997838400006" lon="-66.8985664589399960">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973831906699981" lon="-66.8985793687899957">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973679021499979" lon="-66.8985938301700003">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-44" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973540598100001" lon="-66.8986097092199969">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-43" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973417917899976" lon="-66.8986268589300010">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-42" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973312116699979" lon="-66.8986451205699808">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973224173700004" lon="-66.8986643250599968">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973154903199983" lon="-66.8986842946400060">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973104946299998" lon="-66.8987048444499948">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-38" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973074765499987" lon="-66.8987257842500043">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973064640199976" lon="-66.8987469201999971">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973074664100015" lon="-66.8987680566499989">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973104744399990" lon="-66.8987889979199934">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973154602699985" lon="-66.8988095501800046">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-33" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973223777499989" lon="-66.8988295231499990">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-32" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973309210999997" lon="-66.8988466650699820">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973408521400007" lon="-66.8988630257099999">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973521014100015" lon="-66.8988784906400014">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973645902299975" lon="-66.8988929517099820">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973782312399972" lon="-66.8989063077499964">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-27" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4973929290399965" lon="-66.8989184653599978">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-26" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974085808299993" lon="-66.8989293394899960">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-25" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974250771200008" lon="-66.8989388540999954">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974423025500023" lon="-66.8989469426300047">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974601366199991" lon="-66.8989535485099935">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974784545999977" lon="-66.8989586255299997">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-21" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4974971283699983" lon="-66.8989621381799964">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975160273199979" lon="-66.8989640618899983">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975350192499981" lon="-66.8989643832200045">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4975539713399986" lon="-66.8989630999000013">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841" lat="10.4976622110699989" lon="-66.8989826400199945">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8988753224482480">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.9015157811893317">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.9014250645420958">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4972461297405815" lon="-66.9026599999999974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4972460760916597" lon="-66.9026599999999974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4979393027591037" lon="-66.9026599999999974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4957905455867380" lon="-66.9026599999999974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4953000000000003" lon="-66.9007426004998393">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4953000000000003" lon="-66.9022314112524441">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8989876058872994">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8989771105911757">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8992280761345768">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999979" lon="-66.8985977731945383">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4985999999999962" lon="-66.8986737444705426">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4960415504698421" lon="-66.9026599999999974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="10.4964387863919075" lon="-66.9026599999999974">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <way visible="true" id="-3167" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-1804"/>
-        <nd ref="-86"/>
-        <nd ref="-87"/>
-        <nd ref="-88"/>
-        <nd ref="-89"/>
-        <nd ref="-90"/>
-        <nd ref="-91"/>
-        <nd ref="-92"/>
-        <nd ref="-93"/>
-        <nd ref="-94"/>
-        <nd ref="-95"/>
-        <nd ref="-1809"/>
-        <tag k="alt_name" v="Av. Este 10 bis"/>
-        <tag k="maxspeed:conditional" v="60 @ (22:00-06:00)"/>
-        <tag k="surface" v="asphalt"/>
+    <way visible="true" id="-3143" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-97"/>
+        <nd ref="-169"/>
+        <nd ref="-170"/>
+        <nd ref="-171"/>
+        <nd ref="-1707"/>
         <tag k="z_order" v="-999999"/>
-        <tag k="lit" v="yes"/>
-        <tag k="toll" v="no"/>
+        <tag k="destination:ref" v="A-01"/>
+        <tag k="destination:symbol" v="motorway"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Distribuidor: San Agustín del Norte"/>
-        <tag k="source:datetime" v="2015-12-15T02:07:00.000Z;2015-06-10T00:02:17.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="bicycle" v="no"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-11-30T21:06:28.000Z;2019-01-17T19:50:06Z"/>
         <tag k="way_area" v="-999999"/>
-        <tag k="maxheight" v="5"/>
-        <tag k="incline" v="10%"/>
-        <tag k="lanes" v="2"/>
-        <tag k="maxspeed" v="50"/>
-        <tag k="bus:lanes" v="no|yes"/>
-        <tag k="uuid" v="{22a82dc7-8817-40e1-9204-b335c659de38}"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="maxspeed:lanes" v="50|30"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
         <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
         <tag k="attribution" v="osm"/>
-        <tag k="minspeed" v="40"/>
         <tag k="oneway" v="yes"/>
-        <tag k="cycleway" v="no"/>
-        <tag k="foot" v="no"/>
-        <tag k="overtaking" v="no"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z"/>
-        <tag k="sidewalk" v="none"/>
-        <tag k="hgv:lanes" v="no|yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;Yahoo;osm:line"/>
-        <tag k="destination" v="San Agustín del Norte"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
         <tag k="highway" v="motorway_link"/>
-        <tag k="maxweight" v="20"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
-    <way visible="true" id="-3164" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1807"/>
-        <nd ref="-105"/>
-        <tag k="source" v="osm:line"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
-        <tag k="highway" v="road"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
-        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="attribution" v="osm"/>
+    <way visible="true" id="-3142" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-1707"/>
+        <nd ref="-172"/>
         <tag k="z_order" v="-999999"/>
+        <tag k="destination:ref" v="A-01"/>
+        <tag k="layer" v="2"/>
+        <tag k="destination:symbol" v="motorway"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
-    <way visible="true" id="-3160" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1805"/>
-        <nd ref="-268"/>
-        <nd ref="-267"/>
-        <nd ref="-266"/>
-        <nd ref="-265"/>
-        <nd ref="-264"/>
-        <nd ref="-263"/>
-        <nd ref="-262"/>
-        <nd ref="-261"/>
+    <way visible="true" id="-3139" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-164"/>
+        <nd ref="-176"/>
+        <nd ref="-175"/>
+        <nd ref="-174"/>
+        <nd ref="-1705"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="layer" v="-1"/>
+        <tag k="destination:ref" v="A-01"/>
+        <tag k="destination:symbol" v="motorway"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2014-09-05T04:44:06.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{0b879342-4f8f-4441-bac0-749e8971415a};{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
+    </way>
+    <way visible="true" id="-3138" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-173"/>
+        <nd ref="-1705"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="destination:ref" v="A-01"/>
+        <tag k="layer" v="2"/>
+        <tag k="destination:symbol" v="motorway"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Distribuidor: Botánico"/>
+        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="lanes" v="3"/>
+        <tag k="uuid" v="{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="destination" v="Plaza Venezuela;Petare"/>
+    </way>
+    <way visible="true" id="-3135" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1703"/>
+        <nd ref="-285"/>
+        <nd ref="-284"/>
+        <nd ref="-283"/>
+        <nd ref="-282"/>
+        <nd ref="-281"/>
+        <nd ref="-280"/>
+        <nd ref="-279"/>
+        <nd ref="-278"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -967,12 +1001,12 @@
         <tag k="highway" v="motorway"/>
         <tag k="maxweight" v="20"/>
     </way>
-    <way visible="true" id="-3158" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1805"/>
-        <nd ref="-269"/>
-        <nd ref="-270"/>
-        <nd ref="-271"/>
-        <nd ref="-1804"/>
+    <way visible="true" id="-3133" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1703"/>
+        <nd ref="-286"/>
+        <nd ref="-287"/>
+        <nd ref="-288"/>
+        <nd ref="-1702"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -1010,114 +1044,80 @@
         <tag k="highway" v="motorway"/>
         <tag k="maxweight" v="20"/>
     </way>
-    <way visible="true" id="-3155" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-80"/>
-        <nd ref="-152"/>
-        <nd ref="-153"/>
-        <nd ref="-154"/>
-        <nd ref="-1801"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="destination:ref" v="A-01"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="source:datetime" v="2014-11-30T21:06:28.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-    </way>
-    <way visible="true" id="-3154" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-1801"/>
-        <nd ref="-155"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="destination:ref" v="A-01"/>
-        <tag k="layer" v="2"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="uuid" v="{d6301467-078a-4887-9721-e695c7326c60}"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-    </way>
-    <way visible="true" id="-3151" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-147"/>
-        <nd ref="-159"/>
-        <nd ref="-158"/>
-        <nd ref="-157"/>
-        <nd ref="-1799"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="layer" v="-1"/>
-        <tag k="destination:ref" v="A-01"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2014-09-05T04:44:06.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="uuid" v="{0b879342-4f8f-4441-bac0-749e8971415a};{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z;2019-01-17T19:50:05.713Z"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-    </way>
-    <way visible="true" id="-3150" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-156"/>
-        <nd ref="-1799"/>
-        <tag k="z_order" v="-999999"/>
-        <tag k="destination:ref" v="A-01"/>
-        <tag k="layer" v="2"/>
-        <tag k="destination:symbol" v="motorway"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="name" v="Distribuidor: Botánico"/>
-        <tag k="source:datetime" v="2014-10-13T00:42:46.000Z;2019-01-17T19:50:06Z"/>
-        <tag k="way_area" v="-999999"/>
-        <tag k="lanes" v="3"/>
-        <tag k="uuid" v="{a8119095-4ce1-43b7-821c-e0212cfff2ef}"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="oneway" v="yes"/>
-        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.713Z"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="osm_id" v="-999999"/>
-        <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
-        <tag k="highway" v="motorway_link"/>
-        <tag k="destination" v="Plaza Venezuela;Petare"/>
-    </way>
-    <way visible="true" id="-92" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-99"/>
+    <way visible="true" id="-3128" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-1702"/>
         <nd ref="-103"/>
-        <nd ref="-83"/>
-        <nd ref="-85"/>
-        <nd ref="-102"/>
-        <nd ref="-101"/>
+        <nd ref="-104"/>
+        <nd ref="-105"/>
+        <nd ref="-106"/>
+        <nd ref="-107"/>
+        <nd ref="-108"/>
+        <nd ref="-109"/>
+        <nd ref="-110"/>
+        <nd ref="-111"/>
+        <nd ref="-112"/>
+        <nd ref="-1698"/>
+        <tag k="alt_name" v="Av. Este 10 bis"/>
+        <tag k="maxspeed:conditional" v="60 @ (22:00-06:00)"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="z_order" v="-999999"/>
+        <tag k="lit" v="yes"/>
+        <tag k="toll" v="no"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="name" v="Distribuidor: San Agustín del Norte"/>
+        <tag k="source:datetime" v="2015-12-15T02:07:00.000Z;2015-06-10T00:02:17.000Z;2019-01-17T19:50:06Z"/>
+        <tag k="bicycle" v="no"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="maxheight" v="5"/>
+        <tag k="incline" v="10%"/>
+        <tag k="lanes" v="2"/>
+        <tag k="maxspeed" v="50"/>
+        <tag k="bus:lanes" v="no|yes"/>
+        <tag k="uuid" v="{22a82dc7-8817-40e1-9204-b335c659de38}"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="maxspeed:lanes" v="50|30"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="minspeed" v="40"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="cycleway" v="no"/>
+        <tag k="foot" v="no"/>
+        <tag k="overtaking" v="no"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.653Z"/>
+        <tag k="sidewalk" v="none"/>
+        <tag k="hgv:lanes" v="no|yes"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="source" v="albertoq2004@hotmail.com;Yahoo;osm:line"/>
+        <tag k="destination" v="San Agustín del Norte"/>
+        <tag k="highway" v="motorway_link"/>
+        <tag k="maxweight" v="20"/>
+    </way>
+    <way visible="true" id="-3125" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1696"/>
+        <nd ref="-122"/>
+        <tag k="source" v="osm:line"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.644Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="uuid" v="{ba18fba0-a24a-4c64-8450-fb6b959dc789}"/>
+        <tag k="source:datetime" v="2019-01-17T19:50:06Z"/>
+        <tag k="tags" v="\&quot;source:datetime\&quot;=&gt;\&quot;2018-10-30T13:05:51Z\\"/>
+        <tag k="way_area" v="-999999"/>
+        <tag k="osm_id" v="-999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="z_order" v="-999999"/>
+    </way>
+    <way visible="true" id="-62" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-116"/>
+        <nd ref="-120"/>
         <nd ref="-100"/>
-        <nd ref="-80"/>
+        <nd ref="-102"/>
+        <nd ref="-119"/>
+        <nd ref="-118"/>
+        <nd ref="-117"/>
+        <nd ref="-97"/>
         <tag k="service" v="drive-through"/>
         <tag k="z_order" v="-999999"/>
         <tag k="hoot:status" v="3"/>
@@ -1142,17 +1142,17 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="primary"/>
     </way>
-    <way visible="true" id="-89" timestamp="2019-01-10T17:16:06Z" version="1">
-        <nd ref="-112"/>
-        <nd ref="-111"/>
-        <nd ref="-110"/>
-        <nd ref="-109"/>
-        <nd ref="-108"/>
-        <nd ref="-107"/>
-        <nd ref="-106"/>
-        <nd ref="-1807"/>
-        <nd ref="-341"/>
-        <nd ref="-342"/>
+    <way visible="true" id="-52" timestamp="2019-01-10T17:16:06Z" version="1">
+        <nd ref="-129"/>
+        <nd ref="-128"/>
+        <nd ref="-127"/>
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-123"/>
+        <nd ref="-1696"/>
+        <nd ref="724"/>
+        <nd ref="725"/>
         <tag k="maxspeed:conditional" v="60 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -1190,19 +1190,19 @@
         <tag k="highway" v="motorway_link"/>
         <tag k="maxweight" v="20"/>
     </way>
-    <way visible="true" id="-31" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-80"/>
-        <nd ref="-247"/>
-        <nd ref="-246"/>
-        <nd ref="-245"/>
-        <nd ref="-244"/>
-        <nd ref="-243"/>
-        <nd ref="-242"/>
-        <nd ref="-241"/>
-        <nd ref="-240"/>
-        <nd ref="-239"/>
-        <nd ref="-238"/>
-        <nd ref="-237"/>
+    <way visible="true" id="-48" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-97"/>
+        <nd ref="-264"/>
+        <nd ref="-263"/>
+        <nd ref="-262"/>
+        <nd ref="-261"/>
+        <nd ref="-260"/>
+        <nd ref="-259"/>
+        <nd ref="-258"/>
+        <nd ref="-257"/>
+        <nd ref="-256"/>
+        <nd ref="-255"/>
+        <nd ref="-254"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="60"/>
@@ -1220,25 +1220,25 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-30" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-63"/>
-        <nd ref="-199"/>
-        <nd ref="-200"/>
-        <nd ref="-201"/>
-        <nd ref="-202"/>
-        <nd ref="-203"/>
-        <nd ref="-204"/>
-        <nd ref="-205"/>
-        <nd ref="-206"/>
-        <nd ref="-207"/>
-        <nd ref="-208"/>
-        <nd ref="-209"/>
-        <nd ref="-210"/>
-        <nd ref="-211"/>
-        <nd ref="-212"/>
-        <nd ref="-213"/>
-        <nd ref="-214"/>
-        <nd ref="-215"/>
+    <way visible="true" id="-47" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-80"/>
+        <nd ref="-216"/>
+        <nd ref="-217"/>
+        <nd ref="-218"/>
+        <nd ref="-219"/>
+        <nd ref="-220"/>
+        <nd ref="-221"/>
+        <nd ref="-222"/>
+        <nd ref="-223"/>
+        <nd ref="-224"/>
+        <nd ref="-225"/>
+        <nd ref="-226"/>
+        <nd ref="-227"/>
+        <nd ref="-228"/>
+        <nd ref="-229"/>
+        <nd ref="-230"/>
+        <nd ref="-231"/>
+        <nd ref="-232"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="60"/>
@@ -1257,19 +1257,19 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-29" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-188"/>
-        <nd ref="-189"/>
-        <nd ref="-190"/>
-        <nd ref="-191"/>
-        <nd ref="-192"/>
-        <nd ref="-193"/>
-        <nd ref="-194"/>
-        <nd ref="-195"/>
-        <nd ref="-196"/>
-        <nd ref="-197"/>
-        <nd ref="-198"/>
-        <nd ref="-146"/>
+    <way visible="true" id="-46" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-205"/>
+        <nd ref="-206"/>
+        <nd ref="-207"/>
+        <nd ref="-208"/>
+        <nd ref="-209"/>
+        <nd ref="-210"/>
+        <nd ref="-211"/>
+        <nd ref="-212"/>
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-163"/>
         <tag k="z_order" v="-999999"/>
         <tag k="layer" v="-1"/>
         <tag k="destination:symbol" v="centre"/>
@@ -1289,23 +1289,23 @@
         <tag k="highway" v="primary_link"/>
         <tag k="destination" v="Centro"/>
     </way>
-    <way visible="true" id="-28" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-160"/>
-        <nd ref="-161"/>
+    <way visible="true" id="-45" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-177"/>
+        <nd ref="-178"/>
+        <nd ref="-179"/>
+        <nd ref="-180"/>
+        <nd ref="-181"/>
+        <nd ref="-182"/>
+        <nd ref="-183"/>
+        <nd ref="-184"/>
+        <nd ref="-185"/>
+        <nd ref="-186"/>
+        <nd ref="-187"/>
+        <nd ref="-188"/>
+        <nd ref="-189"/>
+        <nd ref="-190"/>
+        <nd ref="-191"/>
         <nd ref="-162"/>
-        <nd ref="-163"/>
-        <nd ref="-164"/>
-        <nd ref="-165"/>
-        <nd ref="-166"/>
-        <nd ref="-167"/>
-        <nd ref="-168"/>
-        <nd ref="-169"/>
-        <nd ref="-170"/>
-        <nd ref="-171"/>
-        <nd ref="-172"/>
-        <nd ref="-173"/>
-        <nd ref="-174"/>
-        <nd ref="-145"/>
         <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1323,12 +1323,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-24" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-82"/>
-        <nd ref="-150"/>
-        <nd ref="-151"/>
-        <nd ref="-149"/>
-        <nd ref="-63"/>
+    <way visible="true" id="-41" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-99"/>
+        <nd ref="-167"/>
+        <nd ref="-168"/>
+        <nd ref="-166"/>
+        <nd ref="-80"/>
         <tag k="z_order" v="-999999"/>
         <tag k="layer" v="-1"/>
         <tag k="hoot:status" v="3"/>
@@ -1348,9 +1348,9 @@
         <tag k="highway" v="secondary"/>
         <tag k="destination" v="Bellas Artes;Colegio de Ingenieros"/>
     </way>
-    <way visible="true" id="-23" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-105"/>
-        <nd ref="-116"/>
+    <way visible="true" id="-40" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-122"/>
+        <nd ref="-133"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -1366,9 +1366,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-22" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-96"/>
-        <nd ref="-102"/>
+    <way visible="true" id="-39" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-113"/>
+        <nd ref="-119"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1385,10 +1385,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-20" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-12"/>
-        <nd ref="-98"/>
-        <nd ref="-99"/>
+    <way visible="true" id="-37" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-29"/>
+        <nd ref="-115"/>
+        <nd ref="-116"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1405,12 +1405,12 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-19" timestamp="2019-01-17T19:50:06Z" version="1">
-        <nd ref="-1809"/>
-        <nd ref="-96"/>
-        <nd ref="-97"/>
-        <nd ref="-98"/>
-        <nd ref="-13"/>
+    <way visible="true" id="-36" timestamp="2019-01-17T19:50:06Z" version="1">
+        <nd ref="-1698"/>
+        <nd ref="-113"/>
+        <nd ref="-114"/>
+        <nd ref="-115"/>
+        <nd ref="-30"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1427,25 +1427,25 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-18" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
-        <nd ref="-80"/>
-        <nd ref="-79"/>
-        <nd ref="-78"/>
-        <nd ref="-77"/>
-        <nd ref="-76"/>
-        <nd ref="-75"/>
-        <nd ref="-74"/>
-        <nd ref="-73"/>
-        <nd ref="-72"/>
-        <nd ref="-71"/>
-        <nd ref="-70"/>
-        <nd ref="-69"/>
-        <nd ref="-68"/>
-        <nd ref="-67"/>
-        <nd ref="-66"/>
-        <nd ref="-65"/>
-        <nd ref="-64"/>
-        <nd ref="-17"/>
+    <way visible="true" id="-35" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-97"/>
+        <nd ref="-96"/>
+        <nd ref="-95"/>
+        <nd ref="-94"/>
+        <nd ref="-93"/>
+        <nd ref="-92"/>
+        <nd ref="-91"/>
+        <nd ref="-90"/>
+        <nd ref="-89"/>
+        <nd ref="-88"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-81"/>
+        <nd ref="-34"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="lit" v="yes"/>
@@ -1469,7 +1469,24 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-17" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+    <way visible="true" id="-34" timestamp="2019-01-17T19:50:06Z" version="1" changeset="841">
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
         <nd ref="-63"/>
         <nd ref="-62"/>
         <nd ref="-61"/>
@@ -1500,23 +1517,6 @@
         <nd ref="-36"/>
         <nd ref="-35"/>
         <nd ref="-34"/>
-        <nd ref="-33"/>
-        <nd ref="-32"/>
-        <nd ref="-31"/>
-        <nd ref="-30"/>
-        <nd ref="-29"/>
-        <nd ref="-28"/>
-        <nd ref="-27"/>
-        <nd ref="-26"/>
-        <nd ref="-25"/>
-        <nd ref="-24"/>
-        <nd ref="-23"/>
-        <nd ref="-22"/>
-        <nd ref="-21"/>
-        <nd ref="-20"/>
-        <nd ref="-19"/>
-        <nd ref="-18"/>
-        <nd ref="-17"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="30"/>
@@ -1535,11 +1535,11 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-17"/>
-        <nd ref="-82"/>
-        <nd ref="-81"/>
-        <nd ref="-16"/>
+    <way visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-34"/>
+        <nd ref="-99"/>
+        <nd ref="-98"/>
+        <nd ref="-33"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
         <tag k="lit" v="yes"/>
@@ -1563,9 +1563,9 @@
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-83"/>
-        <nd ref="-15"/>
+    <way visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-100"/>
+        <nd ref="-32"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1582,10 +1582,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-85"/>
-        <nd ref="-84"/>
-        <nd ref="-14"/>
+    <way visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-31"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1602,10 +1602,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-11"/>
-        <nd ref="-104"/>
-        <nd ref="-99"/>
+    <way visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28"/>
+        <nd ref="-121"/>
+        <nd ref="-116"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="20"/>
@@ -1623,12 +1623,12 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-10"/>
-        <nd ref="-115"/>
-        <nd ref="-114"/>
-        <nd ref="-113"/>
-        <nd ref="-112"/>
+    <way visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-27"/>
+        <nd ref="-132"/>
+        <nd ref="-131"/>
+        <nd ref="-130"/>
+        <nd ref="-129"/>
         <tag k="z_order" v="-999999"/>
         <tag k="surface" v="asphalt"/>
         <tag k="hoot:status" v="3"/>
@@ -1651,21 +1651,21 @@
         <tag k="source" v="osm:line"/>
         <tag k="highway" v="secondary"/>
     </way>
-    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-105"/>
-        <nd ref="-128"/>
-        <nd ref="-127"/>
-        <nd ref="-126"/>
-        <nd ref="-125"/>
-        <nd ref="-124"/>
-        <nd ref="-123"/>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-122"/>
-        <nd ref="-121"/>
-        <nd ref="-120"/>
-        <nd ref="-119"/>
-        <nd ref="-118"/>
-        <nd ref="-117"/>
-        <nd ref="-9"/>
+        <nd ref="-145"/>
+        <nd ref="-144"/>
+        <nd ref="-143"/>
+        <nd ref="-142"/>
+        <nd ref="-141"/>
+        <nd ref="-140"/>
+        <nd ref="-139"/>
+        <nd ref="-138"/>
+        <nd ref="-137"/>
+        <nd ref="-136"/>
+        <nd ref="-135"/>
+        <nd ref="-134"/>
+        <nd ref="-26"/>
         <tag k="source" v="osm:line"/>
         <tag k="oneway" v="no"/>
         <tag k="hoot:status" v="3"/>
@@ -1681,25 +1681,25 @@
         <tag k="osm_id" v="-999999"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-112"/>
-        <nd ref="-144"/>
-        <nd ref="-143"/>
-        <nd ref="-142"/>
-        <nd ref="-141"/>
-        <nd ref="-140"/>
-        <nd ref="-139"/>
-        <nd ref="-138"/>
-        <nd ref="-137"/>
-        <nd ref="-136"/>
-        <nd ref="-135"/>
-        <nd ref="-134"/>
-        <nd ref="-133"/>
-        <nd ref="-132"/>
-        <nd ref="-131"/>
-        <nd ref="-130"/>
+    <way visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-129"/>
-        <nd ref="-8"/>
+        <nd ref="-161"/>
+        <nd ref="-160"/>
+        <nd ref="-159"/>
+        <nd ref="-158"/>
+        <nd ref="-157"/>
+        <nd ref="-156"/>
+        <nd ref="-155"/>
+        <nd ref="-154"/>
+        <nd ref="-153"/>
+        <nd ref="-152"/>
+        <nd ref="-151"/>
+        <nd ref="-150"/>
+        <nd ref="-149"/>
+        <nd ref="-148"/>
+        <nd ref="-147"/>
+        <nd ref="-146"/>
+        <nd ref="-25"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="hoot:status" v="3"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.640Z"/>
@@ -1713,9 +1713,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-145"/>
-        <nd ref="-7"/>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-162"/>
+        <nd ref="-24"/>
         <tag k="source" v="albertoq2004@hotmail.com;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="hoot:status" v="3"/>
@@ -1733,9 +1733,9 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-146"/>
-        <nd ref="-6"/>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-163"/>
+        <nd ref="-23"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="60"/>
@@ -1753,10 +1753,10 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-5"/>
-        <nd ref="-148"/>
-        <nd ref="-147"/>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22"/>
+        <nd ref="-165"/>
+        <nd ref="-164"/>
         <tag k="z_order" v="-999999"/>
         <tag k="layer" v="-1"/>
         <tag k="destination:symbol" v="motorway"/>
@@ -1776,21 +1776,21 @@
         <tag k="highway" v="motorway_link"/>
         <tag k="destination" v="Plaza Venezuela;Petare"/>
     </way>
-    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-187"/>
-        <nd ref="-186"/>
-        <nd ref="-185"/>
-        <nd ref="-184"/>
-        <nd ref="-183"/>
-        <nd ref="-182"/>
-        <nd ref="-181"/>
-        <nd ref="-180"/>
-        <nd ref="-179"/>
-        <nd ref="-178"/>
-        <nd ref="-177"/>
-        <nd ref="-176"/>
-        <nd ref="-175"/>
-        <nd ref="-4"/>
+    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-204"/>
+        <nd ref="-203"/>
+        <nd ref="-202"/>
+        <nd ref="-201"/>
+        <nd ref="-200"/>
+        <nd ref="-199"/>
+        <nd ref="-198"/>
+        <nd ref="-197"/>
+        <nd ref="-196"/>
+        <nd ref="-195"/>
+        <nd ref="-194"/>
+        <nd ref="-193"/>
+        <nd ref="-192"/>
+        <nd ref="-21"/>
         <tag k="source" v="osm:line"/>
         <tag k="hoot:status" v="1"/>
         <tag k="source:ingest:datetime" v="2019-01-17T19:50:05.712Z"/>
@@ -1804,29 +1804,29 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-216"/>
-        <nd ref="-217"/>
-        <nd ref="-218"/>
-        <nd ref="-219"/>
-        <nd ref="-220"/>
-        <nd ref="-221"/>
-        <nd ref="-222"/>
-        <nd ref="-223"/>
-        <nd ref="-224"/>
-        <nd ref="-225"/>
-        <nd ref="-226"/>
-        <nd ref="-227"/>
-        <nd ref="-228"/>
-        <nd ref="-229"/>
-        <nd ref="-230"/>
-        <nd ref="-231"/>
-        <nd ref="-232"/>
+    <way visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-233"/>
         <nd ref="-234"/>
         <nd ref="-235"/>
         <nd ref="-236"/>
-        <nd ref="-3"/>
+        <nd ref="-237"/>
+        <nd ref="-238"/>
+        <nd ref="-239"/>
+        <nd ref="-240"/>
+        <nd ref="-241"/>
+        <nd ref="-242"/>
+        <nd ref="-243"/>
+        <nd ref="-244"/>
+        <nd ref="-245"/>
+        <nd ref="-246"/>
+        <nd ref="-247"/>
+        <nd ref="-248"/>
+        <nd ref="-249"/>
+        <nd ref="-250"/>
+        <nd ref="-251"/>
+        <nd ref="-252"/>
+        <nd ref="-253"/>
+        <nd ref="-20"/>
         <tag k="source" v="Yahoo;osm:line"/>
         <tag k="oneway" v="yes"/>
         <tag k="maxspeed" v="50"/>
@@ -1843,22 +1843,22 @@
         <tag k="attribution" v="osm"/>
         <tag k="z_order" v="-999999"/>
     </way>
-    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2"/>
-        <nd ref="-260"/>
-        <nd ref="-259"/>
-        <nd ref="-258"/>
-        <nd ref="-116"/>
-        <nd ref="-257"/>
-        <nd ref="-256"/>
-        <nd ref="-255"/>
-        <nd ref="-254"/>
-        <nd ref="-253"/>
-        <nd ref="-252"/>
-        <nd ref="-251"/>
-        <nd ref="-250"/>
-        <nd ref="-249"/>
-        <nd ref="-248"/>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-19"/>
+        <nd ref="-277"/>
+        <nd ref="-276"/>
+        <nd ref="-275"/>
+        <nd ref="-133"/>
+        <nd ref="-274"/>
+        <nd ref="-273"/>
+        <nd ref="-272"/>
+        <nd ref="-271"/>
+        <nd ref="-270"/>
+        <nd ref="-269"/>
+        <nd ref="-268"/>
+        <nd ref="-267"/>
+        <nd ref="-266"/>
+        <nd ref="-265"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>
@@ -1893,16 +1893,16 @@
         <tag k="highway" v="motorway"/>
         <tag k="maxweight" v="20"/>
     </way>
-    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1"/>
-        <nd ref="-277"/>
-        <nd ref="-276"/>
-        <nd ref="-275"/>
-        <nd ref="-274"/>
-        <nd ref="-273"/>
-        <nd ref="-272"/>
-        <nd ref="-86"/>
-        <nd ref="-1804"/>
+    <way visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18"/>
+        <nd ref="-294"/>
+        <nd ref="-293"/>
+        <nd ref="-292"/>
+        <nd ref="-291"/>
+        <nd ref="-290"/>
+        <nd ref="-289"/>
+        <nd ref="-103"/>
+        <nd ref="-1702"/>
         <tag k="maxspeed:conditional" v="120 @ (22:00-06:00)"/>
         <tag k="surface" v="asphalt"/>
         <tag k="z_order" v="-999999"/>


### PR DESCRIPTION
Refs #3149 
Turning on `reader.conflate.use.data.source.ids.2` for attribute conflation requires input files to be loaded in reverse order so that the secondary dataset keeps its IDs no matter the IDs in the source dataset.