### PR TITLE
Fix memory leaks matches

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/highway/HighwayMatchTest.cpp
@@ -32,15 +32,15 @@
 #include <cppunit/TestFixture.h>
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/TestUtils.h>
 #include <hoot/core/algorithms/subline-matching/MaximalNearestSublineMatcher.h>
 #include <hoot/core/algorithms/subline-matching/MaximalSublineStringMatcher.h>
 #include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
 #include <hoot/core/conflate/highway/HighwayMatch.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
@@ -108,17 +108,17 @@ public:
     std::shared_ptr<MaximalSublineStringMatcher> sublineMatcher(new MaximalSublineStringMatcher());
     sublineMatcher->setMinSplitSize(5.0);
     sublineMatcher->setMaxRelevantAngle(toRadians(60.0));
-    HighwayMatch match12(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
-      mt);
+    MatchPtr match12(new HighwayMatch(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
+      mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-1) Way(-2) P: match: 0.129353 miss: 0.870647 review: 0",
-                    match12.toString());
+                    match12->toString());
 
-    HighwayMatch match23(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
-      mt);
+    MatchPtr match23(new HighwayMatch(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
+      mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-2) Way(-3) P: match: 0.129353 miss: 0.870647 review: 0",
-                    match23.toString());
+                    match23->toString());
 
-    CPPUNIT_ASSERT_EQUAL(true, match12.isConflicting(match23, map));
+    CPPUNIT_ASSERT_EQUAL(true, match12->isConflicting(match23, map));
   }
 
   /**
@@ -158,17 +158,17 @@ public:
     std::shared_ptr<MaximalSublineStringMatcher> sublineMatcher(new MaximalSublineStringMatcher());
     sublineMatcher->setMinSplitSize(5.0);
     sublineMatcher->setMaxRelevantAngle(toRadians(60.0));
-    HighwayMatch match12(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
-                         mt);
+    MatchPtr match12(new HighwayMatch(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
+                         mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-1) Way(-2) P: match: 0.0921884 miss: 0.907812 review: 0",
-                    match12.toString());
+                    match12->toString());
 
-    HighwayMatch match23(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
-                         mt);
+    MatchPtr match23(new HighwayMatch(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
+                         mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-2) Way(-3) P: match: 0.0921884 miss: 0.907812 review: 0",
-                    match23.toString());
+                    match23->toString());
 
-    CPPUNIT_ASSERT_EQUAL(false, match12.isConflicting(match23, map));
+    CPPUNIT_ASSERT_EQUAL(false, match12->isConflicting(match23, map));
   }
 
   /**
@@ -206,17 +206,17 @@ public:
     std::shared_ptr<MaximalSublineStringMatcher> sublineMatcher(new MaximalSublineStringMatcher());
     sublineMatcher->setMinSplitSize(5.0);
     sublineMatcher->setMaxRelevantAngle(toRadians(60.0));
-    HighwayMatch match12(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
-                         mt);
+    MatchPtr match12(new HighwayMatch(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
+                         mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-1) Way(-2) P: match: 0.101976 miss: 0.898024 review: 0",
-                    match12.toString());
+                    match12->toString());
 
-    HighwayMatch match23(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
-                         mt);
+    MatchPtr match23(new HighwayMatch(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
+                         mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-2) Way(-3) P: match: 0.101976 miss: 0.898024 review: 0",
-                    match23.toString());
+                    match23->toString());
 
-    CPPUNIT_ASSERT_EQUAL(false, match12.isConflicting(match23, map));
+    CPPUNIT_ASSERT_EQUAL(false, match12->isConflicting(match23, map));
   }
 
   /**
@@ -252,17 +252,17 @@ public:
     std::shared_ptr<MaximalSublineStringMatcher> sublineMatcher(new MaximalSublineStringMatcher());
     sublineMatcher->setMinSplitSize(5.0);
     sublineMatcher->setMaxRelevantAngle(toRadians(60.0));
-    HighwayMatch match12(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
-                         mt);
+    MatchPtr match12(new HighwayMatch(classifier, sublineMatcher, map, w1->getElementId(), w2->getElementId(),
+                         mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-1) Way(-2) P: match: 0.138093 miss: 0.861907 review: 0",
-                    match12.toString());
+                    match12->toString());
 
-    HighwayMatch match23(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
-                         mt);
+    MatchPtr match23(new HighwayMatch(classifier, sublineMatcher, map, w2->getElementId(), w3->getElementId(),
+                         mt));
     HOOT_STR_EQUALS("HighwayMatch Way(-2) Way(-3) P: match: 0.138093 miss: 0.861907 review: 0",
-                    match23.toString());
+                    match23->toString());
 
-    CPPUNIT_ASSERT_EQUAL(true, match12.isConflicting(match23, map));
+    CPPUNIT_ASSERT_EQUAL(true, match12->isConflicting(match23, map));
   }
 
   /**
@@ -326,14 +326,14 @@ public:
 
     WaySublineMatchString m = sublineMatcher->findMatch(map, w218, w948);
 
-    HighwayMatch match218v948(classifier, sublineMatcher, map, w218->getElementId(),
-      w948->getElementId(), mt);
-    HighwayMatch match218v582(classifier, sublineMatcher, map, w218->getElementId(),
-      w582->getElementId(), mt);
+    std::shared_ptr<HighwayMatch> match218v948(new HighwayMatch(classifier, sublineMatcher, map, w218->getElementId(),
+      w948->getElementId(), mt));
+    std::shared_ptr<HighwayMatch> match218v582(new HighwayMatch(classifier, sublineMatcher, map, w218->getElementId(),
+      w582->getElementId(), mt));
 
-    LOG_VAR(match218v948.getSublineMatch());
-    LOG_VAR(match218v582.getSublineMatch());
-    HOOT_STR_EQUALS(false, match218v948.isConflicting(match218v582, map));
+    LOG_VAR(match218v948->getSublineMatch());
+    LOG_VAR(match218v582->getSublineMatch());
+    HOOT_STR_EQUALS(false, match218v948->isConflicting(match218v582, map));
   }
 
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/GreedyConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/GreedyConstrainedMatchesTest.cpp
@@ -26,14 +26,14 @@
  */
 
 // Hoot
-#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/TestUtils.h>
+#include <hoot/core/conflate/matching/GreedyConstrainedMatches.h>
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
-#include <hoot/core/conflate/matching/GreedyConstrainedMatches.h>
 #include <hoot/core/util/Log.h>
 
 // CPP Unit
@@ -54,12 +54,12 @@ using namespace Tgs;
 namespace hoot
 {
 
-class ConstrainedFakeMatch : public Match
+class GreedyConstrainedFakeMatch : public Match
 {
 public:
 
-  ConstrainedFakeMatch() : Match(MatchThresholdPtr()) {}
-  ConstrainedFakeMatch(ElementId eid1, ElementId eid2, double p,
+  GreedyConstrainedFakeMatch() : Match(MatchThresholdPtr()) {}
+  GreedyConstrainedFakeMatch(ElementId eid1, ElementId eid2, double p,
     ConstMatchThresholdPtr threshold) :
     Match(threshold),
     _eid1(eid1),
@@ -67,13 +67,12 @@ public:
     _p(p)
   {}
 
-  ConstrainedFakeMatch* addConflict(const Match* conflict)
+  void addConflict(ConstMatchPtr conflict)
   {
     _conflicts.insert(conflict);
-    return this;
   }
 
-  virtual const MatchClassification& getClassification() const
+  virtual const MatchClassification& getClassification() const override
   {
     _c.setMatchP(_p);
     _c.setMissP(1 - _p);
@@ -81,50 +80,36 @@ public:
     return _c;
   }
 
-  virtual QString getMatchName() const { return "Fake Match"; }
+  virtual QString getMatchName() const override { return "Fake Match"; }
 
-  virtual double getProbability() const { return _p; }
+  virtual double getProbability() const override { return _p; }
 
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& /*map*/) const
+  virtual bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& /*map*/) const override
   {
-    // this isn't a good way to do this since it relies on pointers, but it works for the unit test.
-    if (_conflicts.find(&other) == _conflicts.end())
+    QString otherString = other->toString();
+    for (MatchSet::iterator it = _conflicts.begin(); it != _conflicts.end(); ++it)
     {
-      return false;
+      if (otherString == (*it)->toString())
+        return false;
     }
-    else
-    {
-      return true;
-    }
+    return true;
   }
 
-  virtual set<pair<ElementId, ElementId>> getMatchPairs() const
+  virtual set<pair<ElementId, ElementId>> getMatchPairs() const override
   {
     set<pair<ElementId, ElementId>> result;
     result.insert(pair<ElementId, ElementId>(_eid1, _eid2));
     return result;
   }
 
-  ConstrainedFakeMatch* init(ElementId eid1, ElementId eid2, double p,
-    ConstMatchThresholdPtr threshold)
-  {
-    _eid1 = eid1;
-    _eid2 = eid2;
-    _p = p;
-    _threshold = threshold;
-    return this;
-  }
-
-  virtual QString toString() const
+  virtual QString toString() const override
   {
     stringstream ss;
     ss << "pairs: " << getMatchPairs() << " p: " << getProbability();
     return QString::fromStdString(ss.str());
   }
 
-  MatchType getType() const { return _threshold->getType(*this); }
-
-  virtual QString getDescription() const { return ""; }
+  virtual QString getDescription() const override { return ""; }
 
 private:
 
@@ -132,10 +117,9 @@ private:
   ElementId _eid1, _eid2;
   double _p;
   MatchSet _conflicts;
-  ConstMatchThresholdPtr _threshold;
 };
 
-class ConstrainedFakeCreator : public MergerCreator
+class GreedyConstrainedFakeCreator : public MergerCreator
 {
 public:
 
@@ -145,19 +129,15 @@ public:
     return false;
   }
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const
   {
-    const ConstrainedFakeMatch* cfm1 = dynamic_cast<const ConstrainedFakeMatch*>(m1);
-    const ConstrainedFakeMatch* cfm2 = dynamic_cast<const ConstrainedFakeMatch*>(m2);
-
-    return cfm1->isConflicting(*cfm2, map);
+    return m1->isConflicting(m2, map);
   }
 
   vector<CreatorDescription> getAllCreators() const
   {
     return vector<CreatorDescription>();
   }
-
 };
 
 class GreedyConstrainedMatchesTest : public HootTestFixture
@@ -182,36 +162,35 @@ public:
     ElementId b2 = ElementId::way(5);
     ElementId b3 = ElementId::way(6);
 
-    vector<const Match*> matches;
-
-    // force the pointers to be in order which forces the set to be consistent between runs.
-    ConstrainedFakeMatch* fm = new ConstrainedFakeMatch[4];
     MatchThresholdPtr mt(new MatchThreshold(0.5, 0.5));
+    vector<std::shared_ptr<GreedyConstrainedFakeMatch>> fm(4);
+    fm[0].reset(new GreedyConstrainedFakeMatch(a1, b1, 0.8, mt));
+    fm[1].reset(new GreedyConstrainedFakeMatch(a2, b1, 1.0, mt));
+    fm[2].reset(new GreedyConstrainedFakeMatch(a2, b2, 0.9, mt));
+    fm[3].reset(new GreedyConstrainedFakeMatch(a3, b3, 0.9, mt));
 
-    matches.push_back(fm[0].init(a1, b1, 0.8, mt)->addConflict(&fm[1]));
-    matches.push_back(fm[1].init(a2, b1, 1, mt)->addConflict(&fm[2]));
-    matches.push_back(fm[2].init(a2, b2, 0.9, mt));
-    matches.push_back(fm[3].init(a3, b3, 0.9, mt));
+    fm[0]->addConflict(fm[1]);
+    fm[1]->addConflict(fm[2]);
 
     ConstOsmMapPtr empty;
     GreedyConstrainedMatches uut(empty);
 
-    uut.addMatches(matches.begin(), matches.end());
-    vector<const Match*> subsetVector = uut.calculateSubset();
+    uut.addMatches(fm.begin(), fm.end());
+    vector<ConstMatchPtr> subsetVector = uut.calculateSubset();
 
     MatchSet matchSet;
     matchSet.insert(subsetVector.begin(), subsetVector.end());
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.9, uut.getScore(), 0.001);
     CPPUNIT_ASSERT_EQUAL((size_t)2, matchSet.size());
-    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(&fm[1]) != matchSet.end());
-    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(&fm[3]) != matchSet.end());
+    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[1]) != matchSet.end());
+    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[3]) != matchSet.end());
   }
 
   virtual void setUp()
   {
     MergerFactory::getInstance().clear();
-    MergerFactory::getInstance().registerCreator(new ConstrainedFakeCreator());
+    MergerFactory::getInstance().registerCreator(new GreedyConstrainedFakeCreator());
   }
 
   virtual void tearDown()
@@ -219,7 +198,6 @@ public:
     MergerFactory::getInstance().clear();
     MergerFactory::getInstance().registerDefaultCreators();
   }
-
 };
 
 //CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(GreedyConstrainedMatchesTest, "current");

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
@@ -181,15 +181,11 @@ public:
     MatchSet matchSet;
     matchSet.insert(subsetVector.begin(), subsetVector.end());
 
-//TODO: FIX ME
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.6, uut.getScore(), 0.001);
     CPPUNIT_ASSERT_EQUAL((size_t)3, matchSet.size());
     CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[0]) != matchSet.end());
     CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[2]) != matchSet.end());
     CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[3]) != matchSet.end());
-
-//DELETE ME:
-//    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[1]) != matchSet.end());
   }
 
   virtual void setUp()

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
@@ -31,9 +31,9 @@
 #include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
+#include <hoot/core/conflate/matching/OptimalConstrainedMatches.h>
 #include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
-#include <hoot/core/conflate/matching/OptimalConstrainedMatches.h>
 #include <hoot/core/util/Log.h>
 
 // CPP Unit
