### PR TITLE
Valgrind Memory Leaks - Mergers

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/GreedyConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/GreedyConstrainedMatchesTest.cpp
@@ -123,7 +123,7 @@ class GreedyConstrainedFakeCreator : public MergerCreator
 {
 public:
 
-  virtual bool createMergers(const MatchSet&, vector<Merger*>&) const
+  virtual bool createMergers(const MatchSet&, vector<MergerPtr>&) const override
   {
     assert(false);
     return false;

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/matching/OptimalConstrainedMatchesTest.cpp
@@ -123,7 +123,7 @@ class OptimalConstrainedFakeCreator : public MergerCreator
 {
 public:
 
-  virtual bool createMergers(const MatchSet&, vector<Merger*>&) const
+  virtual bool createMergers(const MatchSet&, vector<MergerPtr>&) const override
   {
     assert(false);
     return false;

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreatorTest.cpp
@@ -102,12 +102,12 @@ public:
 
     MatchSet matches;
     matches.insert(match1);
-    vector<Merger*> mergers;
+    vector<MergerPtr> mergers;
     PoiPolygonMergerCreator uut;
     uut.setOsmMap(map.get());
     HOOT_STR_EQUALS(1, uut.createMergers(matches, mergers));
     HOOT_STR_EQUALS(1, mergers.size());
-    HOOT_STR_EQUALS(1, (dynamic_cast<PoiPolygonMerger*>(mergers[0]) != 0));
+    HOOT_STR_EQUALS(1, (dynamic_pointer_cast<PoiPolygonMerger>(mergers[0]) != 0));
   }
 
   void reviewTest()
@@ -164,14 +164,14 @@ public:
 
     MatchSet matches;
     matches.insert(matchesV.begin(), matchesV.end());
-    vector<Merger*> mergers;
+    vector<MergerPtr> mergers;
     PoiPolygonMergerCreator uut;
     uut.setOsmMap(map.get());
 
     HOOT_STR_EQUALS(1, uut.createMergers(matches, mergers));
     HOOT_STR_EQUALS(1, mergers.size());
     LOG_VART(*mergers[0]);
-    HOOT_STR_EQUALS(1, (dynamic_cast<MarkForReviewMerger*>(mergers[0]) != 0));
+    HOOT_STR_EQUALS(1, (dynamic_pointer_cast<MarkForReviewMerger>(mergers[0]) != 0));
   }
 
   void crossConflateMergeTest()
@@ -195,7 +195,7 @@ public:
 
     MatchSet matches;
     matches.insert(matchesV.begin(), matchesV.end());
-    vector<Merger*> mergers;
+    vector<MergerPtr> mergers;
     PoiPolygonMergerCreator uut;
     // Neither of the match types used here actually require a map to calculate isConflicting, but
     // since the merger creator requires a map we'll pass in an empty one.
@@ -206,7 +206,7 @@ public:
     HOOT_STR_EQUALS(1, uut.createMergers(matches, mergers));
     HOOT_STR_EQUALS(1, mergers.size());
     LOG_VART(*mergers[0]);
-    HOOT_STR_EQUALS(1, (dynamic_cast<PoiPolygonMerger*>(mergers[0]) != 0));
+    HOOT_STR_EQUALS(1, (dynamic_pointer_cast<PoiPolygonMerger>(mergers[0]) != 0));
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -399,10 +399,10 @@ void UnifyingConflator::_replaceElementIds(const vector<pair<ElementId, ElementI
 {
   for (size_t i = 0; i < replaced.size(); ++i)
   {
-    HashMap<ElementId, vector<Merger*>>::const_iterator it = _e2m.find(replaced[i].first);
+    HashMap<ElementId, vector<MergerPtr>>::const_iterator it = _e2m.find(replaced[i].first);
     if (it != _e2m.end())
     {
-      const vector<Merger*>& mergers = it->second;
+      const vector<MergerPtr>& mergers = it->second;
       // replace the element id in all mergers.
       for (size_t i = 0; i < mergers.size(); ++i)
       {
@@ -437,7 +437,7 @@ void UnifyingConflator::_reset()
 
   _e2m.clear();
   _matches.clear();
-  _deleteAll(_mergers);
+  _mergers.clear();
 }
 
 void UnifyingConflator::_validateConflictSubset(const ConstOsmMapPtr& map,

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.h
@@ -29,6 +29,7 @@
 
 // hoot
 #include <hoot/core/conflate/matching/MatchGraph.h>
+#include <hoot/core/conflate/merging/Merger.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/info/SingleStat.h>
 #include <hoot/core/io/Serializable.h>
@@ -51,7 +52,6 @@ class Match;
 class MatchClassification;
 class MatchFactory;
 class MatchThreshold;
-class Merger;
 class MergerFactory;
 class ElementId;
 
@@ -114,25 +114,15 @@ private:
   std::shared_ptr<MatchThreshold> _matchThreshold;
   std::shared_ptr<MergerFactory> _mergerFactory;
   Settings _settings;
-  HashMap<ElementId, std::vector<Merger*>> _e2m;
+  HashMap<ElementId, std::vector<MergerPtr>> _e2m;
   std::vector<ConstMatchPtr> _matches;
-  std::vector<Merger*> _mergers;
+  std::vector<MergerPtr> _mergers;
   QList<SingleStat> _stats;
   int _taskStatusUpdateInterval;
   Progress _progress;
 
   void _addReviewTags(const OsmMapPtr &map, const std::vector<ConstMatchPtr> &matches);
   void _addScoreTags(const ElementPtr& e, const MatchClassification& mc);
-
-  template <typename InputCollection>
-  void _deleteAll(InputCollection& ic)
-  {
-    for (typename InputCollection::const_iterator it = ic.begin(); it != ic.end(); ++it)
-    {
-      delete *it;
-    }
-    ic.clear();
-  }
 
   /**
    * Populates the _e2m map with a mapping of ElementIds to their respective Merger objects. This

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
@@ -46,7 +46,7 @@ HighwayMergerCreator::HighwayMergerCreator()
   setConfiguration(conf());
 }
 
-bool HighwayMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
+bool HighwayMergerCreator::createMergers(const MatchSet& matches, vector<MergerPtr>& mergers) const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
 
@@ -86,11 +86,11 @@ bool HighwayMergerCreator::createMergers(const MatchSet& matches, vector<Merger*
   {
     if (!ConfigOptions().getHighwayMergeTagsOnly())
     {
-      mergers.push_back(new HighwaySnapMerger(eids, sublineMatcher));
+      mergers.push_back(MergerPtr(new HighwaySnapMerger(eids, sublineMatcher)));
     }
     else
     {
-      mergers.push_back(new HighwayTagOnlyMerger(eids, sublineMatcher));
+      mergers.push_back(MergerPtr(new HighwayTagOnlyMerger(eids, sublineMatcher)));
     }
     result = true;
   }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.h
@@ -45,7 +45,7 @@ public:
   /**
    * If there is a single HighwayMatch, a single HighwayMergerCreator will be created and returned.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.cpp
@@ -43,7 +43,7 @@ MarkForReviewMergerCreator::MarkForReviewMergerCreator()
 }
 
 bool MarkForReviewMergerCreator::createMergers(const MatchSet& matches,
-                                               vector<Merger*>& mergers) const
+                                               vector<MergerPtr>& mergers) const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
 
@@ -89,7 +89,8 @@ bool MarkForReviewMergerCreator::createMergers(const MatchSet& matches,
   if (eids.size() > 0)
   {
     mergers.push_back(
-      new MarkForReviewMerger(eids, matchStrings.join(","), reviewType.join(";"), score));
+      MergerPtr(
+        new MarkForReviewMerger(eids, matchStrings.join(","), reviewType.join(";"), score)));
     result = true;
   }
   else

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MarkForReviewMergerCreator.h
@@ -41,7 +41,7 @@ public:
 
   MarkForReviewMergerCreator();
 
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerCreator.h
@@ -30,6 +30,7 @@
 // hoot
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
+#include <hoot/core/conflate/merging/Merger.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/info/CreatorDescription.h>
 
@@ -40,8 +41,6 @@
 
 namespace hoot
 {
-
-class Merger;
 
 /**
  * Abstract base class for creating conflation feature mergers
@@ -64,7 +63,7 @@ public:
    * @return Returns true if one or more mergers were created and added to the provided mergers
    *  vector.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const = 0;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const = 0;
 
   /**
    * Generally this just returns the class name of this creator. However, creators that take

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
@@ -58,7 +58,7 @@ void MergerFactory::reset()
 }
 
 void MergerFactory::createMergers(const OsmMapPtr& map, const MatchSet& matches,
-  vector<Merger*>& result) const
+  vector<MergerPtr>& result) const
 {
   for (size_t i = 0; i < _creators.size(); i++)
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
@@ -67,7 +67,7 @@ public:
    * The caller assumes ownership of the new Mergers in the result.
    */
   void createMergers(const hoot::OsmMapPtr &map, const MatchSet& matches,
-    std::vector<Merger *> &result) const;
+    std::vector<MergerPtr>& result) const;
 
   /**
    * @brief Returns a description of all available match creators.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
@@ -54,7 +54,7 @@ NetworkMergerCreator::NetworkMergerCreator()
   _minMatchOverlapPercentage = ConfigOptions().getNetworkMergerMinLargeMatchOverlapPercentage();
 }
 
-bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merger*>& mergers) const
+bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<MergerPtr>& mergers) const
 {
   LOG_DEBUG("Creating mergers with " << className() << "...");
   LOG_TRACE("Creating mergers for match set: " << matchesIn);
@@ -108,15 +108,18 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
 
       if (!ConfigOptions().getHighwayMergeTagsOnly())
       {
-        mergers.push_back(new PartialNetworkMerger(pairs, edgeMatches, m->getNetworkDetails()));
+        mergers.push_back(
+          MergerPtr(
+            new PartialNetworkMerger(pairs, edgeMatches, m->getNetworkDetails())));
       }
       else
       {
         mergers.push_back(
-          new HighwayTagOnlyMerger(
-            pairs,
-            std::shared_ptr<PartialNetworkMerger>(
-              new PartialNetworkMerger(pairs, edgeMatches, m->getNetworkDetails()))));
+          MergerPtr(
+            new HighwayTagOnlyMerger(
+              pairs,
+              std::shared_ptr<PartialNetworkMerger>(
+                new PartialNetworkMerger(pairs, edgeMatches, m->getNetworkDetails())))));
       }
     }
     else
@@ -130,19 +133,21 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
         if (!ConfigOptions().getHighwayMergeTagsOnly())
         {
           mergers.push_back(
-            new PartialNetworkMerger(
-              larger->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << larger->getEdgeMatch(),
-              larger->getNetworkDetails()));
+            MergerPtr(
+              new PartialNetworkMerger(
+                larger->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << larger->getEdgeMatch(),
+                larger->getNetworkDetails())));
         }
         else
         {
           mergers.push_back(
-            new HighwayTagOnlyMerger(
-              larger->getMatchPairs(),
-              std::shared_ptr<PartialNetworkMerger>(
-                new PartialNetworkMerger(
-                  larger->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << larger->getEdgeMatch(),
-                  larger->getNetworkDetails()))));
+            MergerPtr(
+              new HighwayTagOnlyMerger(
+                larger->getMatchPairs(),
+                std::shared_ptr<PartialNetworkMerger>(
+                  new PartialNetworkMerger(
+                    larger->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << larger->getEdgeMatch(),
+                    larger->getNetworkDetails())))));
         }
       }
       else
@@ -156,19 +161,21 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
           if (!ConfigOptions().getHighwayMergeTagsOnly())
           {
             mergers.push_back(
-              new PartialNetworkMerger(
-                largest->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << largest->getEdgeMatch(),
-                largest->getNetworkDetails()));
+              MergerPtr(
+                new PartialNetworkMerger(
+                  largest->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << largest->getEdgeMatch(),
+                  largest->getNetworkDetails())));
           }
           else
           {
             mergers.push_back(
-              new HighwayTagOnlyMerger(
-                largest->getMatchPairs(),
-                std::shared_ptr<PartialNetworkMerger>(
-                  new PartialNetworkMerger(
-                    largest->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << largest->getEdgeMatch(),
-                    largest->getNetworkDetails()))));
+              MergerPtr(
+                new HighwayTagOnlyMerger(
+                  largest->getMatchPairs(),
+                  std::shared_ptr<PartialNetworkMerger>(
+                    new PartialNetworkMerger(
+                      largest->getMatchPairs(), QSet<ConstEdgeMatchPtr>() << largest->getEdgeMatch(),
+                      largest->getNetworkDetails())))));
           }
         }
         else // Throw a review
@@ -188,12 +195,13 @@ bool NetworkMergerCreator::createMergers(const MatchSet& matchesIn, vector<Merge
 
             const NetworkMatch* m = dynamic_cast<const NetworkMatch*>(it->get());
             mergers.push_back(
-              new MarkForReviewMerger(
-                eids,
-                "A complex road situation was found with multiple plausible solutions. Please "
-                "reference input data/imagery and manually merge or modify as needed.",
-                m->getMatchName(),
-                m->getScore()));
+              MergerPtr(
+                new MarkForReviewMerger(
+                  eids,
+                  "A complex road situation was found with multiple plausible solutions. Please "
+                  "reference input data/imagery and manually merge or modify as needed.",
+                  m->getMatchName(),
+                  m->getScore())));
 
             count++;
             if (count % 100 == 0)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.h
@@ -44,7 +44,7 @@ public:
 
   NetworkMergerCreator();
 
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
@@ -61,7 +61,7 @@ MatchPtr PoiPolygonMergerCreator::_createMatch(const ConstOsmMapPtr& map, Elemen
   return MatchFactory::getInstance().createMatch(map, eid1, eid2);
 }
 
-bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
+bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<MergerPtr>& mergers) const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
 
@@ -121,15 +121,16 @@ bool PoiPolygonMergerCreator::createMergers(const MatchSet& matches, vector<Merg
     if (_isConflictingSet(matches))
     {
       mergers.push_back(
-        new MarkForReviewMerger(
-          eids,
-          QString("Conflicting information: multiple features have been matched to the same ") +
-          QString("feature and require review."),
-          matchTypes.join(";"), 1));
+        MergerPtr(
+          new MarkForReviewMerger(
+            eids,
+            QString("Conflicting information: multiple features have been matched to the same ") +
+            QString("feature and require review."),
+            matchTypes.join(";"), 1)));
     }
     else
     {
-      mergers.push_back(new PoiPolygonMerger(eids));
+      mergers.push_back(MergerPtr(new PoiPolygonMerger(eids)));
     }
 
     result = true;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.h
@@ -53,7 +53,7 @@ public:
    * appended. If there is more than one match and at least one is a PoiPolygonMatch then a
    * MarkForReviewMerger is created.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
@@ -43,7 +43,7 @@ BuildingMergerCreator::BuildingMergerCreator()
 {
 }
 
-bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
+bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<MergerPtr>& mergers) const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
 
@@ -76,7 +76,7 @@ bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<Merger
   // only add the building merge if there are elements to merge.
   if (eids.size() > 0)
   {
-    mergers.push_back(new BuildingMerger(eids));
+    mergers.push_back(MergerPtr(new BuildingMerger(eids)));
     result = true;
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.h
@@ -44,7 +44,7 @@ public:
   /**
    * If all the matches are BuildingMatches, a single BuildingMerge will be created and returned.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagKeyContainsCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagKeyContainsCriterion.h
@@ -44,7 +44,7 @@ public:
 
   static std::string className() { return "hoot::TagKeyContainsCriterion"; }
 
-  TagKeyContainsCriterion() {}
+  TagKeyContainsCriterion() : _text(""), _caseSensitive(false) { }
   explicit TagKeyContainsCriterion(const QString& text);
 
   virtual bool isSatisfied(const ConstElementPtr& e) const override;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
@@ -288,7 +288,7 @@ bool ScriptMatch::_isOrderedConflicting(const ConstOsmMapPtr& map, ElementId sha
     new ScriptMatch(_script, _plugin, copiedMap, copiedMapJs, eid11, eid12, _threshold));
   MatchSet ms;
   ms.insert(m1);
-  vector<Merger*> mergers;
+  vector<MergerPtr> mergers;
   ScriptMergerCreator creator;
   creator.createMergers(ms, mergers);
   m1.reset();

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.cpp
@@ -44,7 +44,7 @@ ScriptMergerCreator::ScriptMergerCreator()
 {
 }
 
-bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>& mergers) const
+bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<MergerPtr>& mergers) const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
 
@@ -62,7 +62,7 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
   {
     ConstMatchPtr m = *it;
     LOG_VART(m->toString());
-    const ScriptMatch* sm = dynamic_cast<const ScriptMatch*>(m.get());
+    std::shared_ptr<const ScriptMatch> sm = dynamic_pointer_cast<const ScriptMatch>(m);
     // check to make sure all the input matches are script matches.
     if (sm == 0)
     {
@@ -89,7 +89,7 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
     }
   }
 
-  ScriptMerger* sm = new ScriptMerger(script, plugin, eids);
+  std::shared_ptr<ScriptMerger> sm(new ScriptMerger(script, plugin, eids));
   // only add the merge if there are elements to merge.
   if (sm->hasFunction("mergeSets"))
   {
@@ -97,10 +97,6 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
     {
       mergers.push_back(sm);
       result = true;
-    }
-    else
-    {
-      delete sm;
     }
   }
   else
@@ -112,14 +108,10 @@ bool ScriptMergerCreator::createMergers(const MatchSet& matches, vector<Merger*>
     }
     else if (eids.size() > 1)
     {
-      delete sm;
       mergers.push_back(
-        new MarkForReviewMerger(eids, "Overlapping matches", matchType.join(";"), 1.0));
+        MergerPtr(
+          new MarkForReviewMerger(eids, "Overlapping matches", matchType.join(";"), 1.0)));
       result = true;
-    }
-    else
-    {
-      delete sm;
     }
   }
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMergerCreator.h
@@ -46,7 +46,7 @@ public:
   /**
    * If all the matches are CustomPoiMatches, a single CustomPoiMerger will be created and returned.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCache.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCache.cpp
@@ -55,24 +55,6 @@ public:
   }
 };
 
-/**
- * Delete the Merger vector in a safe way.
- */
-struct ScopedMergerDeleter
-{
-  ScopedMergerDeleter(std::vector<Merger*>& ms) : _ms(ms) {}
-
-  ~ScopedMergerDeleter()
-  {
-    foreach (Merger* m, _ms)
-    {
-      delete m;
-    }
-  }
-
-  std::vector<Merger*>& _ms;
-};
-
 MultiaryPoiMergeCache::MultiaryPoiMergeCache(const ConstOsmMapPtr& map,
     const std::shared_ptr<MatchCreator>& matchCreator,
     const std::shared_ptr<MergerCreator>& mergerCreator) :
@@ -120,9 +102,8 @@ MultiaryClusterPtr MultiaryPoiMergeCache::merge(const MultiaryClusterPtr& c1, co
     ms.insert(m);
   }
 
-  // create a merge vector and a clean way to clean it up.
-  std::vector<Merger*> mergers;
-  ScopedMergerDeleter deleteMergers(mergers);
+  // create a merge vector
+  std::vector<MergerPtr> mergers;
 
   // create a merger with the provided merge creator.
   _mergerCreator->createMergers(ms, mergers);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.cpp
@@ -39,7 +39,7 @@ MultiaryPoiMergerCreator::MultiaryPoiMergerCreator()
 {
 }
 
-bool MultiaryPoiMergerCreator::createMergers(const MatchSet& matches, std::vector<Merger*>& mergers)
+bool MultiaryPoiMergerCreator::createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers)
   const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
@@ -59,7 +59,7 @@ bool MultiaryPoiMergerCreator::createMergers(const MatchSet& matches, std::vecto
 
   if (eids.size() >= 1)
   {
-    mergers.push_back(new MultiaryPoiMerger(eids));
+    mergers.push_back(MergerPtr(new MultiaryPoiMerger(eids)));
     result = true;
   }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergerCreator.h
@@ -63,7 +63,7 @@ public:
    * This merger is very aggressive and will merge pretty much any set of matches that are passed
    * in. This should generally be the last merger.
    */
-  virtual bool createMergers(const MatchSet& matches, std::vector<Merger*>& mergers) const override;
+  virtual bool createMergers(const MatchSet& matches, std::vector<MergerPtr>& mergers) const override;
 
   /**
    * Returns a description of this merger creator.


### PR DESCRIPTION
Replaced all vector<Merger*> objects with vector<MergerPtr> objects to stop memory leaks.
Also found a place where a class member wasn't being initialized.