### PR TITLE
Hootbot fix endless retries

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -204,6 +204,6 @@ public:
   }
 };
 
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(PoiPolygonMergerCreatorTest, "quick");
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(PoiPolygonMergerCreatorTest, "slow");
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "OsmApiWriterTestServer.h"
+
+//  Hootenanny
+#include <hoot/core/io/OsmApiWriter.h>
+#include <hoot/core/util/Log.h>
+
+//  Standard
+#include <memory>
+
+//  Boost
+#include <boost/bind.hpp>
+#include <boost/asio.hpp>
+
+namespace hoot
+{
+
+const char* OsmApiSampleResponses::SAMPLE_CAPABILITIES =
+    "<?xml version='1.0' encoding='UTF-8'?>"
+    "<osm version='0.6' generator='OpenStreetMap server' copyright='OpenStreetMap and contributors' attribution='https://www.openstreetmap.org/copyright' license='http://opendatacommons.org/licenses/odbl/1-0/'>"
+    "  <api>"
+    "    <version minimum='0.6' maximum='0.6'/>"
+    "    <area maximum='0.25'/>"
+    "    <note_area maximum='25'/>"
+    "    <tracepoints per_page='5000'/>"
+    "    <waynodes maximum='2000'/>"
+    "    <changesets maximum_elements='10000'/>"
+    "    <timeout seconds='300'/>"
+    "    <status database='online' api='online' gpx='online'/>"
+    "  </api>"
+    "  <policy>"
+    "    <imagery>"
+    "      <blacklist regex='http://xdworld\\.vworld\\.kr:8080/.*'/>"
+    "      <blacklist regex='.*\\.here\\.com[/:].*'/>"
+    "    </imagery>"
+    "  </policy>"
+    "</osm>";
+const char* OsmApiSampleResponses::SAMPLE_PERMISSIONS =
+    "<?xml version='1.0' encoding='UTF-8'?>"
+    "<osm version='0.6' generator='OpenStreetMap server'>"
+    "  <permissions>"
+    "    <permission name='allow_read_prefs'/>"
+    "    <permission name='allow_read_gpx'/>"
+    "    <permission name='allow_write_api'/>"
+    "    <permission name='allow_write_gpx'/>"
+    "  </permissions>"
+    "</osm>";
+
+HttpConnection::HttpConnection(boost::asio::io_service& io_service)
+  : _socket(io_service)
+{
+}
+
+void HttpConnection::handle_write(const boost::system::error_code& /*error*/, size_t /*bytes_transferred*/)
+{
+}
+
+HttpConnection::HttpConnectionPtr HttpConnection::create(boost::asio::io_service& io_service)
+{
+  //  Create the connection object
+  return HttpConnectionPtr(new HttpConnection(io_service));
+}
+
+boost::asio::ip::tcp::socket& HttpConnection::socket()
+{
+  return _socket;
+}
+
+bool HttpConnection::start()
+{
+  //  Stop processing by setting this to false
+  bool continue_processing = true;
+  //  Read the HTTP request
+  boost::asio::streambuf buf;
+  boost::asio::read_until(_socket, buf, "\r\n\r\n");
+  std::string input = boost::asio::buffer_cast<const char*>(buf.data());
+  //  Determine the response message's HTTP header
+  std::string message;
+  if (input.find(OsmApiWriter::API_PATH_CAPABILITIES) != std::string::npos)
+    message = std::string("HTTP/1.1 200 OK\r\n\r\n") + OsmApiSampleResponses::SAMPLE_CAPABILITIES + "\r\n";
+  else if (input.find(OsmApiWriter::API_PATH_PERMISSIONS) != std::string::npos)
+    message = std::string("HTTP/1.1 200 OK\r\n\r\n") + OsmApiSampleResponses::SAMPLE_PERMISSIONS + "\r\n";
+  else if (input.find(OsmApiWriter::API_PATH_CREATE_CHANGESET) != std::string::npos)
+    message = std::string("HTTP/1.1 200 OK\r\n\r\n1\r\n");
+  else if (input.find("POST") != std::string::npos)
+    message = std::string("HTTP/1.1 405 Method Not Allowed\r\nAllow: GET\r\n\r\n");
+  else if (input.find("/close/"))
+  {
+    message = std::string("HTTP/1.1 200 OK\r\n\r\n");
+    continue_processing = false;
+  }
+  //  Write out the response async
+  boost::asio::async_write(_socket, boost::asio::buffer(message),
+                           boost::bind(&HttpConnection::handle_write, shared_from_this(),
+                                       boost::asio::placeholders::error,
+                                       boost::asio::placeholders::bytes_transferred));
+  return continue_processing;
+}
+
+const int HttpTestServer::TEST_SERVER_PORT = 8910;
+
+std::shared_ptr<std::thread> HttpTestServer::start()
+{
+  return std::shared_ptr<std::thread>(new std::thread(&HttpTestServer::run_server));
+}
+
+HttpTestServer::HttpTestServer(boost::asio::io_service& io_service)
+  : _acceptor(io_service, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), TEST_SERVER_PORT))
+{
+  start_accept();
+}
+
+void HttpTestServer::run_server()
+{
+  try
+  {
+    boost::asio::io_service io_service;
+    HttpTestServer server(io_service);
+    io_service.run();
+  }
+  catch (std::exception& e)
+  {
+    LOG_ERROR(e.what());
+  }
+}
+
+void HttpTestServer::start_accept()
+{
+  HttpConnection::HttpConnectionPtr new_connection = HttpConnection::create(_acceptor.get_io_service());
+  _acceptor.async_accept(new_connection->socket(),
+                         boost::bind(&HttpTestServer::handle_accept, this, new_connection, boost::asio::placeholders::error));
+}
+
+void HttpTestServer::handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error)
+{
+  bool continue_processing = true;
+  if (!error)
+    continue_processing = new_connection->start();
+
+  if (continue_processing)
+    start_accept();
+}
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef OSM_API_WRITER_TEST_SERVER_H
+#define OSM_API_WRITER_TEST_SERVER_H
+
+//  Hootenanny
+#include <hoot/core/io/OsmApiWriter.h>
+#include <hoot/core/util/Log.h>
+
+//  Standard
+#include <memory>
+
+//  Boost
+#include <boost/bind.hpp>
+#include <boost/asio.hpp>
+
+namespace hoot
+{
+
+class OsmApiSampleResponses
+{
+public:
+  static const char* SAMPLE_CAPABILITIES;
+  static const char* SAMPLE_PERMISSIONS;
+};
+
+
+class HttpConnection : public std::enable_shared_from_this<HttpConnection>
+{
+public:
+  typedef std::shared_ptr<HttpConnection> HttpConnectionPtr;
+
+  boost::asio::ip::tcp::socket& socket();
+
+  static HttpConnectionPtr create(boost::asio::io_service& io_service);
+
+  bool start();
+
+private:
+  HttpConnection(boost::asio::io_service& io_service);
+  void handle_write(const boost::system::error_code& error, size_t bytes_transferred);
+
+  boost::asio::ip::tcp::socket _socket;
+};
+
+class HttpTestServer
+{
+public:
+
+  static const int TEST_SERVER_PORT;
+
+  static std::shared_ptr<std::thread> start();
+
+  HttpTestServer(boost::asio::io_service& io_service);
+
+private:
+
+  static void run_server();
+
+  void start_accept();
+
+  void handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error);
+
+  boost::asio::ip::tcp::acceptor _acceptor;
+};
+
+}
+
+#endif  //  OSM_API_WRITER_TEST_SERVER_H

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmGeoJsonWriterTest.cpp
@@ -75,10 +75,10 @@ public:
   {
     //  Suppress the warning from the OsmXmlReader about missing nodes for ways by temporarily changing
     //  the log level.  We expect the nodes to be missing since the Boston data has issues
-    Log::WarningLevel loglLevel = Log::getInstance().getLevel();
+    Log::WarningLevel logLevel = Log::getInstance().getLevel();
     Log::getInstance().setLevel(Log::Error);
     runTest("test-files/BostonSubsetRoadBuilding_FromOsm.osm", "BostonSubsetRoadBuilding.geojson");
-    Log::getInstance().setLevel(loglLevel);
+    Log::getInstance().setLevel(logLevel);
   }
 
   void runObjectGeoJsonTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmPbfReaderTest.cpp
