### PR TITLE
Changeset splits are non-atomic

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlChangesetFileWriterTest.cpp
@@ -40,7 +40,6 @@ class OsmXmlChangesetFileWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmXmlChangesetFileWriterTest);
   CPPUNIT_TEST(runSimpleTest);
-  CPPUNIT_TEST(runSplitTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -58,22 +57,6 @@ public:
 
     HOOT_FILE_EQUALS( _inputPath + "changeset.osc",
                      _outputPath + "changeset.osc");
-  }
-
-  void runSplitTest()
-  {
-    std::shared_ptr<ChangesetProvider> changesetProvider(new TestOsmChangesetProvider(false));
-    OsmXmlChangesetFileWriter writer;
-    Settings testSettings = conf();
-    testSettings.set("changeset.max.size", "5");
-    writer.setConfiguration(testSettings);
-    writer.write(
-      _outputPath + "changeset.split.osc", changesetProvider);
-
-    HOOT_FILE_EQUALS( _inputPath + "changeset.split.osc",
-                     _outputPath + "changeset.split.osc");
-    HOOT_FILE_EQUALS( _inputPath + "changeset-001.split.osc",
-                     _outputPath + "changeset-001.split.osc");
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
@@ -38,7 +38,6 @@ class ServiceOsmApiDbSqlChangesetFileWriterTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceOsmApiDbSqlChangesetFileWriterTest);
   CPPUNIT_TEST(runBasicTest);
-  CPPUNIT_TEST(runSplitTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -74,26 +73,6 @@ public:
     writer.write(_outputPath + "changeset.osc.sql", changesetProvider);
     HOOT_FILE_EQUALS(_inputPath + "changeset.osc.sql",
                     _outputPath + "changeset.osc.sql");
-  }
-
-  void runSplitTest()
-  {
-    std::shared_ptr<ChangesetProvider> changesetProvider(new TestOsmChangesetProvider(true));
-
-    //clear out the db so we get consistent next id results
-    database.open(ServicesDbTestUtils::getOsmApiDbUrl());
-    database.deleteData();
-    ApiDb::execSqlFile(ServicesDbTestUtils::getOsmApiDbUrl().toString(), _scriptDir + "users.sql");
-
-    OsmApiDbSqlChangesetFileWriter writer(ServicesDbTestUtils::getOsmApiDbUrl());
-    //  Set the changeset max size to 5 (half of the changes) for this test only
-    Settings testSettings = conf();
-    testSettings.set("changeset.max.size", "5");
-    writer.setConfiguration(testSettings);
-    writer.setChangesetUserId(1);
-    writer.write(_outputPath + "changeset.split.osc.sql", changesetProvider);
-    HOOT_FILE_EQUALS(_inputPath + "changeset.split.osc.sql",
-                    _outputPath + "changeset.split.osc.sql");
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -278,6 +278,17 @@ private:
   bool moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way);
   bool moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation);
   /**
+   * @brief moveOrRemoveNode/Way/Relation Move an element from one subset to another, or if all related elements aren't
+   *   able to be moved, the element is removed from the subset and returned to the `available` state
+   * @param source Subset containing the element
+   * @param destination Subset to move to
+   * @param type Type of operation (create/modify/delete)
+   * @param node/way/relation Pointer to the element to be moved
+   */
+  void moveOrRemoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlNode* node);
+  void moveOrRemoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way);
+  void moveOrRemoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation);
+  /**
    * @brief canMoveNode/Way/Relation Query if a node/way/relation can be moved.  This checks downstream relations, ways,
    *  and nodes to see if they can also be moved.
    * @param source Subset containing the element

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
@@ -43,7 +43,6 @@ namespace hoot
 
 OsmApiDbSqlChangesetFileWriter::OsmApiDbSqlChangesetFileWriter(const QUrl& url) :
 _changesetId(0),
-_changesetMaxSize(ConfigOptions().getChangesetMaxSize()),
 _changesetUserId(ConfigOptions().getChangesetUserId()),
 _includeDebugTags(ConfigOptions().getWriterIncludeDebugTags())
 {
@@ -105,13 +104,6 @@ void OsmApiDbSqlChangesetFileWriter::write(const QString& path,
         _changesetBounds.expandToInclude(node->getX(), node->getY());
       }
       changes++;
-    }
-
-    if (changes > _changesetMaxSize)
-    {
-      _updateChangeset(changes);
-      _createChangeSet();
-      changes = 0;
     }
   }
 
@@ -605,7 +597,8 @@ void OsmApiDbSqlChangesetFileWriter::_deleteAll(const QString& tableName, const 
 void OsmApiDbSqlChangesetFileWriter::setConfiguration(const Settings &conf)
 {
   ConfigOptions co(conf);
-  _changesetMaxSize = co.getChangesetMaxSize();
+  _changesetUserId = co.getChangesetUserId();
+  _includeDebugTags = co.getWriterIncludeDebugTags();
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.h
@@ -112,7 +112,6 @@ private:
   geos::geom::Envelope _changesetBounds;
 
   /** Settings from the config file */