@@ -54,12 +54,12 @@ using namespace Tgs;
 namespace hoot
 {
 
-class ConstrainedFakeMatch : public Match
+class OptimalConstrainedFakeMatch : public Match
 {
 public:
 
-  ConstrainedFakeMatch() : Match(std::shared_ptr<MatchThreshold>()) {}
-  ConstrainedFakeMatch(ElementId eid1, ElementId eid2, double p,
+  OptimalConstrainedFakeMatch() : Match(std::shared_ptr<MatchThreshold>()) {}
+  OptimalConstrainedFakeMatch(ElementId eid1, ElementId eid2, double p,
     ConstMatchThresholdPtr threshold) :
     Match(threshold),
     _eid1(eid1),
@@ -67,13 +67,12 @@ public:
     _p(p)
   {}
 
-  ConstrainedFakeMatch* addConflict(const Match* conflict)
+  void addConflict(const ConstMatchPtr& conflict)
   {
     _conflicts.insert(conflict);
-    return this;
   }
 
-  virtual const MatchClassification& getClassification() const
+  virtual const MatchClassification& getClassification() const override
   {
     _c.setMatchP(_p);
     _c.setMissP(1 - _p);
@@ -81,50 +80,36 @@ public:
     return _c;
   }
 
-  virtual QString getMatchName() const { return "Fake Match"; }
+  virtual QString getMatchName() const override { return "Fake Match"; }
 
-  virtual double getProbability() const { return _p; }
+  virtual double getProbability() const override { return _p; }
 
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& /*map*/) const
+  virtual bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& /*map*/) const override
   {
-    // this isn't a good way to do this since it relies on pointers, but it works for the unit test.
-    if (_conflicts.find(&other) == _conflicts.end())
+    QString otherString = other->toString();
+    for (MatchSet::iterator it = _conflicts.begin(); it != _conflicts.end(); ++it)
     {
-      return false;
+      if (otherString == (*it)->toString())
+        return true;
     }
-    else
-    {
-      return true;
-    }
+    return false;
   }
 
-  virtual set<pair<ElementId, ElementId>> getMatchPairs() const
+  virtual set<pair<ElementId, ElementId>> getMatchPairs() const override
   {
     set<pair<ElementId, ElementId>> result;
     result.insert(pair<ElementId, ElementId>(_eid1, _eid2));
     return result;
   }
 
-  ConstrainedFakeMatch* init(ElementId eid1, ElementId eid2, double p,
-    ConstMatchThresholdPtr threshold)
-  {
-    _eid1 = eid1;
-    _eid2 = eid2;
-    _p = p;
-    _threshold = threshold;
-    return this;
-  }
-
-  virtual QString toString() const
+  virtual QString toString() const override
   {
     stringstream ss;
     ss << "pairs: " << getMatchPairs() << " p: " << getProbability();
     return QString::fromStdString(ss.str());
   }
 
-  MatchType getType() const { return _threshold->getType(*this); }
-
-  virtual QString getDescription() const { return ""; }
+  virtual QString getDescription() const override { return ""; }
 
 private:
 
@@ -132,10 +117,9 @@ private:
   ElementId _eid1, _eid2;
   double _p;
   MatchSet _conflicts;
-  std::shared_ptr<const MatchThreshold> _threshold;
 };
 
-class ConstrainedFakeCreator : public MergerCreator
+class OptimalConstrainedFakeCreator : public MergerCreator
 {
 public:
 
@@ -145,12 +129,9 @@ public:
     return false;
   }
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const override
   {
-    const ConstrainedFakeMatch* cfm1 = dynamic_cast<const ConstrainedFakeMatch*>(m1);
-    const ConstrainedFakeMatch* cfm2 = dynamic_cast<const ConstrainedFakeMatch*>(m2);
-
-    return cfm1->isConflicting(*cfm2, map);
+    return m1->isConflicting(m2, map);
   }
 
   vector<CreatorDescription> getAllCreators() const
@@ -181,37 +162,40 @@ public:
     ElementId b2 = ElementId::way(5);
     ElementId b3 = ElementId::way(6);
 
-    vector<const Match*> matches;
+    MatchThresholdPtr mt(new MatchThreshold(0.5, 0.5));
+    vector<std::shared_ptr<OptimalConstrainedFakeMatch>> fm(4);
+    fm[0].reset(new OptimalConstrainedFakeMatch(a1, b1, 0.8, mt));
+    fm[1].reset(new OptimalConstrainedFakeMatch(a2, b1, 1.0, mt));
+    fm[2].reset(new OptimalConstrainedFakeMatch(a2, b2, 0.9, mt));
+    fm[3].reset(new OptimalConstrainedFakeMatch(a3, b3, 0.9, mt));
 
-    // force the pointers to be in order which forces the set to be consistent between runs.
-    ConstrainedFakeMatch* fm = new ConstrainedFakeMatch[4];
-    std::shared_ptr<MatchThreshold> mt(new MatchThreshold(0.5, 0.5));
-
-    matches.push_back(fm[0].init(a1, b1, 0.8, mt)->addConflict(&fm[1]));
-    matches.push_back(fm[1].init(a2, b1, 1, mt)->addConflict(&fm[2]));
-    matches.push_back(fm[2].init(a2, b2, 0.9, mt));
-    matches.push_back(fm[3].init(a3, b3, 0.9, mt));
+    fm[0]->addConflict(fm[1]);
+    fm[1]->addConflict(fm[2]);
 
     ConstOsmMapPtr empty;
     OptimalConstrainedMatches uut(empty);
 
-    uut.addMatches(matches.begin(), matches.end());
-    vector<const Match*> subsetVector = uut.calculateSubset();
+    uut.addMatches(fm.begin(), fm.end());
+    vector<ConstMatchPtr> subsetVector = uut.calculateSubset();
 
     MatchSet matchSet;
     matchSet.insert(subsetVector.begin(), subsetVector.end());
 
+//TODO: FIX ME
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.6, uut.getScore(), 0.001);
     CPPUNIT_ASSERT_EQUAL((size_t)3, matchSet.size());
-    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(&fm[0]) != matchSet.end());
-    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(&fm[2]) != matchSet.end());
-    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(&fm[3]) != matchSet.end());
+    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[0]) != matchSet.end());
+    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[2]) != matchSet.end());
+    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[3]) != matchSet.end());
+
+//DELETE ME:
+//    CPPUNIT_ASSERT_EQUAL(true, matchSet.find(fm[1]) != matchSet.end());
   }
 
   virtual void setUp()
   {
     MergerFactory::getInstance().clear();
-    MergerFactory::getInstance().registerCreator(new ConstrainedFakeCreator());
+    MergerFactory::getInstance().registerCreator(new OptimalConstrainedFakeCreator());
   }
 
   virtual void tearDown()

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreatorTest.cpp
@@ -94,7 +94,7 @@ public:
 
     {
       PoiPolygonMatchCreator uut;
-      vector<const Match*> matches;
+      vector<ConstMatchPtr> matches;
       std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.5, 0.5, 0.5));
       uut.createMatches(map, matches, threshold);
       HOOT_STR_EQUALS(2, matches.size());

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -92,15 +92,16 @@ public:
     n1->getTags()["amenity"] = "cafe";
     map->addNode(n1);
 
-    PoiPolygonMatch match1(map, std::shared_ptr<MatchThreshold>(),
-                           std::shared_ptr<PoiPolygonRfClassifier>(),
-                           PoiPolygonCachePtr(new PoiPolygonCache(map)));
-    match1.setMatchEvidenceThreshold(3);
-    match1.setReviewEvidenceThreshold(1);
-    match1.calculateMatch(w1->getElementId(), n1->getElementId());
+    std::shared_ptr<PoiPolygonMatch> match1(
+          new PoiPolygonMatch(map, std::shared_ptr<MatchThreshold>(),
+                              std::shared_ptr<PoiPolygonRfClassifier>(),
+                              PoiPolygonCachePtr(new PoiPolygonCache(map))));
+    match1->setMatchEvidenceThreshold(3);
+    match1->setReviewEvidenceThreshold(1);
+    match1->calculateMatch(w1->getElementId(), n1->getElementId());
 
     MatchSet matches;
-    matches.insert(&match1);
+    matches.insert(match1);
     vector<Merger*> mergers;
     PoiPolygonMergerCreator uut;
     uut.setOsmMap(map.get());
@@ -138,25 +139,27 @@ public:
     n1->getTags()["amenity"] = "cafe";
     map->addNode(n1);
 
-    vector<const Match*> matchesV;
+    vector<ConstMatchPtr> matchesV;
 
-    PoiPolygonMatch match1(
-      map, std::shared_ptr<MatchThreshold>(), std::shared_ptr<PoiPolygonRfClassifier>(),
-      PoiPolygonCachePtr(new PoiPolygonCache(map)));
-    match1.setMatchEvidenceThreshold(3);
-    match1.setReviewEvidenceThreshold(1);
-    match1.calculateMatch(w1->getElementId(), n1->getElementId());
-    matchesV.push_back(&match1);
+    std::shared_ptr<PoiPolygonMatch> match1(
+          new PoiPolygonMatch(map, std::shared_ptr<MatchThreshold>(),
+                              std::shared_ptr<PoiPolygonRfClassifier>(),
+                              PoiPolygonCachePtr(new PoiPolygonCache(map))));
+    match1->setMatchEvidenceThreshold(3);
+    match1->setReviewEvidenceThreshold(1);
+    match1->calculateMatch(w1->getElementId(), n1->getElementId());
+    matchesV.push_back(match1);
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.5, 0.5, 0.5));
     BuildingMatchCreator().createMatches(map, matchesV, threshold);
 
-    PoiPolygonMatch match2(
-      map, std::shared_ptr<MatchThreshold>(), std::shared_ptr<PoiPolygonRfClassifier>(),
-      PoiPolygonCachePtr(new PoiPolygonCache(map)));
-    match2.setMatchEvidenceThreshold(3);
-    match2.setReviewEvidenceThreshold(1);
-    match2.calculateMatch(w2->getElementId(), n1->getElementId());
-    matchesV.push_back(&match2);
+    std::shared_ptr<PoiPolygonMatch> match2(
+          new PoiPolygonMatch(map, std::shared_ptr<MatchThreshold>(),
+                              std::shared_ptr<PoiPolygonRfClassifier>(),
+                              PoiPolygonCachePtr(new PoiPolygonCache(map))));
+    match2->setMatchEvidenceThreshold(3);
+    match2->setReviewEvidenceThreshold(1);
+    match2->calculateMatch(w2->getElementId(), n1->getElementId());
+    matchesV.push_back(match2);
     LOG_VAR(match2);
 
     MatchSet matches;
@@ -176,19 +179,19 @@ public:
     // Create a building and poi/poly match with feature overlap and ensure they all merge together
     // when cross feature conflate merging is allowed.
 
-    vector<const Match*> matchesV;
+    vector<ConstMatchPtr> matchesV;
 
-    BuildingMatch match1(std::shared_ptr<const MatchThreshold>(new MatchThreshold(0.5, 0.5, 0.5)));
-    match1._p.setMatch();
-    match1._eid1 = ElementId(ElementType::Way, 1);
-    match1._eid2 = ElementId(ElementType::Node, 1);
-    matchesV.push_back(&match1);
+    std::shared_ptr<BuildingMatch> match1(new BuildingMatch(std::shared_ptr<const MatchThreshold>(new MatchThreshold(0.5, 0.5, 0.5))));
+    match1->_p.setMatch();
+    match1->_eid1 = ElementId(ElementType::Way, 1);
+    match1->_eid2 = ElementId(ElementType::Node, 1);
+    matchesV.push_back(match1);
 
-    PoiPolygonMatch match2(std::shared_ptr<const MatchThreshold>(new MatchThreshold(0.6, 0.6, 0.6)));
-    match2._class.setMatch();
-    match2._eid1 = ElementId(ElementType::Way, 2);
-    match2._eid2 = ElementId(ElementType::Node, 1);
-    matchesV.push_back(&match2);
+    std::shared_ptr<PoiPolygonMatch> match2(new PoiPolygonMatch(std::shared_ptr<const MatchThreshold>(new MatchThreshold(0.6, 0.6, 0.6))));
+    match2->_class.setMatch();
+    match2->_eid1 = ElementId(ElementType::Way, 2);
+    match2->_eid2 = ElementId(ElementType::Node, 1);
+    matchesV.push_back(match2);
 
     MatchSet matches;
     matches.insert(matchesV.begin(), matchesV.end());

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/polygon/BuildingMatchCreatorTest.cpp
@@ -82,7 +82,7 @@ public:
     return map->getWay(wids[0]);
   }
 
