### PR TITLE
3531 - Make ManualMatchValidator backward compatible with UUID manual match IDs

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3738,6 +3738,15 @@ the "Translation" section of the Hootenanny User Guide.
 Export some of the images used when evaluating the graph connections between two maps (`score`
 command).
 
+=== score.matches.allow.uuids.as.ids
+
+* Data Type: bool
+* Default Value: `false`
+
+The current manual match ID format is a 6 character hex string created by the AddRef*Visitor
+classes. This option allows backward compatibilty support for UUID ID formats that exist in some
+older manually matched input files.
+
 === score.matches.remove.nodes
 
 * Data Type: bool
@@ -3750,7 +3759,10 @@ Remove REF tags from nodes before match scoring when using the score-matches com
 * Data Type: bool
 * Default Value: `true`
 
-TODO
+In some situations manually matched input data may need to be cropped to allow for smaller test
+runtimes. When this is done, sometimes REF1 features will be removed from the input. Disabling this
+option allows for score-matches to run when there are missing REF1 features. Warnings will be logged
+for any that are found.
 
 === script.test.max.exec.time
 

--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3747,6 +3747,13 @@ The current manual match ID format is a 6 character hex string created by the Ad
 classes. This option allows backward compatibilty support for UUID ID formats that exist in some
 older manually matched input files.
 
+=== score.matches.full.debug.output
+
+* Data Type: bool
+* Default Value: `false`
+
+Adds more detail to manual match validation warning/error messages.
+
 === score.matches.remove.nodes
 
 * Data Type: bool

--- a/docs/commands/score-matches.asciidoc
+++ b/docs/commands/score-matches.asciidoc
@@ -12,11 +12,12 @@ manual match is invalid.
 * +output+            - Output file for debugging; may be any supported output format (e.g. OSM file). Only the first conflation will be output.
 * +--confusion+       - print the confusion matrix
 * +--optimize+        - optimizes the scoring function
+* +--validation-off+  - Turns off manual match validation; recommended for debugging manual matches only
 
 === Usage
 
 --------------------------------------
-score-matches [--confusion] [--optimize] [--validate-inputs] (input1 input2) [input1 input2 ...] (output)
+score-matches [--confusion] [--optimize] [--validation-off] (input1 input2) [input1 input2 ...] (output)
 --------------------------------------
 
 === See Also

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageDetectorClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageDetectorClientTest.cpp
@@ -38,7 +38,6 @@
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/io/ServicesDbTestUtils.h>
-#include <hoot/core/util/UuidHelper.h>
 #include <hoot/core/language/LanguageDetectionConfidenceLevel.h>
 
 namespace hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesTranslatorClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesTranslatorClientTest.cpp
@@ -38,7 +38,6 @@
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/io/ServicesDbTestUtils.h>
-#include <hoot/core/util/UuidHelper.h>
 
 namespace hoot
 {

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ManualMatchValidatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ManualMatchValidatorTest.cpp
@@ -564,7 +564,7 @@ public:
     CPPUNIT_ASSERT(uut.hasErrors());;
     CPPUNIT_ASSERT(uut.getErrors().size() == 1);
     errorItr = uut.getErrors().find(invalidRef2->getElementId());
-    HOOT_STR_EQUALS("Duplicate ID found in REF2=002da0;002da0", errorItr.value().toStdString());
+    HOOT_STR_EQUALS("Duplicate IDs found in REF2: 002da0", errorItr.value().toStdString());
 
     tags.clear();
     map->clear();
@@ -576,7 +576,7 @@ public:
     CPPUNIT_ASSERT(uut.hasErrors());;
     CPPUNIT_ASSERT(uut.getErrors().size() == 1);
     errorItr = uut.getErrors().find(invalidReview->getElementId());
-    HOOT_STR_EQUALS("Duplicate ID found in REVIEW=002da0;002da0", errorItr.value().toStdString());
+    HOOT_STR_EQUALS("Duplicate IDs found in REVIEW: 002da0", errorItr.value().toStdString());
   }
 
   void runFullDebugOutputTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ManualMatchValidatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ManualMatchValidatorTest.cpp
