### PR TITLE
3502 - Fix orphaned nodes in way simplification

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/RdpWayGeneralizerTest.cpp
@@ -245,7 +245,7 @@ public:
     generalizer.setOsmMap(map.get());
     generalizer.generalize(way);
 
-    CPPUNIT_ASSERT_EQUAL((size_t)197, map->getNodes().size());
+    CPPUNIT_ASSERT_EQUAL((size_t)148, map->getNodes().size());
     CPPUNIT_ASSERT_EQUAL((size_t)148, way->getNodeIds().size());
     const QString outFile = _outputPath + "runGeneralizeWayInput1NoInformationNodesTest-out.osm";
     writeMap(map, outFile);
@@ -283,7 +283,7 @@ public:
     generalizer.setOsmMap(map.get());
     generalizer.generalize(way);
 
-    CPPUNIT_ASSERT_EQUAL((size_t)197, map->getNodes().size());
+    CPPUNIT_ASSERT_EQUAL((size_t)137, map->getNodes().size());
     CPPUNIT_ASSERT_EQUAL((size_t)137, way->getNodeIds().size());
     const QString outFile = _outputPath + "runGeneralizeWayInput1WithInformationNodesTest-out.osm";
     writeMap(map, outFile);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/perty/PertyMatchScorerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/perty/PertyMatchScorerTest.cpp
@@ -107,7 +107,7 @@ public:
 
     //can't do a file comparison on the output here since the UUID's added to the file will be
     //different with each run
-    CPPUNIT_ASSERT_EQUAL(100, (int)combinedMap->getElementCount());
+    CPPUNIT_ASSERT_EQUAL(99, (int)combinedMap->getElementCount());
     std::shared_ptr<TagKeyCountVisitor> tagKeyCountVisitorRef1(new TagKeyCountVisitor(MetadataTags::Ref1()));
     combinedMap->visitRo(*tagKeyCountVisitorRef1);
     CPPUNIT_ASSERT_EQUAL(8, (int)tagKeyCountVisitorRef1->getStat());

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/RandomWayGeneralizerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/RandomWayGeneralizerTest.cpp
@@ -74,8 +74,9 @@ public:
   }
 
   void runTest(const QString& inputFile, const int randomNumberGeneratorSeed,
-               const double generalizeProbability, const double epsilon, const QString& outputFile,
-               const QString& outputCompareFile, const bool enableDebugLogging = false)
+               const double generalizeProbability, const double epsilon, const int numNodesRemoved,
+               const QString& outputFile, const QString& outputCompareFile,
+               const bool enableDebugLogging = false)
   {
     Log::WarningLevel levelBefore = Log::getInstance().getLevel();
     if (enableDebugLogging)
@@ -116,8 +117,8 @@ public:
     map->visitRw(wayGeneralizeVisitor);
     MapProjector::projectToWgs84(map);
 
-    const int numNodesRemoved = numNodesBefore - map->getNodes().size();
-    CPPUNIT_ASSERT_EQUAL(0, numNodesRemoved);
+    const int numNodesActuallyRemoved = numNodesBefore - map->getNodes().size();
+    CPPUNIT_ASSERT_EQUAL(numNodesRemoved, numNodesActuallyRemoved);
     LOG_VARD(numNodesRemoved);
     const int numWaysRemoved = numWaysBefore - map->getWays().size();
     CPPUNIT_ASSERT_EQUAL(0, numWaysRemoved);
@@ -142,6 +143,7 @@ public:
       1,
       0.1,
       5.0,
+      2,
       _outputPath + "RandomWayGeneralizerTest-out-1.osm",
       _inputPath + "RandomWayGeneralizerTest-out-1.osm");
   }
@@ -153,6 +155,7 @@ public:
       1,
       0.5,
       5.0,
+      2,
       _outputPath + "RandomWayGeneralizerTest-out-2.osm",
       _inputPath + "RandomWayGeneralizerTest-out-2.osm");
   }
@@ -164,6 +167,7 @@ public:
       1,
       1.0,
       5.0,
+      17,
       _outputPath + "RandomWayGeneralizerTest-out-3.osm",
       _inputPath + "RandomWayGeneralizerTest-out-3.osm");
   }
@@ -175,6 +179,7 @@ public:
       1,
       0.1,
       10.0,
+      2,
       _outputPath + "RandomWayGeneralizerTest-out-4.osm",
       _inputPath + "RandomWayGeneralizerTest-out-4.osm");
   }
@@ -186,6 +191,7 @@ public:
       1,
       0.5,
       10.0,
+      2,
       _outputPath + "RandomWayGeneralizerTest-out-5.osm",
       _inputPath + "RandomWayGeneralizerTest-out-5.osm");
   }
@@ -197,6 +203,7 @@ public:
       1,
       1.0,
       10.0,
+      21,
       _outputPath + "RandomWayGeneralizerTest-out-6.osm",
       _inputPath + "RandomWayGeneralizerTest-out-6.osm");
   }
@@ -208,6 +215,7 @@ public:
       1,
       0.1,
       50.0,
+      2,
       _outputPath + "RandomWayGeneralizerTest-out-7.osm",
       _inputPath + "RandomWayGeneralizerTest-out-7.osm");
   }
@@ -219,6 +227,7 @@ public:
       1,
       0.5,
       50.0,
+      2,
       _outputPath + "RandomWayGeneralizerTest-out-8.osm",
       _inputPath + "RandomWayGeneralizerTest-out-8.osm");
   }
@@ -230,6 +239,7 @@ public:
       1,
       1.0,
       50.0,
+      27,
       _outputPath + "RandomWayGeneralizerTest-out-9.osm",
       _inputPath + "RandomWayGeneralizerTest-out-9.osm");
   }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -29,7 +29,7 @@
 #define RDP_WAY_GENERALIZER_H
 
 // Hoot
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
+#include <hoot/core/elements/OsmMapConsumer.h>
 #include <hoot/core/elements/OsmMap.h>
 
 // Qt
@@ -69,7 +69,7 @@ class Way;
  * would have to have been generated for the points kept in the reduction, while deleting the old
  * ones.  That isn't desirable from a runtime performance standpoint.
  */
