### PR TITLE
Implement `base.config` in Settings.cpp

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.cpp
@@ -52,26 +52,6 @@ ConflateCaseTestSuite::ConflateCaseTestSuite(const QString& dir, bool hideDisabl
   LOG_VART(_numTests);
 }
 
-void ConflateCaseTestSuite::_loadBaseConfig(const QString& testConfigFile, QStringList& confs)
-{
-  // need to grab the whole current config here to avoid errors when calling loadJson
-  Settings tempConfig = conf();
-  tempConfig.loadJson(ConfPath::search(testConfigFile));
-  if (tempConfig.hasKey(Settings::BASE_CONFIG_OPTION_KEY))
-  {
-    const QStringList baseConfigs =
-      tempConfig.getString(Settings::BASE_CONFIG_OPTION_KEY).trimmed().split(",");
-    for (int i = 0; i < baseConfigs.size(); i++)
-    {
-      const QString baseConfig = baseConfigs.at(i);
-      if (!baseConfig.isEmpty() && !confs.contains(baseConfig))
-      {
-        confs.append(baseConfig);
-      }
-    }
-  }
-}
-
 void ConflateCaseTestSuite::loadDir(const QString& dir, QStringList confs)
 {
   if (dir.endsWith(".off"))
@@ -85,11 +65,6 @@ void ConflateCaseTestSuite::loadDir(const QString& dir, QStringList confs)
   if (fi.exists())
   {
     const QString testConfFile = fi.absoluteFilePath();
-
-    // Check for a specified base config option, which allows the test to load a separate base
-    // configuration as its starting point. The other settings in its config file will override
-    // whatever is in the base configuration.
-    _loadBaseConfig(testConfFile, confs);
 
     // load the test's config file
     confs.append(testConfFile);

--- a/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/test/ConflateCaseTestSuite.h
@@ -54,8 +54,6 @@ private:
 
   bool _hideDisableTests;
   int _numTests;
-
-  void _loadBaseConfig(const QString& testConfigFile, QStringList& confs);
 };
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
@@ -45,6 +45,7 @@ class SettingsTest : public HootTestFixture
   CPPUNIT_TEST(envTest);
   CPPUNIT_TEST(replaceTest);
   CPPUNIT_TEST(storeTest);
+  CPPUNIT_TEST(baseSettingsTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -114,6 +115,32 @@ public:
     HOOT_STR_EQUALS(uut.getString("perty.csm.D"), "2");
     HOOT_STR_EQUALS(uut.getString("osm.map.writer.factory.writer"), "1");
     HOOT_STR_EQUALS(uut.getString("osm.map.reader.factory.reader"), "2");
+  }
+
+  void baseSettingsTest()
+  {
+    Settings uut;
+    uut.loadDefaults();
+
+    //  The following
+    //  Default value before change in JSON
+    CPPUNIT_ASSERT_EQUAL(false, uut.getBool("uuid.helper.repeatable"));
+    //  Default value before change in AttributeConflation.conf
+    HOOT_STR_EQUALS("hoot::OverwriteTag2Merger", uut.getString("tag.merger.default"));
+    CPPUNIT_ASSERT_EQUAL(false, uut.getBool("highway.merge.tags.only"));
+    //  Default value before change in NetworkAlgorithm.conf
+    HOOT_STR_EQUALS("hoot::HighwayRfClassifier", uut.getString("conflate.match.highway.classifier"));
+    HOOT_STR_EQUALS("hoot::MaximalNearestSublineMatcher", uut.getString("way.subline.matcher"));
+
+    uut.loadFromString("{ \"base.config\": \"AttributeConflation.conf,NetworkAlgorithm.conf\", \"uuid.helper.repeatable\": \"true\" }");
+    //  From the JSON
+    CPPUNIT_ASSERT_EQUAL(true, uut.getBool("uuid.helper.repeatable"));
+    //  From AttributeConflation.conf
+    HOOT_STR_EQUALS("hoot::OverwriteTag1Merger", uut.getString("tag.merger.default"));
+    CPPUNIT_ASSERT_EQUAL(true, uut.getBool("highway.merge.tags.only"));
+    //  From NetworkAlgorithm.conf
+    HOOT_STR_EQUALS("hoot::HighwayExpertClassifier", uut.getString("conflate.match.highway.classifier"));
+    HOOT_STR_EQUALS("hoot::MaximalSublineMatcher", uut.getString("way.subline.matcher"));
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -56,8 +56,6 @@ class Settings
 {
 public:
 
-  static const QString BASE_CONFIG_OPTION_KEY;
-
   // Technically, this is a Singleton and this constructor should not be publicly accessible.  There
   // does seem to be a use case for passing around temporary settings, though, which then makes
   // sense for it to remain public.  Possibly, we need a separate class for HootSettings that would


### PR DESCRIPTION
Refs #3191 
Removed `base.config` from `ConflateCaseTestSuite` class and implemented it for all uses of the `Settings` class, including test cases.  Also added unit test to ensure `base.config` works correctly.