### PR TITLE
Finish implementation for changeset.allow.deleting.reference.features option

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -380,9 +380,9 @@ See also:
 * Data Type: bool
 * Default Value: `true`
 
-If true, changesets derived can issue delete statements for the reference dataset (first dataset
-passed to the changeset deriver).  If false, no delete statements will be issued for the reference
-dataset.
+If true, changesets derived are allowed to issue delete statements for the reference dataset (first
+dataset passed to the changeset deriver) if calculated.  If false, any delete statements calculated
+for the reference dataset will be ignored and not added to changeset output.
 
 === changeset.apidb.size.max
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
@@ -75,6 +75,8 @@ public:
   int getNumChanges() const
   { return getNumCreateChanges() + getNumModifyChanges() + getNumDeleteChanges(); }
 
+  void setAllowDeletingReferenceFeatures(bool allow) { _allowDeletingReferenceFeatures = allow; }
+
 private:
 
   Change _nextChange();
@@ -87,6 +89,8 @@ private:
 
   long _numFromElementsParsed;
   long _numToElementsParsed;
+  // Prevents any reference features from being deleted. This is useful for Differential Conflation
+  // and can be used as a safety feature for other conflation workflows.
   bool _allowDeletingReferenceFeatures;
   QMap<Change::ChangeType, int> _changesByType;
 

