### PR TITLE
Fix the next batch of memory leaks

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/GreedyConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/GreedyConstrainedMatchesTest.cpp
@@ -189,13 +189,14 @@ public:
 
   virtual void setUp()
   {
-    MergerFactory::getInstance().clear();
-    MergerFactory::getInstance().registerCreator(new GreedyConstrainedFakeCreator());
+    MergerFactory::getInstance().reset();
+    MergerFactory::getInstance().registerCreator(
+          MergerCreatorPtr(new GreedyConstrainedFakeCreator()));
   }
 
   virtual void tearDown()
   {
-    MergerFactory::getInstance().clear();
+    MergerFactory::getInstance().reset();
     MergerFactory::getInstance().registerDefaultCreators();
   }
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
@@ -190,13 +190,14 @@ public:
 
   virtual void setUp()
   {
-    MergerFactory::getInstance().clear();
-    MergerFactory::getInstance().registerCreator(new OptimalConstrainedFakeCreator());
+    MergerFactory::getInstance().reset();
+    MergerFactory::getInstance().registerCreator(
+          MergerCreatorPtr(new OptimalConstrainedFakeCreator()));
   }
 
   virtual void tearDown()
   {
-    MergerFactory::getInstance().clear();
+    MergerFactory::getInstance().reset();
     MergerFactory::getInstance().registerDefaultCreators();
   }
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/OsmMapTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/OsmMapTest.cpp
@@ -466,7 +466,7 @@ public:
     OsmMapPtr mapA(new OsmMap());
     reader.read("test-files/ToyTestA.osm", mapA);
 