-  long _changesetMaxSize;
   double _changesetUserId;
 
   bool _includeDebugTags;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -97,6 +97,10 @@ bool OsmApiWriter::apply()
     return false;
   }
   _stats.append(SingleStat("API Capabilites Query Time (sec)", timer.getElapsedAndRestart()));
+  //  Limit the max changeset size to the max from the API, testing found that smaller (1k to 2k elements)
+  //  pushed across multiple processing threads out performed larger (50k element) datasets
+  if (_maxChangesetSize > _capabilities.getChangesets())
+    _maxChangesetSize = _capabilities.getChangesets();
   //  Setup the network request object with OAuth or with username/password authentication
   request = createNetworkRequest(true);
   //  Validate API permissions

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.cpp
@@ -45,7 +45,6 @@ namespace hoot
 
 OsmXmlChangesetFileWriter::OsmXmlChangesetFileWriter() :
 _precision(ConfigOptions().getWriterPrecision()),
-_changesetMaxSize(ConfigOptions().getChangesetMaxSize()),
 _multipleChangesetsWritten(false),
 _addTimestamp(ConfigOptions().getChangesetXmlWriterAddTimestamp()),
 _includeDebugTags(ConfigOptions().getWriterIncludeDebugTags())
@@ -74,116 +73,97 @@ void OsmXmlChangesetFileWriter::write(const QString& path, const ChangesetProvid
   LOG_VARD(path);
   LOG_VARD(cs->hasMoreChanges());
 
-  QFileInfo info(path);
-  info.setCaching(false);
-  QString file = info.baseName();
-  QString dir = info.path();
-  QString ext = info.completeSuffix();
-  int fileCount = 0;
   QString filepath = path;
 
   _initIdCounters();
 
+  long changesetProgress = 1;
+
+  LOG_INFO("Writing changeset to " << filepath);
+
+  QFile f;
+  f.setFileName(filepath);
+  if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
+  {
+    throw HootException(QObject::tr("Error opening %1 for writing").arg(path));
+  }
+
+  QXmlStreamWriter writer(&f);
+  writer.setCodec("UTF-8");
+  writer.setAutoFormatting(true);
+  writer.writeStartDocument();
+
+  writer.writeStartElement("osmChange");
+  writer.writeAttribute("version", "0.6");
+  writer.writeAttribute("generator", HOOT_PACKAGE_NAME);
+
+  Change::ChangeType last = Change::Unknown;
+
   while (cs->hasMoreChanges())
   {
-    long changesetProgress = 1;
-    //  Create a new filepath if the file is split in multiple files because of the
-    //  changeset.max.size setting
-    //   i.e. <filepath>/<filename>-001.<ext>
-    if (fileCount > 0)
+    LOG_TRACE("Reading next XML change...");
+    _change = cs->readNextChange();
+    LOG_VART(_change.toString());
+    if (_change.getType() != last)
     {
-      filepath =
-        QString("%1/%2-%3.%4").arg(dir).arg(file).arg(fileCount, 3, 10, QChar('0')).arg(ext);
-      _multipleChangesetsWritten = true;
-    }
-    LOG_INFO("Writing changeset to " << filepath);
-
-    QFile f;
-    f.setFileName(filepath);
-    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
-    {
-      throw HootException(QObject::tr("Error opening %1 for writing").arg(path));
-    }
-
-    QXmlStreamWriter writer(&f);
-    writer.setCodec("UTF-8");
-    writer.setAutoFormatting(true);
-    writer.writeStartDocument();
-
-    writer.writeStartElement("osmChange");
-    writer.writeAttribute("version", "0.6");
-    writer.writeAttribute("generator", HOOT_PACKAGE_NAME);
-
-    Change::ChangeType last = Change::Unknown;
-
-    while (cs->hasMoreChanges() && changesetProgress <= _changesetMaxSize)
-    {
-      LOG_TRACE("Reading next XML change...");
-      _change = cs->readNextChange();
-      LOG_VART(_change.toString());
-      if (_change.getType() != last)
+      if (last != Change::Unknown)
       {
-        if (last != Change::Unknown)
-        {
-          writer.writeEndElement();
-        }
-        switch (_change.getType())
-        {
-          case Change::Create:
-            writer.writeStartElement("create");
-            break;
-          case Change::Delete:
-            writer.writeStartElement("delete");
-            break;
-          case Change::Modify:
-            writer.writeStartElement("modify");
-            break;
-          case Change::Unknown:
-            //see comment in ChangesetDeriver::_nextChange() when
-            //_fromE->getElementId() < _toE->getElementId() as to why we do a no-op here.
-            break;
-          default:
-            throw IllegalArgumentException("Unexpected change type.");
-        }
-        last = _change.getType();
-        LOG_VART(last);
+        writer.writeEndElement();
       }
-
-      if (_change.getType() != Change::Unknown)
+      switch (_change.getType())
       {
-        ElementType::Type type = _change.getElement()->getElementType().getEnum();
-        switch (type)
-        {
-          case ElementType::Node:
-            _writeNode(writer, std::dynamic_pointer_cast<const Node>(_change.getElement()));
-            break;
-          case ElementType::Way:
-            _writeWay(writer, std::dynamic_pointer_cast<const Way>(_change.getElement()));
-            break;
-          case ElementType::Relation:
-            _writeRelation(
-              writer, std::dynamic_pointer_cast<const Relation>(_change.getElement()));
-            break;
-          default:
-            throw IllegalArgumentException("Unexpected element type.");
-        }
-        changesetProgress++;
-        //  Update the stats
-        _stats(last, type)++;
+        case Change::Create:
+          writer.writeStartElement("create");
+          break;
+        case Change::Delete:
+          writer.writeStartElement("delete");
+          break;
+        case Change::Modify:
+          writer.writeStartElement("modify");
+          break;
+        case Change::Unknown:
+          //see comment in ChangesetDeriver::_nextChange() when
+          //_fromE->getElementId() < _toE->getElementId() as to why we do a no-op here.
+          break;
+        default:
+          throw IllegalArgumentException("Unexpected change type.");
       }
+      last = _change.getType();
+      LOG_VART(last);
     }
 
-    if (last != Change::Unknown)
+    if (_change.getType() != Change::Unknown)
     {
-      writer.writeEndElement();
+      ElementType::Type type = _change.getElement()->getElementType().getEnum();
+      switch (type)
+      {
+        case ElementType::Node:
+          _writeNode(writer, std::dynamic_pointer_cast<const Node>(_change.getElement()));
+          break;
+        case ElementType::Way:
+          _writeWay(writer, std::dynamic_pointer_cast<const Way>(_change.getElement()));
+          break;
+        case ElementType::Relation:
+          _writeRelation(
+            writer, std::dynamic_pointer_cast<const Relation>(_change.getElement()));
+          break;
+        default:
+          throw IllegalArgumentException("Unexpected element type.");
+      }
+      changesetProgress++;
+      //  Update the stats
+      _stats(last, type)++;
     }
-    writer.writeEndElement();
-    writer.writeEndDocument();
-
-    f.close();
-    //  Increment the file number if needed for split files
-    fileCount++;
   }
+
+  if (last != Change::Unknown)
+  {
+    writer.writeEndElement();
+  }
+  writer.writeEndElement();
+  writer.writeEndDocument();
+
+  f.close();
 }
 
 void OsmXmlChangesetFileWriter::_writeNode(QXmlStreamWriter& writer, ConstNodePtr n)