-class RdpWayGeneralizer : public ConstOsmMapConsumer
+class RdpWayGeneralizer : public OsmMapConsumer
 {
 
 public:
@@ -89,7 +89,7 @@ public:
     */
   void setEpsilon(double epsilon);
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  virtual void setOsmMap(OsmMap* map) { _map = map->shared_from_this(); }
 
 private:
 
@@ -97,7 +97,7 @@ private:
 
   double _epsilon;
 
-  ConstOsmMapPtr _map;
+  OsmMapPtr _map;
 
   /*
     Generates a set of points that make up a generalized set of the input points

--- a/hoot-core/src/main/cpp/hoot/core/visitors/WayGeneralizeVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/WayGeneralizeVisitor.cpp
@@ -31,6 +31,7 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/algorithms/RdpWayGeneralizer.h>
 #include <hoot/core/util/MapProjector.h>
+#include <hoot/core/ops/SuperfluousNodeRemover.h>
 
 namespace hoot
 {
@@ -40,7 +41,6 @@ HOOT_FACTORY_REGISTER(ElementVisitor, WayGeneralizeVisitor)
 WayGeneralizeVisitor::WayGeneralizeVisitor() :
 _epsilon(1.0)
 {
-  //setConfiguration(conf());
 }
 
 void WayGeneralizeVisitor::setConfiguration(const Settings& conf)
@@ -52,7 +52,6 @@ void WayGeneralizeVisitor::setConfiguration(const Settings& conf)
 void WayGeneralizeVisitor::setOsmMap(OsmMap* map)
 {
   _map = map;
-  //MapProjector::projectToPlanar(_map->shared_from_this());
 
   assert(_epsilon != -1.0);
   _generalizer.reset(new RdpWayGeneralizer(_epsilon));

--- a/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1NoInformationNodesTest-out.osm
+++ b/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1NoInformationNodesTest-out.osm
@@ -4,9 +4,6 @@
     <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="654.0000000000000000" lon="148.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="650.0000000000000000" lon="145.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="646.0000000000000000" lon="142.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -16,25 +13,13 @@
     <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="636.0000000000000000" lon="139.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="631.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="625.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="620.0000000000000000" lon="140.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="615.0000000000000000" lon="141.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="610.0000000000000000" lon="141.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="606.0000000000000000" lon="144.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="602.0000000000000000" lon="147.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="598.0000000000000000" lon="150.0000000000000000">
@@ -73,15 +58,6 @@
     <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="556.0000000000000000" lon="212.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="555.0000000000000000" lon="218.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="554.0000000000000000" lon="225.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="553.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="552.0000000000000000" lon="238.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -112,21 +88,6 @@
     <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="306.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="314.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="327.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="336.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="344.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="351.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -137,36 +98,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="374.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="383.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="390.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="399.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="406.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="413.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="420.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="426.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="432.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="438.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="444.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="452.0000000000000000">
@@ -194,9 +125,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="527.0000000000000000" lon="505.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="522.0000000000000000" lon="510.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="517.0000000000000000" lon="515.0000000000000000">
@@ -229,19 +157,10 @@
     <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="467.0000000000000000" lon="540.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="461.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="456.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="451.0000000000000000" lon="540.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="445.0000000000000000" lon="539.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="440.0000000000000000" lon="537.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="435.0000000000000000" lon="535.0000000000000000">
@@ -269,9 +188,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="393.0000000000000000" lon="506.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="389.0000000000000000" lon="501.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="385.0000000000000000" lon="496.0000000000000000">
@@ -316,13 +232,7 @@
     <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="417.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="348.0000000000000000" lon="412.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="347.0000000000000000" lon="407.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="345.0000000000000000" lon="402.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="397.0000000000000000">
@@ -355,16 +265,7 @@
     <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="342.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="338.0000000000000000" lon="337.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="332.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="326.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="320.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="313.0000000000000000">
@@ -382,25 +283,13 @@
     <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="329.0000000000000000" lon="288.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="327.0000000000000000" lon="283.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="325.0000000000000000" lon="278.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="322.0000000000000000" lon="272.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="318.0000000000000000" lon="264.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="313.0000000000000000" lon="258.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="309.0000000000000000" lon="255.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="304.0000000000000000" lon="251.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="300.0000000000000000" lon="248.0000000000000000">
@@ -410,9 +299,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="291.0000000000000000" lon="242.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="284.0000000000000000" lon="239.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="275.0000000000000000" lon="235.0000000000000000">
@@ -427,15 +313,6 @@
     <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="256.0000000000000000" lon="231.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="251.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="246.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="239.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="233.0000000000000000" lon="231.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -443,9 +320,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="223.0000000000000000" lon="234.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="218.0000000000000000" lon="236.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="213.0000000000000000" lon="238.0000000000000000">
@@ -457,22 +331,13 @@
     <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="204.0000000000000000" lon="246.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="200.0000000000000000" lon="249.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="195.0000000000000000" lon="253.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="190.0000000000000000" lon="256.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="187.0000000000000000" lon="260.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="183.0000000000000000" lon="265.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="178.0000000000000000" lon="269.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="174.0000000000000000" lon="272.0000000000000000">
@@ -487,9 +352,6 @@
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="161.0000000000000000" lon="285.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="158.0000000000000000" lon="290.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="155.0000000000000000" lon="295.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -500,9 +362,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="143.0000000000000000" lon="309.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="138.0000000000000000" lon="315.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="134.0000000000000000" lon="320.0000000000000000">
@@ -559,9 +418,6 @@
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="80.0000000000000000" lon="424.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="79.0000000000000000" lon="430.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="437.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -569,9 +425,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="74.0000000000000000" lon="450.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="456.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="462.0000000000000000">

--- a/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1NoInformationNodesTest-out.osm
+++ b/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1NoInformationNodesTest-out.osm
@@ -1,791 +1,595 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="83.0000000000000000" lon="483.0000000000000000">
-        <tag k="hoot:id" v="-1"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="483.0000000000000000">
-        <tag k="hoot:id" v="-2"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="75.0000000000000000" lon="479.0000000000000000">
-        <tag k="hoot:id" v="-3"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="474.0000000000000000">
-        <tag k="hoot:id" v="-4"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="467.0000000000000000">
-        <tag k="hoot:id" v="-5"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="462.0000000000000000">
-        <tag k="hoot:id" v="-6"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="456.0000000000000000">
-        <tag k="hoot:id" v="-7"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="74.0000000000000000" lon="450.0000000000000000">
-        <tag k="hoot:id" v="-8"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="76.0000000000000000" lon="444.0000000000000000">
-        <tag k="hoot:id" v="-9"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="437.0000000000000000">
-        <tag k="hoot:id" v="-10"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="79.0000000000000000" lon="430.0000000000000000">
-        <tag k="hoot:id" v="-11"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="80.0000000000000000" lon="424.0000000000000000">
-        <tag k="hoot:id" v="-12"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="84.0000000000000000" lon="415.0000000000000000">
-        <tag k="hoot:id" v="-13"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="85.0000000000000000" lon="410.0000000000000000">
-        <tag k="hoot:id" v="-14"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="87.0000000000000000" lon="405.0000000000000000">
-        <tag k="hoot:id" v="-15"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="90.0000000000000000" lon="399.0000000000000000">
-        <tag k="hoot:id" v="-16"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="92.0000000000000000" lon="393.0000000000000000">
-        <tag k="hoot:id" v="-17"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="95.0000000000000000" lon="386.0000000000000000">
-        <tag k="hoot:id" v="-18"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="97.0000000000000000" lon="380.0000000000000000">
-        <tag k="hoot:id" v="-19"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="100.0000000000000000" lon="374.0000000000000000">
-        <tag k="hoot:id" v="-20"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="102.0000000000000000" lon="369.0000000000000000">
-        <tag k="hoot:id" v="-21"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="103.0000000000000000" lon="364.0000000000000000">
-        <tag k="hoot:id" v="-22"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="107.0000000000000000" lon="359.0000000000000000">
-        <tag k="hoot:id" v="-23"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="112.0000000000000000" lon="349.0000000000000000">
-        <tag k="hoot:id" v="-24"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="118.0000000000000000" lon="342.0000000000000000">
-        <tag k="hoot:id" v="-25"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="122.0000000000000000" lon="337.0000000000000000">
-        <tag k="hoot:id" v="-26"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="125.0000000000000000" lon="331.0000000000000000">
-        <tag k="hoot:id" v="-27"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="131.0000000000000000" lon="325.0000000000000000">
-        <tag k="hoot:id" v="-28"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="134.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:id" v="-29"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="138.0000000000000000" lon="315.0000000000000000">
-        <tag k="hoot:id" v="-30"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="143.0000000000000000" lon="309.0000000000000000">
-        <tag k="hoot:id" v="-31"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="147.0000000000000000" lon="305.0000000000000000">
-        <tag k="hoot:id" v="-32"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="150.0000000000000000" lon="301.0000000000000000">
-        <tag k="hoot:id" v="-33"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="155.0000000000000000" lon="295.0000000000000000">
-        <tag k="hoot:id" v="-34"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="158.0000000000000000" lon="290.0000000000000000">
-        <tag k="hoot:id" v="-35"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="161.0000000000000000" lon="285.0000000000000000">
-        <tag k="hoot:id" v="-36"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="166.0000000000000000" lon="281.0000000000000000">
-        <tag k="hoot:id" v="-37"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="170.0000000000000000" lon="277.0000000000000000">
-        <tag k="hoot:id" v="-38"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="174.0000000000000000" lon="272.0000000000000000">
-        <tag k="hoot:id" v="-39"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="178.0000000000000000" lon="269.0000000000000000">
-        <tag k="hoot:id" v="-40"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="183.0000000000000000" lon="265.0000000000000000">
-        <tag k="hoot:id" v="-41"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="187.0000000000000000" lon="260.0000000000000000">
-        <tag k="hoot:id" v="-42"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="190.0000000000000000" lon="256.0000000000000000">
-        <tag k="hoot:id" v="-43"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="195.0000000000000000" lon="253.0000000000000000">
-        <tag k="hoot:id" v="-44"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="200.0000000000000000" lon="249.0000000000000000">
-        <tag k="hoot:id" v="-45"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="204.0000000000000000" lon="246.0000000000000000">
-        <tag k="hoot:id" v="-46"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="209.0000000000000000" lon="241.0000000000000000">
-        <tag k="hoot:id" v="-47"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="213.0000000000000000" lon="238.0000000000000000">
-        <tag k="hoot:id" v="-48"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="218.0000000000000000" lon="236.0000000000000000">
-        <tag k="hoot:id" v="-49"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="223.0000000000000000" lon="234.0000000000000000">
-        <tag k="hoot:id" v="-50"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="228.0000000000000000" lon="233.0000000000000000">
-        <tag k="hoot:id" v="-51"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="233.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-52"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="239.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-53"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="246.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-54"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="251.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-55"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="256.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-56"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="263.0000000000000000" lon="233.0000000000000000">
-        <tag k="hoot:id" v="-57"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="270.0000000000000000" lon="234.0000000000000000">
-        <tag k="hoot:id" v="-58"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="275.0000000000000000" lon="235.0000000000000000">
-        <tag k="hoot:id" v="-59"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="284.0000000000000000" lon="239.0000000000000000">
-        <tag k="hoot:id" v="-60"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="291.0000000000000000" lon="242.0000000000000000">
-        <tag k="hoot:id" v="-61"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="295.0000000000000000" lon="245.0000000000000000">
-        <tag k="hoot:id" v="-62"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="300.0000000000000000" lon="248.0000000000000000">
-        <tag k="hoot:id" v="-63"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="304.0000000000000000" lon="251.0000000000000000">
-        <tag k="hoot:id" v="-64"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="309.0000000000000000" lon="255.0000000000000000">
-        <tag k="hoot:id" v="-65"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="313.0000000000000000" lon="258.0000000000000000">
-        <tag k="hoot:id" v="-66"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="318.0000000000000000" lon="264.0000000000000000">
-        <tag k="hoot:id" v="-67"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="322.0000000000000000" lon="272.0000000000000000">
-        <tag k="hoot:id" v="-68"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="325.0000000000000000" lon="278.0000000000000000">
-        <tag k="hoot:id" v="-69"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="327.0000000000000000" lon="283.0000000000000000">
-        <tag k="hoot:id" v="-70"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="329.0000000000000000" lon="288.0000000000000000">
-        <tag k="hoot:id" v="-71"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="331.0000000000000000" lon="294.0000000000000000">
-        <tag k="hoot:id" v="-72"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="333.0000000000000000" lon="299.0000000000000000">
-        <tag k="hoot:id" v="-73"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="335.0000000000000000" lon="305.0000000000000000">
-        <tag k="hoot:id" v="-74"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="313.0000000000000000">
-        <tag k="hoot:id" v="-75"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:id" v="-76"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="326.0000000000000000">
-        <tag k="hoot:id" v="-77"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="332.0000000000000000">
-        <tag k="hoot:id" v="-78"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="338.0000000000000000" lon="337.0000000000000000">
-        <tag k="hoot:id" v="-79"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="342.0000000000000000">
-        <tag k="hoot:id" v="-80"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="349.0000000000000000">
-        <tag k="hoot:id" v="-81"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="355.0000000000000000">
-        <tag k="hoot:id" v="-82"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="360.0000000000000000">
-        <tag k="hoot:id" v="-83"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="366.0000000000000000">
-        <tag k="hoot:id" v="-84"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="371.0000000000000000">
-        <tag k="hoot:id" v="-85"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="376.0000000000000000">
-        <tag k="hoot:id" v="-86"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="341.0000000000000000" lon="383.0000000000000000">
-        <tag k="hoot:id" v="-87"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="391.0000000000000000">
-        <tag k="hoot:id" v="-88"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="397.0000000000000000">
-        <tag k="hoot:id" v="-89"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="345.0000000000000000" lon="402.0000000000000000">
-        <tag k="hoot:id" v="-90"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="347.0000000000000000" lon="407.0000000000000000">
-        <tag k="hoot:id" v="-91"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="348.0000000000000000" lon="412.0000000000000000">
-        <tag k="hoot:id" v="-92"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="417.0000000000000000">
-        <tag k="hoot:id" v="-93"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="424.0000000000000000">
-        <tag k="hoot:id" v="-94"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="350.0000000000000000" lon="430.0000000000000000">
-        <tag k="hoot:id" v="-95"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="353.0000000000000000" lon="437.0000000000000000">
-        <tag k="hoot:id" v="-96"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="355.0000000000000000" lon="445.0000000000000000">
-        <tag k="hoot:id" v="-97"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="357.0000000000000000" lon="450.0000000000000000">
-        <tag k="hoot:id" v="-98"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="361.0000000000000000" lon="455.0000000000000000">
-        <tag k="hoot:id" v="-99"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="363.0000000000000000" lon="460.0000000000000000">
-        <tag k="hoot:id" v="-100"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="367.0000000000000000" lon="466.0000000000000000">
-        <tag k="hoot:id" v="-101"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="370.0000000000000000" lon="472.0000000000000000">
-        <tag k="hoot:id" v="-102"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="374.0000000000000000" lon="478.0000000000000000">
-        <tag k="hoot:id" v="-103"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="377.0000000000000000" lon="483.0000000000000000">
-        <tag k="hoot:id" v="-104"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="380.0000000000000000" lon="487.0000000000000000">
-        <tag k="hoot:id" v="-105"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="385.0000000000000000" lon="496.0000000000000000">
-        <tag k="hoot:id" v="-106"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="389.0000000000000000" lon="501.0000000000000000">
-        <tag k="hoot:id" v="-107"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="393.0000000000000000" lon="506.0000000000000000">
-        <tag k="hoot:id" v="-108"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="398.0000000000000000" lon="510.0000000000000000">
-        <tag k="hoot:id" v="-109"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="402.0000000000000000" lon="514.0000000000000000">
-        <tag k="hoot:id" v="-110"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="409.0000000000000000" lon="519.0000000000000000">
-        <tag k="hoot:id" v="-111"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="415.0000000000000000" lon="523.0000000000000000">
-        <tag k="hoot:id" v="-112"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="420.0000000000000000" lon="527.0000000000000000">
-        <tag k="hoot:id" v="-113"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="425.0000000000000000" lon="530.0000000000000000">
-        <tag k="hoot:id" v="-114"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="431.0000000000000000" lon="532.0000000000000000">
-        <tag k="hoot:id" v="-115"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="435.0000000000000000" lon="535.0000000000000000">
-        <tag k="hoot:id" v="-116"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="440.0000000000000000" lon="537.0000000000000000">
-        <tag k="hoot:id" v="-117"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="445.0000000000000000" lon="539.0000000000000000">
-        <tag k="hoot:id" v="-118"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="451.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-119"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="456.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-120"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="461.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-121"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="467.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-122"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="476.0000000000000000" lon="539.0000000000000000">
-        <tag k="hoot:id" v="-123"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="484.0000000000000000" lon="537.0000000000000000">
-        <tag k="hoot:id" v="-124"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="489.0000000000000000" lon="535.0000000000000000">
-        <tag k="hoot:id" v="-125"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="493.0000000000000000" lon="532.0000000000000000">
-        <tag k="hoot:id" v="-126"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="498.0000000000000000" lon="530.0000000000000000">
-        <tag k="hoot:id" v="-127"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="503.0000000000000000" lon="527.0000000000000000">
-        <tag k="hoot:id" v="-128"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="509.0000000000000000" lon="522.0000000000000000">
-        <tag k="hoot:id" v="-129"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="513.0000000000000000" lon="518.0000000000000000">
-        <tag k="hoot:id" v="-130"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="517.0000000000000000" lon="515.0000000000000000">
-        <tag k="hoot:id" v="-131"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="522.0000000000000000" lon="510.0000000000000000">
-        <tag k="hoot:id" v="-132"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="527.0000000000000000" lon="505.0000000000000000">
-        <tag k="hoot:id" v="-133"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="528.0000000000000000" lon="498.0000000000000000">
-        <tag k="hoot:id" v="-134"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="531.0000000000000000" lon="491.0000000000000000">
-        <tag k="hoot:id" v="-135"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="534.0000000000000000" lon="485.0000000000000000">
-        <tag k="hoot:id" v="-136"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="536.0000000000000000" lon="477.0000000000000000">
-        <tag k="hoot:id" v="-137"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="539.0000000000000000" lon="471.0000000000000000">
-        <tag k="hoot:id" v="-138"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="541.0000000000000000" lon="466.0000000000000000">
-        <tag k="hoot:id" v="-139"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="542.0000000000000000" lon="458.0000000000000000">
-        <tag k="hoot:id" v="-140"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="452.0000000000000000">
-        <tag k="hoot:id" v="-141"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="444.0000000000000000">
-        <tag k="hoot:id" v="-142"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="438.0000000000000000">
-        <tag k="hoot:id" v="-143"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="432.0000000000000000">
-        <tag k="hoot:id" v="-144"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="426.0000000000000000">
-        <tag k="hoot:id" v="-145"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="420.0000000000000000">
-        <tag k="hoot:id" v="-146"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="413.0000000000000000">
-        <tag k="hoot:id" v="-147"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="406.0000000000000000">
-        <tag k="hoot:id" v="-148"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="399.0000000000000000">
-        <tag k="hoot:id" v="-149"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="390.0000000000000000">
-        <tag k="hoot:id" v="-150"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="383.0000000000000000">
-        <tag k="hoot:id" v="-151"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="374.0000000000000000">
-        <tag k="hoot:id" v="-152"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="366.0000000000000000">
-        <tag k="hoot:id" v="-153"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="360.0000000000000000">
-        <tag k="hoot:id" v="-154"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="351.0000000000000000">
-        <tag k="hoot:id" v="-155"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="344.0000000000000000">
-        <tag k="hoot:id" v="-156"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="336.0000000000000000">
-        <tag k="hoot:id" v="-157"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="327.0000000000000000">
-        <tag k="hoot:id" v="-158"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:id" v="-159"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="314.0000000000000000">
-        <tag k="hoot:id" v="-160"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="306.0000000000000000">
-        <tag k="hoot:id" v="-161"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="298.0000000000000000">
-        <tag k="hoot:id" v="-162"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="292.0000000000000000">
-        <tag k="hoot:id" v="-163"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="547.0000000000000000" lon="280.0000000000000000">
-        <tag k="hoot:id" v="-164"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="272.0000000000000000">
-        <tag k="hoot:id" v="-165"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="267.0000000000000000">
-        <tag k="hoot:id" v="-166"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="549.0000000000000000" lon="258.0000000000000000">
-        <tag k="hoot:id" v="-167"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="251.0000000000000000">
-        <tag k="hoot:id" v="-168"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="246.0000000000000000">
-        <tag k="hoot:id" v="-169"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="552.0000000000000000" lon="238.0000000000000000">
-        <tag k="hoot:id" v="-170"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="553.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-171"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="554.0000000000000000" lon="225.0000000000000000">
-        <tag k="hoot:id" v="-172"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="555.0000000000000000" lon="218.0000000000000000">
-        <tag k="hoot:id" v="-173"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="556.0000000000000000" lon="212.0000000000000000">
-        <tag k="hoot:id" v="-174"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="559.0000000000000000" lon="205.0000000000000000">
-        <tag k="hoot:id" v="-175"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="560.0000000000000000" lon="199.0000000000000000">
-        <tag k="hoot:id" v="-176"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="564.0000000000000000" lon="193.0000000000000000">
-        <tag k="hoot:id" v="-177"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="567.0000000000000000" lon="188.0000000000000000">
-        <tag k="hoot:id" v="-178"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="572.0000000000000000" lon="179.0000000000000000">
-        <tag k="hoot:id" v="-179"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="574.0000000000000000" lon="171.0000000000000000">
-        <tag k="hoot:id" v="-180"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="578.0000000000000000" lon="167.0000000000000000">
-        <tag k="hoot:id" v="-181"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="583.0000000000000000" lon="161.0000000000000000">
-        <tag k="hoot:id" v="-182"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="588.0000000000000000" lon="157.0000000000000000">
-        <tag k="hoot:id" v="-183"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="592.0000000000000000" lon="153.0000000000000000">
-        <tag k="hoot:id" v="-184"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="598.0000000000000000" lon="150.0000000000000000">
-        <tag k="hoot:id" v="-185"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="602.0000000000000000" lon="147.0000000000000000">
-        <tag k="hoot:id" v="-186"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="606.0000000000000000" lon="144.0000000000000000">
-        <tag k="hoot:id" v="-187"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="610.0000000000000000" lon="141.0000000000000000">
-        <tag k="hoot:id" v="-188"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="615.0000000000000000" lon="141.0000000000000000">
-        <tag k="hoot:id" v="-189"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="620.0000000000000000" lon="140.0000000000000000">
-        <tag k="hoot:id" v="-190"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="625.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:id" v="-191"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="631.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:id" v="-192"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="636.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:id" v="-193"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="641.0000000000000000" lon="140.0000000000000000">
-        <tag k="hoot:id" v="-194"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="646.0000000000000000" lon="142.0000000000000000">
-        <tag k="hoot:id" v="-195"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="72" minlon="139" maxlat="654" maxlon="540"/>
+    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="654.0000000000000000" lon="148.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="650.0000000000000000" lon="145.0000000000000000">
-        <tag k="hoot:id" v="-196"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="654.0000000000000000" lon="148.0000000000000000">
-        <tag k="hoot:id" v="-197"/>
+    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="646.0000000000000000" lon="142.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="641.0000000000000000" lon="140.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="636.0000000000000000" lon="139.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="631.0000000000000000" lon="139.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="625.0000000000000000" lon="139.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="620.0000000000000000" lon="140.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="615.0000000000000000" lon="141.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="610.0000000000000000" lon="141.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="606.0000000000000000" lon="144.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="602.0000000000000000" lon="147.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="598.0000000000000000" lon="150.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="592.0000000000000000" lon="153.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="588.0000000000000000" lon="157.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="583.0000000000000000" lon="161.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="578.0000000000000000" lon="167.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="574.0000000000000000" lon="171.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="572.0000000000000000" lon="179.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="567.0000000000000000" lon="188.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="564.0000000000000000" lon="193.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="560.0000000000000000" lon="199.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="559.0000000000000000" lon="205.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="556.0000000000000000" lon="212.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="555.0000000000000000" lon="218.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="554.0000000000000000" lon="225.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="553.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="552.0000000000000000" lon="238.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="246.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="251.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="549.0000000000000000" lon="258.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="267.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="272.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="547.0000000000000000" lon="280.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="292.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="298.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="306.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="314.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="320.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="327.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="336.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="344.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="351.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="360.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="366.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="374.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="383.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="390.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="399.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="406.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="413.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="420.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="426.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="432.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="438.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="444.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="452.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="542.0000000000000000" lon="458.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="541.0000000000000000" lon="466.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="539.0000000000000000" lon="471.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="536.0000000000000000" lon="477.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="534.0000000000000000" lon="485.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="531.0000000000000000" lon="491.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="528.0000000000000000" lon="498.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="527.0000000000000000" lon="505.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="522.0000000000000000" lon="510.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="517.0000000000000000" lon="515.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="513.0000000000000000" lon="518.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="509.0000000000000000" lon="522.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="503.0000000000000000" lon="527.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="498.0000000000000000" lon="530.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="493.0000000000000000" lon="532.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="489.0000000000000000" lon="535.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="484.0000000000000000" lon="537.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="476.0000000000000000" lon="539.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="467.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="461.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="456.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="451.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="445.0000000000000000" lon="539.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="440.0000000000000000" lon="537.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="435.0000000000000000" lon="535.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="431.0000000000000000" lon="532.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="425.0000000000000000" lon="530.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="420.0000000000000000" lon="527.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="415.0000000000000000" lon="523.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="409.0000000000000000" lon="519.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="402.0000000000000000" lon="514.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="398.0000000000000000" lon="510.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="393.0000000000000000" lon="506.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="389.0000000000000000" lon="501.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="385.0000000000000000" lon="496.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="380.0000000000000000" lon="487.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="377.0000000000000000" lon="483.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="374.0000000000000000" lon="478.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="370.0000000000000000" lon="472.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="367.0000000000000000" lon="466.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="363.0000000000000000" lon="460.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="361.0000000000000000" lon="455.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="357.0000000000000000" lon="450.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="355.0000000000000000" lon="445.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="353.0000000000000000" lon="437.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="350.0000000000000000" lon="430.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="424.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="417.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="348.0000000000000000" lon="412.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="347.0000000000000000" lon="407.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="345.0000000000000000" lon="402.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="397.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="391.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="341.0000000000000000" lon="383.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="376.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="371.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="366.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="360.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="355.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="349.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="342.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="338.0000000000000000" lon="337.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="332.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="326.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="320.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="313.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="335.0000000000000000" lon="305.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="333.0000000000000000" lon="299.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="331.0000000000000000" lon="294.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="329.0000000000000000" lon="288.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="327.0000000000000000" lon="283.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="325.0000000000000000" lon="278.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="322.0000000000000000" lon="272.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="318.0000000000000000" lon="264.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="313.0000000000000000" lon="258.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="309.0000000000000000" lon="255.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="304.0000000000000000" lon="251.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="300.0000000000000000" lon="248.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="295.0000000000000000" lon="245.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="291.0000000000000000" lon="242.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="284.0000000000000000" lon="239.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="275.0000000000000000" lon="235.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="270.0000000000000000" lon="234.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="263.0000000000000000" lon="233.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="256.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="251.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="246.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="239.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="233.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="228.0000000000000000" lon="233.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="223.0000000000000000" lon="234.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="218.0000000000000000" lon="236.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="213.0000000000000000" lon="238.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="209.0000000000000000" lon="241.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="204.0000000000000000" lon="246.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="200.0000000000000000" lon="249.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="195.0000000000000000" lon="253.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="190.0000000000000000" lon="256.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="187.0000000000000000" lon="260.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="183.0000000000000000" lon="265.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="178.0000000000000000" lon="269.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="174.0000000000000000" lon="272.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="170.0000000000000000" lon="277.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="166.0000000000000000" lon="281.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="161.0000000000000000" lon="285.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="158.0000000000000000" lon="290.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="155.0000000000000000" lon="295.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="150.0000000000000000" lon="301.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="147.0000000000000000" lon="305.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="143.0000000000000000" lon="309.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="138.0000000000000000" lon="315.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="134.0000000000000000" lon="320.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="131.0000000000000000" lon="325.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="125.0000000000000000" lon="331.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="122.0000000000000000" lon="337.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="118.0000000000000000" lon="342.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="112.0000000000000000" lon="349.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="107.0000000000000000" lon="359.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="103.0000000000000000" lon="364.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="102.0000000000000000" lon="369.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="100.0000000000000000" lon="374.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="97.0000000000000000" lon="380.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="95.0000000000000000" lon="386.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="92.0000000000000000" lon="393.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="90.0000000000000000" lon="399.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="87.0000000000000000" lon="405.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="85.0000000000000000" lon="410.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="84.0000000000000000" lon="415.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="80.0000000000000000" lon="424.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="79.0000000000000000" lon="430.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="437.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="76.0000000000000000" lon="444.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="74.0000000000000000" lon="450.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="456.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="462.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="467.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="474.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="75.0000000000000000" lon="479.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="483.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="83.0000000000000000" lon="483.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -937,8 +741,7 @@
         <nd ref="-194"/>
         <nd ref="-195"/>
         <nd ref="-197"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-1"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="error:circular" v="1"/>
     </way>
 </osm>

--- a/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1WithInformationNodesTest-out.osm
+++ b/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1WithInformationNodesTest-out.osm
@@ -4,43 +4,17 @@
     <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="654.0000000000000000" lon="148.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="650.0000000000000000" lon="145.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="646.0000000000000000" lon="142.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="641.0000000000000000" lon="140.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="636.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
-    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="631.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="625.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="620.0000000000000000" lon="140.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="615.0000000000000000" lon="141.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="610.0000000000000000" lon="141.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
-    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="606.0000000000000000" lon="144.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="602.0000000000000000" lon="147.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -81,25 +55,11 @@
     <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="556.0000000000000000" lon="212.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="555.0000000000000000" lon="218.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="554.0000000000000000" lon="225.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="553.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="552.0000000000000000" lon="238.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="246.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="251.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="549.0000000000000000" lon="258.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -113,36 +73,11 @@
     <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="547.0000000000000000" lon="280.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="292.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="298.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="306.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="314.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="327.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="336.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="344.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="351.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="360.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -152,38 +87,6 @@
     </node>
     <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="374.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="383.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="390.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="399.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="406.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="413.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="420.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="426.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="432.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="438.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="444.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="452.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -210,9 +113,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="527.0000000000000000" lon="505.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="522.0000000000000000" lon="510.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="517.0000000000000000" lon="515.0000000000000000">
@@ -245,21 +145,10 @@
     <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="467.0000000000000000" lon="540.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="461.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
-    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="456.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="451.0000000000000000" lon="540.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="445.0000000000000000" lon="539.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="440.0000000000000000" lon="537.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="435.0000000000000000" lon="535.0000000000000000">
@@ -277,11 +166,6 @@
     <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="415.0000000000000000" lon="523.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="409.0000000000000000" lon="519.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="402.0000000000000000" lon="514.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -294,21 +178,11 @@
     <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="389.0000000000000000" lon="501.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="385.0000000000000000" lon="496.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="380.0000000000000000" lon="487.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="377.0000000000000000" lon="483.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="374.0000000000000000" lon="478.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="370.0000000000000000" lon="472.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -321,11 +195,6 @@
     </node>
     <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="361.0000000000000000" lon="455.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="357.0000000000000000" lon="450.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="355.0000000000000000" lon="445.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -342,13 +211,7 @@
     <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="417.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="348.0000000000000000" lon="412.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="347.0000000000000000" lon="407.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="345.0000000000000000" lon="402.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="397.0000000000000000">
@@ -381,24 +244,11 @@
     <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="342.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="338.0000000000000000" lon="337.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="332.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="326.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
-    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="313.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="335.0000000000000000" lon="305.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -412,29 +262,13 @@
     <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="329.0000000000000000" lon="288.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="327.0000000000000000" lon="283.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="325.0000000000000000" lon="278.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="322.0000000000000000" lon="272.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="318.0000000000000000" lon="264.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="313.0000000000000000" lon="258.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="309.0000000000000000" lon="255.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="304.0000000000000000" lon="251.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="300.0000000000000000" lon="248.0000000000000000">
@@ -444,9 +278,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="291.0000000000000000" lon="242.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="284.0000000000000000" lon="239.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="275.0000000000000000" lon="235.0000000000000000">
@@ -461,41 +292,16 @@
     <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="256.0000000000000000" lon="231.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="251.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="246.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="239.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="233.0000000000000000" lon="231.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="228.0000000000000000" lon="233.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="223.0000000000000000" lon="234.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="218.0000000000000000" lon="236.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="213.0000000000000000" lon="238.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="209.0000000000000000" lon="241.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="204.0000000000000000" lon="246.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="200.0000000000000000" lon="249.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="195.0000000000000000" lon="253.0000000000000000">
@@ -504,16 +310,8 @@
     <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="190.0000000000000000" lon="256.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="187.0000000000000000" lon="260.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="183.0000000000000000" lon="265.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="178.0000000000000000" lon="269.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="174.0000000000000000" lon="272.0000000000000000">
         <tag k="hoot:status" v="1"/>
@@ -527,9 +325,6 @@
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="161.0000000000000000" lon="285.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="158.0000000000000000" lon="290.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="155.0000000000000000" lon="295.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -540,9 +335,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="143.0000000000000000" lon="309.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="138.0000000000000000" lon="315.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="134.0000000000000000" lon="320.0000000000000000">
@@ -599,11 +391,6 @@
     <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="80.0000000000000000" lon="424.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="79.0000000000000000" lon="430.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
     <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="437.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
@@ -611,9 +398,6 @@
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="74.0000000000000000" lon="450.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="456.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="462.0000000000000000">
@@ -627,16 +411,6 @@
     </node>
     <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="75.0000000000000000" lon="479.0000000000000000">
         <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="483.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-    </node>
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="83.0000000000000000" lon="483.0000000000000000">
-        <tag k="hoot:status" v="1"/>
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
     </node>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>

--- a/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1WithInformationNodesTest-out.osm
+++ b/test-files/algorithms/RdpWayGeneralizerTest/runGeneralizeWayInput1WithInformationNodesTest-out.osm
@@ -1,838 +1,642 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="83.0000000000000000" lon="483.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-1"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="483.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-2"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="75.0000000000000000" lon="479.0000000000000000">
-        <tag k="hoot:id" v="-3"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="474.0000000000000000">
-        <tag k="hoot:id" v="-4"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="467.0000000000000000">
-        <tag k="hoot:id" v="-5"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="462.0000000000000000">
-        <tag k="hoot:id" v="-6"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="456.0000000000000000">
-        <tag k="hoot:id" v="-7"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="74.0000000000000000" lon="450.0000000000000000">
-        <tag k="hoot:id" v="-8"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="76.0000000000000000" lon="444.0000000000000000">
-        <tag k="hoot:id" v="-9"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="437.0000000000000000">
-        <tag k="hoot:id" v="-10"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="79.0000000000000000" lon="430.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-11"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="80.0000000000000000" lon="424.0000000000000000">
-        <tag k="hoot:id" v="-12"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="84.0000000000000000" lon="415.0000000000000000">
-        <tag k="hoot:id" v="-13"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="85.0000000000000000" lon="410.0000000000000000">
-        <tag k="hoot:id" v="-14"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="87.0000000000000000" lon="405.0000000000000000">
-        <tag k="hoot:id" v="-15"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="90.0000000000000000" lon="399.0000000000000000">
-        <tag k="hoot:id" v="-16"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="92.0000000000000000" lon="393.0000000000000000">
-        <tag k="hoot:id" v="-17"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="95.0000000000000000" lon="386.0000000000000000">
-        <tag k="hoot:id" v="-18"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="97.0000000000000000" lon="380.0000000000000000">
-        <tag k="hoot:id" v="-19"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="100.0000000000000000" lon="374.0000000000000000">
-        <tag k="hoot:id" v="-20"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="102.0000000000000000" lon="369.0000000000000000">
-        <tag k="hoot:id" v="-21"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="103.0000000000000000" lon="364.0000000000000000">
-        <tag k="hoot:id" v="-22"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="107.0000000000000000" lon="359.0000000000000000">
-        <tag k="hoot:id" v="-23"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="112.0000000000000000" lon="349.0000000000000000">
-        <tag k="hoot:id" v="-24"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="118.0000000000000000" lon="342.0000000000000000">
-        <tag k="hoot:id" v="-25"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="122.0000000000000000" lon="337.0000000000000000">
-        <tag k="hoot:id" v="-26"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="125.0000000000000000" lon="331.0000000000000000">
-        <tag k="hoot:id" v="-27"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="131.0000000000000000" lon="325.0000000000000000">
-        <tag k="hoot:id" v="-28"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="134.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:id" v="-29"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="138.0000000000000000" lon="315.0000000000000000">
-        <tag k="hoot:id" v="-30"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="143.0000000000000000" lon="309.0000000000000000">
-        <tag k="hoot:id" v="-31"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="147.0000000000000000" lon="305.0000000000000000">
-        <tag k="hoot:id" v="-32"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="150.0000000000000000" lon="301.0000000000000000">
-        <tag k="hoot:id" v="-33"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="155.0000000000000000" lon="295.0000000000000000">
-        <tag k="hoot:id" v="-34"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="158.0000000000000000" lon="290.0000000000000000">
-        <tag k="hoot:id" v="-35"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="161.0000000000000000" lon="285.0000000000000000">
-        <tag k="hoot:id" v="-36"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="166.0000000000000000" lon="281.0000000000000000">
-        <tag k="hoot:id" v="-37"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="170.0000000000000000" lon="277.0000000000000000">
-        <tag k="hoot:id" v="-38"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="174.0000000000000000" lon="272.0000000000000000">
-        <tag k="hoot:id" v="-39"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="178.0000000000000000" lon="269.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-40"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="183.0000000000000000" lon="265.0000000000000000">
-        <tag k="hoot:id" v="-41"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="187.0000000000000000" lon="260.0000000000000000">
-        <tag k="hoot:id" v="-42"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="190.0000000000000000" lon="256.0000000000000000">
-        <tag k="hoot:id" v="-43"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="195.0000000000000000" lon="253.0000000000000000">
-        <tag k="hoot:id" v="-44"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="200.0000000000000000" lon="249.0000000000000000">
-        <tag k="hoot:id" v="-45"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="204.0000000000000000" lon="246.0000000000000000">
-        <tag k="hoot:id" v="-46"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="209.0000000000000000" lon="241.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-47"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="213.0000000000000000" lon="238.0000000000000000">
-        <tag k="hoot:id" v="-48"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="218.0000000000000000" lon="236.0000000000000000">
-        <tag k="hoot:id" v="-49"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="223.0000000000000000" lon="234.0000000000000000">
-        <tag k="hoot:id" v="-50"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="228.0000000000000000" lon="233.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-51"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="233.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-52"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="239.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-53"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="246.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-54"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="251.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-55"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="256.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-56"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="263.0000000000000000" lon="233.0000000000000000">
-        <tag k="hoot:id" v="-57"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="270.0000000000000000" lon="234.0000000000000000">
-        <tag k="hoot:id" v="-58"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="275.0000000000000000" lon="235.0000000000000000">
-        <tag k="hoot:id" v="-59"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="284.0000000000000000" lon="239.0000000000000000">
-        <tag k="hoot:id" v="-60"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="291.0000000000000000" lon="242.0000000000000000">
-        <tag k="hoot:id" v="-61"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="295.0000000000000000" lon="245.0000000000000000">
-        <tag k="hoot:id" v="-62"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="300.0000000000000000" lon="248.0000000000000000">
-        <tag k="hoot:id" v="-63"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="304.0000000000000000" lon="251.0000000000000000">
-        <tag k="hoot:id" v="-64"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="309.0000000000000000" lon="255.0000000000000000">
-        <tag k="hoot:id" v="-65"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="313.0000000000000000" lon="258.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-66"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="318.0000000000000000" lon="264.0000000000000000">
-        <tag k="hoot:id" v="-67"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="322.0000000000000000" lon="272.0000000000000000">
-        <tag k="hoot:id" v="-68"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="325.0000000000000000" lon="278.0000000000000000">
-        <tag k="hoot:id" v="-69"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="327.0000000000000000" lon="283.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-70"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="329.0000000000000000" lon="288.0000000000000000">
-        <tag k="hoot:id" v="-71"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="331.0000000000000000" lon="294.0000000000000000">
-        <tag k="hoot:id" v="-72"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="333.0000000000000000" lon="299.0000000000000000">
-        <tag k="hoot:id" v="-73"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="335.0000000000000000" lon="305.0000000000000000">
-        <tag k="hoot:id" v="-74"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="313.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-75"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="320.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-76"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="326.0000000000000000">
-        <tag k="hoot:id" v="-77"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="332.0000000000000000">
-        <tag k="hoot:id" v="-78"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="338.0000000000000000" lon="337.0000000000000000">
-        <tag k="hoot:id" v="-79"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="342.0000000000000000">
-        <tag k="hoot:id" v="-80"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="349.0000000000000000">
-        <tag k="hoot:id" v="-81"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="355.0000000000000000">
-        <tag k="hoot:id" v="-82"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="360.0000000000000000">
-        <tag k="hoot:id" v="-83"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="366.0000000000000000">
-        <tag k="hoot:id" v="-84"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="371.0000000000000000">
-        <tag k="hoot:id" v="-85"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="376.0000000000000000">
-        <tag k="hoot:id" v="-86"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="341.0000000000000000" lon="383.0000000000000000">
-        <tag k="hoot:id" v="-87"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="391.0000000000000000">
-        <tag k="hoot:id" v="-88"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="397.0000000000000000">
-        <tag k="hoot:id" v="-89"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="345.0000000000000000" lon="402.0000000000000000">
-        <tag k="hoot:id" v="-90"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="347.0000000000000000" lon="407.0000000000000000">
-        <tag k="hoot:id" v="-91"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="348.0000000000000000" lon="412.0000000000000000">
-        <tag k="hoot:id" v="-92"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="417.0000000000000000">
-        <tag k="hoot:id" v="-93"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="424.0000000000000000">
-        <tag k="hoot:id" v="-94"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="350.0000000000000000" lon="430.0000000000000000">
-        <tag k="hoot:id" v="-95"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="353.0000000000000000" lon="437.0000000000000000">
-        <tag k="hoot:id" v="-96"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="355.0000000000000000" lon="445.0000000000000000">
-        <tag k="hoot:id" v="-97"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="357.0000000000000000" lon="450.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-98"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="361.0000000000000000" lon="455.0000000000000000">
-        <tag k="hoot:id" v="-99"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="363.0000000000000000" lon="460.0000000000000000">
-        <tag k="hoot:id" v="-100"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="367.0000000000000000" lon="466.0000000000000000">
-        <tag k="hoot:id" v="-101"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="370.0000000000000000" lon="472.0000000000000000">
-        <tag k="hoot:id" v="-102"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="374.0000000000000000" lon="478.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-103"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="377.0000000000000000" lon="483.0000000000000000">
-        <tag k="hoot:id" v="-104"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="380.0000000000000000" lon="487.0000000000000000">
-        <tag k="hoot:id" v="-105"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="385.0000000000000000" lon="496.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-106"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="389.0000000000000000" lon="501.0000000000000000">
-        <tag k="hoot:id" v="-107"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="393.0000000000000000" lon="506.0000000000000000">
-        <tag k="hoot:id" v="-108"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="398.0000000000000000" lon="510.0000000000000000">
-        <tag k="hoot:id" v="-109"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="402.0000000000000000" lon="514.0000000000000000">
-        <tag k="hoot:id" v="-110"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="409.0000000000000000" lon="519.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-111"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="415.0000000000000000" lon="523.0000000000000000">
-        <tag k="hoot:id" v="-112"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="420.0000000000000000" lon="527.0000000000000000">
-        <tag k="hoot:id" v="-113"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="425.0000000000000000" lon="530.0000000000000000">
-        <tag k="hoot:id" v="-114"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="431.0000000000000000" lon="532.0000000000000000">
-        <tag k="hoot:id" v="-115"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="435.0000000000000000" lon="535.0000000000000000">
-        <tag k="hoot:id" v="-116"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="440.0000000000000000" lon="537.0000000000000000">
-        <tag k="hoot:id" v="-117"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="445.0000000000000000" lon="539.0000000000000000">
-        <tag k="hoot:id" v="-118"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="451.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-119"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="456.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-120"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="461.0000000000000000" lon="540.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-121"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="467.0000000000000000" lon="540.0000000000000000">
-        <tag k="hoot:id" v="-122"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="476.0000000000000000" lon="539.0000000000000000">
-        <tag k="hoot:id" v="-123"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="484.0000000000000000" lon="537.0000000000000000">
-        <tag k="hoot:id" v="-124"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="489.0000000000000000" lon="535.0000000000000000">
-        <tag k="hoot:id" v="-125"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="493.0000000000000000" lon="532.0000000000000000">
-        <tag k="hoot:id" v="-126"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="498.0000000000000000" lon="530.0000000000000000">
-        <tag k="hoot:id" v="-127"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="503.0000000000000000" lon="527.0000000000000000">
-        <tag k="hoot:id" v="-128"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="509.0000000000000000" lon="522.0000000000000000">
-        <tag k="hoot:id" v="-129"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="513.0000000000000000" lon="518.0000000000000000">
-        <tag k="hoot:id" v="-130"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="517.0000000000000000" lon="515.0000000000000000">
-        <tag k="hoot:id" v="-131"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="522.0000000000000000" lon="510.0000000000000000">
-        <tag k="hoot:id" v="-132"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="527.0000000000000000" lon="505.0000000000000000">
-        <tag k="hoot:id" v="-133"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="528.0000000000000000" lon="498.0000000000000000">
-        <tag k="hoot:id" v="-134"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="531.0000000000000000" lon="491.0000000000000000">
-        <tag k="hoot:id" v="-135"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="534.0000000000000000" lon="485.0000000000000000">
-        <tag k="hoot:id" v="-136"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="536.0000000000000000" lon="477.0000000000000000">
-        <tag k="hoot:id" v="-137"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="539.0000000000000000" lon="471.0000000000000000">
-        <tag k="hoot:id" v="-138"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="541.0000000000000000" lon="466.0000000000000000">
-        <tag k="hoot:id" v="-139"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="542.0000000000000000" lon="458.0000000000000000">
-        <tag k="hoot:id" v="-140"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="452.0000000000000000">
-        <tag k="hoot:id" v="-141"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="444.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-142"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="438.0000000000000000">
-        <tag k="hoot:id" v="-143"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="432.0000000000000000">
-        <tag k="hoot:id" v="-144"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="426.0000000000000000">
-        <tag k="hoot:id" v="-145"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="420.0000000000000000">
-        <tag k="hoot:id" v="-146"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="413.0000000000000000">
-        <tag k="hoot:id" v="-147"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="406.0000000000000000">
-        <tag k="hoot:id" v="-148"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="399.0000000000000000">
-        <tag k="hoot:id" v="-149"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="390.0000000000000000">
-        <tag k="hoot:id" v="-150"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="383.0000000000000000">
-        <tag k="hoot:id" v="-151"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="374.0000000000000000">
-        <tag k="hoot:id" v="-152"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="366.0000000000000000">
-        <tag k="hoot:id" v="-153"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="360.0000000000000000">
-        <tag k="hoot:id" v="-154"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="351.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-155"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="344.0000000000000000">
-        <tag k="hoot:id" v="-156"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="336.0000000000000000">
-        <tag k="hoot:id" v="-157"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="327.0000000000000000">
-        <tag k="hoot:id" v="-158"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="320.0000000000000000">
-        <tag k="hoot:id" v="-159"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="314.0000000000000000">
-        <tag k="hoot:id" v="-160"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="306.0000000000000000">
-        <tag k="hoot:id" v="-161"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="298.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-162"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="292.0000000000000000">
-        <tag k="hoot:id" v="-163"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="547.0000000000000000" lon="280.0000000000000000">
-        <tag k="hoot:id" v="-164"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="272.0000000000000000">
-        <tag k="hoot:id" v="-165"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="267.0000000000000000">
-        <tag k="hoot:id" v="-166"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="549.0000000000000000" lon="258.0000000000000000">
-        <tag k="hoot:id" v="-167"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="251.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-168"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="246.0000000000000000">
-        <tag k="hoot:id" v="-169"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="552.0000000000000000" lon="238.0000000000000000">
-        <tag k="hoot:id" v="-170"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="553.0000000000000000" lon="231.0000000000000000">
-        <tag k="hoot:id" v="-171"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="554.0000000000000000" lon="225.0000000000000000">
-        <tag k="hoot:id" v="-172"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="555.0000000000000000" lon="218.0000000000000000">
-        <tag k="hoot:id" v="-173"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="556.0000000000000000" lon="212.0000000000000000">
-        <tag k="hoot:id" v="-174"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="559.0000000000000000" lon="205.0000000000000000">
-        <tag k="hoot:id" v="-175"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="560.0000000000000000" lon="199.0000000000000000">
-        <tag k="hoot:id" v="-176"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="564.0000000000000000" lon="193.0000000000000000">
-        <tag k="hoot:id" v="-177"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="567.0000000000000000" lon="188.0000000000000000">
-        <tag k="hoot:id" v="-178"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="572.0000000000000000" lon="179.0000000000000000">
-        <tag k="hoot:id" v="-179"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="574.0000000000000000" lon="171.0000000000000000">
-        <tag k="hoot:id" v="-180"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="578.0000000000000000" lon="167.0000000000000000">
-        <tag k="hoot:id" v="-181"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="583.0000000000000000" lon="161.0000000000000000">
-        <tag k="hoot:id" v="-182"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="588.0000000000000000" lon="157.0000000000000000">
-        <tag k="hoot:id" v="-183"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="592.0000000000000000" lon="153.0000000000000000">
-        <tag k="hoot:id" v="-184"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="598.0000000000000000" lon="150.0000000000000000">
-        <tag k="hoot:id" v="-185"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="602.0000000000000000" lon="147.0000000000000000">
-        <tag k="hoot:id" v="-186"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="606.0000000000000000" lon="144.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-187"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="610.0000000000000000" lon="141.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-188"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="615.0000000000000000" lon="141.0000000000000000">
-        <tag k="hoot:id" v="-189"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="620.0000000000000000" lon="140.0000000000000000">
-        <tag k="hoot:id" v="-190"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="625.0000000000000000" lon="139.0000000000000000">
-        <tag k="hoot:id" v="-191"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="631.0000000000000000" lon="139.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-192"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="636.0000000000000000" lon="139.0000000000000000">
-        <tag k="testKey" v="testValue"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-193"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="641.0000000000000000" lon="140.0000000000000000">
-        <tag k="hoot:id" v="-194"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="646.0000000000000000" lon="142.0000000000000000">
-        <tag k="hoot:id" v="-195"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="72" minlon="139" maxlat="654" maxlon="540"/>
+    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="654.0000000000000000" lon="148.0000000000000000">
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-196" timestamp="1970-01-01T00:00:00Z" version="1" lat="650.0000000000000000" lon="145.0000000000000000">
-        <tag k="hoot:id" v="-196"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-197" timestamp="1970-01-01T00:00:00Z" version="1" lat="654.0000000000000000" lon="148.0000000000000000">
-        <tag k="hoot:id" v="-197"/>
+    <node visible="true" id="-195" timestamp="1970-01-01T00:00:00Z" version="1" lat="646.0000000000000000" lon="142.0000000000000000">
         <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-194" timestamp="1970-01-01T00:00:00Z" version="1" lat="641.0000000000000000" lon="140.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-193" timestamp="1970-01-01T00:00:00Z" version="1" lat="636.0000000000000000" lon="139.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-192" timestamp="1970-01-01T00:00:00Z" version="1" lat="631.0000000000000000" lon="139.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-191" timestamp="1970-01-01T00:00:00Z" version="1" lat="625.0000000000000000" lon="139.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-190" timestamp="1970-01-01T00:00:00Z" version="1" lat="620.0000000000000000" lon="140.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-189" timestamp="1970-01-01T00:00:00Z" version="1" lat="615.0000000000000000" lon="141.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-188" timestamp="1970-01-01T00:00:00Z" version="1" lat="610.0000000000000000" lon="141.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-187" timestamp="1970-01-01T00:00:00Z" version="1" lat="606.0000000000000000" lon="144.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-186" timestamp="1970-01-01T00:00:00Z" version="1" lat="602.0000000000000000" lon="147.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-185" timestamp="1970-01-01T00:00:00Z" version="1" lat="598.0000000000000000" lon="150.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-184" timestamp="1970-01-01T00:00:00Z" version="1" lat="592.0000000000000000" lon="153.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-183" timestamp="1970-01-01T00:00:00Z" version="1" lat="588.0000000000000000" lon="157.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-182" timestamp="1970-01-01T00:00:00Z" version="1" lat="583.0000000000000000" lon="161.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-181" timestamp="1970-01-01T00:00:00Z" version="1" lat="578.0000000000000000" lon="167.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-180" timestamp="1970-01-01T00:00:00Z" version="1" lat="574.0000000000000000" lon="171.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-179" timestamp="1970-01-01T00:00:00Z" version="1" lat="572.0000000000000000" lon="179.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-178" timestamp="1970-01-01T00:00:00Z" version="1" lat="567.0000000000000000" lon="188.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-177" timestamp="1970-01-01T00:00:00Z" version="1" lat="564.0000000000000000" lon="193.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-176" timestamp="1970-01-01T00:00:00Z" version="1" lat="560.0000000000000000" lon="199.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-175" timestamp="1970-01-01T00:00:00Z" version="1" lat="559.0000000000000000" lon="205.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-174" timestamp="1970-01-01T00:00:00Z" version="1" lat="556.0000000000000000" lon="212.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-173" timestamp="1970-01-01T00:00:00Z" version="1" lat="555.0000000000000000" lon="218.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-172" timestamp="1970-01-01T00:00:00Z" version="1" lat="554.0000000000000000" lon="225.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-171" timestamp="1970-01-01T00:00:00Z" version="1" lat="553.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-170" timestamp="1970-01-01T00:00:00Z" version="1" lat="552.0000000000000000" lon="238.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-169" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="246.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-168" timestamp="1970-01-01T00:00:00Z" version="1" lat="550.0000000000000000" lon="251.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-167" timestamp="1970-01-01T00:00:00Z" version="1" lat="549.0000000000000000" lon="258.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-166" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="267.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-165" timestamp="1970-01-01T00:00:00Z" version="1" lat="548.0000000000000000" lon="272.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-164" timestamp="1970-01-01T00:00:00Z" version="1" lat="547.0000000000000000" lon="280.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-163" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="292.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-162" timestamp="1970-01-01T00:00:00Z" version="1" lat="546.0000000000000000" lon="298.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-161" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="306.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-160" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="314.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-159" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="320.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-158" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="327.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-157" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="336.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-156" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="344.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-155" timestamp="1970-01-01T00:00:00Z" version="1" lat="545.0000000000000000" lon="351.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-154" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="360.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-153" timestamp="1970-01-01T00:00:00Z" version="1" lat="544.0000000000000000" lon="366.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-152" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="374.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-151" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="383.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-150" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="390.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-149" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="399.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-148" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="406.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-147" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="413.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-146" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="420.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-145" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="426.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-144" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="432.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-143" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="438.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-142" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="444.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-141" timestamp="1970-01-01T00:00:00Z" version="1" lat="543.0000000000000000" lon="452.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-140" timestamp="1970-01-01T00:00:00Z" version="1" lat="542.0000000000000000" lon="458.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-139" timestamp="1970-01-01T00:00:00Z" version="1" lat="541.0000000000000000" lon="466.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-138" timestamp="1970-01-01T00:00:00Z" version="1" lat="539.0000000000000000" lon="471.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-137" timestamp="1970-01-01T00:00:00Z" version="1" lat="536.0000000000000000" lon="477.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-136" timestamp="1970-01-01T00:00:00Z" version="1" lat="534.0000000000000000" lon="485.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-135" timestamp="1970-01-01T00:00:00Z" version="1" lat="531.0000000000000000" lon="491.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-134" timestamp="1970-01-01T00:00:00Z" version="1" lat="528.0000000000000000" lon="498.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-133" timestamp="1970-01-01T00:00:00Z" version="1" lat="527.0000000000000000" lon="505.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-132" timestamp="1970-01-01T00:00:00Z" version="1" lat="522.0000000000000000" lon="510.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-131" timestamp="1970-01-01T00:00:00Z" version="1" lat="517.0000000000000000" lon="515.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-130" timestamp="1970-01-01T00:00:00Z" version="1" lat="513.0000000000000000" lon="518.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-129" timestamp="1970-01-01T00:00:00Z" version="1" lat="509.0000000000000000" lon="522.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-128" timestamp="1970-01-01T00:00:00Z" version="1" lat="503.0000000000000000" lon="527.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-127" timestamp="1970-01-01T00:00:00Z" version="1" lat="498.0000000000000000" lon="530.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-126" timestamp="1970-01-01T00:00:00Z" version="1" lat="493.0000000000000000" lon="532.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-125" timestamp="1970-01-01T00:00:00Z" version="1" lat="489.0000000000000000" lon="535.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1" lat="484.0000000000000000" lon="537.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-123" timestamp="1970-01-01T00:00:00Z" version="1" lat="476.0000000000000000" lon="539.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-122" timestamp="1970-01-01T00:00:00Z" version="1" lat="467.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-121" timestamp="1970-01-01T00:00:00Z" version="1" lat="461.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1" lat="456.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-119" timestamp="1970-01-01T00:00:00Z" version="1" lat="451.0000000000000000" lon="540.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-118" timestamp="1970-01-01T00:00:00Z" version="1" lat="445.0000000000000000" lon="539.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-117" timestamp="1970-01-01T00:00:00Z" version="1" lat="440.0000000000000000" lon="537.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-116" timestamp="1970-01-01T00:00:00Z" version="1" lat="435.0000000000000000" lon="535.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-115" timestamp="1970-01-01T00:00:00Z" version="1" lat="431.0000000000000000" lon="532.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1" lat="425.0000000000000000" lon="530.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-113" timestamp="1970-01-01T00:00:00Z" version="1" lat="420.0000000000000000" lon="527.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-112" timestamp="1970-01-01T00:00:00Z" version="1" lat="415.0000000000000000" lon="523.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-111" timestamp="1970-01-01T00:00:00Z" version="1" lat="409.0000000000000000" lon="519.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1" lat="402.0000000000000000" lon="514.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-109" timestamp="1970-01-01T00:00:00Z" version="1" lat="398.0000000000000000" lon="510.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-108" timestamp="1970-01-01T00:00:00Z" version="1" lat="393.0000000000000000" lon="506.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="389.0000000000000000" lon="501.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-106" timestamp="1970-01-01T00:00:00Z" version="1" lat="385.0000000000000000" lon="496.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="380.0000000000000000" lon="487.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-104" timestamp="1970-01-01T00:00:00Z" version="1" lat="377.0000000000000000" lon="483.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="374.0000000000000000" lon="478.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-102" timestamp="1970-01-01T00:00:00Z" version="1" lat="370.0000000000000000" lon="472.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="367.0000000000000000" lon="466.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-100" timestamp="1970-01-01T00:00:00Z" version="1" lat="363.0000000000000000" lon="460.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-99" timestamp="1970-01-01T00:00:00Z" version="1" lat="361.0000000000000000" lon="455.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-98" timestamp="1970-01-01T00:00:00Z" version="1" lat="357.0000000000000000" lon="450.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-97" timestamp="1970-01-01T00:00:00Z" version="1" lat="355.0000000000000000" lon="445.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-96" timestamp="1970-01-01T00:00:00Z" version="1" lat="353.0000000000000000" lon="437.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-95" timestamp="1970-01-01T00:00:00Z" version="1" lat="350.0000000000000000" lon="430.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-94" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="424.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-93" timestamp="1970-01-01T00:00:00Z" version="1" lat="349.0000000000000000" lon="417.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-92" timestamp="1970-01-01T00:00:00Z" version="1" lat="348.0000000000000000" lon="412.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-91" timestamp="1970-01-01T00:00:00Z" version="1" lat="347.0000000000000000" lon="407.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-90" timestamp="1970-01-01T00:00:00Z" version="1" lat="345.0000000000000000" lon="402.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-89" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="397.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-88" timestamp="1970-01-01T00:00:00Z" version="1" lat="343.0000000000000000" lon="391.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-87" timestamp="1970-01-01T00:00:00Z" version="1" lat="341.0000000000000000" lon="383.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-86" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="376.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-85" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="371.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-84" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="366.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-83" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="360.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-82" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="355.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-81" timestamp="1970-01-01T00:00:00Z" version="1" lat="340.0000000000000000" lon="349.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-80" timestamp="1970-01-01T00:00:00Z" version="1" lat="339.0000000000000000" lon="342.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-79" timestamp="1970-01-01T00:00:00Z" version="1" lat="338.0000000000000000" lon="337.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-78" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="332.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-77" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="326.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-76" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="320.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-75" timestamp="1970-01-01T00:00:00Z" version="1" lat="337.0000000000000000" lon="313.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-74" timestamp="1970-01-01T00:00:00Z" version="1" lat="335.0000000000000000" lon="305.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-73" timestamp="1970-01-01T00:00:00Z" version="1" lat="333.0000000000000000" lon="299.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-72" timestamp="1970-01-01T00:00:00Z" version="1" lat="331.0000000000000000" lon="294.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-71" timestamp="1970-01-01T00:00:00Z" version="1" lat="329.0000000000000000" lon="288.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-70" timestamp="1970-01-01T00:00:00Z" version="1" lat="327.0000000000000000" lon="283.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-69" timestamp="1970-01-01T00:00:00Z" version="1" lat="325.0000000000000000" lon="278.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-68" timestamp="1970-01-01T00:00:00Z" version="1" lat="322.0000000000000000" lon="272.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-67" timestamp="1970-01-01T00:00:00Z" version="1" lat="318.0000000000000000" lon="264.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-66" timestamp="1970-01-01T00:00:00Z" version="1" lat="313.0000000000000000" lon="258.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-65" timestamp="1970-01-01T00:00:00Z" version="1" lat="309.0000000000000000" lon="255.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-64" timestamp="1970-01-01T00:00:00Z" version="1" lat="304.0000000000000000" lon="251.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-63" timestamp="1970-01-01T00:00:00Z" version="1" lat="300.0000000000000000" lon="248.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-62" timestamp="1970-01-01T00:00:00Z" version="1" lat="295.0000000000000000" lon="245.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-61" timestamp="1970-01-01T00:00:00Z" version="1" lat="291.0000000000000000" lon="242.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-60" timestamp="1970-01-01T00:00:00Z" version="1" lat="284.0000000000000000" lon="239.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-59" timestamp="1970-01-01T00:00:00Z" version="1" lat="275.0000000000000000" lon="235.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-58" timestamp="1970-01-01T00:00:00Z" version="1" lat="270.0000000000000000" lon="234.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-57" timestamp="1970-01-01T00:00:00Z" version="1" lat="263.0000000000000000" lon="233.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-56" timestamp="1970-01-01T00:00:00Z" version="1" lat="256.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-55" timestamp="1970-01-01T00:00:00Z" version="1" lat="251.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-54" timestamp="1970-01-01T00:00:00Z" version="1" lat="246.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-53" timestamp="1970-01-01T00:00:00Z" version="1" lat="239.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-52" timestamp="1970-01-01T00:00:00Z" version="1" lat="233.0000000000000000" lon="231.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-51" timestamp="1970-01-01T00:00:00Z" version="1" lat="228.0000000000000000" lon="233.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-50" timestamp="1970-01-01T00:00:00Z" version="1" lat="223.0000000000000000" lon="234.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-49" timestamp="1970-01-01T00:00:00Z" version="1" lat="218.0000000000000000" lon="236.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1" lat="213.0000000000000000" lon="238.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1" lat="209.0000000000000000" lon="241.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="204.0000000000000000" lon="246.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="200.0000000000000000" lon="249.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="195.0000000000000000" lon="253.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="190.0000000000000000" lon="256.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="187.0000000000000000" lon="260.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="183.0000000000000000" lon="265.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="178.0000000000000000" lon="269.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="174.0000000000000000" lon="272.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="170.0000000000000000" lon="277.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="166.0000000000000000" lon="281.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="161.0000000000000000" lon="285.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="158.0000000000000000" lon="290.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="155.0000000000000000" lon="295.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="150.0000000000000000" lon="301.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="147.0000000000000000" lon="305.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-31" timestamp="1970-01-01T00:00:00Z" version="1" lat="143.0000000000000000" lon="309.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-30" timestamp="1970-01-01T00:00:00Z" version="1" lat="138.0000000000000000" lon="315.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-29" timestamp="1970-01-01T00:00:00Z" version="1" lat="134.0000000000000000" lon="320.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-28" timestamp="1970-01-01T00:00:00Z" version="1" lat="131.0000000000000000" lon="325.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-27" timestamp="1970-01-01T00:00:00Z" version="1" lat="125.0000000000000000" lon="331.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="122.0000000000000000" lon="337.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="118.0000000000000000" lon="342.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="112.0000000000000000" lon="349.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="107.0000000000000000" lon="359.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="103.0000000000000000" lon="364.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="102.0000000000000000" lon="369.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="100.0000000000000000" lon="374.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="97.0000000000000000" lon="380.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="95.0000000000000000" lon="386.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="92.0000000000000000" lon="393.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="90.0000000000000000" lon="399.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="87.0000000000000000" lon="405.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="85.0000000000000000" lon="410.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="84.0000000000000000" lon="415.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="80.0000000000000000" lon="424.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="79.0000000000000000" lon="430.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="437.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="76.0000000000000000" lon="444.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="74.0000000000000000" lon="450.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="456.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="462.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="72.0000000000000000" lon="467.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="73.0000000000000000" lon="474.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="75.0000000000000000" lon="479.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="78.0000000000000000" lon="483.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
+    </node>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="83.0000000000000000" lon="483.0000000000000000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="testKey" v="testValue"/>
+        <tag k="error:circular" v="1"/>
     </node>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
@@ -972,8 +776,7 @@
         <nd ref="-194"/>
         <nd ref="-195"/>
         <nd ref="-197"/>
-        <tag k="error:circular" v="1"/>
-        <tag k="hoot:id" v="-1"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="error:circular" v="1"/>
     </way>
 </osm>

--- a/test-files/algorithms/perty/PertyMatchScorerTest/PertyMatchScorerTest-perturbed-out-1.osm
+++ b/test-files/algorithms/perty/PertyMatchScorerTest/PertyMatchScorerTest-perturbed-out-1.osm
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
-    <bounds minlat="38.85323889314078" minlon="-104.9025335227636" maxlat="38.85496003199213" maxlon="-104.8961855584039"/>
-    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539206403870949" lon="-104.8996802925414613"/>
-    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539931170162376" lon="-104.8996651751417772"/>
-    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536262326639488" lon="-104.8998434705389542"/>
-    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535445215721396" lon="-104.8998301009274314"/>
-    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539694955880677" lon="-104.9023849965972488"/>
-    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540204802312914" lon="-104.9025335227636475"/>
+    <bounds minlat="38.85323889314078" minlon="-104.9024273478708" maxlat="38.85496003199213" maxlon="-104.8961855584039"/>
+    <node visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542304526290962" lon="-104.8997146930819184"/>
+    <node visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543029292626727" lon="-104.8996995756514394"/>
+    <node visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539538949494769" lon="-104.8998359474119155"/>
+    <node visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8538721838568080" lon="-104.8998225777474431"/>
+    <node visible="true" id="-42" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540447591657312" lon="-104.9022601248199180"/>
+    <node visible="true" id="-41" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540957439671004" lon="-104.9024086510539604"/>
     <node visible="true" id="-40" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543325194999127" lon="-104.9000627208942689"/>
     <node visible="true" id="-39" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541459510504765" lon="-104.8999248969310969"/>
     <node visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542572211965194" lon="-104.9001012212052615"/>
     <node visible="true" id="-37" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549586975449941" lon="-104.8995518966212330"/>
     <node visible="true" id="-36" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549362491907360" lon="-104.8979053407437618"/>
-    <node visible="true" id="-35" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549520669615234" lon="-104.8987398928910721"/>
     <node visible="true" id="-34" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540534547689020" lon="-104.9024273478708125"/>
     <node visible="true" id="-33" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541287183916708" lon="-104.9023024759909077"/>
     <node visible="true" id="-32" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543290249303865" lon="-104.9017840929884784"/>
@@ -50,34 +49,34 @@
     <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-38"/>
         <nd ref="-7"/>
-        <tag k="REF2" v="000000"/>
-        <tag k="note" v="2"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="REF2" v="000000"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-37"/>
         <nd ref="-36"/>
-        <tag k="REF2" v="000007"/>
-        <tag k="note" v="1"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="REF2" v="000007"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
         <nd ref="-37"/>
-        <tag k="REF2" v="000007"/>
-        <tag k="note" v="1"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="REF2" v="000007"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4"/>
         <nd ref="-29"/>
         <nd ref="-30"/>
-        <tag k="REF2" v="000006"/>
-        <tag k="note" v="3"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="REF2" v="000006"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -86,26 +85,26 @@
         <nd ref="-32"/>
         <nd ref="-31"/>
         <nd ref="-30"/>
-        <tag k="REF2" v="000005"/>
-        <tag k="note" v="0"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="REF2" v="000005"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2"/>
         <nd ref="-3"/>
         <nd ref="-4"/>
-        <tag k="REF2" v="000004"/>
-        <tag k="note" v="2"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="REF2" v="000004"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-30"/>
         <nd ref="-5"/>
-        <tag k="REF2" v="000003"/>
-        <tag k="note" v="0"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="REF2" v="000003"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -132,26 +131,26 @@
         <nd ref="-26"/>
         <nd ref="-27"/>
         <nd ref="-28"/>
-        <tag k="REF2" v="000002"/>
-        <tag k="note" v="0"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="REF2" v="000002"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-5"/>
         <nd ref="-6"/>
         <nd ref="-7"/>
-        <tag k="REF2" v="000001"/>
-        <tag k="note" v="0"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="REF2" v="000001"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4"/>
         <nd ref="-38"/>
-        <tag k="REF2" v="000000"/>
-        <tag k="note" v="2"/>
         <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="REF2" v="000000"/>
         <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-1.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-1.osm
@@ -1,166 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -193,21 +150,19 @@
         <nd ref="-1669773"/>
         <nd ref="-1669775"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669729"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-2.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-2.osm
@@ -1,166 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -193,21 +150,19 @@
         <nd ref="-1669773"/>
         <nd ref="-1669775"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669729"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-3.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-3.osm
@@ -1,166 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -177,20 +89,18 @@
         <nd ref="-1669769"/>
         <nd ref="-1669773"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-4.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-4.osm
@@ -1,166 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -193,21 +150,19 @@
         <nd ref="-1669773"/>
         <nd ref="-1669775"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669729"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-5.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-5.osm
@@ -1,166 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -193,21 +150,19 @@
         <nd ref="-1669773"/>
         <nd ref="-1669775"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669729"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-6.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-6.osm
@@ -1,166 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -173,20 +73,18 @@
         <nd ref="-1669765"/>
         <nd ref="-1669769"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-7.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-7.osm
@@ -1,166 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -193,21 +150,19 @@
         <nd ref="-1669773"/>
         <nd ref="-1669775"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669729"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-8.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-8.osm
@@ -1,166 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
+    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
@@ -193,21 +150,19 @@
         <nd ref="-1669773"/>
         <nd ref="-1669775"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669727"/>
         <nd ref="-1669729"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-9.osm
+++ b/test-files/visitors/RandomWayGeneralizerTest/RandomWayGeneralizerTest-out-9.osm
@@ -1,185 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="hootenanny" srs="GEOGCS[&quot;WGS 84&quot;,&#10;    DATUM[&quot;WGS_1984&quot;,&#10;        SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,&#10;            AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],&#10;        TOWGS84[0,0,0,0,0,0,0],&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],&#10;    PRIMEM[&quot;Greenwich&quot;,0,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],&#10;    UNIT[&quot;degree&quot;,0.0174532925199433,&#10;        AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],&#10;    AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]">
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907652" lon="-104.8997069874790355">
-        <tag k="hoot:id" v="-1669723"/>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121">
-        <tag k="hoot:id" v="-1669725"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715108" lon="-104.9010788637033329">
-        <tag k="hoot:id" v="-1669727"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747270" lon="-104.9005795104799432">
-        <tag k="hoot:id" v="-1669729"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452">
-        <tag k="hoot:id" v="-1669731"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938317" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669733"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630643" lon="-104.8997171368440888">
-        <tag k="hoot:id" v="-1669735"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998801" lon="-104.8996840393162842">
-        <tag k="hoot:id" v="-1669737"/>
+    <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432">
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666300" lon="-104.8996934957527998">
-        <tag k="hoot:id" v="-1669739"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841555" lon="-104.8997542928851772">
-        <tag k="hoot:id" v="-1669741"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016712" lon="-104.8996868263970015">
-        <tag k="hoot:id" v="-1669743"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951">
-        <tag k="hoot:id" v="-1669745"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481071959" lon="-104.8993671807151884">
-        <tag k="hoot:id" v="-1669747"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057997046" lon="-104.8992698972467963">
-        <tag k="hoot:id" v="-1669749"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700599" lon="-104.8990568001255923">
-        <tag k="hoot:id" v="-1669751"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501502" lon="-104.8988321216391171">
-        <tag k="hoot:id" v="-1669753"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669755"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679">
-        <tag k="hoot:id" v="-1669757"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836330" lon="-104.8989155074691695">
-        <tag k="hoot:id" v="-1669759"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809432" lon="-104.8988900284655017">
-        <tag k="hoot:id" v="-1669761"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598">
-        <tag k="hoot:id" v="-1669763"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013712">
-        <tag k="hoot:id" v="-1669765"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794">
-        <tag k="hoot:id" v="-1669767"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457547" lon="-104.8977759011252999">
-        <tag k="hoot:id" v="-1669769"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410">
-        <tag k="hoot:id" v="-1669771"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061552" lon="-104.8968586569948656">
-        <tag k="hoot:id" v="-1669773"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812425" lon="-104.8964394115716487">
-        <tag k="hoot:id" v="-1669775"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856">
-        <tag k="hoot:id" v="-1669777"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605311" lon="-104.9005693264316363">
-        <tag k="hoot:id" v="-1669779"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954201" lon="-104.9005253172435630">
-        <tag k="hoot:id" v="-1669781"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564513">
-        <tag k="hoot:id" v="-1669783"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788">
-        <tag k="hoot:id" v="-1669785"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703">
-        <tag k="hoot:id" v="-1669787"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276">
-        <tag k="hoot:id" v="-1669789"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054">
-        <tag k="hoot:id" v="-1669791"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880607" lon="-104.8979050333482093">
-        <tag k="hoot:id" v="-1669793"/>
+    <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121">
         <tag k="hoot:status" v="1"/>
     </node>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>
-        <tag k="note" v="1"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669801"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669729"/>
         <nd ref="-1669781"/>
-        <tag k="note" v="3"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669799"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669789"/>
         <nd ref="-1669731"/>
         <nd ref="-1669743"/>
         <nd ref="-1669777"/>
-        <tag k="note" v="0"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669797"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-1669795" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669725"/>
         <nd ref="-1669735"/>
-        <tag k="note" v="2"/>
-        <tag k="highway" v="road"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="hoot:id" v="-1669795"/>
         <tag k="hoot:status" v="1"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+        <tag k="error:circular" v="15"/>
     </way>
 </osm>

--- a/test-files/visitors/WayGeneralizeVisitorTest/runBasicTest.osm
+++ b/test-files/visitors/WayGeneralizeVisitorTest/runBasicTest.osm
@@ -2,41 +2,24 @@
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.85324241980388" minlon="-104.9024316099691" maxlat="38.85496143000194" maxlon="-104.8961823052624"/>
     <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321187910905" lon="-104.8979050333482093"/>
-    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524111691014" lon="-104.8987388916486054"/>
     <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541296916970" lon="-104.9024316099691276"/>
-    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298888086146" lon="-104.9023065312240703"/>
-    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319127258044" lon="-104.9017876860593788"/>
-    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207360798585" lon="-104.9008079025564513"/>
     <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289621984570" lon="-104.9005253172435630"/>
-    <node visible="true" id="-1669779" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514001634970" lon="-104.9005693264316363"/>
     <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073169879620" lon="-104.8961823052623856"/>
-    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019056843008" lon="-104.8964394115716487"/>
     <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604190091851" lon="-104.8968586569948656"/>
-    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197248872962" lon="-104.8973219116062410"/>
     <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042833485856" lon="-104.8977759011252999"/>
-    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293169093535" lon="-104.8980654352573794"/>
     <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327046238896" lon="-104.8983109602013712"/>
-    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767872691253" lon="-104.8987070428940598"/>
     <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541334963836036" lon="-104.8988900284655017"/>
     <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585287862081" lon="-104.8989155074691695"/>
-    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204278592085" lon="-104.8987232568054679"/>
     <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194151038643" lon="-104.8987070428940598"/>
-    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508706525050" lon="-104.8988321216391171"/>
-    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689086724148" lon="-104.8990568001255923"/>
     <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535165984020168" lon="-104.8992698972467963"/>
     <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470407094441" lon="-104.8993671807151884"/>
-    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001417018369" lon="-104.8994528828182951"/>
     <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424198038839" lon="-104.8996868263970015"/>
     <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583403863896" lon="-104.8997542928851772"/>
-    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248382690133" lon="-104.8996934957527998"/>
-    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525449024197" lon="-104.8996840393162842"/>
     <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618396657531" lon="-104.8997171368440888"/>
-    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545784971966910" lon="-104.8997171368440888"/>
     <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614300019357" lon="-104.8997124086258452"/>
     <node visible="true" id="-1669729" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599613774300" lon="-104.9005795104799432"/>
     <node visible="true" id="-1669727" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471113741925" lon="-104.9010788637033329"/>
     <node visible="true" id="-1669725" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540850999657010" lon="-104.9014476647277121"/>
-    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541669944934398" lon="-104.8997069874790355"/>
     <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-1669731"/>
         <nd ref="-1669793"/>


### PR DESCRIPTION
Apparently this had been a problem since the very beginning. `RdpWayGeneralizer` was leaving any nodes it removed from ways in the source map....now fixed.