### PR TITLE
Change OGR to OSM building simplification behavior

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2599,7 +2599,7 @@ Merges nearby nodes together when converting from an OGR format to OSM.
 === ogr2osm.simplify.complex.buildings
 
 * Data Type: bool
-* Default Value: `true`
+* Default Value: `false`
 
 Implicitly merges certain individual building parts into a single part when converting from an OGR
 format to OSM.

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.h
@@ -69,13 +69,13 @@ public:
   virtual void writeObject(QDataStream& /*os*/) const {}
 
   virtual QString getInitStatusMessage() const
-  { return "Updating building outlines that changed during conflation..."; }
+  { return "Updating building outlines..."; }
 
   virtual QString getCompletedStatusMessage() const
   { return "Updated " + QString::number(_numAffected) + " building outlines"; }
 
   virtual QString getDescription() const override
-  { return "Updates any multi-part building outlines that changed during conflation"; }
+  { return "Updates multi-part building outlines"; }
 
   virtual void setConfiguration(const Settings& conf);
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingPartMergeOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingPartMergeOp.h
@@ -63,11 +63,9 @@ namespace hoot
 /**
  * UFD Data frequently has buildings mapped out as individual parts where each part has a different
  * height. While they may represent a single building they're presented in the Shapefile as
- * individual rows.
- *
- * I would like to maintain the richness available in the data they've collected (gabled roofs,
- * heights on sections of buildings, etc). This is very applicable to the 3D mapping being done
- * in OSM. [1]
+ * individual rows. We would like to maintain the richness available in the data they've collected
+ * (gabled roofs, heights on sections of buildings, etc). This is very applicable to the 3D mapping
+ * being done in OSM. [1]
  *
  * This class implicitly merges the individual building parts into a single part. If two buildings
  * share two or more contiguous nodes and the relevant tags match then the parts will be merged


### PR DESCRIPTION
* Prior to this when `ogr2osm.simplify.complex.buildings` was enabled (enabled by default) and buildings were simplified during OGR to OSM ingest, the JSOM "role verification" warning would get triggered when viewing the ingested input in JOSM. Updated `BuildingOutlineUpdateOp` to run immediately after `BuildingPartMergeOp` to suppress that warning.
* Turned building simplification off by default during OGR to OSM conversion at the request of users, as it can have detrimental effects with some datasets and doesnt seem crucial to any hoot conflate scenarios we currently have. [This UI issue](https://github.com/ngageoint/hootenanny-ui/issues/1556) will yield the option to turn it on for a per-dataset ingest basis. There is still some utility being able to turn the option on with certain datasets.
* See: https://github.com/DigitalGlobe/VGI-team-repo/issues/1957