### PR TITLE
3530 - Prevent shared nodes from being removed from roundabouts

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -256,6 +256,7 @@ int ConflateCmd::runSimple(QStringList& args)
       map, input2, ConfigOptions().getConflateUseDataSourceIds2(), Status::Unknown2);
     currentTask++;
   }
+  LOG_INFO("Conflating map with " << StringUtils::formatLargeNumber(map->size()) << " elements...");
 
   double inputBytes = IoSingleStat(IoSingleStat::RChar).value - bytesRead;
   LOG_VART(inputBytes);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.cpp
@@ -94,10 +94,9 @@ NodePtr Roundabout::getNewCenter(OsmMapPtr pMap)
   return pNewNode;
 }
 
-RoundaboutPtr Roundabout::makeRoundabout(const OsmMapPtr &pMap,
-                                         WayPtr pWay)
+RoundaboutPtr Roundabout::makeRoundabout(const OsmMapPtr &pMap, WayPtr pWay)
 {
-  RoundaboutPtr rnd(new Roundabout);
+  RoundaboutPtr rnd(new Roundabout());
 
   // Add the way to the roundabout
   rnd->setRoundaboutWay(pWay);
@@ -231,6 +230,7 @@ void Roundabout::handleCrossingWays(OsmMapPtr pMap)
         if (newWays.size() > 0 && replace)
         {
           // Remove pWay
+          LOG_TRACE("Removing original way: " << pWay->getElementId() << "...");
           RemoveWayByEid::removeWayFully(pMap, pWay->getId());
           pMap->addNode(pCenterNode);
         }
@@ -265,17 +265,23 @@ void Roundabout::removeRoundabout(OsmMapPtr pMap)
       extraNodeIDs.insert(_roundaboutNodes[i]->getId());
     }
   }
+  LOG_VART(connectingNodeIDs.size());
+  LOG_VART(extraNodeIDs.size());
 
   // Find our center coord...
   if (!_pCenterNode)
     _pCenterNode = getNewCenter(pMap);
 
   // Remove roundabout way & extra nodes
+  LOG_TRACE("Removing roundabout: " << _roundaboutWay->getElementId() << "...");
   RemoveWayByEid::removeWayFully(pMap, _roundaboutWay->getId());
   for (std::set<long>::iterator it = extraNodeIDs.begin();
        it != extraNodeIDs.end(); ++it)
   {
-    RemoveNodeByEid::removeNode(pMap, *it);
+    LOG_TRACE("Removing extra node with ID: " << *it << "...");
+    // There may be something off with the map index, as I found situation where one of these extra
+    // nodes was still in use. So, changed the removal to only if unused here.
+    RemoveNodeByEid::removeNode(pMap, *it, true);
   }
 
   // Add center node
@@ -424,11 +430,18 @@ void Roundabout::replaceRoundabout(OsmMapPtr pMap)
     // Need to remove temp parts no matter what
     // Delete temp ways we added
     for (size_t i = 0; i < _tempWays.size(); i++)
-      RemoveWayByEid::removeWayFully(pMap, _tempWays[i]->getId());
+    {
+      ConstWayPtr tempWay = _tempWays[i];
+      LOG_TRACE("Removing temp way: " << tempWay->getElementId() << "...");
+      RemoveWayByEid::removeWayFully(pMap, tempWay->getId());
+    }
 
     // Remove center node if no other ways are using it
     if (pMap->getIndex().getNodeToWayMap()->getWaysByNode(_pCenterNode->getId()).size() < 1)
+    {
+      LOG_TRACE("Removing center node: " << _pCenterNode->getElementId() << "...");
       RemoveNodeByEid::removeNodeFully(pMap, _pCenterNode->getId());
+    }
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.h
@@ -103,7 +103,7 @@ public:
    * @brief getCenter - Gets the node set as the roundabout's center
    * @return - Node
    */
-  NodePtr getCenter(){ return _pCenterNode; }
+  NodePtr getCenter() { return _pCenterNode; }
 
   /**
    * @brief makeRoundabout - Creates & populates a roundabout object using the
@@ -112,8 +112,8 @@ public:
    * @param pWay - The roundabout way
    * @return - A newly constructed roundabout object
    */
-  static std::shared_ptr<Roundabout> makeRoundabout (const OsmMapPtr &pMap,
-                                                       WayPtr pWay);
+  static std::shared_ptr<Roundabout> makeRoundabout(const OsmMapPtr &pMap,
+                                                    WayPtr pWay);
 
   /**
    * @brief removeRoundabout - Removes this roundabout from the map, and

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveNodeByEid.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveNodeByEid.cpp
@@ -71,7 +71,9 @@ void RemoveNodeByEid::_removeNode(const OsmMapPtr& map, long nId)
       return;
     }
     else
-      throw HootException("Removing a node, but it is still part of one or more ways.");
+      throw HootException(
+        "Attempting to remove: " + ElementId(ElementType::Node, nId).toString() +
+        ", but it is still part of one or more ways.");
   }
   _removeNodeNoCheck(map, nId);
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
@@ -63,6 +63,7 @@ void RemoveRoundabouts::removeRoundabouts(std::vector<RoundaboutPtr> &removed)
       _todoWays.push_back(it->first);
     }
   }
+  LOG_VART(_todoWays.size());
 
   // Make roundabout objects
   for (size_t i = 0; i < _todoWays.size(); i++)


### PR DESCRIPTION
Added a check to only remove nodes identified as extra by roundabout remove if they are unused by any ways.