@@ -358,7 +338,6 @@ void OsmXmlChangesetFileWriter::setConfiguration(const Settings &conf)
 {
   ConfigOptions co(conf);
   _precision = co.getWriterPrecision();
-  _changesetMaxSize = co.getChangesetMaxSize();
 }
 
 void OsmXmlChangesetFileWriter::_writeTags(QXmlStreamWriter& writer, Tags& tags, const Element* element)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
@@ -58,14 +58,7 @@ public:
   OsmXmlChangesetFileWriter();
 
   /**
-   * Write the changeset out to the specified file and any changes over changeset.max.size
-   * will be written to another file with a path like this:
-   *  <filepath>/<filename>.<ext>
-   *  <filepath>/<filename>-001.<ext>
-   *  <filepath>/<filename>-002.<ext>
-   *  ...
-   *  <filepath>/<filename>-00n.<ext>
-   *
+   * Write the changeset out to the specified file
    * @param path Pathname for the output file(s)
    * @param cs Changeset provider to stream the changes from
    */
@@ -86,7 +79,6 @@ private:
 
   /** Settings from the config file */
   int _precision;
-  long _changesetMaxSize;
 
   Change _change;
 


### PR DESCRIPTION
Refs #3373
Removed changeset output splitting because those splits weren't atomic and cannot be in their current state.