### PR TITLE
Turn on hoot:id tag when writer.include.debug.tags=true

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.cpp
@@ -33,11 +33,11 @@ namespace hoot
 {
 
 AddExportTagsVisitor::AddExportTagsVisitor()
-{  
-  _includeIds = false,
-  _textStatus = ConfigOptions().getWriterTextStatus();
-  _includeDebug = ConfigOptions().getWriterIncludeDebugTags();
-  _includeCircularError = ConfigOptions().getWriterIncludeCircularErrorTags();
+  : _includeIds(false),
+    _textStatus(ConfigOptions().getWriterTextStatus()),
+    _includeCircularError(ConfigOptions().getWriterIncludeCircularErrorTags()),
+    _includeDebug(ConfigOptions().getWriterIncludeDebugTags())
+{
 }
 
 void AddExportTagsVisitor::visit(const ElementPtr& pElement)
@@ -91,7 +91,7 @@ void AddExportTagsVisitor::visit(const ElementPtr& pElement)
   }
 
   // HootId
-  if (_includeIds)
+  if (_includeDebug || _includeIds)
   {
     tags[MetadataTags::HootId()] = QString::number(pElement->getId());
   }
@@ -107,7 +107,7 @@ void AddExportTagsVisitor::overrideDebugSettings()
 {
   _includeIds = true;
   _textStatus = false;
-  _includeCircularError= true;
+  _includeCircularError = true;
   _includeDebug = true;
 }
 


### PR DESCRIPTION
I found that the `AddExportTagsVisitor` class wasn't exporting `hoot:id` when the `writer.include.debug.tags` setting was set.  The unit tests weren't catching it because of the use of `hoot diff` that ignores debug tags or the lack thereof.