### PR TITLE
Fix Hoot Overpass URL reading

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -93,7 +93,7 @@ bool OsmApiReader::isSupported(const QString& url)
   //  Support HTTP and HTTPS URLs to OSM API servers
   for (int i = 0; i < validPrefixes.size(); ++i)
   {
-    if (checkString.startsWith(validPrefixes[i]))
+    if (checkString.startsWith(validPrefixes[i]) && checkString.endsWith("/api/0.6/map"))
       return true;
   }
   //  If we fall out of loop, no dice


### PR DESCRIPTION
The `OsmApiReader` was grabbing all Overpass queries and trying to service them.  Works fine for the XML but not the JSON.  This fixes the problem and makes `OsmApiReader` a little more particular with what it tries to work on.