### PR TITLE
fix stats file parsing bug in conflate cmd

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -632,7 +632,7 @@ See also:
 * Default Value: ``
 
 The string that lists the types of conflation used in the user interface.  The possible values
-are: reference, cookieCutter, average, and advancedConflation.
+are: reference, cookieCutter, average, and advancedConflation. TODO: Is this used anywhere?
 
 === conflate.tag.disable.value.truncation
 

--- a/docs/commands/conflate.asciidoc
+++ b/docs/commands/conflate.asciidoc
@@ -14,7 +14,7 @@ changeset will be written, instead of an OSM map.
 * +--include-tags+ - Include a check for modified tags when doing differential conflation.  The output will include unmodified geometries
                      from Input1, with new/updated tags from Input2 applied, using an overwrite-merge.
 * +--stats+        - Hootenanny map statistics such as node and way count; must be the last option entered and may be optionally followed
-                     by an output file name
+                     by an output JSON file name
 
 === Feature Filtering
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -107,7 +107,7 @@ int ConflateCmd::runSimple(QStringList& args)
       //remove "--stats" from args list
       args.pop_back();
     }
-    else if (args[args.size() - 1] == "--stats")
+    else if (args[args.size() - 2] == "--stats")
     {
       displayStats = true;
       outputStatsFile = args[args.size() - 1];


### PR DESCRIPTION
file wasn't being parsed from the correct argument list position by the `conflate` command