-    const char* exceptionMsg = "<wrong>";
+    QString exceptionMsg = "<wrong>";
     try
     {
       mapA->append(mapA);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -911,7 +911,7 @@ public:
     }
     catch (const HootException& e)
     {
-      exceptionMsg = e.what();\
+      exceptionMsg = e.what();
 
       reader.close();
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -107,6 +107,8 @@ void HttpTestServer::shutdown()
 {
   //  Interupt the threads
   _interupt = true;
+  //  Cancel the acceptor
+  _acceptor->cancel();
   //  Stop the IO service and wait for the server to stop
   _io_service.stop();
   wait();

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/EdgeDistanceExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/EdgeDistanceExtractor.cpp
@@ -167,11 +167,12 @@ std::shared_ptr<Geometry> EdgeDistanceExtractor::_toLines(const OsmMap& map,
   const std::shared_ptr<const Element>& e) const
 {
   std::shared_ptr<Geometry> result;
-  vector<Geometry*> lines;
 
   if (e->getElementType() != ElementType::Node)
   {
-    LinesWaysVisitor v(lines);
+    //  Create a new vector to pass ownership to multilinestring
+    vector<Geometry*>* lines = new vector<Geometry*>();
+    LinesWaysVisitor v(*lines);
     v.setOsmMap(&map);
     e->visitRo(map, v);
     result.reset(GeometryFactory::getDefaultInstance()->createMultiLineString(lines));

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -431,7 +431,7 @@ void UnifyingConflator::_reset()
     _mergerFactory.reset(new MergerFactory());
     // register the mark for review merger first so all reviews get tagged before another merger
     // gets a chance.
-    _mergerFactory->registerCreator(new MarkForReviewMergerCreator());
+    _mergerFactory->registerCreator(MergerCreatorPtr(new MarkForReviewMergerCreator()));
     _mergerFactory->registerDefaultCreators();
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
@@ -49,16 +49,11 @@ MergerFactory::MergerFactory()
 
 MergerFactory::~MergerFactory()
 {
-  clear();
+  reset();
 }
 
-void MergerFactory::clear()
+void MergerFactory::reset()
 {
-  // delete all creators.
-  for (size_t i = 0; i < _creators.size(); ++i)
-  {
-    delete _creators[i];
-  }
   _creators.clear();
 }
 
@@ -69,7 +64,7 @@ void MergerFactory::createMergers(const OsmMapPtr& map, const MatchSet& matches,
   {
     PROGRESS_DEBUG("Creating merger " << i + 1 << " / " << _creators.size() << "...");
 
-    OsmMapConsumer* omc = dynamic_cast<OsmMapConsumer*>(_creators[i]);
+    OsmMapConsumer* omc = dynamic_cast<OsmMapConsumer*>(_creators[i].get());
     if (omc)
     {
       omc->setOsmMap(map.get());
@@ -91,7 +86,6 @@ void MergerFactory::createMergers(const OsmMapPtr& map, const MatchSet& matches,
   if (logWarnCount < Log::getWarnMessageLimit())
   {
     LOG_WARN("Unable to create merger for the provided set of matches: " << matches);
-    LOG_DEBUG("Creators: " << _creators);
   }
   else if (logWarnCount == Log::getWarnMessageLimit())
   {
@@ -165,7 +159,7 @@ void MergerFactory::registerDefaultCreators()
     if (className.length() > 0)
     {
       args.removeFirst();
-      MergerCreator* mc = Factory::getInstance().constructObject<MergerCreator>(className);
+      MergerCreatorPtr mc(Factory::getInstance().constructObject<MergerCreator>(className));
       registerCreator(mc);
 
       if (args.size() > 0)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
@@ -61,11 +61,6 @@ public:
   ~MergerFactory();
 
   /**
-   * Should be avoided on the global instance. Mostly useful for unit testing.
-   */
-  void clear();
-
-  /**
    * Searches through all the available creators in order to create the requested merge. If no
    * appropriate creator is found a NULL will be returned.
    *
@@ -90,11 +85,11 @@ public:
   /**
    * Registers the specified creator with the MergeFactory and takes ownership of the creator.
    */
-  void registerCreator(MergerCreator* creator) { _creators.push_back(creator); }
+  void registerCreator(MergerCreatorPtr creator) { _creators.push_back(creator); }
 
   void registerDefaultCreators();
 
-  void reset() { _creators.clear(); }
+  void reset();
 
 private:
 
@@ -107,7 +102,7 @@ private:
 
   static std::shared_ptr<MergerFactory> _theInstance;
 
-  std::vector<MergerCreator*> _creators;
+  std::vector<MergerCreatorPtr> _creators;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/MultiPolygonCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/MultiPolygonCreator.cpp
@@ -68,8 +68,8 @@ Geometry* MultiPolygonCreator::_addHoles(vector<LinearRing*> &outers,
 {
   const GeometryFactory& gf = *GeometryFactory::getDefaultInstance();
 
-  vector<Geometry*> polygons;
-  vector<Geometry*>& tmpPolygons = polygons;
+  vector<Geometry*>* polygons = new vector<Geometry*>();
+  vector<Geometry*>& tmpPolygons = *polygons;
   tmpPolygons.reserve(outers.size());
 
   vector<double> outerArea;

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
@@ -127,9 +127,11 @@ void OsmMap::append(const ConstOsmMapPtr& appendFromMap, const bool throwOutDupe
     char* wkt1 = 0;
     getProjection()->exportToPrettyWkt(&wkt1);
     QString proj1 = QString::fromLatin1(wkt1);
+    CPLFree(wkt1);
     char* wkt2 = 0;
     appendFromMap->getProjection()->exportToPrettyWkt(&wkt2);
     QString proj2 = QString::fromLatin1(wkt2);
+    CPLFree(wkt2);
     throw HootException(
       "Incompatible maps.  Map being appended to has projection:\n" + proj1 +
       "\nMap being appended from has projection:\n" + proj2);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/RasterComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/RasterComparator.cpp
@@ -98,6 +98,8 @@ double RasterComparator::compareMaps()
   _saveImage(image1, "test-output/image1.png", max);
   _saveImage(image2, "test-output/image2.png", max);
 
+  cvReleaseImage(&diffImage);
+
   return 1 - error;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/GeometryUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/GeometryUtils.cpp
@@ -268,7 +268,7 @@ Geometry* GeometryUtils::validatePolygon(const Polygon* p)
   {
     const LineString* oldShell = p->getExteriorRing();
     std::shared_ptr<LinearRing> oldLinearRing(
-      GeometryFactory::getDefaultInstance()->createLinearRing(*oldShell->getCoordinates()));
+      GeometryFactory::getDefaultInstance()->createLinearRing(oldShell->getCoordinates()));
     LinearRing* shell = validateLinearRing(oldLinearRing.get());
     std::vector<Geometry*>* holes = new vector<Geometry*>();
     holes->reserve(p->getNumInteriorRing());

--- a/hoot-js/src/main/cpp/hoot/js/io/StreamUtilsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/StreamUtilsJs.h
@@ -126,7 +126,7 @@ QString toJson(const v8::Local<T> object)
     v8::Handle<v8::String> s = v8::Handle<v8::String>::Cast(resultValue);
 
     size_t utf8Length = s->Utf8Length() + 1;
-    std::shared_ptr<char> buffer(new char[utf8Length]);
+    std::unique_ptr<char[]> buffer(new char[utf8Length]);
     s->WriteUtf8(buffer.get(), utf8Length);
 
     result = QString::fromUtf8(buffer.get());

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.cpp
@@ -52,7 +52,8 @@ void MultiaryUtilities::conflate(OsmMapPtr map)
 
   MergerFactory::getInstance().reset();
   std::shared_ptr<MergerFactory> mergerFactory(new MergerFactory());
-  mergerFactory->registerCreator(new MultiaryPoiMergerCreator());
+  mergerFactory->registerCreator(
+        MergerCreatorPtr(new MultiaryPoiMergerCreator()));
 
   MatchThresholdPtr mt(new MatchThreshold(0.39, 0.61, 1.1));
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryHierarchicalClusterAlgorithmTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryHierarchicalClusterAlgorithmTest.cpp
@@ -94,12 +94,12 @@ public:
     matchFactory.reset();
     matchFactory.registerCreator("hoot::ScriptMatchCreator,MultiaryPoiGeneric.js");
 
-    std::shared_ptr<MergerCreator> mergerCreator(
+    MergerCreatorPtr mergerCreator(
       Factory::getInstance().constructObject<MergerCreator>(
         QString("hoot::ScriptMergerCreator")));
     MergerFactory& mergerFactory = MergerFactory::getInstance();
     mergerFactory.reset();
-    mergerFactory.registerCreator(mergerCreator.get());
+    mergerFactory.registerCreator(mergerCreator);
 
     std::shared_ptr<MatchCreator> matchCreator = matchFactory.getCreators()[0];
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCacheTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCacheTest.cpp
@@ -94,12 +94,12 @@ public:
     matchFactory.reset();
     matchFactory.registerCreator("hoot::ScriptMatchCreator,MultiaryPoiGeneric.js");
 
-    std::shared_ptr<MergerCreator> mergerCreator(
+    MergerCreatorPtr mergerCreator(
       Factory::getInstance().constructObject<MergerCreator>(
         QString("hoot::ScriptMergerCreator")));
     MergerFactory& mergerFactory = MergerFactory::getInstance();
     mergerFactory.reset();
-    mergerFactory.registerCreator(mergerCreator.get());
+    mergerFactory.registerCreator(mergerCreator);
 
     std::shared_ptr<MatchCreator> matchCreator = matchFactory.getCreators()[0];
 


### PR DESCRIPTION
Make `geos::geom` take ownership of objects
`MergerFactory` now keeps track of all `MergerCreator` objects via shared pointers
Use `std::unique_ptr<char []>` to delete an array since `std::shared_ptr` uses `delete` and not `delete []`
Sneaked in a change to the `HttpTestServer` to cancel the acceptor that is currently listening to accept connections.