--- a/test-files/algorithms/changeset/ChangesetDeriverTest/disableRefDeleteTest-in-1.osm
+++ b/test-files/algorithms/changeset/ChangesetDeriverTest/disableRefDeleteTest-in-1.osm
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="12.0421785" minlon="8.470265400000001" maxlat="12.0546549" maxlon="8.4791547"/>
+    <node visible="true" id="6096481775" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0525096999999999" lon="8.4729293000000006"/>
+    <node visible="true" id="6096481776" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0526611999999993" lon="8.4728809999999992"/>
+    <node visible="true" id="6096481777" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0526783000000002" lon="8.4728870999999994"/>
+    <node visible="true" id="6096481778" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0525511000000005" lon="8.4746083999999993"/>
+    <node visible="true" id="6096481779" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0528376000000002" lon="8.4751460999999999"/>
+    <node visible="true" id="6096481780" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0526880999999992" lon="8.4748725999999994"/>
+    <node visible="true" id="6096481781" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0536344000000000" lon="8.4745352999999994"/>
+    <node visible="true" id="6096481782" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0536600000000007" lon="8.4745097999999999"/>
+    <node visible="true" id="6096481783" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0525824999999998" lon="8.4746842000000004"/>
+    <node visible="true" id="6096481784" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0436382999999996" lon="8.4786436999999992"/>
+    <node visible="true" id="6096481785" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0501021000000001" lon="8.4749251999999995"/>
+    <node visible="true" id="6096481786" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0463676999999993" lon="8.4771590999999997"/>
+    <node visible="true" id="6096481787" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0445892000000008" lon="8.4782937000000000"/>
+    <node visible="true" id="6096481788" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0446396000000000" lon="8.4782765999999992"/>
+    <node visible="true" id="6096481789" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0443466000000008" lon="8.4783653000000001"/>
+    <node visible="true" id="6096481790" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0440498999999992" lon="8.4784515999999996"/>
+    <node visible="true" id="6096481791" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0421785000000003" lon="8.4791547000000005"/>
+    <node visible="true" id="6096481792" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0439924999999999" lon="8.4784682999999994"/>
+    <node visible="true" id="6096481793" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0467455000000001" lon="8.4769123999999998"/>
+    <node visible="true" id="6096481794" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0472248000000004" lon="8.4766448000000008"/>
+    <node visible="true" id="6096481795" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0456608000000003" lon="8.4776056999999998"/>
+    <node visible="true" id="6096481796" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0464331999999992" lon="8.4771219999999996"/>
+    <node visible="true" id="6096481797" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0460711000000007" lon="8.4773353999999994"/>
+    <node visible="true" id="6096481798" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0453063000000000" lon="8.4778029000000004"/>
+    <node visible="true" id="6096481799" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0434350000000006" lon="8.4787195000000004"/>
+    <node visible="true" id="6096481800" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0452016999999998" lon="8.4778956999999995"/>
+    <node visible="true" id="6096481801" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0451882999999995" lon="8.4779181999999995"/>
+    <node visible="true" id="6096481802" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0451712000000004" lon="8.4779648000000005"/>
+    <node visible="true" id="6096481803" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0451554999999999" lon="8.4779812000000003"/>
+    <node visible="true" id="6096481804" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0447544999999998" lon="8.4782320999999996"/>
+    <node visible="true" id="6096481805" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0446875999999996" lon="8.4782601999999994"/>
+    <node visible="true" id="6096481806" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0438744999999994" lon="8.4785043000000009"/>
+    <node visible="true" id="6096481807" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0438164000000008" lon="8.4785357999999995"/>
+    <node visible="true" id="6096481808" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0437557000000002" lon="8.4785866999999993"/>
+    <node visible="true" id="6096481809" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0430683999999992" lon="8.4788374999999991"/>
+    <node visible="true" id="6096481810" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0427359999999997" lon="8.4789401000000009"/>
+    <node visible="true" id="6096481811" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0487561000000003" lon="8.4757175000000000"/>
+    <node visible="true" id="6096481812" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0479284999999994" lon="8.4762257000000005"/>
+    <node visible="true" id="6096481813" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0512677000000004" lon="8.4742127000000007"/>
+    <node visible="true" id="6096481814" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0497908999999996" lon="8.4751004999999999"/>
+    <node visible="true" id="6096481815" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0506043999999992" lon="8.4746018999999997"/>
+    <node visible="true" id="6096481816" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0508609000000000" lon="8.4744522000000000"/>
+    <node visible="true" id="6096481817" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0510003999999995" lon="8.4743682000000007"/>
+    <node visible="true" id="6096481818" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0533877999999994" lon="8.4725169000000005"/>
+    <node visible="true" id="6096481819" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0517792000000004" lon="8.4722150000000003"/>
+    <node visible="true" id="6096481820" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0520879000000001" lon="8.4737132000000006"/>
+    <node visible="true" id="6096481821" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0521338000000000" lon="8.4730472999999993"/>
+    <node visible="true" id="6096481822" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0517413999999992" lon="8.4739074999999993"/>
+    <node visible="true" id="6096481823" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0527890000000006" lon="8.4733152999999994"/>
+    <node visible="true" id="6096481824" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0525058000000005" lon="8.4744895000000007"/>
+    <node visible="true" id="6096481825" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0536790000000007" lon="8.4758203000000005"/>
+    <node visible="true" id="6096481826" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0532915000000003" lon="8.4751800999999993"/>
+    <node visible="true" id="6096481827" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0528010000000005" lon="8.4742870000000003"/>
+    <node visible="true" id="6096481828" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0534216999999995" lon="8.4746282999999991"/>
+    <node visible="true" id="6096481829" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0536639000000001" lon="8.4744814000000002"/>
+    <node visible="true" id="6096481830" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0534032000000000" lon="8.4739199000000003"/>
+    <node visible="true" id="6096481831" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0531196000000005" lon="8.4740737999999993"/>
+    <node visible="true" id="6096481833" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0536022999999997" lon="8.4749856999999995"/>
+    <node visible="true" id="6096481835" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0546548999999992" lon="8.4743714000000008"/>
+    <node visible="true" id="6096481836" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0541978000000007" lon="8.4746196000000005"/>
+    <node visible="true" id="6096481837" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0534777000000002" lon="8.4738738999999992"/>
+    <node visible="true" id="6096481838" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0531401999999996" lon="8.4731088999999997"/>
+    <node visible="true" id="6096481839" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0538200000000000" lon="8.4736925000000003"/>
+    <node visible="true" id="6096481840" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0538278000000005" lon="8.4724001999999992"/>
+    <node visible="true" id="6096481841" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0533832000000007" lon="8.4725003000000001"/>
+    <node visible="true" id="6096481842" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0534935000000001" lon="8.4728852000000003"/>
+    <node visible="true" id="6096481843" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523431999999993" lon="8.4729878000000003"/>
+    <node visible="true" id="6096481844" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0521481000000001" lon="8.4730734999999999"/>
+    <node visible="true" id="6096481845" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0528586000000004" lon="8.4732713999999998"/>
+    <node visible="true" id="6096481846" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0526991999999993" lon="8.4729033000000005"/>
+    <node visible="true" id="6096481847" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0510853999999998" lon="8.4707491000000008"/>
+    <node visible="true" id="6096481848" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0516906000000006" lon="8.4719370999999999"/>
+    <node visible="true" id="6096481849" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0512499999999996" lon="8.4711464000000003"/>
+    <node visible="true" id="6096481850" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0514539000000003" lon="8.4715067000000008"/>
+    <node visible="true" id="6096481851" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0511228999999993" lon="8.4708553000000002"/>
+    <node visible="true" id="6096481852" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0508856000000009" lon="8.4702654000000006"/>
+    <node visible="true" id="6096481853" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0512762000000002" lon="8.4711961999999996"/>
+    <node visible="true" id="6096481854" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0514512000000007" lon="8.4741002000000005"/>
+    <node visible="true" id="6096481855" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0522229000000003" lon="8.4746880000000004"/>
+    <node visible="true" id="6096481856" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0529837000000004" lon="8.4753893999999992"/>
+    <node visible="true" id="6096481857" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0502514000000005" lon="8.4748316999999993"/>
+    <node visible="true" id="6096481858" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0505417999999995" lon="8.4746421999999999"/>
+    <node visible="true" id="6096481859" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0492772000000006" lon="8.4754074999999993"/>
+    <node visible="true" id="6096481860" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0495382000000006" lon="8.4752492000000004"/>
+    <node visible="true" id="6096481861" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0499250999999994" lon="8.4750359999999993"/>
+    <node visible="true" id="6096481862" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524038999999998" lon="8.4735338999999996"/>
+    <node visible="true" id="6096481863" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0518453000000001" lon="8.4724208999999995"/>
+    <node visible="true" id="6096481864" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524459999999998" lon="8.4733753000000007"/>
+    <node visible="true" id="6096481865" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524001999999992" lon="8.4733994999999993"/>
+    <node visible="true" id="6096481866" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524258999999994" lon="8.4734502999999997"/>
+    <node visible="true" id="6096481867" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524716999999999" lon="8.4734260999999993"/>
+    <node visible="true" id="6096481868" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524857000000001" lon="8.4732915000000002"/>
+    <node visible="true" id="6096481869" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524193000000004" lon="8.4733318000000004"/>
+    <node visible="true" id="6096481870" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524512000000001" lon="8.4733856999999997"/>
+    <node visible="true" id="6096481871" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0525172000000005" lon="8.4733459000000000"/>
+    <node visible="true" id="6096481872" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523637000000008" lon="8.4732307999999996"/>
+    <node visible="true" id="6096481873" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523954000000000" lon="8.4733225999999995"/>
+    <node visible="true" id="6096481874" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524387999999991" lon="8.4733070000000001"/>
+    <node visible="true" id="6096481875" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524748000000006" lon="8.4732423000000008"/>
+    <node visible="true" id="6096481876" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524263000000005" lon="8.4732605000000003"/>
+    <node visible="true" id="6096481877" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523951000000000" lon="8.4731739000000008"/>
+    <node visible="true" id="6096481878" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0525290999999992" lon="8.4732166000000007"/>
+    <node visible="true" id="6096481879" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524799999999992" lon="8.4732389000000001"/>
+    <node visible="true" id="6096481880" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524436000000001" lon="8.4731556999999995"/>
+    <node visible="true" id="6096481881" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524930000000001" lon="8.4731330000000007"/>
+    <node visible="true" id="6096481882" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0524071999999993" lon="8.4732152000000003"/>
+    <node visible="true" id="6096481883" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523206999999992" lon="8.4732482999999998"/>
+    <node visible="true" id="6096481884" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523047999999999" lon="8.4732043000000008"/>
+    <node visible="true" id="6096481885" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978" lat="12.0523910000000001" lon="8.4731716000000006"/>
+    <way visible="true" id="649672683" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481862"/>
+        <nd ref="6096481820"/>
+        <nd ref="6096481822"/>
+        <nd ref="6096481854"/>
+        <nd ref="6096481813"/>
+        <nd ref="6096481817"/>
+        <nd ref="6096481816"/>
+        <nd ref="6096481815"/>
+        <nd ref="6096481858"/>
+        <nd ref="6096481857"/>
+        <nd ref="6096481785"/>
+        <nd ref="6096481861"/>
+        <nd ref="6096481814"/>
+        <nd ref="6096481860"/>
+        <nd ref="6096481859"/>
+        <nd ref="6096481811"/>
+        <nd ref="6096481812"/>
+        <nd ref="6096481794"/>
+        <nd ref="6096481793"/>
+        <nd ref="6096481796"/>
+        <nd ref="6096481786"/>
+        <nd ref="6096481797"/>
+        <nd ref="6096481795"/>
+        <nd ref="6096481798"/>
+        <nd ref="6096481800"/>
+        <nd ref="6096481801"/>
+        <nd ref="6096481802"/>
+        <nd ref="6096481803"/>
+        <nd ref="6096481804"/>
+        <nd ref="6096481805"/>
+        <nd ref="6096481788"/>
+        <nd ref="6096481787"/>
+        <nd ref="6096481789"/>
+        <nd ref="6096481790"/>
+        <nd ref="6096481792"/>
+        <nd ref="6096481806"/>
+        <nd ref="6096481807"/>
+        <nd ref="6096481808"/>
+        <nd ref="6096481784"/>
+        <nd ref="6096481799"/>
+        <nd ref="6096481809"/>
+        <nd ref="6096481810"/>
+        <nd ref="6096481791"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:07Z"/>
+    </way>
+    <way visible="true" id="649672684" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481855"/>
+        <nd ref="6096481824"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:08Z"/>
+    </way>
+    <way visible="true" id="649672685" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481824"/>
+        <nd ref="6096481820"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:08Z"/>
+    </way>
+    <way visible="true" id="649672686" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481862"/>
+        <nd ref="6096481844"/>
+        <nd ref="6096481821"/>
+        <nd ref="6096481863"/>
+        <nd ref="6096481819"/>
+        <nd ref="6096481848"/>
+        <nd ref="6096481850"/>
+        <nd ref="6096481853"/>
+        <nd ref="6096481849"/>
+        <nd ref="6096481851"/>
+        <nd ref="6096481847"/>
+        <nd ref="6096481852"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:08Z"/>
+    </way>
+    <way visible="true" id="649672687" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481823"/>
+        <nd ref="6096481831"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:08Z"/>
+    </way>
+    <way visible="true" id="649672688" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481833"/>
+        <nd ref="6096481826"/>
+        <nd ref="6096481856"/>
+        <nd ref="6096481779"/>
+        <nd ref="6096481780"/>
+        <nd ref="6096481783"/>
+        <nd ref="6096481778"/>
+        <nd ref="6096481824"/>
+        <nd ref="6096481827"/>
+        <nd ref="6096481862"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:08Z"/>
+    </way>
+    <way visible="true" id="649672689" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481831"/>
+        <nd ref="6096481827"/>
+        <nd ref="6096481826"/>
+        <nd ref="6096481825"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:08Z"/>
+    </way>
+    <way visible="true" id="649672690" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481830"/>
+        <nd ref="6096481829"/>
+        <nd ref="6096481782"/>
+        <nd ref="6096481781"/>
+        <nd ref="6096481828"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:09Z"/>
+    </way>
+    <way visible="true" id="649672691" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481837"/>
+        <nd ref="6096481830"/>
+        <nd ref="6096481831"/>
+        <nd ref="6096481828"/>
+        <nd ref="6096481833"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:09Z"/>
+    </way>
+    <way visible="true" id="649672693" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481838"/>
+        <nd ref="6096481837"/>
+        <nd ref="6096481839"/>
+        <nd ref="6096481836"/>
+        <nd ref="6096481835"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:09Z"/>
+    </way>
+    <way visible="true" id="649672694" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481844"/>
+        <nd ref="6096481843"/>
+        <nd ref="6096481775"/>
+        <nd ref="6096481776"/>
+        <nd ref="6096481777"/>
+        <nd ref="6096481846"/>
+        <nd ref="6096481845"/>
+        <nd ref="6096481838"/>
+        <nd ref="6096481842"/>
+        <nd ref="6096481818"/>
+        <nd ref="6096481841"/>
+        <nd ref="6096481840"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:09Z"/>
+    </way>
+    <way visible="true" id="649672695" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481845"/>
+        <nd ref="6096481823"/>
+        <nd ref="6096481862"/>
+        <tag k="highway" v="residential"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:09Z"/>
+    </way>
+    <way visible="true" id="649672696" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481867"/>
+        <nd ref="6096481866"/>
+        <nd ref="6096481865"/>
+        <nd ref="6096481864"/>
+        <nd ref="6096481870"/>
+        <nd ref="6096481867"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:09Z"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="649672697" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481871"/>
+        <nd ref="6096481870"/>
+        <nd ref="6096481864"/>
+        <nd ref="6096481869"/>
+        <nd ref="6096481868"/>
+        <nd ref="6096481871"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:10Z"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="649672698" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481882"/>
+        <nd ref="6096481874"/>
+        <nd ref="6096481873"/>
+        <nd ref="6096481872"/>
+        <nd ref="6096481882"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:10Z"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="649672699" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481880"/>
+        <nd ref="6096481877"/>
+        <nd ref="6096481876"/>
+        <nd ref="6096481875"/>
+        <nd ref="6096481880"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:10Z"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="649672700" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481881"/>
+        <nd ref="6096481880"/>
+        <nd ref="6096481879"/>
+        <nd ref="6096481878"/>
+        <nd ref="6096481881"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:10Z"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="649672701" timestamp="2019-07-12T15:20:28Z" version="1" changeset="978">
+        <nd ref="6096481885"/>
+        <nd ref="6096481884"/>
+        <nd ref="6096481883"/>
+        <nd ref="6096481872"/>
+        <nd ref="6096481882"/>
+        <nd ref="6096481885"/>
+        <tag k="source:datetime" v="2019-07-11T20:47:10Z"/>
+        <tag k="building" v="yes"/>
+    </way>
+</osm>

