### PR TITLE
The crop command not passing in the -D crop.* options to the MapCropper

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/CropCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/CropCmd.cpp
@@ -90,6 +90,7 @@ public:
     IoUtils::loadMap(map, in, true);
 
     MapCropper cropper(env);
+    cropper.setConfiguration(Settings::getInstance());
     cropper.apply(map);
     SuperfluousWayRemover::removeWays(map);
     SuperfluousNodeRemover().apply(map);

--- a/hoot-core/src/main/cpp/hoot/core/ops/MapCropper.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MapCropper.cpp
@@ -81,7 +81,6 @@ _numWaysCrossingThreshold(0),
 _numCrossingWaysKept(0),
 _numCrossingWaysRemoved(0)
 {
-  setConfiguration(conf());
 }
 
 MapCropper::MapCropper(const Envelope& envelope) :


### PR DESCRIPTION
The `MapCropper` class is `Configurable` but the crop command wasn't passing in the `Settings` object so commands like this never worked correctly:
```
hoot crop -D crop.keep.entire.features.crossing.bounds=true ...
```