### PR TITLE
Remove Documenation Target

### DIFF
--- a/Hootenanny.pro
+++ b/Hootenanny.pro
@@ -11,7 +11,7 @@ SUBDIRS += \
     tbs \
     tgs \
     hoot-core \
-    hoot-core-test \
+    hoot-core-test
 
 nodejs {
 SUBDIRS += \

--- a/Hootenanny.pro
+++ b/Hootenanny.pro
@@ -12,7 +12,6 @@ SUBDIRS += \
     tgs \
     hoot-core \
     hoot-core-test \
-    docs
 
 nodejs {
 SUBDIRS += \


### PR DESCRIPTION
Remove the `docs` target from the default qmake configuration.  I believe this is the root cause of the RPM pipeline failures, as it forces the docs to be built as part of the default target.  The source archives used to build the RPMs include the built documentation, and trying to regenerate causes failures due to the documentation target trying to call `git log`.