--- a/test-files/algorithms/changeset/ChangesetDeriverTest/disableRefDeleteTest-in-2.osm
+++ b/test-files/algorithms/changeset/ChangesetDeriverTest/disableRefDeleteTest-in-2.osm
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="12.0508968885617" minlon="8.4718" maxlat="12.0533851885601" maxlon="8.4763965"/>
+    <node visible="true" id="-186" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0528611885603993" lon="8.4757698000000001"/>
+    <node visible="true" id="-185" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0527772885605007" lon="8.4756275999999993"/>
+    <node visible="true" id="-141" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0514714885612992" lon="8.4734017000000001"/>
+    <node visible="true" id="-140" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0517413885610996" lon="8.4739074999999993"/>
+    <node visible="true" id="-117" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0525146885605992" lon="8.4728293000000008"/>
+    <node visible="true" id="-116" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0526874885604993" lon="8.4727616999999995"/>
+    <node visible="true" id="-115" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0528753885604001" lon="8.4726946000000005"/>
+    <node visible="true" id="-114" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523670885607004" lon="8.4728703000000003"/>
+    <node visible="true" id="-113" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0526690885604992" lon="8.4723009000000005"/>
+    <node visible="true" id="-112" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0521702885608999" lon="8.4730398999999998"/>
+    <node visible="true" id="-111" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0530588885602992" lon="8.4726262999999999"/>
+    <node visible="true" id="-110" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0528712885604001" lon="8.4722179000000004"/>
+    <node visible="true" id="-105" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0508968885617005" lon="8.4718000000000000"/>
+    <node visible="true" id="-104" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0510072885615998" lon="8.4721019000000002"/>
+    <node visible="true" id="-103" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0510920885615000" lon="8.4723868000000007"/>
+    <node visible="true" id="-102" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0511371885614995" lon="8.4725964999999999"/>
+    <node visible="true" id="-101" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0512373885614004" lon="8.4728397999999991"/>
+    <node visible="true" id="-100" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0513896885614002" lon="8.4732362000000006"/>
+    <node visible="true" id="-95" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0527817885605000" lon="8.4763964999999999"/>
+    <node visible="true" id="-94" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0527658885605007" lon="8.4763629999999992"/>
+    <node visible="true" id="-93" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522189885607993" lon="8.4753960999999993"/>
+    <node visible="true" id="-92" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0519264885609996" lon="8.4749119999999998"/>
+    <node visible="true" id="-91" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522228885608005" lon="8.4746880000000004"/>
+    <node visible="true" id="-90" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0531015885603008" lon="8.4761936999999996"/>
+    <node visible="true" id="-89" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0533851885600996" lon="8.4760027000000004"/>
+    <node visible="true" id="-88" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0529836885602997" lon="8.4753893999999992"/>
+    <node visible="true" id="-87" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0527186885604998" lon="8.4755596999999998"/>
+    <node visible="true" id="-86" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524248885607008" lon="8.4757314000000008"/>
+    <node visible="true" id="-85" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522477885608001" lon="8.4758367000000003"/>
+    <node visible="true" id="-84" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0519435885610005" lon="8.4760244000000000"/>
+    <node visible="true" id="-83" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0516864885612005" lon="8.4761746000000002"/>
+    <node visible="true" id="-67" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523810885607006" lon="8.4730512000000004"/>
+    <node visible="true" id="-66" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523457885607002" lon="8.4730682999999996"/>
+    <node visible="true" id="-65" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523725885607007" lon="8.4731258999999994"/>
+    <node visible="true" id="-64" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524078885606993" lon="8.4731088000000003"/>
+    <node visible="true" id="-49" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523029885608004" lon="8.4730916000000001"/>
+    <node visible="true" id="-48" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522599885608006" lon="8.4731117000000005"/>
+    <node visible="true" id="-47" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522849885607997" lon="8.4731675000000006"/>
+    <node visible="true" id="-46" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522364885607995" lon="8.4731901999999995"/>
+    <node visible="true" id="-45" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0521943885607996" lon="8.4730960999999994"/>
+    <node visible="true" id="-44" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522857885608001" lon="8.4730533000000001"/>
+    <node visible="true" id="-43" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523960885607000" lon="8.4730830000000008"/>
+    <node visible="true" id="-42" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523787885607998" lon="8.4730445999999997"/>
+    <node visible="true" id="-41" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523406885606992" lon="8.4730626000000004"/>
+    <node visible="true" id="-40" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523246885608000" lon="8.4730272000000006"/>
+    <node visible="true" id="-39" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523886885607006" lon="8.4729969000000001"/>
+    <node visible="true" id="-38" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524220885607001" lon="8.4730708000000003"/>
+    <node visible="true" id="-37" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524420885606993" lon="8.4731058000000008"/>
+    <node visible="true" id="-36" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523792885607008" lon="8.4731366000000001"/>
+    <node visible="true" id="-35" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523944885607008" lon="8.4731688999999992"/>
+    <node visible="true" id="-34" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524549885607009" lon="8.4729799999999997"/>
+    <node visible="true" id="-33" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0523969885606999" lon="8.4730103999999997"/>
+    <node visible="true" id="-32" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524279885606997" lon="8.4730723000000001"/>
+    <node visible="true" id="-31" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524474885607003" lon="8.4730620999999999"/>
+    <node visible="true" id="-30" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524360885607003" lon="8.4730395000000005"/>
+    <node visible="true" id="-29" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524746885607001" lon="8.4730193000000007"/>
+    <node visible="true" id="-28" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524571885606999" lon="8.4731380999999999"/>
+    <node visible="true" id="-27" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524302885607000" lon="8.4730779999999992"/>
+    <node visible="true" id="-26" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524882885606992" lon="8.4730495999999995"/>
+    <node visible="true" id="-25" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0525166885605994" lon="8.4731103000000001"/>
+    <node visible="true" id="-24" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0521526885609003" lon="8.4730053999999999"/>
+    <node visible="true" id="-23" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0520655885609003" lon="8.4728147000000007"/>
+    <node visible="true" id="-22" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0521437885608993" lon="8.4727773000000006"/>
+    <node visible="true" id="-21" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522309885607992" lon="8.4729679999999998"/>
+    <node visible="true" id="-20" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0520484885608994" lon="8.4725596000000003"/>
+    <node visible="true" id="-19" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0521293885608998" lon="8.4727569999999996"/>
+    <node visible="true" id="-18" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0520227885608993" lon="8.4725366999999991"/>
+    <node visible="true" id="-17" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522112885607999" lon="8.4724704000000006"/>
+    <node visible="true" id="-16" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522391885607991" lon="8.4724477999999994"/>
+    <node visible="true" id="-15" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524244885606997" lon="8.4723807000000004"/>
+    <node visible="true" id="-14" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524728885607004" lon="8.4723661999999997"/>
+    <node visible="true" id="-13" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0526337885606001" lon="8.4723064000000008"/>
+    <node visible="true" id="-12" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0528618885604004" lon="8.4722220000000004"/>
+    <node visible="true" id="-11" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0530389885602993" lon="8.4726321999999996"/>
+    <node visible="true" id="-10" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0528621885604004" lon="8.4726969000000008"/>
+    <node visible="true" id="-9" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0525449885605997" lon="8.4729148999999992"/>
+    <node visible="true" id="-8" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0526756885605000" lon="8.4727697000000006"/>
+    <node visible="true" id="-7" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0527059885605006" lon="8.4728553000000009"/>
+    <node visible="true" id="-6" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0524909885607006" lon="8.4728218999999996"/>
+    <node visible="true" id="-5" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522531885607993" lon="8.4729174000000000"/>
+    <node visible="true" id="-4" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0522791885607994" lon="8.4729852000000001"/>
+    <node visible="true" id="-3" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0525169885605994" lon="8.4728896999999996"/>
+    <node visible="true" id="-2" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0529626885604007" lon="8.4725599999999996"/>
+    <node visible="true" id="-1" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986" lat="12.0530430885602993" lon="8.4725376000000008"/>
+    <way visible="true" id="-65" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-86"/>
+        <nd ref="-94"/>
+        <nd ref="-95"/>
+        <tag k="highway" v="residential"/>
+    </way>
+    <way visible="true" id="-27" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-105"/>
+        <nd ref="-104"/>
+        <nd ref="-103"/>
+        <nd ref="-102"/>
+        <nd ref="-101"/>
+        <nd ref="-100"/>
+        <nd ref="-141"/>
+        <nd ref="-140"/>
+        <nd ref="-91"/>
+        <nd ref="-92"/>
+        <nd ref="-93"/>
+        <nd ref="-86"/>
+        <tag k="highway" v="residential"/>
+    </way>
+    <way visible="true" id="-19" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-117"/>
+        <nd ref="-6"/>
+        <nd ref="-114"/>
+        <nd ref="-5"/>
+        <nd ref="-4"/>
+        <nd ref="-112"/>
+        <nd ref="-24"/>
+        <nd ref="-21"/>
+        <nd ref="-22"/>
+        <nd ref="-19"/>
+        <nd ref="-20"/>
+        <nd ref="-18"/>
+        <nd ref="-17"/>
+        <nd ref="-16"/>
+        <nd ref="-15"/>
+        <nd ref="-14"/>
+        <nd ref="-13"/>
+        <nd ref="-113"/>
+        <nd ref="-12"/>
+        <nd ref="-110"/>
+        <nd ref="-2"/>
+        <nd ref="-1"/>
+        <nd ref="-111"/>
+        <nd ref="-11"/>
+        <nd ref="-115"/>
+        <nd ref="-10"/>
+        <nd ref="-116"/>
+        <nd ref="-8"/>
+        <nd ref="-117"/>
+        <tag k="amenity" v="school"/>
+    </way>
+    <way visible="true" id="-18" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-87"/>
+        <nd ref="-91"/>
+        <tag k="highway" v="residential"/>
+    </way>
+    <way visible="true" id="-17" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-87"/>
+        <nd ref="-185"/>
+        <nd ref="-186"/>
+        <nd ref="-90"/>
+        <tag k="highway" v="residential"/>
+    </way>
+    <way visible="true" id="-16" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-83"/>
+        <nd ref="-84"/>
+        <nd ref="-85"/>
+        <nd ref="-86"/>
+        <nd ref="-87"/>
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <tag k="highway" v="residential"/>
+    </way>
+    <way visible="true" id="-13" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-64"/>
+        <nd ref="-65"/>
+        <nd ref="-66"/>
+        <nd ref="-67"/>
+        <nd ref="-64"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="-8" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-44"/>
+        <nd ref="-45"/>
+        <nd ref="-46"/>
+        <nd ref="-47"/>
+        <nd ref="-48"/>
+        <nd ref="-49"/>
+        <nd ref="-44"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="-7" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-38"/>
+        <nd ref="-39"/>
+        <nd ref="-40"/>
+        <nd ref="-41"/>
+        <nd ref="-42"/>
+        <nd ref="-67"/>
+        <nd ref="-43"/>
+        <nd ref="-38"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="-6" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-28"/>
+        <nd ref="-35"/>
+        <nd ref="-36"/>
+        <nd ref="-37"/>
+        <nd ref="-28"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="-5" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-29"/>
+        <nd ref="-30"/>
+        <nd ref="-31"/>
+        <nd ref="-32"/>
+        <nd ref="-33"/>
+        <nd ref="-34"/>
+        <nd ref="-29"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="-4" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-25"/>
+        <nd ref="-26"/>
+        <nd ref="-27"/>
+        <nd ref="-37"/>
+        <nd ref="-28"/>
+        <nd ref="-25"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="-3" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-21"/>
+        <nd ref="-22"/>
+        <nd ref="-23"/>
+        <nd ref="-24"/>
+        <nd ref="-21"/>
+        <tag k="building" v="school"/>
+    </way>
+    <way visible="true" id="-2" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-7"/>
+        <nd ref="-8"/>
+        <nd ref="-117"/>
+        <nd ref="-9"/>
+        <nd ref="-7"/>
+        <tag k="building" v="school"/>
+    </way>
+    <way visible="true" id="-1" timestamp="2019-07-12T16:07:43Z" version="1" changeset="986">
+        <nd ref="-3"/>
+        <nd ref="-4"/>
+        <nd ref="-5"/>
+        <nd ref="-114"/>
+        <nd ref="-6"/>
+        <nd ref="-3"/>
+        <tag k="building" v="school"/>
+    </way>
+</osm>


### PR DESCRIPTION
The original implemenation was only partially completed for an unknown reason. This option is particularly helpful when generating changesets for Differential Conflation output when you don't want to change any reference features. Given that, technically, we could implement something similar to suppress modify statements but haven't seen a use case for that yet.