### PR TITLE
Fix Jenkins Provision

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -72,8 +72,6 @@ else
          nodejs-devel \
          proj \
          proj-devel \
-         qt5-qtwebkit \
-         qt5-qtwebkit-devel \
          stxxl \
          stxxl-devel
 
@@ -101,8 +99,6 @@ sudo yum install -y \
      nodejs-devel-$NODE_VERSION \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
-     qt5-qtwebkit-$QT5_WEBKIT_VERSION \
-     qt5-qtwebkit-devel-$QT5_WEBKIT_VERSION \
      stxxl-$STXXL_VERSION \
      stxxl-devel-$STXXL_VERSION
 
@@ -126,8 +122,6 @@ sudo yum versionlock add \
      nodejs-devel-$NODE_VERSION \
      proj-$PROJ_VERSION \
      proj-devel-$PROJ_VERSION \
-     qt5-qtwebkit-$QT5_WEBKIT_VERSION \
-     qt5-qtwebkit-devel-$QT5_WEBKIT_VERSION \
      stxxl-$STXXL_VERSION \
      stxxl-devel-$STXXL_VERSION
 
@@ -184,6 +178,8 @@ sudo yum -y install \
     qt5-qtbase \
     qt5-qtbase-devel \
     qt5-qtbase-postgresql \
+    qt5-qtwebkit \
+    qt5-qtwebkit-devel \
     redhat-lsb-core \
     swig \
     tex-fonts-hebrew \

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -17,10 +17,6 @@ export NODE_VERSION=8.9.3
 export PROJ_VERSION=4.8.0
 export STXXL_VERSION=1.3.1
 
-# TODO: Remove when CentOS 7.7 is released and qt5-qtbase-5.9.7 is available
-#       in the base repository.
-export QT5_WEBKIT_VERSION=5.9.1-1.el7
-
 # FGDB 1.5 is required to compile using g++ >= 5.1
 # https://trac.osgeo.org/gdal/wiki/FileGDB#HowtodealwithGCC5.1C11ABIonLinux
 export FGDB_VERSION=1.5.1


### PR DESCRIPTION
Removed the `qt5-qtwebkit*` version locks since it is fixed in EPEL now.