@@ -598,7 +598,7 @@ public:
     CPPUNIT_ASSERT(uut.getErrors().size() == 1);
     errorItr = uut.getErrors().find(invalidRef2->getElementId());
     HOOT_STR_EQUALS(
-      "Duplicate ID found in REF2=002da0;002da0; tags: blah = bleh\n",
+      "Duplicate IDs found in REF2: 002da0; tags: blah = bleh\n",
       errorItr.value().toStdString());
   }
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/ManualMatchValidatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/ManualMatchValidatorTest.cpp
@@ -54,6 +54,7 @@ class ManualMatchValidatorTest : public HootTestFixture
   CPPUNIT_TEST(runMultipleRef1Test);
   CPPUNIT_TEST(runInvalidMultipleIdTest);
   CPPUNIT_TEST(runDuplicateIdTest);
+  CPPUNIT_TEST(runFullDebugOutputTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -576,6 +577,29 @@ public:
     CPPUNIT_ASSERT(uut.getErrors().size() == 1);
     errorItr = uut.getErrors().find(invalidReview->getElementId());
     HOOT_STR_EQUALS("Duplicate ID found in REVIEW=002da0;002da0", errorItr.value().toStdString());
+  }
+
+  void runFullDebugOutputTest()
+  {
+    OsmMapPtr map(new OsmMap());
+    Tags tags;
+    ManualMatchValidator uut;
+    QMap<ElementId, QString>::const_iterator errorItr;
+
+    uut.setFullDebugOutput(true);
+
+    tags.set(MetadataTags::Ref2(), "002da0;002da0");
+    tags.set("blah", "bleh");
+    ConstNodePtr invalidRef2 = TestUtils::createNode(map, Status::Unknown2, 0.0, 0.0, 15.0, tags);
+
+    uut.apply(map);
+
+    CPPUNIT_ASSERT(uut.hasErrors());;
+    CPPUNIT_ASSERT(uut.getErrors().size() == 1);
+    errorItr = uut.getErrors().find(invalidRef2->getElementId());
+    HOOT_STR_EQUALS(
+      "Duplicate ID found in REF2=002da0;002da0; tags: blah = bleh\n",
+      errorItr.value().toStdString());
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
@@ -217,6 +217,7 @@ private:
 
     ManualMatchValidator inputValidator;
     inputValidator.setRequireRef1(ConfigOptions().getScoreMatchesRequireRef1());
+    inputValidator.setAllowUuidManualMatchIds(ConfigOptions().getScoreMatchesAllowUuidsAsIds());
     inputValidator.getInitStatusMessage();
     inputValidator.apply(map);
     inputValidator.getCompletedStatusMessage();
@@ -236,10 +237,10 @@ private:
     {
       QFileInfo fileInfo1(map1Path);
       QFileInfo fileInfo2(map2Path);
-      cout << "There are " << QString::number(issues.size()) <<
+      cout << "There are " << StringUtils::formatLargeNumber(issues.size()) <<
               " manual match " << type << " for inputs " <<
-              fileInfo1.completeBaseName().right(25) <<
-              " and " << fileInfo2.completeBaseName().right(25) << ":\n\n";
+              fileInfo1.completeBaseName().right(30) <<
+              " and " << fileInfo2.completeBaseName().right(30) << ":\n\n";
       int issueCount = 0;
       for (QMap<ElementId, QString>::const_iterator itr = issues.begin();
            itr != issues.end(); ++itr)

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
@@ -85,6 +85,13 @@ public:
       args.removeAll("--optimize");
       optimizeThresholds = true;
     }
+    bool validateManualMatches = true;
+    if (args.contains("--validation-off"))
+    {
+      args.removeAll("--validation-off");
+      validateManualMatches = false;
+    }
+
     if (args.size() < 3 || args.size() % 2 != 1)
     {
       LOG_VAR(args);
@@ -107,7 +114,7 @@ public:
       IoUtils::loadMap(map, map2Path, false, Status::Unknown2);
 
       // If any of the map files have errors, we'll print some out and terminate.
-      if (_validateMatches(map, map1Path, map2Path))
+      if (validateManualMatches && _validateMatches(map, map1Path, map2Path))
       {
         return 1;
       }

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
@@ -218,6 +218,7 @@ private:
     ManualMatchValidator inputValidator;
     inputValidator.setRequireRef1(ConfigOptions().getScoreMatchesRequireRef1());
     inputValidator.setAllowUuidManualMatchIds(ConfigOptions().getScoreMatchesAllowUuidsAsIds());
+    inputValidator.setFullDebugOutput(ConfigOptions().getScoreMatchesFullDebugOutput());
     inputValidator.getInitStatusMessage();
     inputValidator.apply(map);
     inputValidator.getCompletedStatusMessage();

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
@@ -104,8 +104,10 @@ void ManualMatchValidator::_validate(const ConstElementPtr& element)
   Tags::const_iterator tagRef2Itr = tags.find(MetadataTags::Ref2());
   if (tagRef2Itr != tags.end())
   {
-    ref2 = tagRef2Itr.value().trimmed().toLower().split(";");
-    if (ref2.isEmpty() || (ref2.size() == 1 && ref2.at(0).isEmpty()))
+    // use SkipEmptyParts to get past trailing semicolons
+    ref2 =
+      tagRef2Itr.value().trimmed().toLower().split(";", QString::SplitBehavior::SkipEmptyParts);
+    if (ref2.isEmpty() || (ref2.size() == 1 && ref2.at(0).trimmed().isEmpty()))
     {
       _recordIssue(element, "Empty REF2 tag");
       return;
@@ -117,8 +119,9 @@ void ManualMatchValidator::_validate(const ConstElementPtr& element)
   Tags::const_iterator tagReviewItr = tags.find(MetadataTags::Review());
   if (tagReviewItr != tags.end())
   {
-    review = tagReviewItr.value().trimmed().toLower().split(";");
-    if (review.isEmpty() || (review.size() == 1 && review.at(0).isEmpty()))
+    review =
+      tagReviewItr.value().trimmed().toLower().split(";", QString::SplitBehavior::SkipEmptyParts);
+    if (review.isEmpty() || (review.size() == 1 && review.at(0).trimmed().isEmpty()))
     {
       _recordIssue(element, "Empty REVIEW tag");
       return;

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
@@ -107,6 +107,7 @@ void ManualMatchValidator::_validate(const ConstElementPtr& element)
     // use SkipEmptyParts to get past trailing semicolons
     ref2 =
       tagRef2Itr.value().trimmed().toLower().split(";", QString::SplitBehavior::SkipEmptyParts);
+    ref2.removeAll(";");
     if (ref2.isEmpty() || (ref2.size() == 1 && ref2.at(0).trimmed().isEmpty()))
     {
       _recordIssue(element, "Empty REF2 tag");
@@ -121,6 +122,7 @@ void ManualMatchValidator::_validate(const ConstElementPtr& element)
   {
     review =
       tagReviewItr.value().trimmed().toLower().split(";", QString::SplitBehavior::SkipEmptyParts);
+    review.removeAll(";");
     if (review.isEmpty() || (review.size() == 1 && review.at(0).trimmed().isEmpty()))
     {
       _recordIssue(element, "Empty REVIEW tag");
@@ -169,11 +171,15 @@ void ManualMatchValidator::_validate(const ConstElementPtr& element)
   // check for dupes
   else if (!ref2.isEmpty() && ref2.toSet().size() != ref2.size() )
   {
-    _recordIssue(element, "Duplicate ID found in REF2=" + ref2.join(";"));
+    const QStringList duplicates = StringUtils::getDuplicates(ref2).toList();
+    assert(duplicates.size() > 0);
+    _recordIssue(element, "Duplicate IDs found in REF2: " + duplicates.join(";"));
   }
   else if (!review.isEmpty() && review.toSet().size() != review.size())
   {
-    _recordIssue(element, "Duplicate ID found in REVIEW=" + review.join(";"));
+    const QStringList duplicates = StringUtils::getDuplicates(review).toList();
+    assert(duplicates.size() > 0);
+    _recordIssue(element, "Duplicate IDs found in REVIEW: " + duplicates.join(";"));
   }
   else if (!ref2.isEmpty())
   {

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.h
@@ -102,6 +102,7 @@ public:
   bool hasWarnings() const { return _warnings.size() > 0; }
 
   void setRequireRef1(bool require) { _requireRef1 = require; }
+  void setAllowUuidManualMatchIds(bool allow) { _allowUuidManualMatchIds = allow; }
 
 private:
 
@@ -110,6 +111,12 @@ private:
   ElementIdToTagValueMapper _ref1Mappings;
   // if true, every ref2/review id must have a correponding ref1 id in order to not trigger an error
   bool _requireRef1;
+  // The original manual matching implementation used uuids as ids instead of the 6 char hex used
+  // now, since manual matchers found the uuids a little unwieldy. There are still some regression
+  // tests with the uuid ids, so to avoid the cost of redoing the matches we'll support them on a
+  // case by case basis.
+  bool _allowUuidManualMatchIds;
+  QRegExp _uuidRegEx;
 
   void _validate(const ConstElementPtr& element);
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.h
@@ -103,20 +103,26 @@ public:
 
   void setRequireRef1(bool require) { _requireRef1 = require; }
   void setAllowUuidManualMatchIds(bool allow) { _allowUuidManualMatchIds = allow; }
+  void setFullDebugOutput(bool fullDebugOutput) { _fullDebugOutput = fullDebugOutput; }
 
 private:
 
   QMap<ElementId, QString> _errors;
   QMap<ElementId, QString> _warnings;
   ElementIdToTagValueMapper _ref1Mappings;
+
   // if true, every ref2/review id must have a correponding ref1 id in order to not trigger an error
   bool _requireRef1;
+
   // The original manual matching implementation used uuids as ids instead of the 6 char hex used
   // now, since manual matchers found the uuids a little unwieldy. There are still some regression
   // tests with the uuid ids, so to avoid the cost of redoing the matches we'll support them on a
   // case by case basis.
   bool _allowUuidManualMatchIds;
   QRegExp _uuidRegEx;
+
+  // TODO
+  bool _fullDebugOutput;
 
   void _validate(const ConstElementPtr& element);
 

--- a/hoot-core/src/main/cpp/hoot/core/util/StringUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/StringUtils.cpp
@@ -161,4 +161,23 @@ void StringUtils::removeEmptyStrings(QStringList& strings)
   strings = output;
 }
 
+QSet<QString> StringUtils::getDuplicates(const QStringList& input)
+{
+  QSet<QString> duplicateStrings;
+  QSet<QString> uniqueStrings;
+  for (int i = 0; i < input.size(); i++)
+  {
+    const QString str = input.at(i);
+    if (uniqueStrings.contains(str))
+    {
+      duplicateStrings.insert(str);
+    }
+    else
+    {
+      uniqueStrings.insert(str);
+    }
+  }
+  return duplicateStrings;
+}
+
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/StringUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/StringUtils.h
@@ -30,6 +30,7 @@
 
 // Qt
 #include <QStringList>
+#include <QSet>
 
 // Boost
 #include <boost/property_tree/json_parser.hpp>
@@ -127,6 +128,14 @@ public:
    * @return true if the string contains only alphanumeric characters; false otherwise
    */
   static bool isAlphaNumeric(const QString& input);
+
+  /**
+   * Finds duplicate strings in a list
+   *
+   * @param input the list to search
+   * @return a collection of duplicated strings
+   */
+  static QSet<QString> getDuplicates(const QStringList& input);
 };
 
 }


### PR DESCRIPTION
Manual match IDs were originally implemented as UUIDs and currently they exist as 6 character hex. There are still some old regression tests around that use the UUIDs, so rather than spend the resources to update the input data, its easier to support the UUID on a case by case basis.