### PR TITLE
Fix builds

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -126,11 +126,11 @@ sudo yum versionlock add \
 # install useful and needed packages for working with hootenanny
 echo "### Installing dependencies from repos..."
 sudo yum -y install \
-    \ #################################################################
-    \ # TODO: Remove this once qt5-qtwebkit is fixed in the EPEL repo #
-    \ #################################################################
+    `#################################################################` \
+    `# TODO: Remove this once qt5-qtwebkit is fixed in the EPEL repo #` \
+    `#################################################################` \
     --skip-broken \
-    \ #################################################################
+    `#################################################################` \
     asciidoc \
     autoconf \
     autoconf-archive \

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -73,7 +73,9 @@ else
          proj \
          proj-devel \
          stxxl \
-         stxxl-devel
+         stxxl-devel \
+         qt5-qtwebkit \
+         qt5-qtwebkit-devel \
 
 fi
 
@@ -98,7 +100,9 @@ sudo yum install -y \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
      stxxl-$STXXL_VERSION \
-     stxxl-devel-$STXXL_VERSION
+     stxxl-devel-$STXXL_VERSION \
+     qt5-qtwebkit-$QT_VERSION \
+     qt5-qtwebkit-devel-$QT_VERSION
 
 echo "### Locking versions of libraries"
 sudo yum versionlock add \
@@ -121,12 +125,13 @@ sudo yum versionlock add \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
      stxxl-$STXXL_VERSION \
-     stxxl-devel-$STXXL_VERSION
+     stxxl-devel-$STXXL_VERSION \
+     qt5-qtwebkit-$QT_VERSION \
+     qt5-qtwebkit-devel-$QT_VERSION
 
 # install useful and needed packages for working with hootenanny
 echo "### Installing dependencies from repos..."
 sudo yum -y install \
-    --skip-broken \
     asciidoc \
     autoconf \
     autoconf-archive \
@@ -177,8 +182,6 @@ sudo yum -y install \
     qt5-qtbase \
     qt5-qtbase-devel \
     qt5-qtbase-postgresql \
-    qt5-qtwebkit \
-    qt5-qtwebkit-devel \
     redhat-lsb-core \
     swig \
     tex-fonts-hebrew \

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -73,9 +73,7 @@ else
          proj \
          proj-devel \
          stxxl \
-         stxxl-devel \
-         qt5-qtwebkit \
-         qt5-qtwebkit-devel \
+         stxxl-devel
 
 fi
 
@@ -100,9 +98,7 @@ sudo yum install -y \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
      stxxl-$STXXL_VERSION \
-     stxxl-devel-$STXXL_VERSION \
-     qt5-qtwebkit-$QT_VERSION \
-     qt5-qtwebkit-devel-$QT_VERSION
+     stxxl-devel-$STXXL_VERSION
 
 echo "### Locking versions of libraries"
 sudo yum versionlock add \
@@ -125,13 +121,16 @@ sudo yum versionlock add \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
      stxxl-$STXXL_VERSION \
-     stxxl-devel-$STXXL_VERSION \
-     qt5-qtwebkit-$QT_VERSION \
-     qt5-qtwebkit-devel-$QT_VERSION
+     stxxl-devel-$STXXL_VERSION
 
 # install useful and needed packages for working with hootenanny
 echo "### Installing dependencies from repos..."
 sudo yum -y install \
+    \ #################################################################
+    \ # TODO: Remove this once qt5-qtwebkit is fixed in the EPEL repo #
+    \ #################################################################
+    --skip-broken \
+    \ #################################################################
     asciidoc \
     autoconf \
     autoconf-archive \
@@ -182,6 +181,8 @@ sudo yum -y install \
     qt5-qtbase \
     qt5-qtbase-devel \
     qt5-qtbase-postgresql \
+    qt5-qtwebkit \
+    qt5-qtwebkit-devel \
     redhat-lsb-core \
     swig \
     tex-fonts-hebrew \

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -126,6 +126,7 @@ sudo yum versionlock add \
 # install useful and needed packages for working with hootenanny
 echo "### Installing dependencies from repos..."
 sudo yum -y install \
+    --skip-broken \
     asciidoc \
     autoconf \
     autoconf-archive \

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -17,6 +17,9 @@ export NODE_VERSION=8.9.3
 export PROJ_VERSION=4.8.0
 export STXXL_VERSION=1.3.1
 
+# Qt Version 5.9.1-2 for qt5-qtwebkit is currently broken, when it is fixed remove this
+export QT_VERSION=5.9.1-1.el7
+
 # FGDB 1.5 is required to compile using g++ >= 5.1
 # https://trac.osgeo.org/gdal/wiki/FileGDB#HowtodealwithGCC5.1C11ABIonLinux
 export FGDB_VERSION=1.5.1

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -17,9 +17,6 @@ export NODE_VERSION=8.9.3
 export PROJ_VERSION=4.8.0
 export STXXL_VERSION=1.3.1
 
-# Qt Version 5.9.1-2 for qt5-qtwebkit is currently broken, when it is fixed remove this
-export QT_VERSION=5.9.1-1.el7
-
 # FGDB 1.5 is required to compile using g++ >= 5.1
 # https://trac.osgeo.org/gdal/wiki/FileGDB#HowtodealwithGCC5.1C11ABIonLinux
 export FGDB_VERSION=1.5.1


### PR DESCRIPTION
Since EPEL is at 7.7 and CentOS is 7.6 there is a dependency error in qt5-qtwebkit and qt5-qtwebkit-devel that must be ignored for now.