### PR TITLE
OSM API testing server updates

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -67,13 +67,11 @@ const char* OsmApiSampleResponses::SAMPLE_PERMISSIONS =
 
 bool CapabilitiesTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
 {
-  //  Read the HTTP request
-  boost::asio::streambuf buf;
-  boost::asio::read_until(connection->socket(), buf, "\r\n\r\n");
-  std::string input = boost::asio::buffer_cast<const char*>(buf.data());
+  //  Read the HTTP request headers
+  std::string headers = read_request_headers(connection);
   //  Make sure that the capabilities were requested
   std::string message;
-  if (input.find(OsmApiWriter::API_PATH_CAPABILITIES) != std::string::npos)
+  if (headers.find(OsmApiWriter::API_PATH_CAPABILITIES) != std::string::npos)
     message = HTTP_200_OK + OsmApiSampleResponses::SAMPLE_CAPABILITIES + "\r\n";
   else
     message = HTTP_404_NOT_FOUND;
@@ -85,13 +83,11 @@ bool CapabilitiesTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
 
 bool PermissionsTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
 {
-  //  Read the HTTP request
-  boost::asio::streambuf buf;
-  boost::asio::read_until(connection->socket(), buf, "\r\n\r\n");
-  std::string input = boost::asio::buffer_cast<const char*>(buf.data());
+  //  Read the HTTP request headers
+  std::string headers = read_request_headers(connection);
   //  Make sure that the permissions were requested
   std::string message;
-  if (input.find(OsmApiWriter::API_PATH_PERMISSIONS) != std::string::npos)
+  if (headers.find(OsmApiWriter::API_PATH_PERMISSIONS) != std::string::npos)
     message = HTTP_200_OK + OsmApiSampleResponses::SAMPLE_PERMISSIONS + "\r\n";
   else
     message = HTTP_404_NOT_FOUND;
@@ -105,21 +101,19 @@ bool RetryConflictsTestServer::respond(HttpConnection::HttpConnectionPtr& connec
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
-  //  Read the HTTP request
-  boost::asio::streambuf buf;
-  boost::asio::read_until(connection->socket(), buf, "\r\n\r\n");
-  std::string input = boost::asio::buffer_cast<const char*>(buf.data());
+  //  Read the HTTP request headers
+  std::string headers = read_request_headers(connection);
   //  Determine the response message's HTTP header
   std::string message;
-  if (input.find(OsmApiWriter::API_PATH_CAPABILITIES) != std::string::npos)
+  if (headers.find(OsmApiWriter::API_PATH_CAPABILITIES) != std::string::npos)
     message = HTTP_200_OK + OsmApiSampleResponses::SAMPLE_CAPABILITIES + "\r\n";
-  else if (input.find(OsmApiWriter::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (headers.find(OsmApiWriter::API_PATH_PERMISSIONS) != std::string::npos)
     message = HTTP_200_OK + OsmApiSampleResponses::SAMPLE_PERMISSIONS + "\r\n";
-  else if (input.find(OsmApiWriter::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (headers.find(OsmApiWriter::API_PATH_CREATE_CHANGESET) != std::string::npos)
     message = HTTP_200_OK + "1\r\n";
-  else if (input.find("POST") != std::string::npos)
+  else if (headers.find("POST") != std::string::npos)
     message = std::string("HTTP/1.1 405 Method Not Allowed\r\nAllow: GET\r\n\r\n");
-  else if (input.find("/close/"))
+  else if (headers.find("/close/"))
   {
     message = HTTP_200_OK;
     continue_processing = false;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -34,37 +34,6 @@
 namespace hoot
 {
 
-const char* OsmApiSampleResponses::SAMPLE_CAPABILITIES =
-    "<?xml version='1.0' encoding='UTF-8'?>"
-    "<osm version='0.6' generator='OpenStreetMap server' copyright='OpenStreetMap and contributors' attribution='https://www.openstreetmap.org/copyright' license='http://opendatacommons.org/licenses/odbl/1-0/'>"
-    "  <api>"
-    "    <version minimum='0.6' maximum='0.6'/>"
-    "    <area maximum='0.25'/>"
-    "    <note_area maximum='25'/>"
-    "    <tracepoints per_page='5000'/>"
-    "    <waynodes maximum='2000'/>"
-    "    <changesets maximum_elements='10000'/>"
-    "    <timeout seconds='300'/>"
-    "    <status database='online' api='online' gpx='online'/>"
-    "  </api>"
-    "  <policy>"
-    "    <imagery>"
-    "      <blacklist regex='http://xdworld\\.vworld\\.kr:8080/.*'/>"
-    "      <blacklist regex='.*\\.here\\.com[/:].*'/>"
-    "    </imagery>"
-    "  </policy>"
-    "</osm>";
-const char* OsmApiSampleResponses::SAMPLE_PERMISSIONS =
-    "<?xml version='1.0' encoding='UTF-8'?>"
-    "<osm version='0.6' generator='OpenStreetMap server'>"
-    "  <permissions>"
-    "    <permission name='allow_read_prefs'/>"
-    "    <permission name='allow_read_gpx'/>"
-    "    <permission name='allow_write_api'/>"
-    "    <permission name='allow_write_gpx'/>"
-    "  </permissions>"
-    "</osm>";
-
 bool CapabilitiesTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
 {
   //  Read the HTTP request headers
@@ -129,5 +98,36 @@ bool RetryConflictsTestServer::respond(HttpConnection::HttpConnectionPtr& connec
   //  Return true if we should continue listening and processing requests
   return continue_processing;
 }
+
+const char* OsmApiSampleResponses::SAMPLE_CAPABILITIES =
+    "<?xml version='1.0' encoding='UTF-8'?>"
+    "<osm version='0.6' generator='OpenStreetMap server' copyright='OpenStreetMap and contributors' attribution='https://www.openstreetmap.org/copyright' license='http://opendatacommons.org/licenses/odbl/1-0/'>"
+    "  <api>"
+    "    <version minimum='0.6' maximum='0.6'/>"
+    "    <area maximum='0.25'/>"
+    "    <note_area maximum='25'/>"
+    "    <tracepoints per_page='5000'/>"
+    "    <waynodes maximum='2000'/>"
+    "    <changesets maximum_elements='10000'/>"
+    "    <timeout seconds='300'/>"
+    "    <status database='online' api='online' gpx='online'/>"
+    "  </api>"
+    "  <policy>"
+    "    <imagery>"
+    "      <blacklist regex='http://xdworld\\.vworld\\.kr:8080/.*'/>"
+    "      <blacklist regex='.*\\.here\\.com[/:].*'/>"
+    "    </imagery>"
+    "  </policy>"
+    "</osm>";
+const char* OsmApiSampleResponses::SAMPLE_PERMISSIONS =
+    "<?xml version='1.0' encoding='UTF-8'?>"
+    "<osm version='0.6' generator='OpenStreetMap server'>"
+    "  <permissions>"
+    "    <permission name='allow_read_prefs'/>"
+    "    <permission name='allow_read_gpx'/>"
+    "    <permission name='allow_write_api'/>"
+    "    <permission name='allow_write_gpx'/>"
+    "  </permissions>"
+    "</osm>";
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -33,38 +33,51 @@
 namespace hoot
 {
 
-class OsmApiSampleResponses
-{
-public:
-  static const char* SAMPLE_CAPABILITIES;
-  static const char* SAMPLE_PERMISSIONS;
-};
-
 class CapabilitiesTestServer : public HttpTestServer
 {
 public:
+  /** Constructor */
   CapabilitiesTestServer(int port) : HttpTestServer(port) { }
 
 protected:
+  /** respond() function that responds once to the OSM API Capabilities request */
   virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
 };
 
 class PermissionsTestServer : public HttpTestServer
 {
 public:
+  /** Constructor */
   PermissionsTestServer(int port) : HttpTestServer(port) { }
 
 protected:
+  /** respond() function that responds once to the OSM API Permissions request */
   virtual bool respond(HttpConnection::HttpConnectionPtr &connection) override;
 };
 
 class RetryConflictsTestServer : public HttpTestServer
 {
 public:
+  /** Constructor */
   RetryConflictsTestServer(int port) : HttpTestServer(port) { }
 
 protected:
+  /** respond() function that responds to a series of OSM API requests
+   *  Requests, in order:
+   *   - Capabilities
+   *   - Permissions
+   *   - Changeset Create
+   *   - Changeset Upload - responding with an HTTP 405 error for the test
+   *   - Changeset Close
+   */
   virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+};
+
+class OsmApiSampleResponses
+{
+public:
+  static const char* SAMPLE_CAPABILITIES;
+  static const char* SAMPLE_PERMISSIONS;
 };
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -28,16 +28,7 @@
 #ifndef OSM_API_WRITER_TEST_SERVER_H
 #define OSM_API_WRITER_TEST_SERVER_H
 
-//  Hootenanny
-#include <hoot/core/io/OsmApiWriter.h>
-#include <hoot/core/util/Log.h>
-
-//  Standard
-#include <memory>
-
-//  Boost
-#include <boost/bind.hpp>
-#include <boost/asio.hpp>
+#include <hoot/core/util/HttpTestServer.h>
 
 namespace hoot
 {
@@ -49,44 +40,31 @@ public:
   static const char* SAMPLE_PERMISSIONS;
 };
 
-
-class HttpConnection : public std::enable_shared_from_this<HttpConnection>
+class CapabilitiesTestServer : public HttpTestServer
 {
 public:
-  typedef std::shared_ptr<HttpConnection> HttpConnectionPtr;
+  CapabilitiesTestServer(int port) : HttpTestServer(port) { }
 
-  boost::asio::ip::tcp::socket& socket();
-
-  static HttpConnectionPtr create(boost::asio::io_service& io_service);
-
-  bool start();
-
-private:
-  HttpConnection(boost::asio::io_service& io_service);
-  void handle_write(const boost::system::error_code& error, size_t bytes_transferred);
-
-  boost::asio::ip::tcp::socket _socket;
+protected:
+  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
 };
 
-class HttpTestServer
+class PermissionsTestServer : public HttpTestServer
 {
 public:
+  PermissionsTestServer(int port) : HttpTestServer(port) { }
 
-  static const int TEST_SERVER_PORT;
+protected:
+  virtual bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+};
 
-  static std::shared_ptr<std::thread> start();
+class RetryConflictsTestServer : public HttpTestServer
+{
+public:
+  RetryConflictsTestServer(int port) : HttpTestServer(port) { }
 
-  HttpTestServer(boost::asio::io_service& io_service);
-
-private:
-
-  static void run_server();
-
-  void start_accept();
-
-  void handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error);
-
-  boost::asio::ip::tcp::acceptor _acceptor;
+protected:
+  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
 };
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -76,7 +76,13 @@ protected:
 class OsmApiSampleResponses
 {
 public:
+  /** Sample Capabilities response body from '/api/0.6/capabilities'
+   *  see: https://wiki.openstreetmap.org/wiki/API_v0.6#Capabilities:_GET_.2Fapi.2Fcapabilities
+   */
   static const char* SAMPLE_CAPABILITIES;
+  /** Sample Permissions response body from '/api/0.6/permissions'
+   *  see: https://wiki.openstreetmap.org/wiki/API_v0.6#Retrieving_permissions:_GET_.2Fapi.2F0.6.2Fpermissions
+   */
   static const char* SAMPLE_PERMISSIONS;
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "HttpTestServer.h"
+
+namespace hoot
+{
+
+std::string HttpTestServer::HTTP_200_OK = "HTTP/1.1 200 OK\r\n\r\n";
+std::string HttpTestServer::HTTP_404_NOT_FOUND = "HTTP/1.1 404 Not Found\r\n\r\n";
+
+HttpTestServer::HttpTestServer(int port)
+  : _port(port)
+{
+}
+
+void HttpTestServer::start()
+{
+  _thread.reset(new std::thread(std::bind(&HttpTestServer::run_server, this, _port)));
+}
+
+void HttpTestServer::wait()
+{
+  _thread->join();
+}
+
+void HttpTestServer::shutdown()
+{
+  //  Stop the IO service and wait for the server to stop
+  _io_service.stop();
+  wait();
+}
+
+void HttpTestServer::run_server(int port)
+{
+  try
+  {
+    _acceptor.reset(new boost::asio::ip::tcp::acceptor(_io_service, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)));
+    start_accept();
+    _io_service.run();
+  }
+  catch (std::exception& e)
+  {
+    LOG_ERROR(e.what());
+  }
+}
+
+void HttpTestServer::start_accept()
+{
+  HttpConnection::HttpConnectionPtr new_connection(new HttpConnection(_acceptor->get_io_service()));
+  _acceptor->async_accept(new_connection->socket(),
+                         boost::bind(&HttpTestServer::handle_accept, this, new_connection, boost::asio::placeholders::error));
+}
+
+void HttpTestServer::handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error)
+{
+  bool continue_processing = true;
+  if (!error)
+    continue_processing = respond(new_connection);
+
+  if (continue_processing)
+    start_accept();
+}
+
+bool HttpTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+{
+  //  Stop processing by setting this to false
+  bool continue_processing = true;
+  //  Read the HTTP request
+  boost::asio::streambuf buf;
+  boost::asio::read_until(connection->socket(), buf, "\r\n\r\n");
+  //  Respond with HTTP 200 OK
+  std::string message;
+  message = std::string(HTTP_200_OK);
+  //  Write out the response
+  write_response(connection, message);
+  //  Return true if we should continue listening and processing requests
+  return continue_processing;
+}
+
+void HttpTestServer::write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response)
+{
+  //  Write the response to the socket asynchronously
+  boost::asio::async_write(connection->socket(), boost::asio::buffer(response),
+                           boost::bind(&HttpConnection::handle_write, connection,
+                                       boost::asio::placeholders::error,
+                                       boost::asio::placeholders::bytes_transferred));
+}
+
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -27,6 +27,9 @@
 
 #include "HttpTestServer.h"
 
+//  Hootenanny
+#include <hoot/core/util/Log.h>
+
 namespace hoot
 {
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef HTTP_TEST_SERVER_H
+#define HTTP_TEST_SERVER_H
+
+//  Hootenanny
+//#include <hoot/core/io/OsmApiWriter.h>
+//#include <hoot/core/util/Log.h>
+
+//  Standard
+#include <memory>
+#include <thread>
+
+//  Boost
+#include <boost/bind.hpp>
+#include <boost/asio.hpp>
+
+namespace hoot
+{
+
+class HttpConnection : public std::enable_shared_from_this<HttpConnection>
+{
+public:
+  typedef std::shared_ptr<HttpConnection> HttpConnectionPtr;
+
+  HttpConnection(boost::asio::io_service& io_service) : _socket(io_service) { }
+
+  boost::asio::ip::tcp::socket& socket() { return _socket; }
+
+  void handle_write(const boost::system::error_code& /* error */, size_t /* bytes_transferred */) { }
+
+private:
+
+  boost::asio::ip::tcp::socket _socket;
+
+};
+
+class HttpTestServer
+{
+public:
+
+  static const int DEFAULT_SERVER_PORT = 8910;
+
+  HttpTestServer(int port = DEFAULT_SERVER_PORT);
+
+  void start();
+
+  void wait();
+
+  void shutdown();
+
+  int get_port() { return _port; }
+
+protected:
+
+  virtual bool respond(HttpConnection::HttpConnectionPtr& connection);
+
+  void write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response);
+
+  static std::string HTTP_200_OK;
+  static std::string HTTP_404_NOT_FOUND;
+
+private:
+
+  void run_server(int port);
+
+  void start_accept();
+
+  void handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error);
+
+  std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
+
+  boost::asio::io_service _io_service;
+
+  std::shared_ptr<std::thread> _thread;
+
+  int _port;
+};
+
+}
+
+#endif  //  OSM_API_WRITER_TEST_SERVER_H

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
@@ -28,10 +28,6 @@
 #ifndef HTTP_TEST_SERVER_H
 #define HTTP_TEST_SERVER_H
 
-//  Hootenanny
-//#include <hoot/core/io/OsmApiWriter.h>
-//#include <hoot/core/util/Log.h>
-
 //  Standard
 #include <memory>
 #include <thread>
@@ -43,64 +39,78 @@
 namespace hoot
 {
 
+/**
+ * @brief The HttpConnection class encapsulates an HTTP connection on a socket
+ */
 class HttpConnection : public std::enable_shared_from_this<HttpConnection>
 {
 public:
+  /** Type def for shared pointer */
   typedef std::shared_ptr<HttpConnection> HttpConnectionPtr;
-
+  /** Constructor */
   HttpConnection(boost::asio::io_service& io_service) : _socket(io_service) { }
-
+  /** Socket accessor */
   boost::asio::ip::tcp::socket& socket() { return _socket; }
-
+  /** Error checking for write function, empty for test server */
   void handle_write(const boost::system::error_code& /* error */, size_t /* bytes_transferred */) { }
 
 private:
-
+  /** Socket for this HTTP connection */
   boost::asio::ip::tcp::socket _socket;
-
 };
 
+/**
+ * @brief The HttpTestServer class is a base class that provides simple HTTP server capabilites.
+ *  In its basic form it runs forever and returns an HTTP 200 OK message and must be shutdown by
+ *  calling the shutdown() function.
+ *
+ *  The only thing required to derive a class from this is to override the virtual respond() function
+ *  that first calls read_request_headers(), decides how to respond, and finally writes out the
+ *  response by calling the write_response() function.
+ */
 class HttpTestServer
 {
 public:
-
+  /** Static constants for use in the HttpTestServer class */
   static const int DEFAULT_SERVER_PORT = 8910;
-
-  HttpTestServer(int port = DEFAULT_SERVER_PORT);
-
-  void start();
-
-  void wait();
-
-  void shutdown();
-
-  int get_port() { return _port; }
-
-protected:
-
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection);
-
-  std::string read_request_headers(HttpConnection::HttpConnectionPtr& connection);
-
-  void write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response);
-
   static const std::string HTTP_200_OK;
   static const std::string HTTP_404_NOT_FOUND;
+  /** Constructor */
+  HttpTestServer(int port = DEFAULT_SERVER_PORT);
+  /** Function to start the HTTP server */
+  void start();
+  /** Function to wait for the HTTP server to finish processing */
+  void wait();
+  /** Function to shutdown the HTTP server even if it is still running */
+  void shutdown();
+
+protected:
+  /**
+   * @brief respond() function is overridden in derived classes to respond to different HTTP
+   *  test requests
+   * @param connection Current connection
+   * @return True if the server should continue to listen for connections, false to stop
+   */
+  virtual bool respond(HttpConnection::HttpConnectionPtr& connection);
+  /** Read the HTTP headers from the request and return them, called by the overridden respond() function */
+  std::string read_request_headers(HttpConnection::HttpConnectionPtr& connection);
+  /** Write the response back to the requestor, called by the overridden respond() function */
+  void write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response);
 
 private:
-
+  /** Function that starts the server listening and accepting connections */
   void run_server(int port);
-
+  /** Begin the process of accepting an HTTP connection */
   void start_accept();
-
+  /** Handle the HTTP connection and calls the overridden respond() function */
   void handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error);
-
-  std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
-
+  /** IO Service object */
   boost::asio::io_service _io_service;
-
+  /** Pointer to the ASIO TCP connection acceptor */
+  std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor;
+  /** HTTP Test server thread */
   std::shared_ptr<std::thread> _thread;
-
+  /** HTTP listening port */
   int _port;
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
@@ -80,10 +80,12 @@ protected:
 
   virtual bool respond(HttpConnection::HttpConnectionPtr& connection);
 
+  std::string read_request_headers(HttpConnection::HttpConnectionPtr& connection);
+
   void write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response);
 
-  static std::string HTTP_200_OK;
-  static std::string HTTP_404_NOT_FOUND;
+  static const std::string HTTP_200_OK;
+  static const std::string HTTP_404_NOT_FOUND;
 
 private:
 


### PR DESCRIPTION
Refs #3291 
Testing framework changes to allow for better testing of OSM API writer so that work on 3291 can progress.  Reorganized the OsmApiWriterTestServer to be more extensible and able to be using in more tests by deriving a class and overriding the respond() function.