### PR TITLE
3327

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,7 +66,7 @@ Vagrant.configure(2) do |config|
     config.vm.network "forwarded_port", guest: 8096, host: mergePort
   end
 
-  def aws_provider(config, os, instance_name)
+  def aws_provider(config, os)
     # AWS Provider.  Set enviornment variables for values below to use
     config.vm.provider :aws do |aws, override|
       override.nfs.functional = false
@@ -88,7 +88,7 @@ Vagrant.configure(2) do |config|
       end
 
       aws.tags = {
-        'Name' => ENV.fetch('AWS_INSTANCE_NAME_TAG', "jenkins-hootenanny-#{instance_name.downcase}"),
+        'Name' => ENV.fetch('AWS_INSTANCE_NAME_TAG', "jenkins-hootenanny-#{os.downcase}"),
         'URL'  => ENV.fetch('AWS_INSTANCE_URL_TAG', 'https://github.com/ngageoint/hootenanny'),
       }
 
@@ -151,7 +151,7 @@ Vagrant.configure(2) do |config|
 
     mount_shares(hoot_centos7_prov)
     set_provisioners(hoot_centos7_prov)
-    aws_provider(hoot_centos7_prov, 'CentOS7', 'CentOS7')
+    aws_provider(hoot_centos7_prov, 'CentOS7')
   end
   
   # Centos7 box - not preprovisioned
@@ -165,7 +165,7 @@ Vagrant.configure(2) do |config|
     $addRepos = "yes"
     $yumUpdate = "yes"    
     set_provisioners(hoot_centos7)
-    aws_provider(hoot_centos7, 'CentOS7', 'CentOS7')
+    aws_provider(hoot_centos7, 'CentOS7')
   end
 
   # Centos7 - Hoot core ONLY. No UI

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,8 +78,13 @@ Vagrant.configure(2) do |config|
         aws.keypair_name = ENV['AWS_KEYPAIR_NAME']
       end
 
+      $security_grp = ENV['AWS_SECURITY_GROUP']
       if ENV.key?('AWS_SECURITY_GROUP')
