### PR TITLE
Exclude geospatial packages from PGDG repository.

### DIFF
--- a/scripts/yum/pgdg-repo.sh
+++ b/scripts/yum/pgdg-repo.sh
@@ -69,6 +69,7 @@ cat > "$PGDG_REPO" <<EOF
 name=PostgreSQL $PG_MAJOR_VERSION \$releasever - \$basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/$PG_MAJOR_VERSION/redhat/rhel-\$releasever-\$basearch
 enabled=1
+exclude=CGAL* geos* gdal* ogdi* ogr* osm* postgis* proj* SFCGAL*
 gpgcheck=1
 gpgkey=file://$PGDG_KEY
 


### PR DESCRIPTION
Fixes proj related errors on regression tests.  Avoids pgdg repo from installing conflicting version of proj.