### PR TITLE
3486 - Remove building tag from multi-poly relation building members during Attribute Conflation

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -263,6 +263,14 @@ reference dataset will be lost.
 If true, all reviews outside of the score range established by the configuration options
 review.score.criterion.max/min.threshold will be removed.
 
+=== attribute.conflation.suppress.building.tag.on.multipoly.relation.constituents
+
+* Data Type: bool
+* Default Value: `true`
+
+If true, any buildings that are part of a multipolygon relation will have their building=yes tags
+removed during Attribute Conflation.
+
 === attribute.score.extractor.use.weight
 
 * Data Type: bool

--- a/conf/services/conflationTypes.json
+++ b/conf/services/conflationTypes.json
@@ -18,6 +18,7 @@
             "attribute.conflation.aggressive.highway.joining": "Aggressively join roads",
             "attribute.conflation.allow.reviews.by.score": "Allow reviews by score",
             "attribute.conflation.ref.tag.overwrite.exclude": "Reference feature tags not to be overwritten",
+            "attribute.conflation.suppress.building.tag.on.multipoly.relation.constituents": "Suppress building tags on multi-polygon relation building members",
             "attribute.conflation.update.building.outlines": "Update building outlines after conflation"
         }
     },

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -571,6 +571,13 @@ RelationPtr BuildingMerger::combineConstituentBuildingsIntoRelation(
   relationTags = parentRelation->getTags();
   LOG_VART(relationTags);
 
+  // Doing this for multipoly relations in Attribute Conflation only for the time being.
+  const bool suppressBuildingTagOnConstituents =
+    // relatively loose way to identify AC; also used in ConflateCmd
+    ConfigOptions().getHighwayMergeTagsOnly() &&
+    // allAreBuildingParts = building relation
+    !allAreBuildingParts &&
+    ConfigOptions().getAttributeConflationSuppressBuildingTagOnMultipolyRelationConstituents();
   for (Tags::const_iterator it = relationTags.begin(); it != relationTags.end(); ++it)
   {
     // Remove any tags in the parent relation from each of the constituent buildings.
@@ -579,7 +586,8 @@ RelationPtr BuildingMerger::combineConstituentBuildingsIntoRelation(
       ElementPtr constituentBuilding = constituentBuildings[i];
       // leave building=* on the relation member; remove status here since it will be on the parent
       // relation as conflated
-      if (it.key() != "building" &&
+      const bool isBuildingTag = it.key() == "building";
+      if ((!isBuildingTag || (isBuildingTag && suppressBuildingTagOnConstituents)) &&
           (constituentBuilding->getTags().contains(it.key()) ||
            it.key() == MetadataTags::HootStatus()))
       {

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -98,7 +98,6 @@ public:
   std::shared_ptr<Envelope> getBoundingBoxFromConfig(const Settings& s, OGRSpatialReference* srs);
 
   Meters getDefaultCircularError() const { return _defaultCircularError; }
-
   Status getDefaultStatus() const { return _status; }
 
   QString getTranslationFile() const { return _translatePath; }
@@ -124,9 +123,7 @@ public:
   void readNext(const OsmMapPtr& map);
 
   void setDefaultCircularError(Meters circularError) { _defaultCircularError = circularError; }
-
   void setDefaultStatus(Status s) { _status = s; }
-
   void setLimit(long limit) { _limit = limit; }
 
   void setSchemaTranslationScript(const QString& translate)
@@ -137,7 +134,6 @@ public:
   void setUseDataSourceIds(bool useIds);
 
   ElementPtr readNextElement();
-
   bool hasMoreElements();
 
   std::shared_ptr<OGRSpatialReference> getProjection() const;
@@ -176,17 +172,11 @@ protected:
   Progress _progress;
 
   void _addFeature(OGRFeature* f);
-
   void _addGeometry(OGRGeometry* g, Tags& t);
-
   void _addLineString(OGRLineString* ls, Tags& t);
-
   void _addMultiPolygon(OGRMultiPolygon* mp, Tags& t);
-
   void _addPolygon(OGRPolygon* p, Tags& t);
-
   void _addPoint(OGRPoint* p, Tags& t);
-
   void _addPolygon(OGRPolygon* p, RelationPtr r, Meters circularError);
 
   WayPtr _createWay(OGRLinearRing* lr, Meters circularError);
@@ -202,7 +192,6 @@ protected:
   void _initTranslate();
 
   void _openLayer(const QString& path, const QString& layer);
-
   void _openNextLayer();
 
   Meters _parseCircularError(Tags& t);
@@ -1329,7 +1318,6 @@ std::shared_ptr<OGRSpatialReference> OgrReaderInternal::getProjection() const
   {
     throw HootException("Error creating EPSG:4326 projection.");
   }
-
   return wgs84;
 }
 

--- a/test-files/cases/attribute/unifying/Config.conf
+++ b/test-files/cases/attribute/unifying/Config.conf
@@ -1,5 +1,8 @@
 {
   "attribute.conflation.aggressive.highway.joining": "true",
+  "#": "Setting this one differently than default for now to avoid having to change a bunch of test output until I'm sure users want",
+  "#": "to enable this.",
+  "attribute.conflation.suppress.building.tag.on.multipoly.relation.constituents": "false",
   "base.config": "AttributeConflation.conf",
   "uuid.helper.repeatable": "true",
   "writer.include.debug.tags": "true",


### PR DESCRIPTION
The new option is: `attribute.conflation.suppress.building.tag.on.multipoly.relation.constituents`; note that its turned off in AC case tests until we verify its the behavior we indeed want to avoid having to unnecessarily change a bunch of test output