@@ -413,7 +413,7 @@ public:
     //Suppress the warning from the OsmXmlReader about missing nodes for ways by temporarily changing
     //the log level.  We expect the nodes to be missing since we're doing partial map reads and
     //don't need to see the messages.
-    Log::WarningLevel loglLevel = Log::getInstance().getLevel();
+    Log::WarningLevel logLevel = Log::getInstance().getLevel();
     Log::getInstance().setLevel(Log::Error);
 
     int ctr = 0;
@@ -434,7 +434,7 @@ public:
       ctr++;
       CPPUNIT_ASSERT(ctr < 5);  //to prevent an infinite loop if hasMoreElements fails
     }
-    Log::getInstance().setLevel(loglLevel);
+    Log::getInstance().setLevel(logLevel);
     reader.finalizePartial();
 
     CPPUNIT_ASSERT_EQUAL(4, ctr);
@@ -454,7 +454,7 @@ public:
     //Suppress the warning from the OsmXmlReader about missing nodes for ways by temporarily changing
     //the log level.  We expect the nodes to be missing since we're doing partial map reads and
     //don't need to see the messages.
-    Log::WarningLevel loglLevel = Log::getInstance().getLevel();
+    Log::WarningLevel logLevel = Log::getInstance().getLevel();
     Log::getInstance().setLevel(Log::Error);
 
     int ctr = 0;