-  bool contains(const vector<const Match*>& matches, ElementId eid1, ElementId eid2)
+  bool contains(const vector<ConstMatchPtr>& matches, ElementId eid1, ElementId eid2)
   {
     bool result = false;
     for (size_t i = 0; i < matches.size(); i++)
@@ -137,7 +137,7 @@ public:
     OsmMapPtr map = getTestMap();
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
 
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
     uut.createMatches(map, matches, threshold);
@@ -192,7 +192,7 @@ public:
     conf().set("building.review.if.secondary.newer", "true");
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
     uut.createMatches(map, matches, threshold);
     LOG_VARD(matches);
@@ -210,9 +210,9 @@ public:
      */
 
     CPPUNIT_ASSERT_EQUAL(3, int(matches.size()));
-    for (vector<const Match*>::const_iterator it = matches.begin(); it != matches.end(); ++it)
+    for (vector<ConstMatchPtr>::const_iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      const Match* match = *it;
+      ConstMatchPtr match = *it;
       std::set<std::pair<ElementId, ElementId>> matchPairs = match->getMatchPairs();
       LOG_VART(matchPairs.size());
       assert(matchPairs.size() == 1);
@@ -252,7 +252,7 @@ public:
     conf().set("building.review.if.secondary.newer", "true");
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
     uut.createMatches(map, matches, threshold);
 
@@ -280,7 +280,7 @@ public:
     conf().set("building.review.if.secondary.newer", "true");
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
     uut.createMatches(map, matches, threshold);
 
@@ -307,7 +307,7 @@ public:
     conf().set("building.review.if.secondary.newer", "true");
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
 
     QString exceptionMsg("");
@@ -329,15 +329,15 @@ public:
     conf().set("building.review.matches.other.than.one.to.one", "true");
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
     uut.createMatches(map, matches, threshold);
     LOG_VARD(matches);
 
     CPPUNIT_ASSERT_EQUAL(3, int(matches.size()));
-    for (vector<const Match*>::const_iterator it = matches.begin(); it != matches.end(); ++it)
+    for (vector<ConstMatchPtr>::const_iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      const Match* match = *it;
+      ConstMatchPtr match = *it;
       CPPUNIT_ASSERT_EQUAL(1.0, match->getClassification().getReviewP());
     }
   }
@@ -352,7 +352,7 @@ public:
     conf().set("building.review.matches.other.than.one.to.one", "true");
 
     BuildingMatchCreator uut;
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     std::shared_ptr<const MatchThreshold> threshold(new MatchThreshold(0.6, 0.6));
     uut.createMatches(map, matches, threshold);
     LOG_VARD(matches);
@@ -371,9 +371,9 @@ public:
      */
 
     CPPUNIT_ASSERT_EQUAL(7, int(matches.size()));
-    for (vector<const Match*>::const_iterator it = matches.begin(); it != matches.end(); ++it)
+    for (vector<ConstMatchPtr>::const_iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      const Match* match = *it;
+      ConstMatchPtr match = *it;
       std::set<std::pair<ElementId, ElementId>> matchPairs = match->getMatchPairs();
       LOG_VART(matchPairs.size());
       assert(matchPairs.size() == 1);

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitorTest.cpp
@@ -86,7 +86,7 @@ public:
 
   void runIsCandidateTest()
   {
-    std::vector<const Match*> result;
+    std::vector<ConstMatchPtr> result;
 
     OsmMapPtr map = getTestMap1();
     CPPUNIT_ASSERT(

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
@@ -28,17 +28,18 @@
 #define DIFFCONFLATOR_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/changeset/ChangesetDeriver.h>
 #include <hoot/core/algorithms/changeset/MemChangesetProvider.h>
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchGraph.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/info/SingleStat.h>
 #include <hoot/core/io/Serializable.h>
 #include <hoot/core/ops/OsmMapOperation.h>
 #include <hoot/core/util/Boundable.h>
-#include <hoot/core/info/SingleStat.h>
 #include <hoot/core/util/Configurable.h>
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/util/ProgressReporter.h>
+#include <hoot/core/util/Settings.h>
 
 // tgs
 #include <tgs/HashMap.h>
@@ -49,7 +50,6 @@
 namespace hoot
 {
 
-class Match;
 class MatchFactory;
 class MatchThreshold;
 
@@ -189,7 +189,7 @@ private:
   bool _conflateTags = false;
 
   // Stores the matches we found
-  std::vector<const Match*> _matches;
+  std::vector<ConstMatchPtr> _matches;
 
   // Stores stats calcuated during conflation
   QList<SingleStat> _stats;
@@ -206,26 +206,16 @@ private:
 
   Progress _progress;
 
-  template <typename InputCollection>
-  void _deleteAll(InputCollection& ic)
-  {
-    for (typename InputCollection::const_iterator it = ic.begin(); it != ic.end(); ++it)
-    {
-      delete *it;
-    }
-    ic.clear();
-  }
-
   /**
    * Cleans up any resources used by the object during conflation. This also makes exceptions that
    * might be thrown during apply() clean up the leftovers nicely (albeit delayed).
    */
   void _reset();
 
-  void _validateConflictSubset(const ConstOsmMapPtr& map, std::vector<const Match*> matches);
+  void _validateConflictSubset(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr> matches);
 
-  void _printMatches(std::vector<const Match*> matches);
-  void _printMatches(std::vector<const Match*> matches, const MatchType& typeFilter);
+  void _printMatches(std::vector<ConstMatchPtr> matches);
+  void _printMatches(std::vector<ConstMatchPtr> matches, const MatchType& typeFilter);
 
   ChangesetProviderPtr _getChangesetFromMap(OsmMapPtr pMap);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.h
@@ -28,15 +28,15 @@
 #define UNIFYINGCONFLATOR_H
 
 // hoot
+#include <hoot/core/conflate/matching/MatchGraph.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/info/SingleStat.h>
 #include <hoot/core/io/Serializable.h>
 #include <hoot/core/ops/OsmMapOperation.h>
 #include <hoot/core/util/Boundable.h>
 #include <hoot/core/util/Configurable.h>
-#include <hoot/core/util/Settings.h>
-#include <hoot/core/conflate/matching/MatchGraph.h>
-#include <hoot/core/info/SingleStat.h>
 #include <hoot/core/util/ProgressReporter.h>
+#include <hoot/core/util/Settings.h>
 
 // tgs
 #include <tgs/HashMap.h>
@@ -82,30 +82,30 @@ public:
    * Conflates the specified map. If the map is not in a planar projection it is reprojected. The
    * map is not reprojected back to the original projection when conflation is complete.
    */
-  virtual void apply(OsmMapPtr& map);
+  virtual void apply(OsmMapPtr& map) override;
 
-  virtual std::string getClassName() const { return className(); }
+  virtual std::string getClassName() const override { return className(); }
 
   QList<SingleStat> getStats() const { return _stats; }
 
-  virtual void readObject(QDataStream& /*is*/) {}
+  virtual void readObject(QDataStream& /*is*/) override {}
 
-  virtual void setBounds(const geos::geom::Envelope& bounds) { _bounds = bounds; }
+  virtual void setBounds(const geos::geom::Envelope& bounds) override { _bounds = bounds; }
 
-  virtual void setConfiguration(const Settings &conf);
+  virtual void setConfiguration(const Settings &conf) override;
 
   /**
    * Set the factory to use when creating mergers. This method is likely only useful when testing.
    */
   void setMergerFactory(const std::shared_ptr<MergerFactory>& mf) { _mergerFactory = mf; }
 
-  virtual void writeObject(QDataStream& /*os*/) const {}
+  virtual void writeObject(QDataStream& /*os*/) const override {}
 
-  virtual QString getDescription() const
+  virtual QString getDescription() const override
   { return "Conflates two inputs maps into one with Unifying Conflation"; }
 
-  virtual void setProgress(Progress progress) { _progress = progress; }
-  virtual unsigned int getNumSteps() const { return 3; }
+  virtual void setProgress(Progress progress) override { _progress = progress; }
+  virtual unsigned int getNumSteps() const override { return 3; }
 
 private:
 
@@ -115,13 +115,13 @@ private:
   std::shared_ptr<MergerFactory> _mergerFactory;
   Settings _settings;
   HashMap<ElementId, std::vector<Merger*>> _e2m;
-  std::vector<const Match*> _matches;
+  std::vector<ConstMatchPtr> _matches;
   std::vector<Merger*> _mergers;
   QList<SingleStat> _stats;
   int _taskStatusUpdateInterval;
   Progress _progress;
 
-  void _addReviewTags(const OsmMapPtr &map, const std::vector<const Match *> &matches);
+  void _addReviewTags(const OsmMapPtr &map, const std::vector<ConstMatchPtr> &matches);
   void _addScoreTags(const ElementPtr& e, const MatchClassification& mc);
 
   template <typename InputCollection>
@@ -144,7 +144,7 @@ private:
    */
   void _mapElementIdsToMergers();
 
-  void _removeWholeGroups(std::vector<const Match *> &matches, MatchSetVector &matchSets,
+  void _removeWholeGroups(std::vector<ConstMatchPtr> &matches, MatchSetVector &matchSets,
     const OsmMapPtr &map);
 
   void _replaceElementIds(const std::vector<std::pair<ElementId, ElementId>>& replaced);
@@ -155,10 +155,10 @@ private:
    */
   void _reset();
 
-  void _validateConflictSubset(const ConstOsmMapPtr& map, std::vector<const Match *> matches);
+  void _validateConflictSubset(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr> matches);
 
-  void _printMatches(std::vector<const Match*> matches);
-  void _printMatches(std::vector<const Match*> matches, const MatchType& typeFilter);
+  void _printMatches(std::vector<ConstMatchPtr> matches);
+  void _printMatches(std::vector<ConstMatchPtr> matches, const MatchType& typeFilter);
   QString _matchSetToString(const MatchSet& matchSet) const;
 
   void _updateProgress(const int currentStep, const QString message);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
@@ -30,24 +30,24 @@
 #include <geos/geom/LineString.h>
 
 // hoot
-#include <hoot/core/algorithms/splitter/MultiLineStringSplitter.h>
-#include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
-#include <hoot/core/algorithms/splitter/WaySplitter.h>
 #include <hoot/core/algorithms/aggregator/RmseAggregator.h>
 #include <hoot/core/algorithms/aggregator/SigmaAggregator.h>
-#include <hoot/core/algorithms/linearreference/WaySublineMatchString.h>
-#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
 #include <hoot/core/algorithms/extractors/AngleHistogramExtractor.h>
 #include <hoot/core/algorithms/extractors/EdgeDistanceExtractor.h>
+#include <hoot/core/algorithms/linearreference/WaySublineMatchString.h>
+#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
+#include <hoot/core/algorithms/splitter/MultiLineStringSplitter.h>
+#include <hoot/core/algorithms/splitter/WaySplitter.h>
+#include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
 #include <hoot/core/conflate/highway/HighwayClassifier.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/elements/ElementId.h>
-#include <hoot/core/ops/CopyMapSubsetOp.h>
-#include <hoot/core/util/GeometryConverter.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/elements/OsmUtils.h>
+#include <hoot/core/ops/CopyMapSubsetOp.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/GeometryConverter.h>
 
 using namespace std;
 
@@ -178,9 +178,9 @@ double HighwayMatch::getProbability() const
   return _c.getMatchP();
 }
 
-bool HighwayMatch::isConflicting(const Match& other, const ConstOsmMapPtr& map) const
+bool HighwayMatch::isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map) const
 {
-  const HighwayMatch* hm = dynamic_cast<const HighwayMatch*>(&other);
+  const HighwayMatch* hm = dynamic_cast<const HighwayMatch*>(other.get());
   // if the other match isn't a highway match then this is a conflict.
   if (hm == 0)
   {
@@ -190,7 +190,7 @@ bool HighwayMatch::isConflicting(const Match& other, const ConstOsmMapPtr& map) 
   else
   {
     // See ticket #5272
-    if (getClassification().getReviewP() == 1.0 || other.getClassification().getReviewP() == 1.0)
+    if (getClassification().getReviewP() == 1.0 || other->getClassification().getReviewP() == 1.0)
     {
       return true;
     }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.h
@@ -28,12 +28,12 @@
 #define HIGHWAYMATCH_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/WaySublineMatchString.h>
 #include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchDetails.h>
+#include <hoot/core/elements/OsmMap.h>
 
 // Qt
 #include <QHash>
@@ -60,34 +60,34 @@ public:
                const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
                ConstMatchThresholdPtr mt);
 
-  virtual QString explain() const;
+  virtual QString explain() const override;
 
-  virtual const MatchClassification& getClassification() const { return _c; }
+  virtual const MatchClassification& getClassification() const override { return _c; }
 
-  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const;
+  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const override;
 
-  virtual QString getMatchName() const { return getHighwayMatchName(); }
+  virtual QString getMatchName() const override { return getHighwayMatchName(); }
   static QString getHighwayMatchName() { return _matchName; }
 
-  virtual double getProbability() const;
+  virtual double getProbability() const override;
 
-  virtual double getScore() const { return _score; }
+  virtual double getScore() const override { return _score; }
 
   const std::shared_ptr<SublineStringMatcher>& getSublineMatcher() const
   { return _sublineMatcher; }
 
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& map) const;
+  virtual bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map) const override;
 
   /**
    * Simply returns the two elements that were matched.
    */
-  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const;
+  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const override;
 
   const WaySublineMatchString& getSublineMatch() const { return _sublineMatch; }
 
-  virtual QString toString() const;
+  virtual QString toString() const override;
 
-  virtual QString getDescription() const
+  virtual QString getDescription() const override
   { return "Matches roads with the 2nd Generation (Unifying) Algorithm"; }
 
 private:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -48,14 +48,14 @@ public:
   HighwayMatchCreator();
 
   /**
-   * Not implemented.
+   * Create the match
    */
-  virtual Match* createMatch(const ConstOsmMapPtr&, ElementId eid1, ElementId eid2);
+  virtual MatchPtr createMatch(const ConstOsmMapPtr&, ElementId eid1, ElementId eid2) override;
 
   /**
    * Search the provided map for highway matches and add the matches to the matches vector.
    */
-  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<const Match*>& matches,
+  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
     ConstMatchThresholdPtr threshold) override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
@@ -30,9 +30,9 @@
 #include <hoot/core/conflate/highway/HighwayMatch.h>
 #include <hoot/core/conflate/highway/HighwaySnapMerger.h>
 #include <hoot/core/conflate/highway/HighwayTagOnlyMerger.h>
+#include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/util/ConfigOptions.h>
 
 using namespace std;
 
@@ -59,9 +59,9 @@ bool HighwayMergerCreator::createMergers(const MatchSet& matches, vector<Merger*
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* m = *it;
+    ConstMatchPtr m = *it;
     LOG_VART(m->toString());
-    const HighwayMatch* hm = dynamic_cast<const HighwayMatch*>(m);
+    const HighwayMatch* hm = dynamic_cast<const HighwayMatch*>(m.get());
     // check to make sure all the input matches are building matches.
     if (hm == 0)
     {
@@ -107,15 +107,12 @@ vector<CreatorDescription> HighwayMergerCreator::getAllCreators() const
   return result;
 }
 
-bool HighwayMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Match* m1,
-  const Match* m2) const
+bool HighwayMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
+  ConstMatchPtr m2) const
 {
-  const HighwayMatch* hm1 = dynamic_cast<const HighwayMatch*>(m1);
-  const HighwayMatch* hm2 = dynamic_cast<const HighwayMatch*>(m2);
-
-  if (hm1 && hm2)
+  if (m1 && m2)
   {
-    const bool conflicting = hm1->isConflicting(*hm2, map);
+    const bool conflicting = m1->isConflicting(m2, map);
     if (conflicting)
     {
       LOG_TRACE("Conflicting matches: " << m1 << ", " << m2);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
@@ -110,8 +110,8 @@ vector<CreatorDescription> HighwayMergerCreator::getAllCreators() const
 bool HighwayMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
   ConstMatchPtr m2) const
 {
-  const HighwayMatch* hm1 = dynamic_cast<const HighwayMatch*>(m1);
-  const HighwayMatch* hm2 = dynamic_cast<const HighwayMatch*>(m2);
+  const HighwayMatch* hm1 = dynamic_cast<const HighwayMatch*>(m1.get());
+  const HighwayMatch* hm2 = dynamic_cast<const HighwayMatch*>(m2.get());
 
   if (hm1 && hm2)
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
@@ -110,7 +110,10 @@ vector<CreatorDescription> HighwayMergerCreator::getAllCreators() const
 bool HighwayMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
   ConstMatchPtr m2) const
 {
-  if (m1 && m2)
+  const HighwayMatch* hm1 = dynamic_cast<const HighwayMatch*>(m1);
+  const HighwayMatch* hm2 = dynamic_cast<const HighwayMatch*>(m2);
+
+  if (hm1 && hm2)
   {
     const bool conflicting = m1->isConflicting(m2, map);
     if (conflicting)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.h
@@ -49,9 +49,9 @@ public:
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const override;
 
-  virtual void setConfiguration(const Settings &conf);
+  virtual void setConfiguration(const Settings &conf) override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/ConstrainedMatches.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/ConstrainedMatches.h
@@ -28,8 +28,9 @@
 #define CONSTRAINEDMATCHES_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchConflicts.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/Configurable.h>
 
 // Standard
@@ -39,8 +40,6 @@
 
 namespace hoot
 {
-
-class Match;
 
 /**
  * A class for determining a subset of matches that meet a set of constraints (isConflicting) and
@@ -72,7 +71,7 @@ public:
    * scores. All matches will be considered so if you don't want matches below a threshold included
    * then don't add them.
    */
-  virtual std::vector<const Match*> calculateSubset() = 0;
+  virtual std::vector<ConstMatchPtr> calculateSubset() = 0;
 
   /**
    * Returns the score for the last calculateSubset operation.
@@ -86,7 +85,7 @@ public:
 protected:
 
   const ConstOsmMapPtr& _map;
-  std::vector<const Match*> _matches;
+  std::vector<ConstMatchPtr> _matches;
 
   MatchConflicts::ConflictMap _conflicts;
   double _score;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/GreedyConstrainedMatches.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/GreedyConstrainedMatches.cpp
@@ -46,7 +46,7 @@ class MatchComparator
 {
 public:
 
-  MatchComparator(const vector<const Match*>& matches) : _matches(matches) {}
+  MatchComparator(const vector<ConstMatchPtr>& matches) : _matches(matches) {}
 
   bool operator()(size_t i, size_t j)
   {
@@ -55,13 +55,13 @@ public:
 
 private:
 
-  const vector<const Match*>& _matches;
+  const vector<ConstMatchPtr>& _matches;
 };
 
-vector<const Match*> GreedyConstrainedMatches::calculateSubset()
+vector<ConstMatchPtr> GreedyConstrainedMatches::calculateSubset()
 {
   _score = -1;
-  vector<const Match*> result;
+  vector<ConstMatchPtr> result;
 
   if (_matches.size() == 0)
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/GreedyConstrainedMatches.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/GreedyConstrainedMatches.h
@@ -46,7 +46,7 @@ public:
 
   GreedyConstrainedMatches(const ConstOsmMapPtr& map);
 
-  virtual std::vector<const Match*> calculateSubset() override;
+  virtual std::vector<ConstMatchPtr> calculateSubset() override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
@@ -101,7 +101,7 @@ public:
    * Two matches can only be conflicting if they contain the same ElementIds in getMatchPairs().
    *
    */
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& map) const = 0;
+  virtual bool isConflicting(const std::shared_ptr<const Match>& other, const ConstOsmMapPtr& map) const = 0;
 
   /**
    * If the match should _not_ be optimized into a group of non-conflicting matches, then this
@@ -157,7 +157,10 @@ protected:
   const std::shared_ptr<const MatchThreshold> _threshold;
 };
 
-inline std::ostream& operator<<(std::ostream & o, const Match* m)
+typedef std::shared_ptr<Match> MatchPtr;
+typedef std::shared_ptr<const Match> ConstMatchPtr;
+
+inline std::ostream& operator<<(std::ostream & o, ConstMatchPtr m)
 {
   o << m->toString().toStdString();
   return o;
@@ -168,7 +171,7 @@ inline std::ostream& operator<<(std::ostream & o, const Match* m)
  */
 struct MatchPtrComparator
 {
-  bool operator() (const Match* m1, const Match* m2) const
+  bool operator() (ConstMatchPtr m1, ConstMatchPtr m2) const
   {
     return m1->_order < m2->_order;
   }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.cpp
@@ -45,8 +45,7 @@ MatchConflicts::MatchConflicts(const ConstOsmMapPtr& map) :
 {
 }
 
-MatchConflicts::EidIndexMap MatchConflicts::calculateEidIndexMap(
-  const vector<const Match*>& matches) const
+MatchConflicts::EidIndexMap MatchConflicts::calculateEidIndexMap(const std::vector<ConstMatchPtr>& matches) const
 {
   LOG_TRACE("Calculating element ID to index map...");
   EidIndexMap eidToMatches;
@@ -70,7 +69,7 @@ MatchConflicts::EidIndexMap MatchConflicts::calculateEidIndexMap(
   return eidToMatches;
 }
 
-void MatchConflicts::calculateMatchConflicts(const vector<const Match*>& matches,
+void MatchConflicts::calculateMatchConflicts(const std::vector<ConstMatchPtr>& matches,
   ConflictMap& conflicts)
 {
   LOG_VART(matches.size());
@@ -111,7 +110,7 @@ void MatchConflicts::calculateMatchConflicts(const vector<const Match*>& matches
   calculateSubsetConflicts(matches, conflicts, matchSet);
 }
 
-void MatchConflicts::calculateSubsetConflicts(const vector<const Match*>& matches,
+void MatchConflicts::calculateSubsetConflicts(const std::vector<ConstMatchPtr>& matches,
                                               ConflictMap& conflicts, const vector<int>& matchSet)
 {
   LOG_VART(matches.size());

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.h
@@ -28,6 +28,7 @@
 #define MATCHCONFLICTS_H
 
 // hoot
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/elements/OsmMap.h>
 
 // Qt
@@ -50,15 +51,15 @@ public:
 
   MatchConflicts(const ConstOsmMapPtr& map);
 
-  EidIndexMap calculateEidIndexMap(const std::vector<const Match*>& matches) const;
+  EidIndexMap calculateEidIndexMap(const std::vector<ConstMatchPtr>& matches) const;
 
   /**
    * Calculates all the conflicts between matches and puts the indexes to the conflicting pairs in
    * the provided conflicts set. conflicts is cleared before inserting conflicts.
    */
-  void calculateMatchConflicts(const std::vector<const Match*> &matches, ConflictMap& conflicts);
+  void calculateMatchConflicts(const std::vector<ConstMatchPtr>& matches, ConflictMap& conflicts);
 
-  void calculateSubsetConflicts(const std::vector<const Match*>& matches, ConflictMap& conflicts,
+  void calculateSubsetConflicts(const std::vector<ConstMatchPtr>& matches, ConflictMap& conflicts,
                                 const std::vector<int>& matchSet);
 
 private:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -28,6 +28,7 @@
 #define MATCHCREATOR_H
 
 // Hoot
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/info/CreatorDescription.h>
 
@@ -41,8 +42,6 @@
 namespace hoot
 {
 
-class Match;
-
 class MatchCreator
 {
 public:
@@ -55,12 +54,12 @@ public:
    * Given two elements, create a match if it is appropriate. If it is not appropriate then return
    * null.
    */
-  virtual Match* createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) = 0;
+  virtual MatchPtr createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) = 0;
 
   /**
    * Search the provided map for building matches and add the matches to the matches vector.
    */
-  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<const Match*>& matches,
+  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
     ConstMatchThresholdPtr threshold) = 0;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
@@ -54,14 +54,14 @@ MatchFactory::MatchFactory()
   setConfiguration(conf());
 }
 
-Match* MatchFactory::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const
+MatchPtr MatchFactory::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const
 {
   LOG_VART(eid1);
   LOG_VART(eid2);
 
   for (size_t i = 0; i < _creators.size(); ++i)
   {
-    Match* m = _creators[i]->createMatch(map, eid1, eid2);
+    MatchPtr m = _creators[i]->createMatch(map, eid1, eid2);
 
     if (m)
     {
@@ -72,7 +72,7 @@ Match* MatchFactory::createMatch(const ConstOsmMapPtr& map, ElementId eid1, Elem
   return 0;
 }
 
-void MatchFactory::createMatches(const ConstOsmMapPtr& map, vector<const Match*>& matches,
+void MatchFactory::createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
   const Envelope& bounds, std::shared_ptr<const MatchThreshold> threshold) const
 {
   for (size_t i = 0; i < _creators.size(); ++i)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -29,6 +29,7 @@
 
 // hoot
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/util/Configurable.h>
 
@@ -38,7 +39,6 @@
 namespace hoot
 {
 
-class Match;
 class MatchThreshold;
 
 /**
@@ -62,13 +62,13 @@ public:
    * a match by any MatchCreator a null is returned. Not all MatchCreators are guaranteed to support
    * this mechanism (e.g. a road that matches two one way streets).
    */
-  Match* createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const;
+  MatchPtr createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const;
 
   /**
    * Goes through all registered MatchCreators and calls createMatches in the order the creators
    * were registered.
    */
-  void createMatches(const ConstOsmMapPtr& map, std::vector<const Match *> &matches,
+  void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr> &matches,
     const geos::geom::Envelope &bounds,
     std::shared_ptr<const MatchThreshold> threshold = std::shared_ptr<MatchThreshold>()) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
@@ -68,7 +68,7 @@ class MatchEdge
 public:
 
   MatchEdge() : match(0) {}
-  MatchEdge(const Match* m) : match(m) {}
+  MatchEdge(ConstMatchPtr m) : match(m) {}
 
   typedef enum
   {
@@ -76,7 +76,7 @@ public:
     MatchWith
   } MatchType;
 
-  const Match* match;
+  ConstMatchPtr match;
   MatchType type;
 };
 
@@ -108,7 +108,7 @@ class MatchGraphInternal
 {
 public:
 
-  MatchGraphInternal(const vector<const Match*>& matches) : _matches(matches) {}
+  MatchGraphInternal(const vector<ConstMatchPtr>& matches) : _matches(matches) {}
 
   /**
    * Only return true for edges that are matches and meet the specified threshold.
@@ -128,7 +128,7 @@ public:
     bool operator()(const MatchEdgeId& edgeId) const
     {
       MatchEdge::MatchType type = (*_graph)[edgeId].type;
-      const Match* m = (*_graph)[edgeId].match;
+      ConstMatchPtr m = (*_graph)[edgeId].match;
       return (type == MatchEdge::MatchWith && m->getProbability() >= _threshold);
     }
 
@@ -161,7 +161,7 @@ public:
 
     for (size_t i = 0; i < _matches.size(); i++)
     {
-      const Match* m = _matches[i];
+      ConstMatchPtr m = _matches[i];
       MatchType type = m->getType();
       // if this is a solid match, then add it into the group.
       if (type == MatchType::Match)
@@ -200,10 +200,10 @@ public:
       // while this is O(n^2) matches should generally be pretty small.
       for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
       {
-        const Match* m1 = *it;
+        ConstMatchPtr m1 = *it;
         for (MatchSet::const_iterator jt = matches.begin(); jt != matches.end(); ++jt)
         {
-          const Match* m2 = *jt;
+          ConstMatchPtr m2 = *jt;
           if (m1 != m2)
           {
             if (checkForConflicts && MergerFactory::getInstance().isConflicting(map, m1, m2))
@@ -231,7 +231,7 @@ public:
     {
       for (size_t i = 0; i < _matches.size(); i++)
       {
-        const Match* m = _matches[i];
+        ConstMatchPtr m = _matches[i];
         _addMatchWith(m);
       }
     }
@@ -247,9 +247,9 @@ private:
 
   MatchBoostGraph _graph;
   QHash<ElementId, MatchVertexId> _eid2Vertex;
-  const vector<const Match*>& _matches;
+  const vector<ConstMatchPtr>& _matches;
 
-  void _addMatchWith(const Match* m)
+  void _addMatchWith(ConstMatchPtr m)
   {
     MatchEdge matchWith(m);
     matchWith.type = MatchEdge::MatchWith;
@@ -282,7 +282,7 @@ private:
     for (boost::tie(ei, eend) = out_edges(mvi, _graph); ei != eend; ++ei)
     {
       const MatchEdge& edge = _graph[*ei];
-      const Match* match = edge.match;
+      ConstMatchPtr match = edge.match;
       if (match->getType() == MatchType::Match)
       {
         matches.insert(match);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
@@ -28,6 +28,7 @@
 #define MATCHGRAPH_H
 
 // Hoot
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
 
 // Standard
@@ -38,7 +39,6 @@
 namespace hoot
 {
 
-class Match;
 class MatchGraphInternal;
 
 typedef std::vector<MatchSet> MatchSetVector;
@@ -84,7 +84,7 @@ public:
 
 private:
 
-  std::vector<const Match*> _matches;
+  std::vector<ConstMatchPtr> _matches;
   bool _checkForConflicts;
   /**
    * An internal data structure to prevent users of the class from recompiling the boost graph

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchSet.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchSet.h
@@ -36,7 +36,7 @@
 namespace hoot
 {
 
-typedef std::set<const Match*, MatchPtrComparator> MatchSet;
+typedef std::set<ConstMatchPtr, MatchPtrComparator> MatchSet;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/OptimalConstrainedMatches.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/OptimalConstrainedMatches.cpp
@@ -43,10 +43,10 @@ OptimalConstrainedMatches::OptimalConstrainedMatches(const ConstOsmMapPtr& map) 
   _timeLimit = -1;
 }
 
-vector<const Match*> OptimalConstrainedMatches::calculateSubset()
+std::vector<ConstMatchPtr> OptimalConstrainedMatches::calculateSubset()
 {
   _score = -1;
-  vector<const Match*> result;
+  vector<ConstMatchPtr> result;
 
   if (_matches.size() == 0)
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/OptimalConstrainedMatches.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/OptimalConstrainedMatches.h
@@ -53,7 +53,7 @@ public:
    * scores. All matches will be considered so if you don't want matches below a threshold included
    * then don't add them.
    */
-  virtual std::vector<const Match*> calculateSubset() override;
+  virtual std::vector<ConstMatchPtr> calculateSubset() override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.cpp
@@ -59,7 +59,7 @@ bool MarkForReviewMergerCreator::createMergers(const MatchSet& matches,
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* match = *it;
+    ConstMatchPtr match = *it;
     LOG_VART(match->toString());
     MatchType type = match->getType();
     LOG_VART(type);
@@ -107,7 +107,7 @@ vector<CreatorDescription> MarkForReviewMergerCreator::getAllCreators() const
   return vector<CreatorDescription>();
 }
 
-bool MarkForReviewMergerCreator::isConflicting(const ConstOsmMapPtr&, const Match*, const Match*)
+bool MarkForReviewMergerCreator::isConflicting(const ConstOsmMapPtr&, ConstMatchPtr, ConstMatchPtr)
   const
 {
   return false;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.h
@@ -45,7 +45,7 @@ public:
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerCreator.h
@@ -28,8 +28,9 @@
 #define MERGECREATOR_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/info/CreatorDescription.h>
 
 // Standard
@@ -40,7 +41,6 @@
 namespace hoot
 {
 
-class Match;
 class Merger;
 
 /**
@@ -76,7 +76,7 @@ public:
    * Returns true if m1 and m2 are conflicting. If the MergerCreator has no information on the two
    * input matches then false is returned.
    */
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const = 0;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const = 0;
 
   virtual void setArguments(QStringList /*args*/) { throw IllegalArgumentException(); }
 };

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
@@ -137,8 +137,8 @@ MergerFactory& MergerFactory::getInstance()
   return *_theInstance;
 }
 
-bool MergerFactory::isConflicting(const ConstOsmMapPtr& map, const Match* m1,
-                                  const Match* m2) const
+bool MergerFactory::isConflicting(const ConstOsmMapPtr& map, const ConstMatchPtr& m1,
+                                  const ConstMatchPtr& m2) const
 {
   LOG_VART(_creators.size());
   // if any creator considers a match conflicting then it is a conflict

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
@@ -84,7 +84,8 @@ public:
    */
   static MergerFactory& getInstance();
 
-  bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  bool isConflicting(const ConstOsmMapPtr& map,  const ConstMatchPtr& m1,
+                     const ConstMatchPtr& m2) const;
 
   /**
    * Registers the specified creator with the MergeFactory and takes ownership of the creator.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.cpp
@@ -27,9 +27,9 @@
 #include "NetworkMatch.h"
 
 // hoot
-#include <hoot/core/util/Log.h>
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/Log.h>
 
 // Standard
 #include <math.h>
@@ -148,9 +148,9 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
   LOG_VART(_pairs);
 }
 
-bool NetworkMatch::isConflicting(const Match& other, const ConstOsmMapPtr& /*map*/) const
+bool NetworkMatch::isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& /*map*/) const
 {
-  set<pair<ElementId, ElementId>> s = other.getMatchPairs();
+  set<pair<ElementId, ElementId>> s = other->getMatchPairs();
 
   // if any element ids overlap then they're conflicting.
   for (set<pair<ElementId, ElementId>>::const_iterator it = s.begin(); it != s.end(); ++it)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.h
@@ -54,7 +54,7 @@ public:
   /**
    * Classifies the match and returns a classification object.
    */
-  virtual const MatchClassification& getClassification() const { return _classification; }
+  virtual const MatchClassification& getClassification() const override { return _classification; }
 
   ConstNetworkDetailsPtr getNetworkDetails() const { return _details; }
 
@@ -64,28 +64,28 @@ public:
    * This may require modification if the network matcher ever matches things besides lines. E.g.
    * river polygons.
    */
-  virtual MatchMembers getMatchMembers() const { return MatchMembers::Polyline; }
+  virtual MatchMembers getMatchMembers() const override { return MatchMembers::Polyline; }
 
   /**
    * As new network matching routines are introduced this will need to be modified. E.g. Railway
    */
-  virtual QString getMatchName() const { return HighwayMatch::getHighwayMatchName(); }
+  virtual QString getMatchName() const override { return HighwayMatch::getHighwayMatchName(); }
 
-  virtual double getScore() const { return getProbability(); }
+  virtual double getScore() const override { return getProbability(); }
 
-  virtual double getProbability() const { return _classification.getMatchP(); }
+  virtual double getProbability() const override { return _classification.getMatchP(); }
 
   /**
    * Returns true if any of the elements in this are also in other's match pairs.
    */
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& map) const;
+  virtual bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map) const override;
 
   /**
    * Returns true if either of the matched strings contains a non-whole edge.
    */
   bool isPartialMatch() const { return _edgeMatch->containsPartial(); }
 
-  virtual bool isWholeGroup() const { return true; }
+  virtual bool isWholeGroup() const override { return true; }
 
   /**
    * Returns a set of pairs that this match represents. For instance, if this match represents
@@ -100,17 +100,17 @@ public:
    * In general Unknown1 should be the status of the first element and Unknown2 the status of the
    * second element.
    */
-  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const { return _pairs; }
+  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const override { return _pairs; }
 
-  virtual QString toString() const;
+  virtual QString toString() const override;
 
-  virtual MatchType getType() const { return _threshold->getType(getClassification()); }
+  virtual MatchType getType() const override { return _threshold->getType(getClassification()); }
 
   bool isVerySimilarTo(const NetworkMatch* other) const;
 
   bool contains(const NetworkMatch* other) const;
 
-  virtual QString getDescription() const { return "Matches roads with the Network Algorithm"; }
+  virtual QString getDescription() const override { return "Matches roads with the Network Algorithm"; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
@@ -27,25 +27,25 @@
 #include "NetworkMatchCreator.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/util/MapProjector.h>
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
-#include <hoot/core/elements/ConstElementVisitor.h>
+#include <hoot/core/conflate/network/NetworkMatch.h>
+#include <hoot/core/conflate/network/NetworkMatcher.h>
+#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/ChainCriterion.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/criterion/StatusCriterion.h>
+#include <hoot/core/elements/ConstElementVisitor.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/network/NetworkMatch.h>
-#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
-#include <hoot/core/conflate/network/NetworkMatcher.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/util/StringUtils.h>
+#include <hoot/core/util/NotImplementedException.h>
 
 // Standard
 #include <fstream>
@@ -72,23 +72,22 @@ _matchScoringFunctionCurveSteepness(ConfigOptions().getNetworkMatchScoringFuncti
   _userCriterion.reset(new HighwayCriterion());
 }
 
-Match* NetworkMatchCreator::createMatch(const ConstOsmMapPtr& /*map*/, ElementId /*eid1*/,
+MatchPtr NetworkMatchCreator::createMatch(const ConstOsmMapPtr& /*map*/, ElementId /*eid1*/,
   ElementId /*eid2*/)
 {
-  Match* result = 0;
-  return result;
+  return MatchPtr();
 }
 
-const Match* NetworkMatchCreator::_createMatch(const NetworkDetailsPtr& map, NetworkEdgeScorePtr e,
+ConstMatchPtr NetworkMatchCreator::_createMatch(const NetworkDetailsPtr& map, NetworkEdgeScorePtr e,
   ConstMatchThresholdPtr mt)
 {
-  return
+  return ConstMatchPtr(
     new NetworkMatch(
       map, e->getEdgeMatch(), e->getScore(), mt, _matchScoringFunctionMax,
-      _matchScoringFunctionCurveMidpointX, _matchScoringFunctionCurveSteepness);
+      _matchScoringFunctionCurveMidpointX, _matchScoringFunctionCurveSteepness));
 }
 
-void NetworkMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const Match*>& matches,
+void NetworkMatchCreator::createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
   ConstMatchThresholdPtr threshold)
 {
   QElapsedTimer timer;
@@ -163,7 +162,7 @@ void NetworkMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const 
     if (edgeMatch[i]->getScore() > matcher->getMatchThreshold())
     {
       LOG_VART(edgeMatch[i]->getEdgeMatch()->getUid());
-      const Match* match = _createMatch(details, edgeMatch[i], threshold);
+      ConstMatchPtr match = _createMatch(details, edgeMatch[i], threshold);
       LOG_VART(match);
       matches.push_back(match);
     }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.h
@@ -29,9 +29,9 @@
 
 // hoot
 #include <hoot/core/conflate/matching/MatchCreator.h>
-#include <hoot/core/criterion/ElementCriterion.h>
 #include <hoot/core/conflate/network/NetworkDetails.h>
 #include <hoot/core/conflate/network/NetworkEdgeScore.h>
+#include <hoot/core/criterion/ElementCriterion.h>
 
 namespace hoot
 {
@@ -45,12 +45,12 @@ public:
 
   NetworkMatchCreator();
 
-  virtual Match* createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2);
+  virtual MatchPtr createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2);
 
   /**
    * Search the provided map for network matches and add the matches to the matches vector.
    */
-  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<const Match*>& matches,
+  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
                              ConstMatchThresholdPtr threshold) override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
@@ -68,7 +68,7 @@ private:
   double _matchScoringFunctionCurveMidpointX;
   double _matchScoringFunctionCurveSteepness;
 
-  const Match* _createMatch(const NetworkDetailsPtr &map, NetworkEdgeScorePtr e,
+  ConstMatchPtr _createMatch(const NetworkDetailsPtr &map, NetworkEdgeScorePtr e,
     ConstMatchThresholdPtr mt);
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
@@ -27,8 +27,9 @@
 #include "NetworkMergerCreator.h"
 
 // hoot
-#include <hoot/core/conflate/matching/MatchThreshold.h>
+#include <hoot/core/conflate/highway/HighwayTagOnlyMerger.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
+#include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/merging/MarkForReviewMerger.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
 #include <hoot/core/conflate/network/NetworkMatch.h>
@@ -36,7 +37,6 @@
 #include <hoot/core/conflate/polygon/BuildingMatch.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/highway/HighwayTagOnlyMerger.h>
 
 // Standard
 #include <typeinfo>
@@ -64,7 +64,7 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
   {
     for (MatchSet::const_iterator it = matchesIn.begin(); it != matchesIn.end(); ++it)
     {
-      const NetworkMatch* nmi = dynamic_cast<const NetworkMatch*>(*it);
+      const NetworkMatch* nmi = dynamic_cast<const NetworkMatch*>(it->get());
       if (nmi)
       {
         matchesList += nmi->getEdgeMatch()->getUid() + " ";
@@ -79,7 +79,7 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
 
   bool result = false;
   assert(matches.size() > 0);
-  const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(*matches.begin());
+  const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(matches.begin()->get());
   if (m)
   {
     const bool matchOverlap = _containsOverlap(matches);
@@ -91,9 +91,9 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
       QSet<ConstEdgeMatchPtr> edgeMatches;
       int count = 0;
       set<pair<ElementId, ElementId>> pairs;
-      foreach (const Match* itm, matches)
+      foreach (ConstMatchPtr itm, matches)
       {
-        const NetworkMatch* nm = dynamic_cast<const NetworkMatch*>(itm);
+        const NetworkMatch* nm = dynamic_cast<const NetworkMatch*>(itm.get());
         edgeMatches.insert(nm->getEdgeMatch());
         set<pair<ElementId, ElementId>> p = nm->getMatchPairs();
         pairs.insert(p.begin(), p.end());
@@ -186,7 +186,7 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
             }
             LOG_VART(eids);
 
-            const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(*it);
+            const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(it->get());
             mergers.push_back(
               new MarkForReviewMerger(
                 eids,
@@ -231,17 +231,17 @@ bool NetworkMergerCreator::_containsOverlap(const MatchSet& matches) const
 {
   bool matchOverlap = false;
   assert(matches.size() > 0);
-  const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(*matches.begin());
+  const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(matches.begin()->get());
   if (m)
   {
     for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      const NetworkMatch* nmi = dynamic_cast<const NetworkMatch*>(*it);
+      const NetworkMatch* nmi = dynamic_cast<const NetworkMatch*>(it->get());
 
       MatchSet::const_iterator jt = it;
       for (++jt; jt != matches.end(); ++jt)
       {
-        const NetworkMatch* nmj = dynamic_cast<const NetworkMatch*>(*jt);
+        const NetworkMatch* nmj = dynamic_cast<const NetworkMatch*>(jt->get());
 
         // Sanity check to make sure our matches
         if (!nmi || !nmj)
@@ -276,12 +276,12 @@ double NetworkMergerCreator::_getOverlapPercent(const MatchSet& matches) const
 
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const NetworkMatch* nmi = dynamic_cast<const NetworkMatch*>(*it);
+    const NetworkMatch* nmi = dynamic_cast<const NetworkMatch*>(it->get());
 
     MatchSet::const_iterator jt = it;
     for (++jt; jt != matches.end(); ++jt)
     {
-      const NetworkMatch* nmj = dynamic_cast<const NetworkMatch*>(*jt);
+      const NetworkMatch* nmj = dynamic_cast<const NetworkMatch*>(jt->get());
       LOG_TRACE(nmi->getEdgeMatch()->getUid() << ":" << nmj->getEdgeMatch()->getUid());
       double percent = _getOverlapPercent(nmi, nmj);
       LOG_VART(percent);
@@ -375,11 +375,11 @@ const NetworkMatch* NetworkMergerCreator::_getLargest(const MatchSet& matches) c
     return 0;
   }
 
-  const NetworkMatch* largest = dynamic_cast<const NetworkMatch*>(*matches.begin());
+  const NetworkMatch* largest = dynamic_cast<const NetworkMatch*>(matches.begin()->get());
   double longestLen = 0.0;
-  foreach (const Match* m, matches)
+  foreach (ConstMatchPtr m, matches)
   {
-    const NetworkMatch* nm = dynamic_cast<const NetworkMatch*>(m);
+    const NetworkMatch* nm = dynamic_cast<const NetworkMatch*>(m.get());
 
     double testLen = nm->getEdgeMatch()->getString1()->calculateLength(_map->shared_from_this());
     if (testLen > longestLen)
@@ -399,9 +399,9 @@ const NetworkMatch* NetworkMergerCreator::_getLargestContainer(const MatchSet& m
   const NetworkMatch* largest = _getLargest(matches);
 
   // Figure out if the largest contains the rest
-  foreach (const Match* m, matches)
+  foreach (ConstMatchPtr m, matches)
   {
-    const NetworkMatch* nm = dynamic_cast<const NetworkMatch*>(m);
+    const NetworkMatch* nm = dynamic_cast<const NetworkMatch*>(m.get());
     if (nm != largest && largest->getEdgeMatch()->contains(nm->getEdgeMatch()) == false)
     {
       LOG_TRACE("No largest match found.");
@@ -413,13 +413,13 @@ const NetworkMatch* NetworkMergerCreator::_getLargestContainer(const MatchSet& m
   return largest;
 }
 
-bool NetworkMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Match* m1,
-  const Match* m2) const
+bool NetworkMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
+  ConstMatchPtr m2) const
 {
   bool result = false;
-  if (dynamic_cast<const NetworkMatch*>(m1) || dynamic_cast<const NetworkMatch*>(m2))
+  if (dynamic_cast<const NetworkMatch*>(m1.get()) || dynamic_cast<const NetworkMatch*>(m2.get()))
   {
-    result = m1->isConflicting(*m2, map);
+    result = m1->isConflicting(m2, map);
   }
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.h
@@ -28,8 +28,8 @@
 #define NETWORKMERGERCREATOR_H
 
 // hoot
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
 #include <hoot/core/conflate/merging/MergerCreator.h>
+#include <hoot/core/elements/ConstOsmMapConsumer.h>
 
 namespace hoot
 {
@@ -44,13 +44,13 @@ public:
 
   NetworkMergerCreator();
 
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const;
+  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
 
-  virtual std::vector<CreatorDescription> getAllCreators() const;
+  virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const override;
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map; }
+  virtual void setOsmMap(const OsmMap* map) override { _map = map; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.h
@@ -88,7 +88,7 @@ public:
   virtual double getProbability() const override { return _class.getMatchP(); }
 
   // Is the right implementation for this?
-  virtual bool isConflicting(const Match& /*other*/, const ConstOsmMapPtr& /*map*/) const override
+  virtual bool isConflicting(const ConstMatchPtr& /*other*/, const ConstOsmMapPtr& /*map*/) const override
   { return false; }
 
   virtual bool isWholeGroup() const override { return true; }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -45,7 +45,7 @@ PoiPolygonMatchCreator::PoiPolygonMatchCreator()
 {
 }
 
-Match* PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1,
+MatchPtr PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1,
                                            ElementId eid2)
 {
   if (!_infoCache)
@@ -54,7 +54,7 @@ Match* PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId 
     _infoCache.reset(new PoiPolygonCache(map));
   }
 
-  PoiPolygonMatch* result = 0;
+  std::shared_ptr<PoiPolygonMatch> result;
 
   if (eid1.getType() != eid2.getType())
   {
@@ -65,7 +65,7 @@ Match* PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId 
     const bool foundPoly = _polyCrit.isSatisfied(e1) || _polyCrit.isSatisfied(e2);
     if (foundPoi && foundPoly)
     {
-      result = new PoiPolygonMatch(map, getMatchThreshold(), _getRf(), _infoCache);
+      result.reset(new PoiPolygonMatch(map, getMatchThreshold(), _getRf(), _infoCache));
       result->setConfiguration(conf());
       result->calculateMatch(eid1, eid2);
     }
@@ -75,7 +75,7 @@ Match* PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId 
 }
 
 void PoiPolygonMatchCreator::createMatches(const ConstOsmMapPtr& map,
-                                           std::vector<const Match*>& matches,
+                                           std::vector<ConstMatchPtr>& matches,
                                            ConstMatchThresholdPtr threshold)
 {
   LOG_INFO("Looking for matches with: " << className() << "...");

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.h
@@ -48,15 +48,15 @@ public:
 
   PoiPolygonMatchCreator();
 
-  virtual Match* createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2);
+  virtual MatchPtr createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) override;
 
   /**
    * Search the provided map for POI/Polygon matches and add the matches to the matches vector.
    */
-  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<const Match*>& matches,
-                             ConstMatchThresholdPtr threshold);
+  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
+                             ConstMatchThresholdPtr threshold) override;
 
-  virtual std::vector<CreatorDescription> getAllCreators() const;
+  virtual std::vector<CreatorDescription> getAllCreators() const override;
 
   /**
    * Determines whether an element is a candidate for matching for this match creator
@@ -65,9 +65,9 @@ public:
    * @param map the map the element whose candidacy is being determined belongs to
    * @return true if the element is a match candidate; false otherwise
    */
-  virtual bool isMatchCandidate(ConstElementPtr element, const ConstOsmMapPtr& map);
+  virtual bool isMatchCandidate(ConstElementPtr element, const ConstOsmMapPtr& map) override;
 
-  virtual std::shared_ptr<MatchThreshold> getMatchThreshold();
+  virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
@@ -55,7 +55,7 @@ _allowCrossConflationMerging(ConfigOptions().getPoiPolygonAllowCrossConflationMe
   LOG_VARD(_allowCrossConflationMerging);
 }
 
-Match* PoiPolygonMergerCreator::_createMatch(const ConstOsmMapPtr& map, ElementId eid1,
+MatchPtr PoiPolygonMergerCreator::_createMatch(const ConstOsmMapPtr& map, ElementId eid1,
   ElementId eid2) const
 {
   return MatchFactory::getInstance().createMatch(map, eid1, eid2);
@@ -74,7 +74,7 @@ bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merg
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* m = *it;
+    ConstMatchPtr m = *it;
     LOG_VART(m->toString());
     if (m->getMatchMembers() & MatchMembers::Poi)
     {
@@ -105,7 +105,7 @@ bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merg
     // go through all the matches
     for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      const Match* m = *it;
+      ConstMatchPtr m = *it;
       LOG_VART(m->toString());
 
       //All of the other merger creators check the type of the match and do nothing if it isn't
@@ -146,8 +146,8 @@ vector<CreatorDescription> PoiPolygonMergerCreator::getAllCreators() const
   return result;
 }
 
-bool PoiPolygonMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Match* m1,
-  const Match* m2) const
+bool PoiPolygonMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
+  ConstMatchPtr m2) const
 {
   LOG_VART(m1);
   LOG_VART(m2);
@@ -248,7 +248,7 @@ bool PoiPolygonMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Mat
   // if you don't dereference the m1/m2 pointers it always returns Match as the typeid. Odd.
   else if (typeid(*m1) == typeid(*m2))
   {
-    result = m1->isConflicting(*m2, map);
+    result = m1->isConflicting(m2, map);
     LOG_TRACE("type ids match; conflict=" << result);
   }
   else
@@ -269,11 +269,11 @@ bool PoiPolygonMergerCreator::_isConflictingSet(const MatchSet& matches) const
 
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* m1 = *it;
+    ConstMatchPtr m1 = *it;
     LOG_VART(m1);
     for (MatchSet::const_iterator jt = matches.begin(); jt != matches.end(); ++jt)
     {
-      const Match* m2 = *jt;
+      ConstMatchPtr m2 = *jt;
       LOG_VART(m2);
 
       if (m1 != m2)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.h
@@ -28,10 +28,10 @@
 #define POIPOLYGONMERGERCREATOR_H
 
 // hoot
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
 #include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h>
 #include <hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h>
+#include <hoot/core/elements/ConstOsmMapConsumer.h>
 
 namespace hoot
 {
@@ -53,13 +53,13 @@ public:
    * appended. If there is more than one match and at least one is a PoiPolygonMatch then a
    * MarkForReviewMerger is created.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const;
+  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
 
-  virtual std::vector<CreatorDescription> getAllCreators() const;
+  virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const override;
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map; }
+  virtual void setOsmMap(const OsmMap* map) override { _map = map; }
 
   void setAllowCrossConflationMerging(bool allow) { _allowCrossConflationMerging = allow; }
 
@@ -77,7 +77,7 @@ private:
   PoiPolygonPoiCriterion _poiCrit;
   PoiPolygonPolyCriterion _polyCrit;
 
-  Match* _createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const;
+  MatchPtr _createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const;
 
   /**
    * Returns true if one or more matches are conflicting matches.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
@@ -28,15 +28,15 @@
 
 // hoot
 #include <hoot/core/algorithms/aggregator/QuantileAggregator.h>
+#include <hoot/core/algorithms/extractors/AngleHistogramExtractor.h>
 #include <hoot/core/algorithms/extractors/EdgeDistanceExtractor.h>
 #include <hoot/core/algorithms/extractors/OverlapExtractor.h>
 #include <hoot/core/algorithms/extractors/SmallerOverlapExtractor.h>
-#include <hoot/core/algorithms/extractors/AngleHistogramExtractor.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/conflate/polygon/BuildingRfClassifier.h>
+#include <hoot/core/elements/OsmUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Factory.h>
-#include <hoot/core/elements/OsmUtils.h>
 
 // Qt
 #include <QDateTime>
@@ -255,9 +255,9 @@ double BuildingMatch::getProbability() const
   return _p.getMatchP();
 }
 
-bool BuildingMatch::isConflicting(const Match& other, const ConstOsmMapPtr& /*map*/) const
+bool BuildingMatch::isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& /*map*/) const
 {
-  const BuildingMatch* bm = dynamic_cast<const BuildingMatch*>(&other);
+  const BuildingMatch* bm = dynamic_cast<const BuildingMatch*>(other.get());
   if (bm == 0)
   {
     return true;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.h
@@ -28,11 +28,11 @@
 #define BUILDINGMATCH_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchDetails.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/matching/MatchClassification.h>
+#include <hoot/core/elements/OsmMap.h>
 
 namespace hoot
 {
@@ -55,32 +55,32 @@ public:
   BuildingMatch(const ConstOsmMapPtr& map, const std::shared_ptr<const BuildingRfClassifier>& rf,
                 const ElementId& eid1, const ElementId& eid2, const ConstMatchThresholdPtr& mt);
 
-  virtual const MatchClassification& getClassification() const { return _p; }
+  virtual const MatchClassification& getClassification() const override { return _p; }
 
-  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const;
+  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const override;
 
-  virtual MatchMembers getMatchMembers() const { return MatchMembers::Polygon; }
+  virtual MatchMembers getMatchMembers() const override { return MatchMembers::Polygon; }
 
-  virtual QString getMatchName() const { return _matchName; }
+  virtual QString getMatchName() const override { return _matchName; }
 
-  virtual double getProbability() const;
+  virtual double getProbability() const override;
 
   /**
    * Building matches never conflict other building matches, but conflict with everything else.
    */
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& map) const;
+  virtual bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map) const override;
 
   /**
    * Simply returns the two elements that were matched.
    */
-  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const;
+  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const override;
 
-  virtual QString toString() const;
+  virtual QString toString() const override;
 
-  virtual QString explain() const { return _explainText; }
+  virtual QString explain() const override { return _explainText; }
   virtual void setExplain(const QString& explainText) override { _explainText = explainText; }
 
-  virtual QString getDescription() const { return "Matches buildings"; }
+  virtual QString getDescription() const override { return "Matches buildings"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -73,7 +73,7 @@ class BuildingMatchVisitor : public ConstElementVisitor
 {
 public:
 
-  BuildingMatchVisitor(const ConstOsmMapPtr& map, std::vector<const Match*>& result,
+  BuildingMatchVisitor(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& result,
                        ElementCriterionPtr filter = ElementCriterionPtr()) :
   _map(map),
   _result(result),
@@ -85,7 +85,7 @@ public:
    * @param matchStatus If the element's status matches this status then it is checked for a match.
    */
   BuildingMatchVisitor(const ConstOsmMapPtr& map,
-    std::vector<const Match*>& result, std::shared_ptr<BuildingRfClassifier> rf,
+    std::vector<ConstMatchPtr>& result, std::shared_ptr<BuildingRfClassifier> rf,
     ConstMatchThresholdPtr threshold, ElementCriterionPtr filter = ElementCriterionPtr(),
     Status matchStatus = Status::Invalid) :
     _map(map),
@@ -129,7 +129,7 @@ public:
     _elementsEvaluated++;
     int neighborCount = 0;
 
-    std::vector<Match*> tempMatches;
+    std::vector<MatchPtr> tempMatches;
 
     for (std::set<ElementId>::const_iterator it = neighbors.begin(); it != neighbors.end(); ++it)
     {
@@ -140,13 +140,9 @@ public:
         if (isRelated(neighbor, e))
         {
           // score each candidate and push it on the result vector
-          BuildingMatch* match = createMatch(from, neighborId);
+          std::shared_ptr<BuildingMatch> match = createMatch(from, neighborId);
           // if we're confident this is a miss
-          if (match->getType() == MatchType::Miss)
-          {
-            delete match;
-          }
-          else
+          if (match->getType() != MatchType::Miss)
           {
             tempMatches.push_back(match);
             neighborCount++;
@@ -160,7 +156,7 @@ public:
       _markNonOneToOneMatchesAsReview(tempMatches);
     }
 
-    for (std::vector<Match*>::const_iterator it = tempMatches.begin(); it != tempMatches.end(); ++it)
+    for (std::vector<MatchPtr>::const_iterator it = tempMatches.begin(); it != tempMatches.end(); ++it)
     {
       _result.push_back(*it);
     }
@@ -169,9 +165,9 @@ public:
     _neighborCountMax = std::max(_neighborCountMax, neighborCount);
   }
 
-  BuildingMatch* createMatch(ElementId eid1, ElementId eid2)
+  std::shared_ptr<BuildingMatch> createMatch(ElementId eid1, ElementId eid2)
   {
-    return new BuildingMatch(_map, _rf, eid1, eid2, _mt);
+    return std::shared_ptr<BuildingMatch>(new BuildingMatch(_map, _rf, eid1, eid2, _mt));
   }
 
   static bool isRelated(ConstElementPtr e1, ConstElementPtr e2)
@@ -264,7 +260,7 @@ public:
 private:
 
   const ConstOsmMapPtr& _map;
-  std::vector<const Match*>& _result;
+  std::vector<ConstMatchPtr>& _result;
   std::set<ElementId> _empty;
   std::shared_ptr<BuildingRfClassifier> _rf;
   ConstMatchThresholdPtr _mt;
@@ -285,11 +281,11 @@ private:
   long _numMatchCandidatesVisited;
   int _taskStatusUpdateInterval;
 
-  void _markNonOneToOneMatchesAsReview(std::vector<Match*>& matches)
+  void _markNonOneToOneMatchesAsReview(std::vector<MatchPtr>& matches)
   {
-    for (std::vector<Match*>::iterator it = matches.begin(); it != matches.end(); ++it)
+    for (std::vector<MatchPtr>::iterator it = matches.begin(); it != matches.end(); ++it)
     {
-      Match* match = *it;
+      MatchPtr match = *it;
       //Not proud of this, but not sure what else to do at this point w/o having to change the
       //Match interface.
       MatchClassification& matchClass =
@@ -305,9 +301,9 @@ _conflateMatchBuildingModel(ConfigOptions().getConflateMatchBuildingModel())
 {
 }
 
-Match* BuildingMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2)
+MatchPtr BuildingMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2)
 {
-  BuildingMatch* result = 0;
+  std::shared_ptr<BuildingMatch> result;
 
   if (eid1.getType() != ElementType::Node && eid2.getType() != ElementType::Node)
   {
@@ -317,7 +313,7 @@ Match* BuildingMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId ei
     if (BuildingMatchVisitor::isRelated(e1, e2))
     {
       // score each candidate and push it on the result vector
-      result = new BuildingMatch(map, _getRf(), eid1, eid2, getMatchThreshold());
+      result.reset(new BuildingMatch(map, _getRf(), eid1, eid2, getMatchThreshold()));
     }
   }
 
@@ -325,7 +321,7 @@ Match* BuildingMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId ei
 }
 
 void BuildingMatchCreator::createMatches(const ConstOsmMapPtr& map,
-                                         std::vector<const Match*>& matches,
+                                         std::vector<ConstMatchPtr>& matches,
                                          ConstMatchThresholdPtr threshold)
 {
   QElapsedTimer timer;
@@ -379,7 +375,7 @@ std::shared_ptr<BuildingRfClassifier> BuildingMatchCreator::_getRf()
 
 bool BuildingMatchCreator::isMatchCandidate(ConstElementPtr element, const ConstOsmMapPtr& map)
 {
-  std::vector<const Match*> matches;
+  std::vector<ConstMatchPtr> matches;
   return BuildingMatchVisitor(map, matches, _filter).isMatchCandidate(element);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.h
@@ -49,9 +49,9 @@ public:
 
   BuildingMatchCreator();
 
-  virtual Match* createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2);
+  virtual MatchPtr createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) override;
 
-  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<const Match*>& matches,
+  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
     ConstMatchThresholdPtr threshold) override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
@@ -55,9 +55,9 @@ bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<Merger
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* m = *it;
+    ConstMatchPtr m = *it;
     LOG_VART(m->toString());
-    const BuildingMatch* bm = dynamic_cast<const BuildingMatch*>(m);
+    const BuildingMatch* bm = dynamic_cast<const BuildingMatch*>(m.get());
     // check to make sure all the input matches are building matches.
     if (bm == 0)
     {
@@ -91,17 +91,17 @@ vector<CreatorDescription> BuildingMergerCreator::getAllCreators() const
   return result;
 }
 
-bool BuildingMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Match* m1,
-  const Match* m2) const
+bool BuildingMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
+  ConstMatchPtr m2) const
 {
-  const BuildingMatch* bm1 = dynamic_cast<const BuildingMatch*>(m1);
-  const BuildingMatch* bm2 = dynamic_cast<const BuildingMatch*>(m2);
+  const BuildingMatch* bm1 = dynamic_cast<const BuildingMatch*>(m1.get());
+  const BuildingMatch* bm2 = dynamic_cast<const BuildingMatch*>(m2.get());
 
   // this shouldn't ever return true, but I'm calling the BuildingMatch::isConflicting just in
   // case the logic changes at some point.
   if (bm1 && bm2)
   {
-    return bm1->isConflicting(*bm2, map);
+    return m1->isConflicting(m2, map);
   }
   else
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.h
@@ -48,7 +48,7 @@ public:
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.cpp
@@ -27,12 +27,12 @@
 #include "RemoveDuplicateReviewsOp.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
+#include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
 #include <hoot/core/conflate/review/ReviewMarker.h>
-#include <hoot/core/ops/CopyMapSubsetOp.h>
-#include <hoot/core/conflate/matching/MatchClassification.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/ops/CopyMapSubsetOp.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
 
 using namespace std;
@@ -95,7 +95,7 @@ void RemoveDuplicateReviewsOp::apply(std::shared_ptr<OsmMap>& map)
       copy->getElement(beid)->setStatus(Status::Unknown1);
       copy->getElement(eeid)->setStatus(Status::Unknown2);
 
-      Match* match = MatchFactory::getInstance().createMatch(copy, beid, eeid);
+      MatchPtr match = MatchFactory::getInstance().createMatch(copy, beid, eeid);
       if (match && match->getType() != MatchType::Miss)
       {
         QString explain = match->explain();

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.h
@@ -28,9 +28,9 @@
 #define DUPLICATEREVIEWSOP_H
 
 // Hoot
-#include <hoot/core/ops/OsmMapOperation.h>
-#include <hoot/core/io/Serializable.h>
 #include <hoot/core/info/OperationStatusInfo.h>
+#include <hoot/core/io/Serializable.h>
+#include <hoot/core/ops/OsmMapOperation.h>
 
 // Standard
 #include <set>

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.cpp
@@ -28,16 +28,16 @@
 #include "MatchFeatureExtractor.h"
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/elements/Way.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/conflate/matching/MatchDetails.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
-#include <hoot/core/util/HootException.h>
-#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/elements/ElementId.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/elements/Way.h>
+#include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 
 // Standard
@@ -248,7 +248,7 @@ QString MatchFeatureExtractor::getResults(bool useNulls)
 
 void MatchFeatureExtractor::processMap(const std::shared_ptr<const OsmMap>& map)
 {
-  vector<const Match*> matches;
+  vector<ConstMatchPtr> matches;
   Envelope bounds;
   bounds.setToNull();
   std::shared_ptr<const MatchThreshold> mt(new MatchThreshold(0, 0));
@@ -256,7 +256,7 @@ void MatchFeatureExtractor::processMap(const std::shared_ptr<const OsmMap>& map)
   size_t matchCount = 0;
   for (size_t i = 0; i < matches.size(); i++)
   {
-    const MatchDetails* d = dynamic_cast<const MatchDetails*>(matches[i]);
+    const MatchDetails* d = dynamic_cast<const MatchDetails*>(matches[i].get());
     if (d == 0)
     {
       if (logWarnCount < Log::getWarnMessageLimit())

--- a/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
@@ -48,7 +48,7 @@ namespace hoot
 {
 
 PoiPolygonMatchVisitor::PoiPolygonMatchVisitor(const ConstOsmMapPtr& map,
-                                               std::vector<const Match*>& result,
+                                               std::vector<ConstMatchPtr>& result,
                                                ElementCriterionPtr filter) :
 _map(map),
 _result(result),
@@ -57,7 +57,7 @@ _filter(filter)
 }
 
 PoiPolygonMatchVisitor::PoiPolygonMatchVisitor(const ConstOsmMapPtr& map,
-                                               std::vector<const Match*>& result,
+                                               std::vector<ConstMatchPtr>& result,
                                                ConstMatchThresholdPtr threshold,
                                                std::shared_ptr<PoiPolygonRfClassifier> rf,
                                                PoiPolygonCachePtr infoCache,
@@ -114,18 +114,14 @@ void PoiPolygonMatchVisitor::_checkForMatch(const std::shared_ptr<const Element>
         // score each candidate and push it on the result vector
         LOG_TRACE(
           "Calculating match between: " << poiId << " and " << poly->getElementId() << "...");
-        PoiPolygonMatch* m =
+        std::shared_ptr<PoiPolygonMatch> m(
           new PoiPolygonMatch(
-            _map, _threshold, _rf, _infoCache, _surroundingPolyIds, _surroundingPoiIds);
+            _map, _threshold, _rf, _infoCache, _surroundingPolyIds, _surroundingPoiIds));
         m->setConfiguration(conf());
         m->calculateMatch(poiId, polyId);
 
         // if we're confident this is a miss
-        if (m->getType() == MatchType::Miss)
-        {
-          delete m;
-        }
-        else
+        if (m->getType() != MatchType::Miss)
         {
           _result.push_back(m);
           neighborCount++;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.h
@@ -51,9 +51,9 @@ class PoiPolygonMatchVisitor : public ConstElementVisitor
 
 public:
 
-  PoiPolygonMatchVisitor(const ConstOsmMapPtr& map, std::vector<const Match*>& result,
+  PoiPolygonMatchVisitor(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& result,
                          ElementCriterionPtr filter = ElementCriterionPtr());
-  PoiPolygonMatchVisitor(const ConstOsmMapPtr& map, std::vector<const Match*>& result,
+  PoiPolygonMatchVisitor(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& result,
                          ConstMatchThresholdPtr threshold,
                          std::shared_ptr<PoiPolygonRfClassifier> rf, PoiPolygonCachePtr infoCache,
                          ElementCriterionPtr filter = ElementCriterionPtr());
@@ -79,7 +79,7 @@ private:
   friend class PoiPolygonMatchVisitorTest;
 
   const ConstOsmMapPtr& _map;
-  std::vector<const Match*>& _result;
+  std::vector<ConstMatchPtr>& _result;
   std::set<ElementId> _empty;
   int _neighborCountMax;
   int _neighborCountSum;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
@@ -31,12 +31,13 @@
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/conflate/merging/Merger.h>
 #include <hoot/core/ops/CopyMapSubsetOp.h>
-#include <hoot/js/elements/OsmMapJs.h>
+#include <hoot/core/util/Factory.h>
+
 #include <hoot/js/conflate/merging/ScriptMergerCreator.h>
 #include <hoot/js/elements/ElementJs.h>
-#include <hoot/js/util/HootExceptionJs.h>
+#include <hoot/js/elements/OsmMapJs.h>
 #include <hoot/js/io/StreamUtilsJs.h>
-#include <hoot/core/util/Factory.h>
+#include <hoot/js/util/HootExceptionJs.h>
 
 // Qt
 #include <qnumeric.h>
@@ -156,7 +157,7 @@ double ScriptMatch::getProbability() const
   return _p.getMatchP();
 }
 
-bool ScriptMatch::isConflicting(const Match& other, const ConstOsmMapPtr& map) const
+bool ScriptMatch::isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map) const
 {
   if (_neverCausesConflict)
   {
@@ -165,7 +166,7 @@ bool ScriptMatch::isConflicting(const Match& other, const ConstOsmMapPtr& map) c
 
   bool conflicting = true;
 
-  const ScriptMatch* hm = dynamic_cast<const ScriptMatch*>(&other);
+  const ScriptMatch* hm = dynamic_cast<const ScriptMatch*>(other.get());
   if (hm == 0)
   {
     return true;
@@ -176,7 +177,7 @@ bool ScriptMatch::isConflicting(const Match& other, const ConstOsmMapPtr& map) c
   }
 
   // See ticket #5272
-  if (getClassification().getReviewP() == 1.0 || other.getClassification().getReviewP() == 1.0)
+  if (getClassification().getReviewP() == 1.0 || other->getClassification().getReviewP() == 1.0)
   {
     return true;
   }
@@ -286,7 +287,7 @@ bool ScriptMatch::_isOrderedConflicting(const ConstOsmMapPtr& map, ElementId sha
   std::shared_ptr<ScriptMatch> m1(
     new ScriptMatch(_script, _plugin, copiedMap, copiedMapJs, eid11, eid12, _threshold));
   MatchSet ms;
-  ms.insert(m1.get());
+  ms.insert(m1);
   vector<Merger*> mergers;
   ScriptMergerCreator creator;
   creator.createMergers(ms, mergers);

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.h
@@ -60,22 +60,22 @@ public:
               const ConstOsmMapPtr& map, const v8::Handle<v8::Object>& mapObj,
               const ElementId& eid1, const ElementId& eid2, const ConstMatchThresholdPtr& mt);
 
-  virtual const MatchClassification& getClassification() const { return _p; }
+  virtual const MatchClassification& getClassification() const override { return _p; }
 
   virtual QString explain() const override { return _explainText; }
 
   virtual QString getMatchName() const override { return _matchName; }
 
-  virtual double getProbability() const;
+  virtual double getProbability() const override;
 
-  virtual bool isConflicting(const Match& other, const ConstOsmMapPtr& map) const;
+  virtual bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map) const override;
 
-  virtual bool isWholeGroup() const { return _isWholeGroup; }
+  virtual bool isWholeGroup() const override { return _isWholeGroup; }
 
   /**
    * Simply returns the two elements that were matched.
    */
-  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const;
+  virtual std::set<std::pair<ElementId, ElementId>> getMatchPairs() const override;
 
   v8::Local<v8::Object> getPlugin() const { return ToLocal(&_plugin); }
 
@@ -83,9 +83,9 @@ public:
 
   virtual QString toString() const override;
 
-  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& map) const;
+  virtual std::map<QString, double> getFeatures(const ConstOsmMapPtr& map) const override;
 
-  virtual QString getDescription() const { return "Matches elements with Generic Conflation"; }
+  virtual QString getDescription() const override { return "Matches elements with Generic Conflation"; }
 
 private:
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -27,7 +27,6 @@
 #include "ScriptMatchCreator.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/criterion/ArbitraryCriterion.h>
@@ -37,12 +36,14 @@
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/StringUtils.h>
 #include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
 #include <hoot/core/visitors/IndexElementsVisitor.h>
+
+#include <hoot/js/conflate/matching/ScriptMatch.h>
 #include <hoot/js/elements/OsmMapJs.h>
 #include <hoot/js/elements/ElementJs.h>
-#include <hoot/js/conflate/matching/ScriptMatch.h>
-#include <hoot/core/util/StringUtils.h>
 
 // Qt
 #include <QFileInfo>
@@ -76,7 +77,7 @@ class ScriptMatchVisitor : public ConstElementVisitor
 
 public:
 
-  ScriptMatchVisitor(const ConstOsmMapPtr& map, vector<const Match*>& result,
+  ScriptMatchVisitor(const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
     ConstMatchThresholdPtr mt, std::shared_ptr<PluginContext> script,
                      ElementCriterionPtr filter = ElementCriterionPtr()) :
     _map(map),
@@ -156,14 +157,10 @@ public:
       if (isCorrectOrder(e, e2) && isMatchCandidate(e2))
       {
         // score each candidate and push it on the result vector
-        ScriptMatch* m = new ScriptMatch(_script, plugin, map, mapJs, from, *it, _mt);
+        std::shared_ptr<ScriptMatch> m(new ScriptMatch(_script, plugin, map, mapJs, from, *it, _mt));
         // if we're confident this is a miss
-        if (m->getType() == MatchType::Miss)
+        if (m->getType() != MatchType::Miss)
         {
-          delete m;
-        }
-        else
-        {;
           _result.push_back(m);
         }
       }
@@ -504,7 +501,7 @@ private:
   // don't hold on to the map.
   std::weak_ptr<const OsmMap> _map;
   Persistent<Object> _mapJs;
-  vector<const Match*>& _result;
+  vector<ConstMatchPtr>& _result;
   set<ElementId> _empty;
   int _neighborCountMax;
   int _neighborCountSum;
@@ -571,7 +568,7 @@ void ScriptMatchCreator::setArguments(QStringList args)
   LOG_DEBUG("Set arguments for: " << className() << " - rules: " << scriptFileInfo.fileName());
 }
 
-Match* ScriptMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2)
+MatchPtr ScriptMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2)
 {
   if (isMatchCandidate(map->getElement(eid1), map) && isMatchCandidate(map->getElement(eid2), map))
   {
@@ -582,12 +579,12 @@ Match* ScriptMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1
     Handle<Object> mapJs = OsmMapJs::create(map);
     Persistent<Object> plugin(current, ScriptMatchVisitor::getPlugin(_script));
 
-    return new ScriptMatch(_script, plugin, map, mapJs, eid1, eid2, getMatchThreshold());
+    return MatchPtr(new ScriptMatch(_script, plugin, map, mapJs, eid1, eid2, getMatchThreshold()));
   }
-  return 0;
+  return MatchPtr();
 }
 
-void ScriptMatchCreator::createMatches(const ConstOsmMapPtr& map, vector<const Match*> &matches,
+void ScriptMatchCreator::createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
                                        ConstMatchThresholdPtr threshold)
 {
   if (!_script)
@@ -668,7 +665,7 @@ std::shared_ptr<ScriptMatchVisitor> ScriptMatchCreator::_getCachedVisitor(
     QFileInfo scriptFileInfo(_scriptPath);
     LOG_TRACE("Resetting the match candidate checker " << scriptFileInfo.fileName() << "...");
 
-    vector<const Match*> emptyMatches;
+    vector<ConstMatchPtr> emptyMatches;
     _cachedScriptVisitor.reset(
       new ScriptMatchVisitor(map, emptyMatches, ConstMatchThresholdPtr(), _script, _filter));
     _cachedScriptVisitor->setScriptPath(scriptPath);

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -27,8 +27,8 @@
 #ifndef SCRIPTMATCHCREATOR_H
 #define SCRIPTMATCHCREATOR_H
 
-#include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/conflate/SearchRadiusProvider.h>
+#include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/util/NotImplementedException.h>
 
 #include <hoot/js/PluginContext.h>
@@ -54,17 +54,17 @@ public:
   /**
    * @see SearchRadiusProvider
    */
-  virtual Meters calculateSearchRadius(const ConstOsmMapPtr& map, const ConstElementPtr& e);
+  virtual Meters calculateSearchRadius(const ConstOsmMapPtr& map, const ConstElementPtr& e) override;
 
   /**
    * Not implemented.
    */
-  virtual Match* createMatch(const ConstOsmMapPtr&, ElementId, ElementId);
+  virtual MatchPtr createMatch(const ConstOsmMapPtr&, ElementId, ElementId) override;
 
   /**
    * Search the provided map for POI matches and add the matches to the matches vector.
    */
-  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<const Match*>& matches,
+  virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
     ConstMatchThresholdPtr threshold) override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
@@ -27,8 +27,8 @@
 #include "ScriptMergerCreator.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/conflate/merging/MarkForReviewMerger.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/js/conflate/matching/ScriptMatch.h>
 #include <hoot/js/conflate/merging/ScriptMerger.h>
 
@@ -60,9 +60,9 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* m = *it;
+    ConstMatchPtr m = *it;
     LOG_VART(m->toString());
-    const ScriptMatch* sm = dynamic_cast<const ScriptMatch*>(m);
+    const ScriptMatch* sm = dynamic_cast<const ScriptMatch*>(m.get());
     // check to make sure all the input matches are script matches.
     if (sm == 0)
     {
@@ -138,16 +138,13 @@ vector<CreatorDescription> ScriptMergerCreator::getAllCreators() const
   return result;
 }
 
-bool ScriptMergerCreator::isConflicting(const ConstOsmMapPtr& map, const Match* m1,
-  const Match* m2) const
+bool ScriptMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
+  ConstMatchPtr m2) const
 {
-  const ScriptMatch* sm1 = dynamic_cast<const ScriptMatch*>(m1);
-  const ScriptMatch* sm2 = dynamic_cast<const ScriptMatch*>(m2);
-
   bool result = false;
-  if (sm1 && sm2)
+  if (m1 && m2)
   {
-    result = sm1->isConflicting(*sm2, map);
+    result = m1->isConflicting(m2, map);
   }
 
   return result;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
@@ -141,8 +141,8 @@ vector<CreatorDescription> ScriptMergerCreator::getAllCreators() const
 bool ScriptMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
   ConstMatchPtr m2) const
 {
-  const ScriptMatch* sm1 = dynamic_cast<const ScriptMatch*>(m1);
-  const ScriptMatch* sm2 = dynamic_cast<const ScriptMatch*>(m2);
+  const ScriptMatch* sm1 = dynamic_cast<const ScriptMatch*>(m1.get());
+  const ScriptMatch* sm2 = dynamic_cast<const ScriptMatch*>(m2.get());
 
   bool result = false;
   if (sm1 && sm2)

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
@@ -141,8 +141,11 @@ vector<CreatorDescription> ScriptMergerCreator::getAllCreators() const
 bool ScriptMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1,
   ConstMatchPtr m2) const
 {
+  const ScriptMatch* sm1 = dynamic_cast<const ScriptMatch*>(m1);
+  const ScriptMatch* sm2 = dynamic_cast<const ScriptMatch*>(m2);
+
   bool result = false;
-  if (m1 && m2)
+  if (sm1 && sm2)
   {
     result = m1->isConflicting(m2, map);
   }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.h
@@ -50,7 +50,7 @@ public:
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const;
 
 };
 

--- a/hoot-js/src/test/cpp/hoot/js/conflate/matching/ScriptMatchTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/matching/ScriptMatchTest.cpp
@@ -31,6 +31,7 @@
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/MapProjector.h>
+
 #include <hoot/js/HootJsStable.h>
 #include <hoot/js/conflate/matching/ScriptMatch.h>
 #include <hoot/js/conflate/matching/ScriptMatchCreator.h>
@@ -79,10 +80,10 @@ public:
 
     ScriptMatchCreator smc;
     smc.setArguments(QStringList() << "LineStringGenericTest.js");
-    vector<const Match*> matches;
+    vector<ConstMatchPtr> matches;
     smc.createMatches(map, matches, mt);
     HOOT_STR_EQUALS(2, matches.size());
-    HOOT_STR_EQUALS(false, matches[0]->isConflicting(*matches[1], map));
+    HOOT_STR_EQUALS(false, matches[0]->isConflicting(matches[1], map));
   }
 
   void cacheTest()

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCache.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCache.cpp
@@ -56,24 +56,6 @@ public:
 };
 
 /**
- * Delete the MatchSet structure in a safe way.
- */
-struct ScopedMatchDeleter
-{
-  ScopedMatchDeleter(MatchSet& ms) : _ms(ms) {}
-
-  ~ScopedMatchDeleter()
-  {
-    foreach (const Match* m, _ms)
-    {
-      delete m;
-    }
-  }
-
-  MatchSet _ms;
-};
-
-/**
  * Delete the Merger vector in a safe way.
  */
 struct ScopedMergerDeleter
@@ -120,14 +102,12 @@ MultiaryClusterPtr MultiaryPoiMergeCache::merge(const MultiaryClusterPtr& c1, co
 
   // create a match set that we can populate with the provided match creator.
   MatchSet ms;
-  // clean up the matches in a safe way.
-  ScopedMatchDeleter deleteMatches(ms);
 
   // go through the 2nd through the last element
   for (int i = 1; i < result->size(); ++i)
   {
     // create a match between the ith element and the first element.
-    Match* m = _matchCreator->createMatch(_map, result->at(0)->getElementId(),
+    MatchPtr m = _matchCreator->createMatch(_map, result->at(0)->getElementId(),
         result->at(i)->getElementId());
 
     // if the match isn't valid then this isn't a valid cluster the merge.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.cpp
@@ -52,7 +52,7 @@ bool MultiaryPoiMergerCreator::createMergers(const MatchSet& matches, std::vecto
   // go through all the matches
   for (MatchSet::const_iterator it = matches.begin(); it != matches.end(); ++it)
   {
-    const Match* m = *it;
+    ConstMatchPtr m = *it;
     set<pair<ElementId, ElementId>> s = m->getMatchPairs();
     eids.insert(s.begin(), s.end());
   }
@@ -79,8 +79,8 @@ std::vector<CreatorDescription> MultiaryPoiMergerCreator::getAllCreators() const
   return result;
 }
 
-bool MultiaryPoiMergerCreator::isConflicting(const ConstOsmMapPtr&, const Match*,
-  const Match*) const
+bool MultiaryPoiMergerCreator::isConflicting(const ConstOsmMapPtr&, ConstMatchPtr,
+  ConstMatchPtr) const
 {
   // Any relevant matches that contain conflicts will be resolved during the clustering phase.
   return false;

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.h
@@ -70,7 +70,7 @@ public:
    */
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 
-  virtual bool isConflicting(const ConstOsmMapPtr& map, const Match* m1, const Match* m2) const;
+  virtual bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2) const;
 };
 
 }

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryScoreCache.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryScoreCache.cpp
@@ -26,12 +26,9 @@
  */
 #include "MultiaryScoreCache.h"
 
-// boost
-#include <boost/scoped_ptr.hpp>
-
 // hoot
-#include <hoot/core/util/Log.h>
 #include <hoot/core/conflate/matching/MatchClassification.h>
+#include <hoot/core/util/Log.h>
 
 namespace hoot
 {
@@ -70,8 +67,7 @@ MatchClassification MultiaryScoreCache::getScore(ConstElementPtr e1, ConstElemen
   tmp->addElement(ElementPtr(e1->clone()));
   tmp->addElement(ElementPtr(e2->clone()));
 
-  const std::unique_ptr<Match> m(
-    _matchCreator->createMatch(tmp, e1->getElementId(), e2->getElementId()));
+  ConstMatchPtr m(_matchCreator->createMatch(tmp, e1->getElementId(), e2->getElementId()));
 
   // default to a hard miss.
   MatchClassification result(0, 1, 0);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.cpp
@@ -27,16 +27,17 @@
 #include "MultiaryUtilities.h"
 
 // hoot
+#include <hoot/core/conflate/SearchBoundsCalculator.h>
+#include <hoot/core/conflate/UnifyingConflator.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
-#include <hoot/core/conflate/UnifyingConflator.h>
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmPbfWriter.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/CalculateHashVisitor.h>
+
 #include <hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.h>
-#include <hoot/core/conflate/SearchBoundsCalculator.h>
 
 namespace hoot
 {
@@ -166,7 +167,7 @@ QList<hoot::MultiarySimpleMatch> MultiaryUtilities::findMatches(QByteArray check
 
   for (int i = 0; i < ids.size(); i++)
   {
-    Match* m = matchFactory.createMatch(map, check->getElementId(), ElementId::node(ids[i]));
+    MatchPtr m = matchFactory.createMatch(map, check->getElementId(), ElementId::node(ids[i]));
     if (m && m->getProbability() > 0)
     {
       result.append(MultiarySimpleMatch(i, m->getProbability()));


### PR DESCRIPTION
Matches were kept as `Match*` all throughout the code and leaked more often than not.  This change uses `std::shared_ptr` to keep this from happening.