### PR TITLE
Parallelize GraphComparator to reduce testing runtimes

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/GraphComparatorTest.cpp
@@ -92,6 +92,7 @@ public:
 
       GraphComparator uut(map, map2);
       uut.setIterations(3);
+      uut.setMaxThreads(2);
       uut.setPixelSize(10);
       uut.compareMaps();
       CPPUNIT_ASSERT_DOUBLES_EQUAL(0.973744272810634, uut.getMeanScore(), 0.00001);

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
@@ -38,7 +38,6 @@
 #include <tgs/StreamUtils.h>
 #include <tgs/TgsException.h>
 #include <tgs/Heap/JHeap.h>
-#include <tgs/Statistics/Random.h>
 
 using namespace std;
 
@@ -76,10 +75,21 @@ namespace Tgs
 
   const static float sqrt2 = sqrt(2.0f);
   ProbablePathCalculator::ProbablePathCalculator()
+    : _rows(-1),
+      _cols(-1),
+      _variation(0.0),
+      _verbose(Warning),
+      _randomGenerator(Random::instance())
   {
-    _rows = _cols = -1;
-    _variation = 0.0;
-    _verbose = Warning;
+  }
+
+  ProbablePathCalculator::ProbablePathCalculator(const RandomPtr& random)
+    : _rows(-1),
+      _cols(-1),
+      _variation(0.0),
+      _verbose(Warning),
+      _randomGenerator(random)
+  {
   }
 
   ProbablePathCalculator::~ProbablePathCalculator()
@@ -407,8 +417,8 @@ namespace Tgs
     map<int, float> patch;
     for (int i = 0; i < _patchCount; i++)
     {
-      float r = 1.0f + ((float)Tgs::Random::instance()->generateInt() / (float)RAND_MAX * 2.0f - 1.0f) * _variation;
-      patch[Tgs::Random::instance()->generateInt(_rows * _cols)] = r;
+      float r = 1.0f + ((float)_randomGenerator->generateInt() / (float)RAND_MAX * 2.0f - 1.0f) * _variation;
+      patch[_randomGenerator->generateInt(_rows * _cols)] = r;
     }
 
     float maxValue = -1e10f;
@@ -467,7 +477,7 @@ namespace Tgs
       }
       else
       {
-        float r = 1.0f + ((float)Tgs::Random::instance()->generateInt() / (float)RAND_MAX * 2.0f - 1.0f) * _variation;
+        float r = 1.0f + ((float)_randomGenerator->generateInt() / (float)RAND_MAX * 2.0f - 1.0f) * _variation;
         _currentValues[i] = r * _baseValues[i];
         if (_currentValues[i] < 1e-6)
         {

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __PROBABLE_PATH_CALCULATOR_H__
@@ -37,6 +37,7 @@
 #include <tgs/HashMap.h>
 #include <tgs/TgsExport.h>
 #include <tgs/RasterOps/Image.hpp>
+#include <tgs/Statistics/Random.h>
 
 namespace Tgs
 {
@@ -100,6 +101,7 @@ namespace Tgs
     };
 
     ProbablePathCalculator();
+    ProbablePathCalculator(const RandomPtr& random);
 
     virtual ~ProbablePathCalculator();
 
@@ -209,6 +211,8 @@ namespace Tgs
     std::vector<PpRoute> _routes;
     int _verbose;
     std::stringstream _null;
+    /** Pointer to the random number generator object, defaults to Tgs::Random::instance() */
+    RandomPtr _randomGenerator;
 
     bool _addReturnPaths(const PpPoint& source, const Destination& destination);
 

--- a/tgs/src/main/cpp/tgs/Statistics/Random.h
+++ b/tgs/src/main/cpp/tgs/Statistics/Random.h
@@ -80,6 +80,8 @@ namespace Tgs
     bool _is_single;
 
   };
+
+  typedef std::shared_ptr<Random> RandomPtr;
 }
 
 #endif


### PR DESCRIPTION
Made `GraphComparator` run each iteration separately so that it can be run in multiple threads.  Also had to pass `Tgs::Random` objects to the `ProbablePathCalculator` seeded with the iteration index so that tests are consistent.