### PR TITLE
qt5-webkit version locks

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -72,11 +72,15 @@ else
          nodejs-devel \
          proj \
          proj-devel \
+         qt5-qtwebkit \
+         qt5-qtwebkit-devel \
          stxxl \
          stxxl-devel
 
 fi
 
+# TODO: Remove version locks of qt5-qtwebkit packages when CentOS 7.7 is released and
+#       qt5-qtbase-5.9.7 is available
 echo "### Installing libraries with locked versions"
 sudo yum install -y \
      armadillo-$ARMADILLO_VERSION \
@@ -97,6 +101,8 @@ sudo yum install -y \
      nodejs-devel-$NODE_VERSION \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
+     qt5-qtwebkit-$QT5_WEBKIT_VERSION \
+     qt5-qtwebkit-devel-$QT5_WEBKIT_VERSION \
      stxxl-$STXXL_VERSION \
      stxxl-devel-$STXXL_VERSION
 
@@ -120,17 +126,14 @@ sudo yum versionlock add \
      nodejs-devel-$NODE_VERSION \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
+     qt5-qtwebkit-$QT5_WEBKIT_VERSION \
+     qt5-qtwebkit-devel-$QT5_WEBKIT_VERSION \
      stxxl-$STXXL_VERSION \
      stxxl-devel-$STXXL_VERSION
 
 # install useful and needed packages for working with hootenanny
 echo "### Installing dependencies from repos..."
 sudo yum -y install \
-    `#################################################################` \
-    `# TODO: Remove this once qt5-qtwebkit is fixed in the EPEL repo #` \
-    `#################################################################` \
-    --skip-broken \
-    `#################################################################` \
     asciidoc \
     autoconf \
     autoconf-archive \
@@ -181,8 +184,6 @@ sudo yum -y install \
     qt5-qtbase \
     qt5-qtbase-devel \
     qt5-qtbase-postgresql \
-    qt5-qtwebkit \
-    qt5-qtwebkit-devel \
     redhat-lsb-core \
     swig \
     tex-fonts-hebrew \

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -19,7 +19,7 @@ export STXXL_VERSION=1.3.1
 
 # TODO: Remove when CentOS 7.7 is released and qt5-qtbase-5.9.7 is available
 #       in the base repository.
-export QT5_WEBKIT_VERSION=5.9.1-1
+export QT5_WEBKIT_VERSION=5.9.1-1.el7
 
 # FGDB 1.5 is required to compile using g++ >= 5.1
 # https://trac.osgeo.org/gdal/wiki/FileGDB#HowtodealwithGCC5.1C11ABIonLinux

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -17,6 +17,10 @@ export NODE_VERSION=8.9.3
 export PROJ_VERSION=4.8.0
 export STXXL_VERSION=1.3.1
 
+# TODO: Remove when CentOS 7.7 is released and qt5-qtbase-5.9.7 is available
+#       in the base repository.
+export QT5_WEBKIT_VERSION=5.9.1-1
+
 # FGDB 1.5 is required to compile using g++ >= 5.1
 # https://trac.osgeo.org/gdal/wiki/FileGDB#HowtodealwithGCC5.1C11ABIonLinux
 export FGDB_VERSION=1.5.1

--- a/scripts/yum/hoot-repo.sh
+++ b/scripts/yum/hoot-repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HOOT_BASEURL="${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/qt5}"
+HOOT_BASEURL="${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/release}"
 HOOT_KEY=/etc/pki/rpm-gpg/RPM-GPG-KEY-Hoot
 
 cat > $HOOT_KEY <<EOF

--- a/scripts/yum/hoot-repo.sh
+++ b/scripts/yum/hoot-repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HOOT_BASEURL="${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/release}"
+HOOT_BASEURL="${HOOT_BASEURL:-https://s3.amazonaws.com/hoot-repo/el7/deps/qt5}"
 HOOT_KEY=/etc/pki/rpm-gpg/RPM-GPG-KEY-Hoot
 
 cat > $HOOT_KEY <<EOF


### PR DESCRIPTION
I found archived versions of `qt-webkit-5.9.1-1` packages and added to a testing dependency repository: `el7/deps/qt5`.  I'll promote to `el7/deps/release` and revert 9080858 if tests are successful.