### PR TITLE
Poi poly match fixes

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -560,7 +560,7 @@ local path and then `$HOOT_HOME/conf/`.
 * Data Type: double
 * Default Value: `0.6`
 
-The default threshold at which a match is called a match.
+The default threshold at which a match is called a match. Valid values are between 0.0 and 1.0.
 
 See also:
 
@@ -571,7 +571,7 @@ See also:
 * Data Type: double
 * Default Value: `0.6`
 
-The default threshold at which a miss is called a miss.
+The default threshold at which a miss is called a miss. Valid values are between 0.0 and 1.0.
 
 See also:
 
@@ -620,7 +620,7 @@ See also: <<MapCleanerTransforms,map.cleaner.transforms>>
 * Default Value: `0.6`
 
 The default threshold at which a review is called a review. Reviews are also declared in some
-other situations when the relationship is not clear.
+other situations when the relationship is not clear. Valid values are between 0.0 and 1.0.
 
 See also:
 
@@ -1185,7 +1185,7 @@ is required for unit tests, but shouldn't be used in normal operation.
 * Data Type: double
 * Default Value: `0.161`
 
-The threshold at which a match is called a match for roads.
+The threshold at which a match is called a match for roads. Valid values are between 0.0 and 1.0.
 
 See also:
 
@@ -3174,28 +3174,6 @@ features will be classified as a review or miss, depending on the value of
 'poi.polygon.review.evidence.threshold'.  Generally, this setting should not be changed except
 when working with specific POI/Polygon conflation use cases that require it.
 
-=== poi.polygon.match.threshold
-
-* Data Type: double
-* Default Value: `${conflate.match.threshold.default}`
-
-The threshold at which a match is called a match when comparing POIs to polygons.
-
-See also:
-
- * _Estimate Pairwise Relationships_, <<hootalgo>>
-
-=== poi.polygon.miss.threshold
-
-* Data Type: double
-* Default Value: `${conflate.miss.threshold.default}`
-
-The threshold at which a miss is called a miss when comparing POIs to polygons.
-
-See also:
-
- * _Estimate Pairwise Relationships_, <<hootalgo>>
-
 === poi.polygon.name.score.threshold
 
 * Data Type: double
@@ -3298,14 +3276,6 @@ the command line, surround the entire value string in double quotes.
 If true, POI to polygon conflation always marks matches between POIs and polygons where multi-use
 building polygons are present as needing review.  The definition of multi-use buildings is
 controlled by the Hootenanny schema.
-
-=== poi.polygon.review.threshold
-
-* Data Type: double
-* Default Value: `${conflate.review.threshold.default}`
-
-The threshold at which a review is called a review for PoiPolygon. See
-`conflate.review.threshold.default`.
 
 === poi.polygon.source.tag.key
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.cpp
@@ -486,6 +486,11 @@ void PoiPolygonMatch::calculateMatch(const ElementId& eid1, const ElementId& eid
   LOG_TRACE("**************************");
 }
 
+MatchType PoiPolygonMatch::getType() const
+{
+  return _threshold->getType(_class);
+}
+
 unsigned int PoiPolygonMatch::_getDistanceEvidence(ConstElementPtr poi, ConstElementPtr poly)
 {
   _distance = PoiPolygonDistanceExtractor().extract(*_map, poi, poly);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.h
@@ -68,29 +68,29 @@ public:
     const std::set<ElementId>& polyNeighborIds = std::set<ElementId>(),
     const std::set<ElementId>& poiNeighborIds = std::set<ElementId>());
 
-  virtual void setConfiguration(const Settings& conf);
+  virtual void setConfiguration(const Settings& conf) override;
 
   void calculateMatch(const ElementId& eid1, const ElementId& eid2);
 
-  virtual const MatchClassification& getClassification() const { return _class; }
+  virtual const MatchClassification& getClassification() const override { return _class; }
 