-        aws.security_groups = ENV['AWS_SECURITY_GROUP']
+        if $security_grp.is_a?(String) and $security_grp.include? ',' and $security_grp.split(',').length > 0
+            aws.security_groups = $security_grp.split(',')
+        else
+            aws.security_groups = $security_grp
+        end
       end
 
       aws.tags = {

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -148,6 +148,15 @@ Vagrant.configure(2) do |config|
     set_provisioners(hoot_centos7_prov)
     aws_provider(hoot_centos7_prov, 'CentOS7')
   end
+  
+  config.vm.define "release", primary: true do |hoot_centos7_prov|
+    hoot_centos7_prov.vm.box = "hoot/centos7-hoot"
+    hoot_centos7_prov.vm.hostname = "centos7-hoot"
+
+    mount_shares(hoot_centos7_prov)
+    set_provisioners(hoot_centos7_prov)
+    aws_provider(hoot_centos7_prov, 'release')
+  end
 
   # Centos7 box - not preprovisioned
   config.vm.define "hoot_centos7", autostart: false do |hoot_centos7|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,7 +66,7 @@ Vagrant.configure(2) do |config|
     config.vm.network "forwarded_port", guest: 8096, host: mergePort
   end
 
-  def aws_provider(config, os)
+  def aws_provider(config, os, instance_name)
     # AWS Provider.  Set enviornment variables for values below to use
     config.vm.provider :aws do |aws, override|
       override.nfs.functional = false
@@ -151,7 +151,7 @@ Vagrant.configure(2) do |config|
 
     mount_shares(hoot_centos7_prov)
     set_provisioners(hoot_centos7_prov)
-    aws_provider(hoot_centos7_prov, 'CentOS7')
+    aws_provider(hoot_centos7_prov, 'CentOS7', 'CentOS7')
   end
   
   # Centos7 box - not preprovisioned
@@ -165,7 +165,7 @@ Vagrant.configure(2) do |config|
     $addRepos = "yes"
     $yumUpdate = "yes"    
     set_provisioners(hoot_centos7)
-    aws_provider(hoot_centos7, 'CentOS7')
+    aws_provider(hoot_centos7, 'CentOS7', 'CentOS7')
   end
 
   # Centos7 - Hoot core ONLY. No UI

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,7 +66,7 @@ Vagrant.configure(2) do |config|
     config.vm.network "forwarded_port", guest: 8096, host: mergePort
   end
 
-  def aws_provider(config, os, instance_name)
+  def aws_provider(config, os)
     # AWS Provider.  Set enviornment variables for values below to use
     config.vm.provider :aws do |aws, override|
       override.nfs.functional = false
@@ -78,8 +78,8 @@ Vagrant.configure(2) do |config|
         aws.keypair_name = ENV['AWS_KEYPAIR_NAME']
       end
 
-      $security_grp = ENV['AWS_SECURITY_GROUP']
       if ENV.key?('AWS_SECURITY_GROUP')
+        $security_grp = ENV['AWS_SECURITY_GROUP']
         if $security_grp.is_a?(String) and $security_grp.include? ',' and $security_grp.split(',').length > 0
             aws.security_groups = $security_grp.split(',')
         else
@@ -151,23 +151,9 @@ Vagrant.configure(2) do |config|
 
     mount_shares(hoot_centos7_prov)
     set_provisioners(hoot_centos7_prov)
-    aws_provider(hoot_centos7_prov, 'CentOS7', 'CentOS7')
+    aws_provider(hoot_centos7_prov, 'CentOS7')
   end
   
-  # To lower aws expenses, a daily cleanup of hootenanny lingering instances 
-  # are terminated. Although the hootenanny release at times needs to persist, 
-  # so the release box shall be setup the same way as the 'default' box,
-  # but configured with a different name to prevent the VM from being terminated 
-  # during the manual cleanup process
-  config.vm.define "release", autostart: false  do |hoot_centos7_release|
-    hoot_centos7_release.vm.box = "hoot/centos7-hoot"
-    hoot_centos7_release.vm.hostname = "centos7-hoot-release"
-
-    mount_shares(hoot_centos7_release)
-    set_provisioners(hoot_centos7_release)
-    aws_provider(hoot_centos7_release, 'CentOS7', 'release')
-  end
-
   # Centos7 box - not preprovisioned
   config.vm.define "hoot_centos7", autostart: false do |hoot_centos7|
     hoot_centos7.vm.box = "hoot/centos7-minimal"
@@ -179,7 +165,7 @@ Vagrant.configure(2) do |config|
     $addRepos = "yes"
     $yumUpdate = "yes"    
     set_provisioners(hoot_centos7)
-    aws_provider(hoot_centos7, 'CentOS7', 'CentOS7')
+    aws_provider(hoot_centos7, 'CentOS7')
   end
 
   # Centos7 - Hoot core ONLY. No UI

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -40,16 +40,18 @@ pipeline {
         }
         stage("Setup") {
             steps {
-
-                // Make sure we have the tags info because figuring out the version is required in the build process
-                // Remove any screenshots from previous runs
-                sh '''
-                    export BRANCH_NAME=`git branch | cut -d ' ' -f 2`
-                    if echo "$BRANCH_NAME" | grep -q "3327"; then
+                script {
+                    if (env.BRANCH_NAME == "3327") {
+                        sh '''
                         PREV_EC2_NAME="hoot_centos7_prov, 'CentOS7'"
                         NEW_EC2_NAME="hoot_centos7_prov, 'release'"
                         sed -i "s/${PREV_EC2_NAME}/${NEW_EC2_NAME}/g" Vagrantfile
-                    fi
+                        '''
+                     }
+                }
+                // Make sure we have the tags info because figuring out the version is required in the build process
+                // Remove any screenshots from previous runs
+                sh '''
                     git fetch --tags
                     git submodule update --init
                     cp -R ../software.ubuntu1404 software

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -183,6 +183,7 @@ pipeline {
                     // Always halt the VM to save resources, but don't destroy so devs can troubleshoot on failures
                     sh "vagrant halt ${params.Box}"
                 }
+            }
         }
         aborted {
             script {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -35,8 +35,7 @@ pipeline {
         stage("Box Name") {
             steps {
                 script {
-                    // named 3327 for testing in jenkins
-                    if (env.BRANCH_NAME.startsWith("3327")) {
+                    if (env.BRANCH_NAME.startsWith("release")) {
                         BOX_NAME = "release"
                     }
                     else {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME.startsWith("release")) {
                         sh '''
-                        PREV_EC2_NAME="hoot_centos7_prov, 'CentOS7', 'CentOS7'"
-                        NEW_EC2_NAME="hoot_centos7_prov, 'CentOS7', 'release'"
+                        PREV_EC2_NAME="jenkins-hootenanny-#{os.downcase}"
+                        NEW_EC2_NAME="jenkins-hootenanny-#{os.downcase}-release"
                         sed -i "s/${PREV_EC2_NAME}/${NEW_EC2_NAME}/g" Vagrantfile
                         '''
                      }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME == "3327") {
                         sh '''
-                        PREV_EC2_NAME="hoot_centos7_prov, 'CentOS7'"
-                        NEW_EC2_NAME="hoot_centos7_prov, 'release'"
+                        PREV_EC2_NAME="hoot_centos7_prov, 'CentOS7', 'CentOS7'"
+                        NEW_EC2_NAME="hoot_centos7_prov, 'CentOS7', 'release'"
                         sed -i "s/${PREV_EC2_NAME}/${NEW_EC2_NAME}/g" Vagrantfile
                         '''
                      }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
         SYS_URL = 'UNKOWN'
         SYS_VER = 'UNKOWN'
         BUILD_VERBOSE = 'no'
-        BOX_NAME = 'UNKNOWN'
     }
 
     triggers {
@@ -32,24 +31,11 @@ pipeline {
     }
 
     stages {
-        stage("Box Name") {
-            steps {
-                script {
-                    if (env.BRANCH_NAME.startsWith("release")) {
-                        BOX_NAME = "release"
-                    }
-                    else {
-                        BOX_NAME = "${params.Box}" 
-                    }
-                    echo "Box Name: '${BOX_NAME}'"
-                }
-            }
-        }
         stage("Destroy VM") {
             when { expression { return params.Destroy_VM } }
             steps {
                 // Existing VM may or may not exist depending on previous runs
-                sh "vagrant destroy -f ${BOX_NAME} || true"
+                sh "vagrant destroy -f ${params.Box} || true"
             }
         }
         stage("Setup") {
@@ -58,6 +44,12 @@ pipeline {
                 // Make sure we have the tags info because figuring out the version is required in the build process
                 // Remove any screenshots from previous runs
                 sh '''
+                    export BRANCH_NAME=`git branch | cut -d ' ' -f 2`
+                    if echo "$BRANCH_NAME" | grep -q "3327"; then
+                        PREV_EC2_NAME="hoot_centos7_prov, 'CentOS7'"
+                        NEW_EC2_NAME="hoot_centos7_prov, 'release'"
+                        sed -i "s/${PREV_EC2_NAME}/${NEW_EC2_NAME}/g" Vagrantfile
+                    fi
                     git fetch --tags
                     git submodule update --init
                     cp -R ../software.ubuntu1404 software
@@ -69,10 +61,10 @@ pipeline {
             when { expression { return params.Hoot_provision } }
             steps {
                 // NOTE: Only installs hoot build dependencies
-                sh "vagrant up ${BOX_NAME} --provision-with software,hoot --provider aws"
+                sh "vagrant up ${params.Box} --provision-with software,hoot --provider aws"
                 script {
-                    SYS_VER = sh(returnStdout: true, script: "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./scripts/git/GitVersion.sh'")
-                    SYS_URL = sh(returnStdout: true, script: "vagrant ssh-config ${BOX_NAME} | grep HostName | awk '{print \$2}'")
+                    SYS_VER = sh(returnStdout: true, script: "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/git/GitVersion.sh'")
+                    SYS_URL = sh(returnStdout: true, script: "vagrant ssh-config ${params.Box} | grep HostName | awk '{print \$2}'")
                     SYS_URL = SYS_URL.trim()
                     echo "System under test version ${SYS_VER}  http://${SYS_URL}:8080/hootenanny-id/"
                 }
@@ -86,7 +78,7 @@ pipeline {
                 }
             }
             steps {
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; source ./SetupEnv.sh; ./scripts/TestConfigure.sh &> Hoot_Config_Test || { cat Hoot_Config_Test; false; }'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; ./scripts/TestConfigure.sh &> Hoot_Config_Test || { cat Hoot_Config_Test; false; }'"
             }
         }
         stage("Sonar Config") {
@@ -102,7 +94,7 @@ pipeline {
                 }
             }
             steps{
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
                 sh "sed -i 's/^make \$SILENT_MAKE -j\$(nproc)\$/build-wrapper-linux-x86-64 --out-dir bw-output make \$SILENT_MAKE -j\$(nproc)/' VagrantBuild.sh"
                 script {
@@ -117,37 +109,37 @@ pipeline {
             when { expression { return params.Build } }
             steps {
                 // Set build verbosity
-                sh "vagrant ssh ${BOX_NAME} -c 'echo \"export BUILD_VERBOSE=${env.BUILD_VERBOSE}\" | sudo tee -a /etc/environment'"
+                sh "vagrant ssh ${params.Box} -c 'echo \"export BUILD_VERBOSE=${env.BUILD_VERBOSE}\" | sudo tee -a /etc/environment'"
                 // Perform remainder of provisioning
-                sh "vagrant provision ${BOX_NAME} --provision-with build,EGD,tomcat"
+                sh "vagrant provision ${params.Box} --provision-with build,EGD,tomcat"
                 // Configure authentication and reboot tomcat
-                sh "vagrant ssh ${BOX_NAME} -c 'sed -i 's,oauthRedirectURL=http://localhost:8080/,oauthRedirectURL=http://${SYS_URL}:8080/hootenanny-id/,' /var/lib/tomcat8/webapps/hoot-services/WEB-INF/classes/conf/hoot-services.conf'"
-                sh "vagrant provision ${BOX_NAME} --provision-with tomcat"
+                sh "vagrant ssh ${params.Box} -c 'sed -i 's,oauthRedirectURL=http://localhost:8080/,oauthRedirectURL=http://${SYS_URL}:8080/hootenanny-id/,' /var/lib/tomcat8/webapps/hoot-services/WEB-INF/classes/conf/hoot-services.conf'"
+                sh "vagrant provision ${params.Box} --provision-with tomcat"
             }
         }
         stage("Core Tests") {
             when { expression { return params.Core_tests } }
             steps {
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel'"
             }
         }
         stage("Services Tests") {
             when { expression { return params.Services_tests } }
             steps {
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -sj`nproc` translations-test'"
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -sj`nproc` services-test'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -sj`nproc` translations-test'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -sj`nproc` services-test'"
             }
         }
         stage("UI Hoot 1 Tests") {
             when { expression { return params.UI_hoot1_tests } }
             steps {
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -s ui-test'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -s ui-test'"
             }
         }
         stage("UI Hoot 2 Tests") {
             when { expression { return params.UI_hoot2_tests } }
             steps {
-                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -s ui2x-test'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -s ui2x-test'"
             }
         }
         stage("Sonar") {
@@ -162,7 +154,7 @@ pipeline {
                 }
             }
             steps{
-                    sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; cd hoot-services; mvn sonar:sonar \
+                    sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; cd hoot-services; mvn sonar:sonar \
                         -Dsonar.host.url=https://sonarcloud.io \
                         -Dsonar.organization=hootenanny \
                         -Dsonar.login=${env.SONAR_CLOUD_KEY} \
@@ -172,19 +164,26 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME.startsWith("PR-")) {
                         // PR scan will use github plugin
-                        sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME} -p ${env.CHANGE_ID} -a ${env.DGIS_BOT_TOKEN}'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME} -p ${env.CHANGE_ID} -a ${env.DGIS_BOT_TOKEN}'"
                     }
                     else {
                         if (env.BRANCH_NAME == "develop") {
-                            sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/coverGcov.sh'"
+                            sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/coverGcov.sh'"
                         }
-                        sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME}'"
+                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME}'"
                     }
                 }
             }
         }
     }
     post {
+        always {
+            script {
+                if (!env.BRANCH_NAME.startsWith("3327")) {
+                    // Always halt the VM to save resources, but don't destroy so devs can troubleshoot on failures
+                    sh "vagrant halt ${params.Box}"
+                }
+        }
         aborted {
             script {
                 notifySlack("ABORTED", "#builds_hoot")
@@ -198,7 +197,7 @@ pipeline {
                     slackSend channel: "#builds_hoot", message: "Release candidate version ${SYS_VER} ready for testing http://${SYS_URL}:8080/hootenanny-id/"
                 } else {
                     // If all tests passed, clean everything up
-                    sh "vagrant destroy -f ${BOX_NAME}"
+                    sh "vagrant destroy -f ${params.Box}"
                     cleanWs()
                 }
             }
@@ -207,7 +206,7 @@ pipeline {
             script {
                 notifySlack("FAILURE", "#builds_hoot")
                 // Copy over any UI failure screenshots and send to slack
-                sh "vagrant scp ${BOX_NAME}:~/hoot/test-files/ui/screenshot_*.png ./test-files/ui/"
+                sh "vagrant scp ${params.Box}:~/hoot/test-files/ui/screenshot_*.png ./test-files/ui/"
                 postSlack("${env.WORKSPACE}/test-files/ui/", "screenshot_*.png", "${env.JENKINS_BOT_TOKEN}", "#builds_hoot")
             }
         }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
         stage("Setup") {
             steps {
                 script {
-                    if (env.BRANCH_NAME == "3327") {
+                    if (env.BRANCH_NAME.startsWith("release")) {
                         sh '''
                         PREV_EC2_NAME="hoot_centos7_prov, 'CentOS7', 'CentOS7'"
                         NEW_EC2_NAME="hoot_centos7_prov, 'CentOS7', 'release'"
@@ -181,7 +181,7 @@ pipeline {
     post {
         always {
             script {
-                if (!env.BRANCH_NAME.startsWith("3327")) {
+                if (!env.BRANCH_NAME.startsWith("release")) {
                     // Always halt the VM to save resources, but don't destroy so devs can troubleshoot on failures
                     sh "vagrant halt ${params.Box}"
                 }

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         SYS_URL = 'UNKOWN'
         SYS_VER = 'UNKOWN'
         BUILD_VERBOSE = 'no'
+        BOX_NAME = 'UNKNOWN'
     }
 
     triggers {
@@ -31,11 +32,25 @@ pipeline {
     }
 
     stages {
+        stage("Box Name") {
+            steps {
+                script {
+                    // named 3327 for testing in jenkins
+                    if (env.BRANCH_NAME.startsWith("3327")) {
+                        BOX_NAME = "release"
+                    }
+                    else {
+                        BOX_NAME = "${params.Box}" 
+                    }
+                    echo "Box Name: '${BOX_NAME}'"
+                }
+            }
+        }
         stage("Destroy VM") {
             when { expression { return params.Destroy_VM } }
             steps {
                 // Existing VM may or may not exist depending on previous runs
-                sh "vagrant destroy -f ${params.Box} || true"
+                sh "vagrant destroy -f ${BOX_NAME} || true"
             }
         }
         stage("Setup") {
@@ -55,10 +70,10 @@ pipeline {
             when { expression { return params.Hoot_provision } }
             steps {
                 // NOTE: Only installs hoot build dependencies
-                sh "vagrant up ${params.Box} --provision-with software,hoot --provider aws"
+                sh "vagrant up ${BOX_NAME} --provision-with software,hoot --provider aws"
                 script {
-                    SYS_VER = sh(returnStdout: true, script: "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/git/GitVersion.sh'")
-                    SYS_URL = sh(returnStdout: true, script: "vagrant ssh-config ${params.Box} | grep HostName | awk '{print \$2}'")
+                    SYS_VER = sh(returnStdout: true, script: "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./scripts/git/GitVersion.sh'")
+                    SYS_URL = sh(returnStdout: true, script: "vagrant ssh-config ${BOX_NAME} | grep HostName | awk '{print \$2}'")
                     SYS_URL = SYS_URL.trim()
                     echo "System under test version ${SYS_VER}  http://${SYS_URL}:8080/hootenanny-id/"
                 }
@@ -72,7 +87,7 @@ pipeline {
                 }
             }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; ./scripts/TestConfigure.sh &> Hoot_Config_Test || { cat Hoot_Config_Test; false; }'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; source ./SetupEnv.sh; ./scripts/TestConfigure.sh &> Hoot_Config_Test || { cat Hoot_Config_Test; false; }'"
             }
         }
         stage("Sonar Config") {
@@ -88,7 +103,7 @@ pipeline {
                 }
             }
             steps{
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./scripts/sonar/sonar-install.sh'"
                 // Compile with build watcher to allow for sonar scanning in subsequent steps
                 sh "sed -i 's/^make \$SILENT_MAKE -j\$(nproc)\$/build-wrapper-linux-x86-64 --out-dir bw-output make \$SILENT_MAKE -j\$(nproc)/' VagrantBuild.sh"
                 script {
@@ -103,37 +118,37 @@ pipeline {
             when { expression { return params.Build } }
             steps {
                 // Set build verbosity
-                sh "vagrant ssh ${params.Box} -c 'echo \"export BUILD_VERBOSE=${env.BUILD_VERBOSE}\" | sudo tee -a /etc/environment'"
+                sh "vagrant ssh ${BOX_NAME} -c 'echo \"export BUILD_VERBOSE=${env.BUILD_VERBOSE}\" | sudo tee -a /etc/environment'"
                 // Perform remainder of provisioning
-                sh "vagrant provision ${params.Box} --provision-with build,EGD,tomcat"
+                sh "vagrant provision ${BOX_NAME} --provision-with build,EGD,tomcat"
                 // Configure authentication and reboot tomcat
-                sh "vagrant ssh ${params.Box} -c 'sed -i 's,oauthRedirectURL=http://localhost:8080/,oauthRedirectURL=http://${SYS_URL}:8080/hootenanny-id/,' /var/lib/tomcat8/webapps/hoot-services/WEB-INF/classes/conf/hoot-services.conf'"
-                sh "vagrant provision ${params.Box} --provision-with tomcat"
+                sh "vagrant ssh ${BOX_NAME} -c 'sed -i 's,oauthRedirectURL=http://localhost:8080/,oauthRedirectURL=http://${SYS_URL}:8080/hootenanny-id/,' /var/lib/tomcat8/webapps/hoot-services/WEB-INF/classes/conf/hoot-services.conf'"
+                sh "vagrant provision ${BOX_NAME} --provision-with tomcat"
             }
         }
         stage("Core Tests") {
             when { expression { return params.Core_tests } }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel'"
             }
         }
         stage("Services Tests") {
             when { expression { return params.Services_tests } }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -sj`nproc` translations-test'"
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -sj`nproc` services-test'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -sj`nproc` translations-test'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -sj`nproc` services-test'"
             }
         }
         stage("UI Hoot 1 Tests") {
             when { expression { return params.UI_hoot1_tests } }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -s ui-test'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -s ui-test'"
             }
         }
         stage("UI Hoot 2 Tests") {
             when { expression { return params.UI_hoot2_tests } }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; make -s ui2x-test'"
+                sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; make -s ui2x-test'"
             }
         }
         stage("Sonar") {
@@ -148,7 +163,7 @@ pipeline {
                 }
             }
             steps{
-                    sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; cd hoot-services; mvn sonar:sonar \
+                    sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; cd hoot-services; mvn sonar:sonar \
                         -Dsonar.host.url=https://sonarcloud.io \
                         -Dsonar.organization=hootenanny \
                         -Dsonar.login=${env.SONAR_CLOUD_KEY} \
@@ -158,23 +173,19 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME.startsWith("PR-")) {
                         // PR scan will use github plugin
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME} -p ${env.CHANGE_ID} -a ${env.DGIS_BOT_TOKEN}'"
+                        sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME} -p ${env.CHANGE_ID} -a ${env.DGIS_BOT_TOKEN}'"
                     }
                     else {
                         if (env.BRANCH_NAME == "develop") {
-                            sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/coverGcov.sh'"
+                            sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; ./scripts/cover/coverGcov.sh'"
                         }
-                        sh "vagrant ssh ${params.Box} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME}'"
+                        sh "vagrant ssh ${BOX_NAME} -c 'cd hoot; ./SetupEnv.sh; ./scripts/sonar/sonar-scan.sh -l ${env.SONAR_CLOUD_KEY} -b ${env.BRANCH_NAME}'"
                     }
                 }
             }
         }
     }
     post {
-        always {
-            // Always halt the VM to save resources, but don't destroy so devs can troubleshoot on failures
-            sh "vagrant halt ${params.Box}"
-        }
         aborted {
             script {
                 notifySlack("ABORTED", "#builds_hoot")
@@ -188,7 +199,7 @@ pipeline {
                     slackSend channel: "#builds_hoot", message: "Release candidate version ${SYS_VER} ready for testing http://${SYS_URL}:8080/hootenanny-id/"
                 } else {
                     // If all tests passed, clean everything up
-                    sh "vagrant destroy -f ${params.Box}"
+                    sh "vagrant destroy -f ${BOX_NAME}"
                     cleanWs()
                 }
             }
@@ -197,7 +208,7 @@ pipeline {
             script {
                 notifySlack("FAILURE", "#builds_hoot")
                 // Copy over any UI failure screenshots and send to slack
-                sh "vagrant scp ${params.Box}:~/hoot/test-files/ui/screenshot_*.png ./test-files/ui/"
+                sh "vagrant scp ${BOX_NAME}:~/hoot/test-files/ui/screenshot_*.png ./test-files/ui/"
                 postSlack("${env.WORKSPACE}/test-files/ui/", "screenshot_*.png", "${env.JENKINS_BOT_TOKEN}", "#builds_hoot")
             }
         }


### PR DESCRIPTION
Have the AWS instance be named jenkins-hootenanny-release and allow for multiple security groups from initiation. The name change is to prevent the release candidate VM from getting blown away during a manual cleanup of hootenanny VMs. Allowing for multiple security groups was added, because only the jenkins box had access to the VMs, and remote users couldn't test hootenanny-UI or ssh into them remotely without going through the AWS EC2 portal and adding their security group.