### PR TITLE
JOSM cannot read some Hootenanny output well

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlWriterTest.cpp
@@ -39,6 +39,7 @@ class OsmXmlWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmXmlWriterTest);
   CPPUNIT_TEST(runEncodeCharsTest);
+  CPPUNIT_TEST(runChangesetIdTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -71,6 +72,34 @@ public:
     const QString output = _outputPath + "runEncodeCharsTest-out.osm";
     uut.write(map, output);
     HOOT_FILE_EQUALS(_inputPath + "runEncodeCharsTest.osm", output);
+  }
+
+  void runChangesetIdTest()
+  {
+    OsmXmlWriter uut;
+
+    OsmMapPtr map(new OsmMap());
+    Tags tags1;
+    tags1.set("Note", "Node1");
+    NodePtr node1 = TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, tags1);
+    node1->setChangeset(10);
+
+    Tags tags2;
+    tags2.set("Note", "Node2");
+    NodePtr node2 = TestUtils::createNode(map, Status::Unknown1, 0.0, 0.0, 15.0, tags2);
+    node2->setId(10);
+    node2->setChangeset(10);
+
+    //  The values of the IDs and Changeset IDs shouldn't change here
+    CPPUNIT_ASSERT_EQUAL(-1L, node1->getId());
+    CPPUNIT_ASSERT_EQUAL(10L, node1->getChangeset());
+    CPPUNIT_ASSERT_EQUAL(10L, node2->getId());
+    CPPUNIT_ASSERT_EQUAL(10L, node2->getChangeset());
+    //  But when written out Node1 shouldn't have a changeset ID because it has a negative Node ID
+
+    const QString output = _outputPath + "runChangesetIdTest-out.osm";
+    uut.write(map, output);
+    HOOT_FILE_EQUALS(_inputPath + "runChangesetIdTest.osm", output);
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -280,7 +280,8 @@ void OsmXmlWriter::_writeMetadata(const Element *e)
       _writer->writeAttribute("version", QString::number(e->getVersion()));
     }
   }
-  if (e->getChangeset() != ElementData::CHANGESET_EMPTY)
+  if (e->getChangeset() != ElementData::CHANGESET_EMPTY &&
+      e->getId() > 0) //  Negative IDs are considered "new" elements and shouldn't have a changeset
   {
     _writer->writeAttribute("changeset", QString::number(e->getChangeset()));
   }

--- a/test-files/io/OsmXmlWriterTest/runChangesetIdTest.osm
+++ b/test-files/io/OsmXmlWriterTest/runChangesetIdTest.osm
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="0" minlon="0" maxlat="0" maxlon="0"/>
+    <node visible="true" id="10" timestamp="1970-01-01T00:00:00Z" version="1" changeset="10" lat="0.0000000000000000" lon="0.0000000000000000">
+        <tag k="Note" v="Node2"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.0000000000000000" lon="0.0000000000000000">
+        <tag k="Note" v="Node1"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+</osm>


### PR DESCRIPTION
Refs #3320 
Don't output the changeset ID when the element ID is negative.