-  virtual MatchMembers getMatchMembers() const { return MatchMembers::Poi | MatchMembers::Polygon; }
+  virtual MatchMembers getMatchMembers() const override { return MatchMembers::Poi | MatchMembers::Polygon; }
 
-  virtual QString getMatchName() const { return _matchName; }
+  virtual QString getMatchName() const override { return _matchName; }
 
-  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const;
+  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const override;
 
-  virtual double getProbability() const { return _class.getMatchP(); }
+  virtual double getProbability() const override { return _class.getMatchP(); }
 
   // Is the right implementation for this?
-  virtual bool isConflicting(const Match& /*other*/, const ConstOsmMapPtr& /*map*/) const
+  virtual bool isConflicting(const Match& /*other*/, const ConstOsmMapPtr& /*map*/) const override
   { return false; }
 
-  virtual bool isWholeGroup() const { return true; }
+  virtual bool isWholeGroup() const override { return true; }
 
-  virtual QString toString() const;
+  virtual QString toString() const override;
 
-  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const;
+  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const override;
 
   /**
    * Pass through to the same method in PoiPolygonDistanceTruthRecorder
@@ -102,9 +102,11 @@ public:
    */
   static void resetMatchDistanceInfo();
 
-  virtual QString explain() const { return _explainText; }
+  virtual QString explain() const override { return _explainText; }
 
-  virtual QString getDescription() const { return "Matches POIs with polygons"; }
+  virtual QString getDescription() const override { return "Matches POIs with polygons"; }
+
+  virtual MatchType getType() const override;
 
   void setMatchDistanceThreshold(const double distance);
   void setReviewDistanceThreshold(const double distance);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -146,13 +146,9 @@ bool PoiPolygonMatchCreator::isMatchCandidate(ConstElementPtr element,
 
 std::shared_ptr<MatchThreshold> PoiPolygonMatchCreator::getMatchThreshold()
 {
+  //  Since the POI to Poly matcher is an additive model, all thresholds are 1.0
   if (!_matchThreshold.get())
-  {
-    ConfigOptions config;
-    _matchThreshold.reset(
-      new MatchThreshold(config.getPoiPolygonMatchThreshold(), config.getPoiPolygonMissThreshold(),
-                         config.getPoiPolygonReviewThreshold()));
-  }
+    _matchThreshold.reset(new MatchThreshold(1.0, 1.0, 1.0));
   return _matchThreshold;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonReviewReducer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonReviewReducer.cpp
@@ -703,16 +703,20 @@ bool PoiPolygonReviewReducer::_poiNeighborIsCloserToPolyThanPoi(ConstElementPtr 
         {
           LOG_VART(poi);
           LOG_VART(poiNeighbor);
+          //  This only handles ways as polygons and not relations
           ConstWayPtr polyWay = std::dynamic_pointer_cast<const Way>(poly);
+          if (polyWay)
+          {
             std::shared_ptr<const LineString> polyLineStr =
               std::dynamic_pointer_cast<const LineString>(
                 ElementConverter(_map).convertToLineString(polyWay));
-          const long neighborPoiToPolyDist = polyLineStr->distance(poiNeighborGeom.get());
-          LOG_VART(neighborPoiToPolyDist);
-          if (_distance > neighborPoiToPolyDist)
-          {
-            LOG_TRACE("Returning miss per review reduction rule #25a...");
-            return true;
+            const long neighborPoiToPolyDist = polyLineStr->distance(poiNeighborGeom.get());
+            LOG_VART(neighborPoiToPolyDist);
+            if (_distance > neighborPoiToPolyDist)
+            {
+              LOG_TRACE("Returning miss per review reduction rule #25a...");
+              return true;
+            }
           }
         }
       }


### PR DESCRIPTION
Using the match/miss/review thresholds for the non-additive matching was causing problems when a bad value (i.e. > 1) was passed in.  I removed these options and updated the match thresholds to all be 1 because the additive matching strategy assigns the score to 1 when it calculates the match/miss/review.