### PR TITLE
Halt VMs after jenkins runs

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -171,6 +171,10 @@ pipeline {
         }
     }
     post {
+        always {
+            // Always halt the VM to save resources, but don't destroy so devs can troubleshoot on failures
+            sh "vagrant halt ${params.Box}"
+        }
         aborted {
             script {
                 notifySlack("ABORTED", "#builds_hoot")


### PR DESCRIPTION
After some conversation we've decided to halt all jobs in the jenkinsfile post step to help save resources.  A dev can still go in the workspace and restart the VM if they would like to for troubleshooting.