@@ -478,14 +478,13 @@ public:
       ctr++;
       CPPUNIT_ASSERT(ctr < 5);  //to prevent an infinite loop if hasMoreElements fails
     }
-    Log::getInstance().setLevel(loglLevel);
+    Log::getInstance().setLevel(logLevel);
     reader.finalizePartial();
 
     CPPUNIT_ASSERT_EQUAL(4, ctr);
   }
 
-  void runHasMoreElementsTest(
-      void )
+  void runHasMoreElementsTest()
   {
     OsmPbfReader reader1;
 
@@ -505,8 +504,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(reader3.hasMoreElements(), false);
   }
 
-  void runReadNextElementTest(
-      void )
+  void runReadNextElementTest()
   {
     OsmPbfReader reader(QString("test-files/ToyTestA.osm.pbf"));
 
@@ -548,7 +546,7 @@ public:
     //Suppress the warning from the OsmXmlReader about missing nodes for ways by temporarily changing
     //the log level.  We expect the nodes to be missing since we're doing partial map reads and
     //don't need to see the messages.
-    Log::WarningLevel loglLevel = Log::getInstance().getLevel();
+    Log::WarningLevel logLevel = Log::getInstance().getLevel();
     Log::getInstance().setLevel(Log::Error);
     reader1.read(map1);
 
@@ -567,7 +565,7 @@ public:
     reader2.setPermissive(false);
 
     reader2.read(map2);
-    Log::getInstance().setLevel(loglLevel);
+    Log::getInstance().setLevel(logLevel);
 
     CPPUNIT_ASSERT_EQUAL(false, reader2.getSortedTypeThenId());
     CPPUNIT_ASSERT_EQUAL(6, (int)map2->getNodes().size());

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -132,7 +132,7 @@ public:
    * @brief updateFailedChangeset Update the changeset to mark elements as failed if the ChangesetInfo object has been "fixed"
    * @param changeset - Pointer to changeset info object with one element that has failed
    */
-  void updateFailedChangeset(ChangesetInfoPtr changeset);
+  void updateFailedChangeset(ChangesetInfoPtr changeset, bool forceFailure = false);
   /**
    * @brief getChangesetString Get the .OSC formatted string for this subset of the changeset with the changeset ID in it
    * @param changeset - Subset of the changeset to render
@@ -427,41 +427,32 @@ public:
   typedef typename container::iterator iterator;
   typedef typename container::const_iterator const_iterator;
   /** Constructor */
-  ChangesetInfo() : _changesetIssuesResolved(false) { }
+  ChangesetInfo();
   /**
    * @brief add Add an element ID of a certain type to the changeset type
    * @param element_type Describes the 'id' argument as a node, way, or relation
    * @param changeset_type Describes the changeset method as create, modify, or delete
    * @param id Element ID of the element to add
    */
-  void add(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id)
-  { _changeset[element_type][changeset_type].insert(id); }
+  void add(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id);
   /**
    * @brief remove Remove an element ID of a certain type from the changeset type
    * @param element_type Describes the 'id' argument as a node, way, or relation
    * @param changeset_type Describes the changeset method as create, modify, or delete
    * @param id Element ID of the element to remove
    */
-  void remove(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id)
-  {
-    container& selectedSet = _changeset[element_type][changeset_type];
-    if (selectedSet.find(id) != selectedSet.end())
-      selectedSet.erase(id);
-  }
-
-  long getFirst(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type)
-  { return *(_changeset[element_type][changeset_type].begin()); }
+  void remove(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id);
+  /**
+   * @brief getFirst Get the first element of the types
+   * @param element_type Describes the element type: node, way, or relation
+   * @param changeset_type Describes the type: create, modify, delete
+   * @return
+   */
+  long getFirst(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type);
   /**
    * @brief clear Clear out this entire changeset subset
    */
-  void clear()
-  {
-    for (int i = 0; i < (int)ElementType::Unknown; ++i)
-    {
-      for (int j = 0; j < (int)XmlChangeset::TypeMax; ++j)
-        _changeset[i][j].clear();
-    }
-  }
+  void clear();
   /**
    * @brief contains Check if this subset contains an element described by types and ID
    * @param element_type Describes the 'id' argument as a node, way, or relation
@@ -469,28 +460,21 @@ public:
    * @param id Element ID that is being searched for
    * @return true if it is found
    */
-  bool contains(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id)
-  {
-    return _changeset[element_type][changeset_type].find(id) != end(element_type, changeset_type);
-  }
+  bool contains(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id);
   /**
    * @brief begin Begin iterator
    * @param element_type Describes the type (node/way/relation) to iterate
    * @param changeset_type Describes the type (create/modify/delete) to iterate
    * @return iterator pointing to the beginning of the set
    */
-  iterator begin(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type)
-  {
-    return _changeset[element_type][changeset_type].begin();
-  }
+  iterator begin(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type);
   /**
    * @brief end End iterator
    * @param element_type Describes the type (node/way/relation) to iterate
    * @param changeset_type Describes the type (create/modify/delete) to iterate
    * @return iterator pointing off of the end of the set
    */
-  iterator end(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type)
-  { return _changeset[element_type][changeset_type].end(); }
+  iterator end(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type);
   /**
    * @brief size Total number of ElementType::Type elements (node/way/relation) of a specific changeset
    *  type (create/modify/delete) within this subset
@@ -498,35 +482,26 @@ public:
    * @param changesetType Describes the type (create/modify/delete) to count
    * @return count based on types
    */
-  size_t size(ElementType::Type elementType, XmlChangeset::ChangesetType changesetType)
-  {
-    return _changeset[(int)elementType][(int)changesetType].size();
-  }
+  size_t size(ElementType::Type elementType, XmlChangeset::ChangesetType changesetType);
   /**
    * @brief size Total number of elements in the subset
    * @return total count
    */
-  size_t size()
-  {
-    size_t s = 0;
-    //  Iterate element types
-    for (int i = 0; i < (int)ElementType::Unknown; ++i)
-    {
-      //  Sum up all counts for each changeset type
-      for (int j = 0; j < (int)XmlChangeset::TypeMax; ++j)
-        s += _changeset[i][j].size();
-    }
-    return s;
-  }
-
-  bool getChangesetIssuesResolved() { return _changesetIssuesResolved; }
-  void setChangesetIssuesResolved(bool resolved) { _changesetIssuesResolved = resolved; }
-
+  size_t size();
+  /** Set/get _attemptedResolveChangesetIssues member */
+  bool getAttemptedResolveChangesetIssues();
+  void setAttemptedResolveChangesetIssues(bool attempted);
+  /** Set/get _numRetries member */
+  bool canRetry();
+  void retry();
 private:
   /** 3x3 array of containers for elements in this subset */
   std::array<std::array<container, XmlChangeset::TypeMax>, ElementType::Unknown> _changeset;
   /** Flag set after attempt to resolve changeset issues has completed. */
-  bool _changesetIssuesResolved;
+  bool _attemptedResolveChangesetIssues;
+  /** Number of times this exact changeset has been retried unsuccessfully */
+  int _numRetries;
+  const int MAX_RETRIES = 5;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -54,20 +54,20 @@ class OsmApiWriterTest;
 
 class OsmApiWriter : public Configurable, public ProgressReporter
 {
+public:
   /** OSM API URL paths */
-  const QString API_PATH_CAPABILITIES = "/api/capabilities/";
-  const QString API_PATH_PERMISSIONS = "/api/0.6/permissions/";
-  const QString API_PATH_CREATE_CHANGESET = "/api/0.6/changeset/create/";
-  const QString API_PATH_CLOSE_CHANGESET = "/api/0.6/changeset/%1/close/";
-  const QString API_PATH_UPLOAD_CHANGESET = "/api/0.6/changeset/%1/upload/";
-  const QString API_PATH_GET_ELEMENT = "/api/0.6/%1/%2/";
+  const static char* API_PATH_CAPABILITIES;
+  const static char* API_PATH_PERMISSIONS;
+  const static char* API_PATH_CREATE_CHANGESET;
+  const static char* API_PATH_CLOSE_CHANGESET;
+  const static char* API_PATH_UPLOAD_CHANGESET;
+  const static char* API_PATH_GET_ELEMENT;
   /**
    *  Max number of jobs waiting in the work queue = multiplier * number of threads,
    *  this keeps the producer thread from creating too many sub-changesets too early
    *  that only consist of nodes after ways are blocked.
    */
   const int QUEUE_SIZE_MULTIPLIER = 2;
-public:
   /** Constructors with one or multiple files consisting of one large changeset */
   OsmApiWriter(const QUrl& url, const QString& changeset);
   OsmApiWriter(const QUrl& url, const QList<QString>& changesets);

--- a/test-files/io/OsmChangesetElementTest/ToyTestAConflicts.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestAConflicts.osc
@@ -21,7 +21,7 @@
     </modify>
     <delete>
         <node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="">
-          <tag k="node" v="Should fail"/>
+            <tag k="node" v="Should fail"/>
         </node>
         <node id="2" version="1" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp=""/>
     </delete>


### PR DESCRIPTION
Updated `OsmApiWriter` to retry some datasets up to 5 times before failing instead of failing endlessly.