### PR TITLE
Valgrind memory leaks

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -327,14 +327,16 @@ void OgrWriter::_createLayer(const std::shared_ptr<const Layer>& layer)
   else
   {
     LOG_DEBUG("Layer: " << layerName << " not found.  Creating layer...");
-    poLayer = _ds->CreateLayer(layerName.toLatin1(),
-                  MapProjector::createWgs84Projection()->Clone(), gtype, options.getCrypticOptions());
+    std::shared_ptr<OGRSpatialReference> projection = MapProjector::createWgs84Projection();
+    poLayer = _ds->CreateLayer(layerName.toLatin1(), projection.get(),
+                  gtype, options.getCrypticOptions());
 
     if (poLayer == NULL)
     {
       throw HootException(QString("Layer creation failed. %1").arg(layerName));
     }
     _layers[layer->getName()] = poLayer;
+    _projections[layer->getName()] = projection;
 
     std::shared_ptr<const FeatureDefinition> fd = layer->getFeatureDefinition();
     for (size_t i = 0; i < fd->getFieldCount(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -147,6 +147,7 @@ protected:
   std::shared_ptr<GDALDataset> _ds;
   /** Hash of layer names and corresponding layer objects that are owned by the GDALDataset */
   QHash<QString, OGRLayer*> _layers;
+  QHash<QString, std::shared_ptr<OGRSpatialReference>> _projections;
   QString _prependLayerName;
   std::shared_ptr<const Schema> _schema;
   StrictChecking _strictChecking;

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.cpp
@@ -180,10 +180,10 @@ void BuildingOutlineUpdateOp::_unionOutline(const RelationPtr& pBuilding,
   catch (const geos::util::TopologyException& e)
   {
     LOG_TRACE("Attempting to clean way geometry after union error: " << e.what());
-    Geometry* cleanedGeom = GeometryUtils::validateGeometry(pGeometry.get());
+    std::shared_ptr<Geometry> cleanedGeom(GeometryUtils::validateGeometry(pGeometry.get()));
     try
     {
-      pOutline.reset(pOutline->Union(cleanedGeom));
+      pOutline.reset(pOutline->Union(cleanedGeom.get()));
       LOG_VART(pOutline->getGeometryTypeId());
     }
     catch (const geos::util::TopologyException& e)

--- a/hoot-core/src/main/cpp/hoot/core/util/GeometryUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/GeometryUtils.cpp
@@ -226,7 +226,8 @@ Geometry* GeometryUtils::validateGeometryCollection(
 
   for (size_t i = 0; i < gc->getNumGeometries(); i++)
   {
-    Geometry* tmp = result->Union(validateGeometry(gc->getGeometryN(i)));
+    std::shared_ptr<Geometry> geometry(validateGeometry(gc->getGeometryN(i)));
+    Geometry* tmp = result->Union(geometry.get());
     delete result;
     result = tmp;
   }

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
@@ -189,6 +189,7 @@ public:
   void DeleteEdge(InternalEdge * e);
   void Draw();
   InternalEdge* MakeEdge();
+  Point2d* MakePoint(const Point2d& pt);
 
   InternalEdge* getStartingEdge() const { return startingEdge; }
 
@@ -200,6 +201,7 @@ private:
   InternalEdge * startingEdge;
 
   set<QuadEdge*> _edges;
+  vector<Point2d*> _data;
 };
 
 class QuadEdge
@@ -322,6 +324,13 @@ InternalEdge *Subdivision::MakeEdge()
   return ql->e;
 }
 
+Point2d* Subdivision::MakePoint(const Point2d& pt)
+{
+  Point2d* point = new Point2d(pt);
+  _data.push_back(point);
+  return point;
+}
+
 void Splice(InternalEdge * a, InternalEdge * b)
 // This operator affects the two edge rings around the origins of a and b,
 // and, independently, the two edge rings around the left faces of a and b.
@@ -356,8 +365,9 @@ void Subdivision::DeleteEdge(InternalEdge * e)
 Subdivision::Subdivision(const Point2d & a, const Point2d & b, const Point2d & c)
 // Initialize a subdivision to the triangle defined by the points a, b, c.
 {
-  Point2d *da, *db, *dc;
-  da = new Point2d(a), db = new Point2d(b), dc = new Point2d(c);
+  Point2d* da = MakePoint(a);
+  Point2d* db = MakePoint(b);
+  Point2d* dc = MakePoint(c);
   InternalEdge *ea = MakeEdge();
   ea->EndPoints(da, db);
   InternalEdge *eb = MakeEdge();
@@ -373,10 +383,11 @@ Subdivision::Subdivision(const Point2d & a, const Point2d & b, const Point2d & c
 Subdivision::~Subdivision()
 {
   for (set<QuadEdge*>::iterator it = _edges.begin(); it != _edges.end(); ++it)
-  {
-    delete *it;
-  }
+    delete (*it);
   _edges.clear();
+  for (vector<Point2d*>::iterator it = _data.begin(); it != _data.end(); ++it)
+    delete (*it);
+  _data.clear();
 }
 
 InternalEdge *Subdivision::Connect(InternalEdge * a, InternalEdge * b)
@@ -551,7 +562,7 @@ void Subdivision::InsertSite(const Point2d & x)
   // triangle (or quadrilateral, if the new point fell on an
   // existing edge.)
   InternalEdge *base = MakeEdge();
-  base->EndPoints(e->Org(), new Point2d(x));
+  base->EndPoints(e->Org(), MakePoint(x));
   Splice(base, e);
   startingEdge = base;
   do


### PR DESCRIPTION
Delaunay Triangulation `data` members weren't being deleted.
`Geometry::Union` doesn't assume ownership of memory passed in.
`OgrWriter` was leaking projection objects.