### PR TITLE
Joining loses parent way IDs

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
@@ -38,6 +38,7 @@
 #include <hoot/core/schema/TagMergerFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/UpdateWayParentVisitor.h>
 
 #include <unordered_set>
 #include <vector>
@@ -354,6 +355,10 @@ bool WayJoiner::_joinWays(const WayPtr &parent, const WayPtr &child)
   //  Update any relations that contain the child to use the parent
   ReplaceElementOp(child->getElementId(), parent->getElementId()).apply(_map);
   child->getTags().clear();
+  //  Update any ways that have the child's ID as their parent to the parent's ID
+  UpdateWayParentVisitor visitor(child->getId(), parent->getId());
+  _map->visitWaysRw(visitor);
+  //  Delete the child
   RecursiveElementRemover(child->getElementId()).apply(_map);
 
   _numJoined++;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/UpdateWayParentVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/UpdateWayParentVisitor.cpp
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "UpdateWayParentVisitor.h"
+
+using namespace std;
+
+namespace hoot
+{
+
+UpdateWayParentVisitor::UpdateWayParentVisitor(long oldParentId, long newParentId)
+  : _oldParentId(oldParentId),
+    _newParentId(newParentId)
+{
+}
+
+void UpdateWayParentVisitor::visit(const ElementPtr& e)
+{
+  if (e->getElementType() == ElementType::Way)
+  {
+    WayPtr w = std::dynamic_pointer_cast<Way>(e);
+    if (w->getPid() == _oldParentId)
+      w->setPid(_newParentId);
+  }
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/visitors/UpdateWayParentVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/UpdateWayParentVisitor.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#ifndef UPDATE_WAY_PARENT_VISITOR_H
+#define UPDATE_WAY_PARENT_VISITOR_H
+
+#include <hoot/core/elements/ElementVisitor.h>
+#include <hoot/core/elements/OsmMap.h>
+
+namespace hoot
+{
+
+class UpdateWayParentVisitor : public ElementVisitor
+{
+public:
+
+  UpdateWayParentVisitor(long oldParentId, long newParentId);
+
+  virtual void visit(const ElementPtr& e) override;
+
+  virtual QString getDescription() const override { return "Updates all way parent IDs to a new ID"; }
+
+private:
+  long _oldParentId;
+  long _newParentId;
+
+};
+
+}
+
+#endif // UPDATE_WAY_PARENT_VISITOR_H

--- a/test-files/cmd/glacial/NetworkConflateCmdInputReverseTest/output.osm
+++ b/test-files/cmd/glacial/NetworkConflateCmdInputReverseTest/output.osm
@@ -3586,6 +3586,26 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-22948" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5040"/>
+        <nd ref="-102282"/>
+        <nd ref="-49438"/>
+        <nd ref="-49439"/>
+        <nd ref="-49440"/>
+        <nd ref="-1026"/>
+        <nd ref="-49441"/>
+        <nd ref="-36954"/>
+        <nd ref="-49442"/>
+        <nd ref="-49443"/>
+        <nd ref="-49444"/>
+        <nd ref="-49445"/>
+        <nd ref="-49446"/>
+        <nd ref="-49447"/>
+        <nd ref="-49448"/>
+        <nd ref="-49449"/>
+        <nd ref="-49450"/>
+        <nd ref="-49451"/>
+        <nd ref="-49452"/>
+        <nd ref="-49453"/>
         <nd ref="-1151"/>
         <nd ref="-49454"/>
         <nd ref="-49455"/>
@@ -3622,26 +3642,6 @@
         <nd ref="-49436"/>
         <nd ref="-49437"/>
         <nd ref="-5040"/>
-        <nd ref="-102282"/>
-        <nd ref="-49438"/>
-        <nd ref="-49439"/>
-        <nd ref="-49440"/>
-        <nd ref="-1026"/>
-        <nd ref="-49441"/>
-        <nd ref="-36954"/>
-        <nd ref="-49442"/>
-        <nd ref="-49443"/>
-        <nd ref="-49444"/>
-        <nd ref="-49445"/>
-        <nd ref="-49446"/>
-        <nd ref="-49447"/>
-        <nd ref="-49448"/>
-        <nd ref="-49449"/>
-        <nd ref="-49450"/>
-        <nd ref="-49451"/>
-        <nd ref="-49452"/>
-        <nd ref="-49453"/>
-        <nd ref="-1151"/>
         <tag k="highway" v="unclassified"/>
         <tag k="name" v="Washington Cir NW"/>
         <tag k="alt_name" v="WASHINGTON CIR NW"/>
@@ -4058,40 +4058,6 @@
         <nd ref="-1084"/>
         <tag k="highway" v="road"/>
         <tag k="name" v="E ST EXPY NW"/>
-        <tag k="error:circular" v="5"/>
-    </way>
-    <way visible="true" id="-5549" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-28017"/>
-        <nd ref="-70706"/>
-        <nd ref="-70707"/>
-        <nd ref="-70708"/>
-        <nd ref="-70709"/>
-        <nd ref="-70710"/>
-        <nd ref="-70711"/>
-        <nd ref="-70712"/>
-        <nd ref="-70713"/>
-        <nd ref="-70714"/>
-        <nd ref="-70715"/>
-        <nd ref="-70716"/>
-        <nd ref="-70717"/>
-        <nd ref="-70718"/>
-        <nd ref="-70719"/>
-        <nd ref="-70720"/>
-        <nd ref="-70721"/>
-        <nd ref="-70722"/>
-        <nd ref="-70723"/>
-        <nd ref="-70724"/>
-        <nd ref="-70725"/>
-        <nd ref="-70726"/>
-        <nd ref="-70727"/>
-        <nd ref="-70728"/>
-        <nd ref="-70729"/>
-        <nd ref="-70730"/>
-        <nd ref="-70731"/>
-        <nd ref="-70732"/>
-        <nd ref="-61014"/>
-        <tag k="highway" v="unclassified"/>
-        <tag k="name" v="Lincoln Memorial Cir"/>
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-5539" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -7963,6 +7929,34 @@
         <tag k="error:circular" v="5"/>
     </way>
     <way visible="true" id="-658" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-28017"/>
+        <nd ref="-70706"/>
+        <nd ref="-70707"/>
+        <nd ref="-70708"/>
+        <nd ref="-70709"/>
+        <nd ref="-70710"/>
+        <nd ref="-70711"/>
+        <nd ref="-70712"/>
+        <nd ref="-70713"/>
+        <nd ref="-70714"/>
+        <nd ref="-70715"/>
+        <nd ref="-70716"/>
+        <nd ref="-70717"/>
+        <nd ref="-70718"/>
+        <nd ref="-70719"/>
+        <nd ref="-70720"/>
+        <nd ref="-70721"/>
+        <nd ref="-70722"/>
+        <nd ref="-70723"/>
+        <nd ref="-70724"/>
+        <nd ref="-70725"/>
+        <nd ref="-70726"/>
+        <nd ref="-70727"/>
+        <nd ref="-70728"/>
+        <nd ref="-70729"/>
+        <nd ref="-70730"/>
+        <nd ref="-70731"/>
+        <nd ref="-70732"/>
         <nd ref="-61014"/>
         <nd ref="-70649"/>
         <nd ref="-70650"/>

--- a/test-files/cmd/glacial/PowerLineConflateTest/output.osm
+++ b/test-files/cmd/glacial/PowerLineConflateTest/output.osm
@@ -206,33 +206,43 @@
     <node visible="true" id="-2367492" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8750400999999925" lon="-122.2708178000000032"/>
     <node visible="true" id="-2367488" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8573827000000023" lon="-122.0779252999999898">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367487" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9848117000000016" lon="-122.3367839000000004">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367486" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9853339000000005" lon="-122.3373015999999893">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367485" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9849808999999894" lon="-122.3374893999999813">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367483" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9656534999999948" lon="-122.2783359999999817">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367481" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9627119999999962" lon="-122.2779927000000129">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367479" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9603773999999987" lon="-122.2770699999999948">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367475" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9580599999999961" lon="-122.2679774000000066">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367471" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7628766999999996" lon="-122.2131729999999976">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367470" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7614008999999982" lon="-122.2111023000000074">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367466" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7884860999999930" lon="-122.2901190000000042"/>
     <node visible="true" id="-2367465" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7885169999999917" lon="-122.2886432999999897"/>
@@ -292,6 +302,7 @@
         <tag k="power" v="substation"/>
         <tag k="name" v="Palo Seco Substation"/>
         <tag k="operator" v="PG&amp;E"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367361" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9937587999999948" lon="-122.1293273999999798"/>
     <node visible="true" id="-2367360" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9934594999999931" lon="-122.1298129999999986"/>
@@ -304,12 +315,15 @@
     <node visible="true" id="-2367332" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7727914000000027" lon="-122.2429300000000012"/>
     <node visible="true" id="-2367331" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8499174000000025" lon="-122.1586257000000018">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367329" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8494115999999963" lon="-122.1598852000000051">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367327" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8499563999999964" lon="-122.1621034999999864">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367324" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8515054000000006" lon="-122.2629100999999991"/>
     <node visible="true" id="-2367323" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8511992000000035" lon="-122.2628099999999876"/>
@@ -328,6 +342,7 @@
         <tag k="name" v="PG&amp;E Substation"/>
         <tag k="building" v="industrial"/>
         <tag k="operator" v="Pacific Gas &amp; Electric"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367301" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8483189000000024" lon="-122.2286927000000105"/>
     <node visible="true" id="-2367300" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8482569000000026" lon="-122.2284819000000056"/>
@@ -347,54 +362,71 @@
     <node visible="true" id="-2367260" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7961785999999975" lon="-122.2808953999999915"/>
     <node visible="true" id="-2367259" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0121397999999928" lon="-122.2758205999999888">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367258" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0117228999999881" lon="-122.2737371000000195">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367256" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8554760999999900" lon="-122.1870947000000029">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367255" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8540562000000023" lon="-122.1708482999999887">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367254" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8517819999999929" lon="-122.1800453000000033">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367253" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8553895000000011" lon="-122.1872874999999965">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367252" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8515275999999972" lon="-122.1800949000000003">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367251" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8526582000000005" lon="-122.1853066999999982">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367250" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8534393999999992" lon="-122.1762567999999902">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367249" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8536549999999892" lon="-122.1762135999999970">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367248" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8552942000000101" lon="-122.1874988999999943">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367247" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8538560000000004" lon="-122.1762102999999939">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367246" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8539197999999999" lon="-122.1707960999999898">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367245" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8537389999999974" lon="-122.1709376000000020">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367244" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8512526000000022" lon="-122.1801090000000016">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367243" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8527812000000097" lon="-122.1850314999999938">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367242" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8525278999999912" lon="-122.1854936000000009">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367241" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8375607999999914" lon="-122.2633859000000029"/>
     <node visible="true" id="-2367240" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8376762999999912" lon="-122.2640456000000029"/>
@@ -416,6 +448,7 @@
     <node visible="true" id="-2367221" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7965202000000033" lon="-122.2818510999999830"/>
     <node visible="true" id="-2367220" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8760039999999947" lon="-122.2452935000000025">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367218" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8476782999999912" lon="-122.2283909000000079"/>
     <node visible="true" id="-2367215" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8469410000000011" lon="-122.2278138999999868"/>
@@ -430,49 +463,62 @@
     <node visible="true" id="-2367202" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0235048999999989" lon="-122.1285564999999878"/>
     <node visible="true" id="-2367201" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0259549999999891" lon="-122.1163514999999933">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367200" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0241035999999966" lon="-122.1264077000000015">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367199" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0246396999999874" lon="-122.1242576000000071">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367198" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0232027999999929" lon="-122.1298800999999941"/>
     <node visible="true" id="-2367173" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8051751999999937" lon="-122.2315439999999995"/>
     <node visible="true" id="-2367170" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8058328999999986" lon="-122.2302563999999876">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367164" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8053094999999857" lon="-122.2316524999999814"/>
     <node visible="true" id="-2367163" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8054991999999928" lon="-122.2308984000000009"/>
     <node visible="true" id="-2367153" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8057607999999945" lon="-122.2291151000000156">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367151" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8055732999999989" lon="-122.2309581999999892">
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367150" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8056344999999894" lon="-122.2310075999999981"/>
     <node visible="true" id="-2367144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0130872999999880" lon="-122.1800494000000157">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0029009999999943" lon="-122.1993961999999954">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367124" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9161464999999893" lon="-122.3043644999999913"/>
     <node visible="true" id="-2367122" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9166512000000111" lon="-122.3008414000000101">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367114" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9163094999999970" lon="-122.3041525999999948">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367107" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9154587999999961" lon="-122.3035463999999877">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367106" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9162480999999971" lon="-122.3044396000000091"/>
     <node visible="true" id="-2367104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0365529999999907" lon="-122.2340531999999911">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367085" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9165971999999911" lon="-122.3022615999999942">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367083" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0160802999999987" lon="-122.1160770999999841"/>
     <node visible="true" id="-2367082" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0160850999999909" lon="-122.1159455999999892"/>
@@ -494,6 +540,7 @@
     <node visible="true" id="-2367066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0163263999999970" lon="-122.1161146999999971"/>
     <node visible="true" id="-2367065" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9163983999999985" lon="-122.3021109999999965">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367061" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0120483999999976" lon="-122.2647127999999839"/>
     <node visible="true" id="-2367060" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0118156999999854" lon="-122.2641730999999794"/>
@@ -501,227 +548,288 @@
     <node visible="true" id="-2367058" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0124197999999893" lon="-122.2644549000000040"/>
     <node visible="true" id="-2367052" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9935412999999897" lon="-122.1298287000000045">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367050" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8480599000000026" lon="-122.1628060999999974">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367049" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9940512000000012" lon="-122.1300022000000070">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367047" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8542109999999923" lon="-122.1557896000000056">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367046" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8467559999999921" lon="-122.1611686000000105"/>
     <node visible="true" id="-2367044" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0044345000000021" lon="-122.2327877999999828">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367041" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0139818999999974" lon="-122.1160503000000119"/>
     <node visible="true" id="-2367039" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8492504999999966" lon="-122.1661730999999804">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367034" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0445278999999985" lon="-122.2567980999999833"/>
     <node visible="true" id="-2367030" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0451046000000019" lon="-122.2570560999999856"/>
     <node visible="true" id="-2367027" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0042929999999828" lon="-122.2321615999999835">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367022" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0138936999999970" lon="-122.1156016000000051"/>
     <node visible="true" id="-2367020" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9058413999999928" lon="-122.2071535999999981"/>
     <node visible="true" id="-2367018" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0045194999999936" lon="-122.2356041999999974">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367017" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9936819999999997" lon="-122.1296938999999924">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367016" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9061636999999862" lon="-122.2094857999999817"/>
     <node visible="true" id="-2367015" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0384603999999840" lon="-122.2340213999999889">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367013" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8482454999999902" lon="-122.1601373000000024"/>
     <node visible="true" id="-2367011" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8514380000000017" lon="-122.1607479000000183">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367007" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9942400999999919" lon="-122.1301634000000007">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367006" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8519125999999986" lon="-122.1601766999999938">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2367003" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8473856000000026" lon="-122.1616173000000032"/>
     <node visible="true" id="-2366998" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8486612999999963" lon="-122.1625148000000110"/>
     <node visible="true" id="-2366996" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9941800000000001" lon="-122.1302138999999869">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366995" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9046610999999984" lon="-122.2059433999999811">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366985" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0443685999999985" lon="-122.2580602000000027"/>
     <node visible="true" id="-2366983" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9595579000000072" lon="-122.2040566999999953">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366981" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0439664000000022" lon="-122.2568208999999939"/>
     <node visible="true" id="-2366976" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0044122000000115" lon="-122.2321564999999879">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366973" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8656054999999938" lon="-122.1770896000000022">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366971" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8543311000000031" lon="-122.1715506999999832">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366965" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8492086999999984" lon="-122.1594582999999972">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366964" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8493025999999944" lon="-122.1598911000000101">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366963" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9047059000000033" lon="-122.2088178000000198">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366959" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9055583999999968" lon="-122.2095431000000048"/>
     <node visible="true" id="-2366955" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9039581999999911" lon="-122.2068412999999936">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366944" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0144390999999899" lon="-122.1160347999999800"/>
     <node visible="true" id="-2366942" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0049082000000098" lon="-122.2344848000000042">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366938" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9056938000000017" lon="-122.2069680000000034"/>
     <node visible="true" id="-2366936" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8481163000000009" lon="-122.1600715000000008"/>
     <node visible="true" id="-2366929" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9406166999999925" lon="-122.2041512999999924">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366923" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0383272999999917" lon="-122.2338349999999991">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366919" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9940511999999941" lon="-122.1302296000000069"/>
     <node visible="true" id="-2366915" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0044931999999989" lon="-122.2346856000000201">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366905" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0447732000000016" lon="-122.2565477999999928"/>
     <node visible="true" id="-2366901" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8499157999999909" lon="-122.1694851000000028">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366900" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0450439000000031" lon="-122.2579286999999795"/>
     <node visible="true" id="-2366898" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9059079000000025" lon="-122.2092228999999861"/>
     <node visible="true" id="-2366897" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9773568000000026" lon="-122.2156633999999968">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366892" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8657421999999926" lon="-122.1805425999999954">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366890" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0443491999999921" lon="-122.2560136999999969">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366882" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8521111000000019" lon="-122.1576984999999951">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366880" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9940427999999955" lon="-122.1300550999999928">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366878" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0388633999999897" lon="-122.2338155000000057">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366875" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9051959999999823" lon="-122.2090860999999933"/>
     <node visible="true" id="-2366874" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0044587999999948" lon="-122.2338620999999961">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366869" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0401086999999976" lon="-122.2340316999999885">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366868" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0143337000000017" lon="-122.1160670000000010"/>
     <node visible="true" id="-2366861" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0440523999999840" lon="-122.2574961999999914"/>
     <node visible="true" id="-2366858" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8480088000000094" lon="-122.1589091999999823">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366855" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0010340999999912" lon="-122.2342890999999838">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366854" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0142155999999929" lon="-122.1156064999999984"/>
     <node visible="true" id="-2366848" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8478272999999916" lon="-122.1619369000000006"/>
     <node visible="true" id="-2366844" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9941450999999830" lon="-122.1304906999999957">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366843" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9048453999999992" lon="-122.2058127999999897">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366838" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9059071999999944" lon="-122.2099991999999986"/>
     <node visible="true" id="-2366829" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9966630999999992" lon="-122.2306863000000021">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366827" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0181669999999912" lon="-122.2344027000000182">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366822" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0404024999999919" lon="-122.2335556000000025">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366820" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0144380999999996" lon="-122.1157994000000002"/>
     <node visible="true" id="-2366819" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8470591000000027" lon="-122.1614153000000016"/>
     <node visible="true" id="-2366813" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9999453000000003" lon="-122.2390342999999859">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366809" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8498530999999971" lon="-122.1620681999999789">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366808" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0138936999999899" lon="-122.1158772999999798"/>
     <node visible="true" id="-2366806" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8649452000000011" lon="-122.1762721999999854">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366801" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8484310999999920" lon="-122.1623644000000013"/>
     <node visible="true" id="-2366798" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8484498999999843" lon="-122.1603369999999842"/>
     <node visible="true" id="-2366797" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9044160999999988" lon="-122.2079592999999846">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366796" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8477685999999949" lon="-122.1598295000000007"/>
     <node visible="true" id="-2366795" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0044770000000014" lon="-122.2342122000000160">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366788" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0447757999999894" lon="-122.2567374000000200"/>
     <node visible="true" id="-2366786" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9047361999999950" lon="-122.2058599999999871">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366781" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8542180000000101" lon="-122.1711259000000069">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366780" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8471341999999922" lon="-122.1619392000000062">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366778" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0450412999999941" lon="-122.2572811999999800"/>
     <node visible="true" id="-2366773" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9059847999999846" lon="-122.2093122999999935"/>
     <node visible="true" id="-2366772" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0360929999999868" lon="-122.2335911999999922">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366768" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9939935000000020" lon="-122.1304100999999918"/>
     <node visible="true" id="-2366767" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8504931000000013" lon="-122.1628512999999998">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0443248999999923" lon="-122.2562807999999990">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0442547999999903" lon="-122.2574532000000005"/>
     <node visible="true" id="-2366762" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0260507999999859" lon="-122.1088483000000053">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366760" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0259903999999835" lon="-122.1141346999999797">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0159062999999904" lon="-122.1160745999999904"/>
     <node visible="true" id="-2366757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0147718000000054" lon="-122.1158121999999793"/>
     <node visible="true" id="-2366756" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0261783999999992" lon="-122.1060686999999945">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0279172999999915" lon="-122.1129322999999971">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0260916999999949" lon="-122.1078880999999967">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366752" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0163233000000034" lon="-122.1159808000000027"/>
     <node visible="true" id="-2366749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0153728999999956" lon="-122.1157438999999982"/>
     <node visible="true" id="-2366748" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0261951999999894" lon="-122.1050628000000131">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0261181999999920" lon="-122.1069760000000031">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366746" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0145645999999928" lon="-122.1166288999999807"/>
     <node visible="true" id="-2366745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0159025999999969" lon="-122.1158435999999909"/>
@@ -729,24 +837,30 @@
     <node visible="true" id="-2366743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0145674999999912" lon="-122.1160100000000028"/>
     <node visible="true" id="-2366741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0268688000000026" lon="-122.1128922999999844">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366740" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8100393999999937" lon="-122.2718463999999869"/>
     <node visible="true" id="-2366739" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8102993999999981" lon="-122.2717808999999960"/>
     <node visible="true" id="-2366738" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8103418999999974" lon="-122.2720510999999846"/>
     <node visible="true" id="-2366723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0158410000000018" lon="-122.1764629999999840">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366721" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0286608999999984" lon="-122.2037018000000188">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366694" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8069847999999951" lon="-122.2269414999999810">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366693" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8058568000000008" lon="-122.2291549999999916">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366692" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8059135000000026" lon="-122.2302849000000151">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366690" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7979249999999993" lon="-122.2829705999999987"/>
     <node visible="true" id="-2366689" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7973930999999936" lon="-122.2816203999999800"/>
@@ -768,32 +882,41 @@
     <node visible="true" id="-2366673" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8103499999999926" lon="-122.2711438999999984"/>
     <node visible="true" id="-2366672" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0027979999999914" lon="-122.2342709999999926">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366670" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0043501999999975" lon="-122.2338409000000041">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366669" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0043560999999954" lon="-122.2342172000000033">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366658" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9880246999999969" lon="-122.3145978999999812">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366657" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9861712000000011" lon="-122.3192585000000037">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366656" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9892423000000008" lon="-122.3110444999999942">
         <tag k="source" v="survey"/>
         <tag k="power" v="tower"/>
         <tag k="ref" v="12-74;40746158"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366642" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9906800999999916" lon="-122.3094897999999944">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366589" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8760872999999947" lon="-122.1829917999999822">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366587" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8767030999999932" lon="-122.1842292999999984">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366583" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8761784999999946" lon="-122.1870646999999792"/>
     <node visible="true" id="-2366582" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8761737999999895" lon="-122.1868766999999991"/>
@@ -803,24 +926,31 @@
     <node visible="true" id="-2366578" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8759619000000001" lon="-122.1873600999999923"/>
     <node visible="true" id="-2366570" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8846908999999883" lon="-122.1878909999999792">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366567" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8875766999999897" lon="-122.1937274999999943">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366566" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8849822000000032" lon="-122.1906548000000043">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366560" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8881659999999982" lon="-122.1946200999999945">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366559" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8860401000000024" lon="-122.1926069999999811">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366529" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9930641999999992" lon="-122.1315519999999850">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366527" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9936455999999936" lon="-122.1294342000000057">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366526" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9943087999999918" lon="-122.1301100999999818"/>
     <node visible="true" id="-2366525" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9940720999999968" lon="-122.1300071000000003"/>
@@ -829,252 +959,335 @@
     <node visible="true" id="-2366522" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9941735999999963" lon="-122.1306249999999807"/>
     <node visible="true" id="-2366511" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0291361000000023" lon="-122.2049075000000045">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366504" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0292644999999894" lon="-122.2038189999999815">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366489" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0146604999999980" lon="-122.1740559999999789">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366488" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0172435999999934" lon="-122.1794210000000049">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366480" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0271694999999923" lon="-122.2004919999999828">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366479" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0282308999999970" lon="-122.2027579999999887">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366478" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0075935999999928" lon="-122.2001060000000194">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366477" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0128883999999942" lon="-122.1993964999999918">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366476" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0146265999999855" lon="-122.2013159999999914">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366470" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0280753999999916" lon="-122.2036250000000166">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366469" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0023252000000014" lon="-122.1992220000000060">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366468" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0036845999999926" lon="-122.1994619999999827">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366454" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9973871000000045" lon="-122.2312598999999977">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366453" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9949379999999977" lon="-122.2292555999999877">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366452" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9934093000000033" lon="-122.2280367999999982">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366451" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9911837999999946" lon="-122.2263287999999903">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366450" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9881803999999903" lon="-122.2239598999999828">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366449" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9850956000000011" lon="-122.2215307999999965">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366448" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9835531999999958" lon="-122.2203034999999858">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366447" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9804750999999996" lon="-122.2178916000000015">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366446" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9782221999999976" lon="-122.2160376999999869">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366445" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9774711999999965" lon="-122.2154539999999940">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366444" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9753264000000001" lon="-122.2136944999999884">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366443" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9732967000000059" lon="-122.2120551000000148">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366442" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9713818999999972" lon="-122.2105015999999864">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366441" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9691151999999974" lon="-122.2086477000000002">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366440" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9669971999999945" lon="-122.2069138999999893">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366439" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9652446999999924" lon="-122.2054976999999951">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366438" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9635529999999974" lon="-122.2041157999999967">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366437" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9615701999999970" lon="-122.2038582999999790">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366436" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9596550999999991" lon="-122.2036436999999864">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366435" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9577737999999982" lon="-122.2034548999999970">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366434" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9555269999999823" lon="-122.2032316999999892">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366411" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9056744999999964" lon="-122.2106406999999990">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366405" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9015026999999947" lon="-122.2046239999999955">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366403" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9047940999999966" lon="-122.2061173999999824">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366401" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9044690999999929" lon="-122.2056967999999841">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366399" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9045773999999938" lon="-122.2094562000000053">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366398" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9047060999999914" lon="-122.2096106999999989">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366397" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9051530999999855" lon="-122.2099110999999994">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366395" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9070222000000001" lon="-122.2070872999999978">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366394" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9068392999999872" lon="-122.2088210999999944">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366393" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9080514999999920" lon="-122.2094562000000053">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366392" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9242279999999994" lon="-122.2137732999999997">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366391" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9305651000000026" lon="-122.2079884999999990">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366390" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9320002999999915" lon="-122.2066839000000016">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366389" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9350128000000026" lon="-122.2040060000000210">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366388" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9382214999999903" lon="-122.2040060000000210">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366387" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9427769999999924" lon="-122.2049930000000018">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366386" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9452814999999930" lon="-122.2055251999999825">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366385" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9238761000000011" lon="-122.2137563999999799">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366384" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9248442000000026" lon="-122.2128550999999845">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366383" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9271664999999913" lon="-122.2107436999999948">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366382" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9304770999999974" lon="-122.2077309999999812">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366381" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9321560000000062" lon="-122.2062204000000065">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366380" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9349924999999999" lon="-122.2036455000000075">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366379" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9504796000000013" lon="-122.2050359999999927">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366378" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9483136999999999" lon="-122.2058598999999930">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366377" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9452611999999903" lon="-122.2051474999999812">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366376" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9425197999999924" lon="-122.2045380999999793">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366375" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9382620999999958" lon="-122.2036282999999912">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366374" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9505384999999933" lon="-122.2052934000000022">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366373" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9525099999999966" lon="-122.2042978000000062">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366372" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9083353999999986" lon="-122.2099848999999949">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366371" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9084505000000007" lon="-122.2097188999999844">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366370" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9210723999999999" lon="-122.2163277999999877">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366369" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9210521000000043" lon="-122.2166969000000023">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366368" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9125949000000091" lon="-122.2177269000000024">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366367" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9124797999999998" lon="-122.2179586000000029">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366366" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9107259000000028" lon="-122.2155810999999801">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366365" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9108883999999833" lon="-122.2154351999999875">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366364" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9144841000000028" lon="-122.2203018000000014">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366363" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9142673999999928" lon="-122.2205679000000060">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366362" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9165494000000010" lon="-122.2204390999999788">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366352" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0064654999999902" lon="-122.2337299999999942">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366351" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0047611999999972" lon="-122.2342449999999872">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366350" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0050791000000032" lon="-122.2336013000000037">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366349" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0050791000000032" lon="-122.2337557999999973">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366348" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0026511000000085" lon="-122.2337642999999900">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366346" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0002610000000018" lon="-122.2335471000000098">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366345" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9989277999999899" lon="-122.2367560999999938">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366341" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9069055999999875" lon="-122.2085498000000001">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366325" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9406298999999976" lon="-122.2027733999999981">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366297" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0032572000000002" lon="-122.2084296000000165"/>
     <node visible="true" id="-2366296" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0023306999999946" lon="-122.2078630999999973"/>
@@ -1088,36 +1301,47 @@
     <node visible="true" id="-2366288" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0028513999999973" lon="-122.2090476000000052"/>
     <node visible="true" id="-2366287" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0251590000000022" lon="-122.1221297999999820">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366266" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9571763999999945" lon="-122.2683884000000063">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366265" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9596760000000017" lon="-122.2660295999999818">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366263" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9193430999999990" lon="-122.2815897000000120">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366233" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8739913000000001" lon="-122.1820825000000070">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366232" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8769020999999952" lon="-122.1836832000000044">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366210" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8464138999999946" lon="-122.1616922999999986">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366208" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8563640999999933" lon="-122.1516994999999923">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366202" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8557474999999926" lon="-122.1522573999999963">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366201" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8540609000000075" lon="-122.1555347999999839">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366199" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8484379999999945" lon="-122.1590594999999837">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366198" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8465981999999883" lon="-122.1597246999999982"/>
     <node visible="true" id="-2366197" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8469369999999969" lon="-122.1600165000000118"/>
@@ -1144,15 +1368,19 @@
     <node visible="true" id="-2366176" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8460085000000035" lon="-122.1608061999999819"/>
     <node visible="true" id="-2366175" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8483630999999932" lon="-122.1629271000000045">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366174" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8488674000000032" lon="-122.1652713000000006">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366171" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8474793000000034" lon="-122.1623682999999971">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366115" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9069550000000035" lon="-122.2054337000000004">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366114" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9046997999999888" lon="-122.2087209999999828"/>
     <node visible="true" id="-2366113" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9045304999999999" lon="-122.2087381999999991"/>
@@ -1171,183 +1399,242 @@
     <node visible="true" id="-2366100" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9059661999999946" lon="-122.2103345999999817"/>
     <node visible="true" id="-2366098" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9430077000000026" lon="-122.2023351999999932">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366097" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9405912000000001" lon="-122.2025153999999958">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366084" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9086750999999893" lon="-122.2092446000000052">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366083" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9071038999999956" lon="-122.2077940000000069">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366082" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9596069999999983" lon="-122.2038960999999802">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366081" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9615383000000008" lon="-122.2041128000000043">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366080" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9634127999999933" lon="-122.2043179000000066">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366070" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9526592999999934" lon="-122.2045066999999960">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366069" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9555695000000100" lon="-122.2034767999999900">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366066" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0401741999999885" lon="-122.2337464999999952">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366065" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0361280999999849" lon="-122.2338330999999840">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366052" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0048829999999995" lon="-122.2340133000000151">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366051" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0026916999999855" lon="-122.2335068999999947">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366049" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9689974999999933" lon="-122.2088586999999933">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366048" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9712858999999838" lon="-122.2107100000000059">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366047" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9730185000000020" lon="-122.2121118000000166">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366046" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9752799999999979" lon="-122.2139415000000042">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366045" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9782247999999925" lon="-122.2163240999999942">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366044" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9803815999999941" lon="-122.2180691999999880">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366043" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9834464999999852" lon="-122.2205491999999794">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366042" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9882198999999900" lon="-122.2243051999999892">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366041" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9910678000000033" lon="-122.2265625000000142">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366022" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8144281000000007" lon="-122.2129352000000040">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366018" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8473279999999903" lon="-122.2280346000000009">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366017" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8475776999999951" lon="-122.2282040999999992">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2366016" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8479244999999977" lon="-122.2280331000000047">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365993" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8467472999999828" lon="-122.1617760000000033">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365991" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8568320999999912" lon="-122.1719085000000007">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365988" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8670230999999902" lon="-122.1773850999999951">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365987" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8654849999999996" lon="-122.1765352999999834">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365986" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8649222000000023" lon="-122.1764919999999961">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365985" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8565508999999878" lon="-122.1890808999999791">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365984" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8586742999999970" lon="-122.1898951999999952">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365983" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8597230000000096" lon="-122.1912413999999956">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365982" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8617957999999888" lon="-122.1936527000000012">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365959" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8620286999999891" lon="-122.1933239999999898">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365958" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8598470999999961" lon="-122.1910799000000054">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365957" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8586865999999844" lon="-122.1896349999999813">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365956" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8565224999999899" lon="-122.1887391000000065">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365955" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8655518999999927" lon="-122.1768234000000035">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365952" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8565004999999886" lon="-122.1884107999999856">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365951" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8586913999999908" lon="-122.1893452999999994">
         <tag k="power" v="tower"/>
         <tag k="FIXME" v="some towers in this area being relocated"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365950" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8600147999999948" lon="-122.1910179000000056">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365937" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8373155999999895" lon="-122.2629944999999907"/>
     <node visible="true" id="-2365936" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8371514999999903" lon="-122.2631607999999801"/>
     <node visible="true" id="-2365935" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8245959999999997" lon="-122.2039412000000027">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365927" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9165245999999954" lon="-122.2207800000000049">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365926" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9250202999999928" lon="-122.2130439999999965">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365925" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9272476999999952" lon="-122.2109669000000167">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365924" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9391555999999923" lon="-122.2042033999999973">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365923" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9481783999999962" lon="-122.2061688999999944">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365922" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9577389000000025" lon="-122.2036971999999793">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365921" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9653382999999991" lon="-122.2058858999999984">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365920" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9670096999999984" lon="-122.2072505999999805">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365919" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9854395999999994" lon="-122.2220992999999964">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365918" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9929211999999907" lon="-122.2279958999999963">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365917" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9948218999999909" lon="-122.2294806999999963">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365916" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9972840000000005" lon="-122.2314891999999986">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365915" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9998206999999937" lon="-122.2325758000000064">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365896" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0053967999999927" lon="-122.2506855000000030">
         <tag k="power" v="pole"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365890" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.0001941999999957" lon="-122.2350291000000055">
         <tag k="power" v="tower"/>
+        <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-2365882" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.9849418288101646" lon="-122.3379999999999939"/>
     <node visible="true" id="-2365881" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.8565482805662299" lon="-122.0769999999999982"/>
@@ -3665,6 +3952,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Moraga-Castro Valley/Moraga-San Ramon"/>
@@ -3678,7 +3966,6 @@
         <tag k="Length_Fee" v="73305.37694486"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.21578742515570001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383052" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2341817"/>
@@ -3689,6 +3976,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="00032d"/>
@@ -3702,7 +3990,6 @@
         <tag k="Length_Fee" v="73305.37694486"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.21578742515570001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383049" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2360957"/>
@@ -3737,23 +4024,23 @@
         <nd ref="-2360957"/>
         <nd ref="-2365851"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2402"/>
         <tag k="Length_Mil" v="0"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.912Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Shape__Len" v="0.0076799270110660001"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="2484.57402546"/>
-        <tag k="OBJECTID" v="2402"/>
-        <tag k="REF1" v="000279"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="000279"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.912Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="2484.57402546"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.0076799270110660001"/>
     </way>
     <way visible="true" id="-2383042" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2350987"/>
@@ -3808,6 +4095,7 @@
         <tag k="voltage" v="230000"/>
         <tag k="status" v="operational"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Contra Costa-Moraga"/>
@@ -3824,7 +4112,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.31530577793533998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383030" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365859"/>
@@ -3896,6 +4183,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Pittsburg - Sobrante"/>
@@ -3910,7 +4198,6 @@
         <tag k="wires" v="double"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.39549692137577402"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383024" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365860"/>
@@ -3936,6 +4223,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Pittsburg - Martinez"/>
@@ -3950,7 +4238,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.051991888445569998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383019" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346539"/>
@@ -3969,6 +4256,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="Oleum - North Tower - Christie 115kV transmission line"/>
         <tag k="REF1" v="000024"/>
         <tag k="power" v="line"/>
@@ -3981,7 +4269,6 @@
         <tag k="Length_Fee" v="13988.29157662"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.039390861959535999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383014" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366919"/>
@@ -3991,6 +4278,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383012" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349035"/>
@@ -4001,6 +4289,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000070"/>
@@ -4014,7 +4303,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.00090148772428400004"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2383004" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349167"/>
@@ -4022,23 +4310,23 @@
         <nd ref="-2349163"/>
         <nd ref="-2339943"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1234"/>
         <tag k="Length_Mil" v="1"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.091Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Shape__Len" v="0.0076626932828919997"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
-        <tag k="Length_Fee" v="2732.35842856"/>
-        <tag k="OBJECTID" v="1234"/>
-        <tag k="REF1" v="000072"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_230kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 230kV"/>
+        <tag k="REF1" v="000072"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="230"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.091Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="2732.35842856"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.0076626932828919997"/>
     </way>
     <way visible="true" id="-2383000" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338247"/>
@@ -4047,23 +4335,23 @@
         <nd ref="-2349021"/>
         <nd ref="-2349013"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1239"/>
         <tag k="Length_Mil" v="1"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.091Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.01619272216101"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="5150.09088459"/>
-        <tag k="OBJECTID" v="1239"/>
-        <tag k="REF1" v="00006d"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="00006d"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.091Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="5150.09088459"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.01619272216101"/>
     </way>
     <way visible="true" id="-2382996" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349013"/>
@@ -4073,23 +4361,23 @@
         <nd ref="-2349005"/>
         <nd ref="-2349003"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1240"/>
         <tag k="Length_Mil" v="0"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.092Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Shape__Len" v="0.006880524642741"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="2359.93612564"/>
-        <tag k="OBJECTID" v="1240"/>
-        <tag k="REF1" v="00006c"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="00006c"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.092Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="2359.93612564"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.006880524642741"/>
     </way>
     <way visible="true" id="-2382975" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365987"/>
@@ -4098,6 +4386,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="note" v="disconnected"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382955" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346705"/>
@@ -4107,6 +4396,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382952" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346707"/>
@@ -4137,6 +4427,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Sobrante - Claremont"/>
@@ -4152,7 +4443,6 @@
         <tag k="frequency" v="60"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.073990390109161003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382947" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2348907"/>
@@ -4203,6 +4493,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - El Cerrito"/>
         <tag k="REF1" v="000066"/>
@@ -4215,7 +4506,6 @@
         <tag k="Length_Fee" v="28164.38775402"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.095780580340901006"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382942" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2348825"/>
@@ -4226,6 +4516,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000066"/>
@@ -4238,7 +4529,6 @@
         <tag k="Length_Fee" v="28164.38775402"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.095780580340901006"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382939" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2348747"/>
@@ -4248,6 +4538,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Sobrante - El Cerrito"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382937" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2348747"/>
@@ -4258,6 +4549,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000065"/>
         <tag k="power" v="line"/>
@@ -4268,7 +4560,6 @@
         <tag k="Length_Fee" v="29681.0744457"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.100622191214974"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382936" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2348819"/>
@@ -4314,6 +4605,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - El Cerrito"/>
         <tag k="REF1" v="000065"/>
@@ -4326,7 +4618,6 @@
         <tag k="Length_Fee" v="29681.0744457"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.100622191214974"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382924" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2337211"/>
@@ -4339,6 +4630,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - El Cerrito"/>
         <tag k="REF1" v="000065"/>
@@ -4351,7 +4643,6 @@
         <tag k="Length_Fee" v="29681.0744457"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.100622191214974"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382918" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2348821"/>
@@ -4362,6 +4653,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000065"/>
@@ -4374,7 +4666,6 @@
         <tag k="Length_Fee" v="29681.0744457"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.100622191214974"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382914" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338841"/>
@@ -4428,6 +4719,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Oleum - El Cerrito"/>
         <tag k="REF1" v="0002ab"/>
@@ -4440,7 +4732,6 @@
         <tag k="Length_Fee" v="38790.08417009"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.11587733916562"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382895" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349183"/>
@@ -4463,6 +4754,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000073"/>
         <tag k="power" v="line"/>
@@ -4473,7 +4765,6 @@
         <tag k="Length_Fee" v="37796.49735604"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.122685915835216"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382892" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365861"/>
@@ -4523,6 +4814,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="tiger:cfcc" v="C20"/>
@@ -4538,7 +4830,6 @@
         <tag k="Length_Fee" v="37796.49735604"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.122685915835216"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382859" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349175"/>
@@ -4565,6 +4856,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="tiger:cfcc" v="C20"/>
@@ -4580,7 +4872,6 @@
         <tag k="Length_Fee" v="37796.49735604"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.122685915835216"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382833" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347011"/>
@@ -4635,6 +4926,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000033"/>
@@ -4648,13 +4940,13 @@
         <tag k="Length_Fee" v="29979.79913248"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.092586216840936"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382821" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347013"/>
         <nd ref="-2347017"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382812" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347029"/>
@@ -4668,23 +4960,23 @@
         <nd ref="-2347013"/>
         <nd ref="-2346993"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1296"/>
         <tag k="Length_Mil" v="0"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.105Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.0080791688186990004"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="2582.92098913"/>
-        <tag k="OBJECTID" v="1296"/>
-        <tag k="REF1" v="000034"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="000034"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.105Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="2582.92098913"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.0080791688186990004"/>
     </way>
     <way visible="true" id="-2382798" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349099"/>
@@ -4696,6 +4988,7 @@
         <tag k="cables" v="6"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="000071"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382797" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367052"/>
@@ -4706,6 +4999,7 @@
         <tag k="cables" v="6"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="000071"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382794" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349161"/>
@@ -4759,6 +5053,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="000071"/>
@@ -4772,7 +5067,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.18038848370772501"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382782" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349031"/>
@@ -4784,6 +5078,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="00006f"/>
@@ -4797,7 +5092,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.004831019352687"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382774" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345253"/>
@@ -4854,6 +5148,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Parkway - Moraga/Bahia - Moraga"/>
@@ -4869,7 +5164,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.12218611195533501"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382764" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345251"/>
@@ -4883,6 +5177,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Parkway - Moraga/Bahia - Moraga"/>
@@ -4898,7 +5193,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.12218611195533501"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382754" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2339941"/>
@@ -4909,6 +5203,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="0002d5"/>
@@ -4922,7 +5217,6 @@
         <tag k="Length_Fee" v="40312.98545586"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.118714951278515"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382743" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346535"/>
@@ -4935,6 +5229,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="00006f"/>
@@ -4948,7 +5243,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.004831019352687"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382740" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338839"/>
@@ -5024,6 +5318,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="tiger:cfcc" v="C20"/>
@@ -5040,7 +5335,6 @@
         <tag k="Length_Fee" v="38790.08417009"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.11587733916562"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382642" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338249"/>
@@ -5072,6 +5366,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="0002c2"/>
         <tag k="power" v="line"/>
@@ -5082,7 +5377,6 @@
         <tag k="Length_Fee" v="58645.62823076"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.187034405899031"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382632" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338881"/>
@@ -5109,6 +5403,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Oleum - El Cerrito"/>
         <tag k="REF1" v="0002c2"/>
@@ -5121,7 +5416,6 @@
         <tag k="Length_Fee" v="58645.62823076"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.187034405899031"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382627" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346557"/>
@@ -5130,6 +5424,7 @@
         <tag k="name" v="Oleum - North Tower - Christie 115kV transmission line"/>
         <tag k="voltage" v="115000"/>
         <tag k="REF2" v="000026"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382626" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346551"/>
@@ -5141,6 +5436,7 @@
         <tag k="name" v="Oleum - North Tower - Christie 115kV transmission line"/>
         <tag k="voltage" v="115000"/>
         <tag k="REF2" v="000026"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382613" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2360819"/>
@@ -5173,23 +5469,23 @@
         <nd ref="-2360769"/>
         <nd ref="-2360767"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2405"/>
         <tag k="Length_Mil" v="3"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.913Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.058357895690229998"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
-        <tag k="Length_Fee" v="18252.09735487"/>
-        <tag k="OBJECTID" v="2405"/>
-        <tag k="REF1" v="000275"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="000275"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="000275"/>
+        <tag k="REF2" v="000275"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.913Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="18252.09735487"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.058357895690229998"/>
     </way>
     <way visible="true" id="-2382608" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2360821"/>
@@ -5200,6 +5496,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="000275"/>
         <tag k="power" v="line"/>
@@ -5210,7 +5507,6 @@
         <tag k="Length_Fee" v="18252.09735487"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.058357895690229998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382600" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347163"/>
@@ -5227,6 +5523,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Moraga - Claremont"/>
         <tag k="REVIEW" v="000037"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382583" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347087"/>
@@ -5237,6 +5534,7 @@
         <tag k="cables" v="6"/>
         <tag k="ref" v="East Portal-Claremont"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382580" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347087"/>
@@ -5275,6 +5573,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="East Portal-Claremont"/>
@@ -5291,7 +5590,6 @@
         <tag k="Type" v="OH"/>
         <tag k="source" v="Bing"/>
         <tag k="Shape__Len" v="0.081639752705853996"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382574" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365864"/>
@@ -5344,6 +5642,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="00003b"/>
@@ -5356,7 +5655,6 @@
         <tag k="Length_Fee" v="58236.82114167"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.17128387068380199"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382569" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347345"/>
@@ -5373,6 +5671,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="00003b"/>
@@ -5386,7 +5685,6 @@
         <tag k="Length_Fee" v="58236.82114167"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.17128387068380199"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382558" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365865"/>
@@ -5439,6 +5737,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="00003a"/>
@@ -5451,7 +5750,6 @@
         <tag k="Length_Fee" v="58259.75743441"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.171340978803453"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382553" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347345"/>
@@ -5469,6 +5767,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="00003a"/>
@@ -5482,7 +5781,6 @@
         <tag k="Length_Fee" v="58259.75743441"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.171340978803453"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382543" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367255"/>
@@ -5499,6 +5797,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Sobrante - Claremont"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382523" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338111"/>
@@ -5507,6 +5806,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382522" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367198"/>
@@ -5518,6 +5818,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382511" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338101"/>
@@ -5529,6 +5830,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="00023b"/>
         <tag k="power" v="line"/>
@@ -5539,7 +5841,6 @@
         <tag k="Length_Fee" v="1401.65918347"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0043396957192989999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382510" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338097"/>
@@ -5550,6 +5851,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="00023b"/>
@@ -5563,7 +5865,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0043396957192989999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382506" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2360821"/>
@@ -5579,6 +5880,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000278"/>
         <tag k="REF2" v="todo"/>
@@ -5590,7 +5892,6 @@
         <tag k="Length_Fee" v="2660.78913489"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0092071043745129994"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382503" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366748"/>
@@ -5602,6 +5903,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382496" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338897"/>
@@ -5612,6 +5914,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="0002c3"/>
         <tag k="power" v="line"/>
@@ -5622,7 +5925,6 @@
         <tag k="Length_Fee" v="5333.34877055"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.014630481680501999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382495" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338881"/>
@@ -5633,6 +5935,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Oleum - El Cerrito"/>
         <tag k="REF1" v="0002c3"/>
@@ -5645,7 +5948,6 @@
         <tag k="Length_Fee" v="5333.34877055"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.014630481680501999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382491" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2339855"/>
@@ -5664,6 +5966,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Oleum - El Cerrito"/>
         <tag k="REF1" v="0002d4"/>
@@ -5676,51 +5979,50 @@
         <tag k="Length_Fee" v="7990.28513193"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.026611604306196"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382486" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2339837"/>
         <nd ref="-2338881"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1780"/>
         <tag k="Length_Mil" v="2"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.199Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Shape__Len" v="0.026611604306196"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="7990.28513193"/>
-        <tag k="OBJECTID" v="1780"/>
-        <tag k="REF1" v="0002d4"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="0002d4"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.199Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="7990.28513193"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.026611604306196"/>
     </way>
     <way visible="true" id="-2382479" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2339857"/>
         <nd ref="-2339855"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1780"/>
         <tag k="Length_Mil" v="2"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.199Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Shape__Len" v="0.026611604306196"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="7990.28513193"/>
-        <tag k="OBJECTID" v="1780"/>
-        <tag k="REF1" v="0002d4"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="0002d4"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.199Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="7990.28513193"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.026611604306196"/>
     </way>
     <way visible="true" id="-2382466" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345709"/>
@@ -5732,6 +6034,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000015"/>
@@ -5747,7 +6050,6 @@
         <tag k="wires" v="double"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0015556265734830001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382462" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345713"/>
@@ -5759,6 +6061,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000016"/>
@@ -5774,7 +6077,6 @@
         <tag k="wires" v="double"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.001392038258421"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382458" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338895"/>
@@ -5784,23 +6086,23 @@
         <nd ref="-2338887"/>
         <nd ref="-2365844"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1874"/>
         <tag k="Length_Mil" v="1"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.224Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Shape__Len" v="0.014630481680501999"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="5333.34877055"/>
-        <tag k="OBJECTID" v="1874"/>
-        <tag k="REF1" v="0002c3"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="0002c3"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.224Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="5333.34877055"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.014630481680501999"/>
     </way>
     <way visible="true" id="-2382443" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367250"/>
@@ -5812,6 +6114,7 @@
         <tag k="cables" v="6"/>
         <tag k="ref" v="Moraga - Claremont"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382441" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346709"/>
@@ -5822,6 +6125,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000027"/>
         <tag k="power" v="line"/>
@@ -5832,7 +6136,6 @@
         <tag k="Length_Fee" v="24947.68210708"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.073990390109161003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382435" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346717"/>
@@ -5846,6 +6149,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Moraga - Claremont"/>
@@ -5860,7 +6164,6 @@
         <tag k="Length_Fee" v="24947.68210708"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.073990390109161003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382430" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346719"/>
@@ -5871,6 +6174,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000027"/>
@@ -5884,7 +6188,6 @@
         <tag k="Length_Fee" v="24947.68210708"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.073990390109161003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382427" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347075"/>
@@ -5897,6 +6200,7 @@
         <tag k="cables" v="6"/>
         <tag k="REVIEW" v="0002d5"/>
         <tag k="REF2" v="000035"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382426" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365922"/>
@@ -5930,10 +6234,6 @@
         <tag k="cables" v="6"/>
         <tag k="REVIEW" v="0002d5"/>
         <tag k="REF2" v="000035"/>
-    </way>
-    <way visible="true" id="-2382424" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2347039"/>
-        <nd ref="-2347037"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382413" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -5947,6 +6247,7 @@
         <tag k="cables" v="6"/>
         <tag k="REVIEW" v="0002d5"/>
         <tag k="REF2" v="000035"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382403" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347095"/>
@@ -5959,26 +6260,6 @@
         <tag k="cables" v="6"/>
         <tag k="REVIEW" v="0002d5"/>
         <tag k="REF2" v="000035"/>
-    </way>
-    <way visible="true" id="-2382400" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2347089"/>
-        <nd ref="-2346707"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1295"/>
-        <tag k="Length_Mil" v="6"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="REF1" v="000035"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.101Z"/>
-        <tag k="circuits" v="2"/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="32315.51980185"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.099957525011448001"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382396" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -5995,6 +6276,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Sobrante - Claremont"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382394" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346893"/>
@@ -6025,6 +6307,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - Claremont"/>
         <tag k="REF1" v="000031"/>
@@ -6038,7 +6321,6 @@
         <tag k="Type" v="OH"/>
         <tag k="source" v="Bing"/>
         <tag k="Shape__Len" v="0.072837944861390003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382380" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347649"/>
@@ -6051,6 +6333,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="00003c"/>
         <tag k="REF2" v="todo"/>
@@ -6064,7 +6347,6 @@
         <tag k="source" v="Yahoo"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0036052084460860001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382375" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365863"/>
@@ -6077,6 +6359,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="00003d"/>
         <tag k="REF2" v="todo"/>
@@ -6090,7 +6373,6 @@
         <tag k="source" v="Yahoo"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.107089847915945"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382366" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365862"/>
@@ -6105,6 +6387,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000042"/>
         <tag k="REF2" v="todo"/>
@@ -6118,7 +6401,6 @@
         <tag k="source" v="Yahoo"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.114548422810257"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382362" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346721"/>
@@ -6129,6 +6411,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000029"/>
@@ -6141,7 +6424,6 @@
         <tag k="Length_Fee" v="61.87193626"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.000198593838851"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382358" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346721"/>
@@ -6153,6 +6435,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="00002b"/>
@@ -6165,7 +6448,6 @@
         <tag k="Length_Fee" v="135.99512327"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.00044696531921799998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382353" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346613"/>
@@ -6175,6 +6457,7 @@
         <tag k="ref" v="Christie - Sobrante"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="000026"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382305" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345163"/>
@@ -6228,6 +6511,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Christie - Sobrante"/>
@@ -6241,7 +6525,6 @@
         <tag k="Length_Fee" v="48230.41800181"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.137410656126703"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382300" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345163"/>
@@ -6251,6 +6534,7 @@
         <tag k="ref" v="Christie - Sobrante"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="000026"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382293" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346733"/>
@@ -6261,6 +6545,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="00002e"/>
@@ -6273,7 +6558,6 @@
         <tag k="Length_Fee" v="289.53575539"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.00092524724585700004"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382290" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346721"/>
@@ -6283,6 +6567,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382282" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346727"/>
@@ -6291,6 +6576,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382277" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346669"/>
@@ -6301,6 +6587,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Sobrante - East Portal"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382255" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346669"/>
@@ -6315,6 +6602,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - East Portal"/>
         <tag k="REF1" v="000036"/>
@@ -6327,7 +6615,6 @@
         <tag k="Length_Fee" v="12893.72789489"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.038454877708572997"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382243" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346665"/>
@@ -6346,6 +6633,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Sobrante - Claremont"/>
@@ -6359,7 +6647,6 @@
         <tag k="Length_Fee" v="24947.68210708"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.073990390109161003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382234" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346847"/>
@@ -6369,6 +6656,7 @@
         <tag k="ref" v="Sobrante - Claremont"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382221" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346673"/>
@@ -6378,6 +6666,7 @@
         <tag k="ref" v="Sobrante - Claremont"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382206" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346743"/>
@@ -6392,6 +6681,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="00002a"/>
@@ -6404,7 +6694,6 @@
         <tag k="Length_Fee" v="1342.66646523"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0043703082411"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382190" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346647"/>
@@ -6415,6 +6704,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Sobrante - Claremont"/>
@@ -6428,7 +6718,6 @@
         <tag k="Length_Fee" v="1342.66646523"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0043703082411"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382180" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346899"/>
@@ -6489,6 +6778,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="East Portal-Claremont"/>
@@ -6502,7 +6792,6 @@
         <tag k="Length_Fee" v="22493.87282968"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.072837944861390003"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382175" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345169"/>
@@ -6514,6 +6803,7 @@
         <tag k="cables" v="3"/>
         <tag k="ref" v="Parkway - Moraga"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382169" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345177"/>
@@ -6525,6 +6815,7 @@
         <tag k="cables" v="3"/>
         <tag k="ref" v="Bahia - Moraga"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382158" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345871"/>
@@ -6578,51 +6869,6 @@
         <tag k="REF2" v="000017"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-2382130" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2345867"/>
-        <nd ref="-2345865"/>
-        <nd ref="-2345863"/>
-        <nd ref="-2345861"/>
-        <nd ref="-2345859"/>
-        <nd ref="-2345857"/>
-        <nd ref="-2345855"/>
-        <nd ref="-2345853"/>
-        <nd ref="-2345851"/>
-        <nd ref="-2345849"/>
-        <nd ref="-2345847"/>
-        <nd ref="-2345845"/>
-        <nd ref="-2345843"/>
-        <nd ref="-2345841"/>
-        <nd ref="-2345839"/>
-        <nd ref="-2345837"/>
-        <nd ref="-2345835"/>
-        <nd ref="-2345833"/>
-        <nd ref="-2345831"/>
-        <nd ref="-2365867"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1329"/>
-        <tag k="Length_Mil" v="21"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="cables" v="6"/>
-        <tag k="ref" v="Lakeville-Sobrante/Ignacio-Sobrante"/>
-        <tag k="REF1" v="000017"/>
-        <tag k="REF2" v="000017"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.111Z"/>
-        <tag k="circuits" v="2"/>
-        <tag k="comments" v="Triple circuit for 5 miles; 115 line shares 230 poles."/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="110683.54659046"/>
-        <tag k="frequency" v="60"/>
-        <tag k="wires" v="double"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.316891218278267"/>
-        <tag k="error:circular" v="15"/>
-    </way>
     <way visible="true" id="-2382119" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346919"/>
         <nd ref="-2346917"/>
@@ -6632,6 +6878,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - East Portal/East Portal - Claremont"/>
         <tag k="REF1" v="000032"/>
@@ -6644,7 +6891,6 @@
         <tag k="Length_Fee" v="850.09915195"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0029216124809159998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382115" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347101"/>
@@ -6656,6 +6902,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="3"/>
         <tag k="ref" v="Parkway - Moraga"/>
@@ -6670,7 +6917,6 @@
         <tag k="Length_Fee" v="32315.51980185"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.099957525011448001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382110" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367245"/>
@@ -6682,6 +6928,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382108" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347189"/>
@@ -6693,6 +6940,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000037"/>
         <tag k="power" v="line"/>
@@ -6703,7 +6951,6 @@
         <tag k="Length_Fee" v="25386.01066699"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.081639752705853996"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382107" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347195"/>
@@ -6716,6 +6963,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="REF1" v="000037"/>
@@ -6729,7 +6977,6 @@
         <tag k="Length_Fee" v="25386.01066699"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.081639752705853996"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382102" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347197"/>
@@ -6740,6 +6987,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000037"/>
@@ -6753,7 +7001,6 @@
         <tag k="Length_Fee" v="25386.01066699"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.081639752705853996"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382099" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347203"/>
@@ -6765,6 +7012,7 @@
         <tag k="cables" v="6"/>
         <tag k="ref" v="Moraga - Station X"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382097" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347203"/>
@@ -6826,6 +7074,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Moraga - Station X"/>
@@ -6839,7 +7088,6 @@
         <tag k="Length_Fee" v="26793.19004001"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.085592316255965001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382081" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347265"/>
@@ -6850,6 +7098,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000038"/>
@@ -6863,58 +7112,58 @@
         <tag k="Length_Fee" v="26793.19004001"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.085592316255965001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382062" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366976"/>
         <nd ref="-2361181"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382052" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2361189"/>
         <nd ref="-2361185"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2396"/>
         <tag k="Length_Mil" v="0"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.0013714918582190001"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
-        <tag k="Length_Fee" v="424.40308855"/>
-        <tag k="OBJECTID" v="2396"/>
-        <tag k="REF1" v="000280"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="000280"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="424.40308855"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.0013714918582190001"/>
     </way>
     <way visible="true" id="-2382037" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2361185"/>
         <nd ref="-2338847"/>
         <nd ref="-2345867"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2397"/>
         <tag k="Length_Mil" v="1"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.026473919768262001"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
-        <tag k="Length_Fee" v="7641.75913657"/>
-        <tag k="OBJECTID" v="2397"/>
-        <tag k="REF1" v="00027f"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="00027f"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="7641.75913657"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.026473919768262001"/>
     </way>
     <way visible="true" id="-2382033" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367151"/>
@@ -6925,6 +7174,7 @@
         <tag k="ref" v="Moraga - Station X"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382031" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347267"/>
@@ -6985,6 +7235,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Moraga - Station X"/>
@@ -6998,7 +7249,6 @@
         <tag k="Length_Fee" v="26789.93374941"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.085687036624263996"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382011" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347329"/>
@@ -7009,6 +7259,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000039"/>
@@ -7022,7 +7273,6 @@
         <tag k="Length_Fee" v="26789.93374941"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.085687036624263996"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2382007" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2360821"/>
@@ -7044,6 +7294,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="00027e"/>
         <tag k="power" v="line"/>
@@ -7054,99 +7305,6 @@
         <tag k="Length_Fee" v="18258.84326879"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.061870607572109"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2382006" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2361137"/>
-        <nd ref="-2361135"/>
-        <nd ref="-2345181"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="tiger:upload_uuid" v="bulk_upload.pl-c06aeebd-526f-4861-b1a6-aa2b0d38e820"/>
-        <tag k="OBJECTID" v="2398"/>
-        <tag k="Length_Mil" v="3"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="60000"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
-        <tag k="tiger:cfcc" v="C20"/>
-        <tag k="REF1" v="00027e"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="tiger:county" v="Contra Costa, CA"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
-        <tag k="circuits" v="1"/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="18258.84326879"/>
-        <tag k="tiger:tlid" v="192077615:192090945:192117152"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.061870607572109"/>
-        <tag k="tiger:source" v="tiger_import_dch_v0.6_20070809"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2382001" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2345181"/>
-        <nd ref="-2345173"/>
-        <nd ref="-2361133"/>
-        <nd ref="-2345869"/>
-        <nd ref="-2338845"/>
-        <nd ref="-2361131"/>
-        <nd ref="-2361129"/>
-        <nd ref="-2361127"/>
-        <nd ref="-2361125"/>
-        <nd ref="-2361123"/>
-        <nd ref="-2361121"/>
-        <nd ref="-2361119"/>
-        <nd ref="-2361117"/>
-        <nd ref="-2361115"/>
-        <nd ref="-2361113"/>
-        <nd ref="-2361111"/>
-        <nd ref="-2361109"/>
-        <nd ref="-2361107"/>
-        <nd ref="-2367978"/>
-        <nd ref="-2361105"/>
-        <nd ref="-2361103"/>
-        <nd ref="-2361101"/>
-        <nd ref="-2361099"/>
-        <nd ref="-2361097"/>
-        <nd ref="-2361095"/>
-        <nd ref="-2361093"/>
-        <nd ref="-2361091"/>
-        <nd ref="-2361089"/>
-        <nd ref="-2361087"/>
-        <nd ref="-2361085"/>
-        <nd ref="-2361083"/>
-        <nd ref="-2361081"/>
-        <nd ref="-2361079"/>
-        <nd ref="-2361077"/>
-        <nd ref="-2361075"/>
-        <nd ref="-2361073"/>
-        <nd ref="-2361071"/>
-        <nd ref="-2361069"/>
-        <nd ref="-2361061"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="tiger:upload_uuid" v="bulk_upload.pl-c06aeebd-526f-4861-b1a6-aa2b0d38e820"/>
-        <tag k="OBJECTID" v="2398"/>
-        <tag k="Length_Mil" v="3"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="60000"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
-        <tag k="tiger:cfcc" v="C20"/>
-        <tag k="REF1" v="00027e"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="tiger:county" v="Contra Costa, CA"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
-        <tag k="circuits" v="1"/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="18258.84326879"/>
-        <tag k="Type" v="OH"/>
-        <tag k="tiger:tlid" v="192077615:192090945:192117152"/>
-        <tag k="Shape__Len" v="0.061870607572109"/>
-        <tag k="tiger:source" v="tiger_import_dch_v0.6_20070809"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2368051" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345867"/>
@@ -7158,6 +7316,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="00027f"/>
         <tag k="power" v="line"/>
@@ -7168,7 +7327,6 @@
         <tag k="Length_Fee" v="7641.75913657"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.026473919768262001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2368044" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346919"/>
@@ -7201,6 +7359,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="000281"/>
         <tag k="power" v="line"/>
@@ -7211,7 +7370,6 @@
         <tag k="Length_Fee" v="16005.3039981"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.050269877773390002"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2368039" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347649"/>
@@ -7260,6 +7418,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000274"/>
@@ -7273,7 +7432,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.023082844656214001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2368029" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2339939"/>
@@ -7345,6 +7503,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000036"/>
         <tag k="power" v="line"/>
@@ -7355,7 +7514,6 @@
         <tag k="Length_Fee" v="12893.72789489"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.038454877708572997"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2368004" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347095"/>
@@ -7403,6 +7561,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000026"/>
         <tag k="REF2" v="000026"/>
@@ -7415,7 +7574,6 @@
         <tag k="Length_Fee" v="48230.41800181"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.137410656126703"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367984" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338847"/>
@@ -7468,6 +7626,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="tiger:cfcc" v="C20"/>
@@ -7484,7 +7643,6 @@
         <tag k="Length_Fee" v="58645.62823076"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.187034405899031"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367979" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2361063"/>
@@ -7539,23 +7697,23 @@
         <nd ref="-2361193"/>
         <nd ref="-2355895"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2395"/>
         <tag k="Length_Mil" v="3"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.050269877773390002"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
-        <tag k="Length_Fee" v="16005.3039981"/>
-        <tag k="OBJECTID" v="2395"/>
-        <tag k="REF1" v="000281"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="000281"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="16005.3039981"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.050269877773390002"/>
     </way>
     <way visible="true" id="-2367974" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345251"/>
@@ -7580,6 +7738,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000071"/>
         <tag k="REF2" v="000071;todo"/>
@@ -7591,7 +7750,6 @@
         <tag k="Length_Fee" v="55124.05488235"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.18038848370772501"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367973" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2361185"/>
@@ -7602,6 +7760,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="000280"/>
         <tag k="power" v="line"/>
@@ -7612,37 +7771,6 @@
         <tag k="Length_Fee" v="424.40308855"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0013714918582190001"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367967" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2347037"/>
-        <nd ref="-2346729"/>
-        <nd ref="-2346741"/>
-        <nd ref="-2346929"/>
-        <nd ref="-2347035"/>
-        <nd ref="-2347033"/>
-        <nd ref="-2347031"/>
-        <nd ref="-2345955"/>
-        <nd ref="-2346645"/>
-        <nd ref="-2345161"/>
-        <nd ref="-2339937"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="Length_Mil" v="6"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.101Z"/>
-        <tag k="Shape__Len" v="0.099957525011448001"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="power" v="line"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Length_Fee" v="32315.51980185"/>
-        <tag k="OBJECTID" v="1295"/>
-        <tag k="REF1" v="000035"/>
-        <tag k="Type" v="OH"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367955" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347015"/>
@@ -7652,169 +7780,6 @@
         <nd ref="-2347093"/>
         <nd ref="-2347091"/>
         <nd ref="-2347089"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1295"/>
-        <tag k="Length_Mil" v="6"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="cables" v="6"/>
-        <tag k="ref" v="Parkway - Moraga/Bahia - Moraga"/>
-        <tag k="REF1" v="000035"/>
-        <tag k="REF2" v="000035"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="REVIEW" v="0002d5"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.101Z"/>
-        <tag k="circuits" v="2"/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="32315.51980185"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.099957525011448001"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367929" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2345183"/>
-        <nd ref="-2345175"/>
-        <nd ref="-2345869"/>
-        <nd ref="-2345867"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="Length_Mil" v="21"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.111Z"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="power" v="line"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Shape__Len" v="0.316891218278267"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="comments" v="Triple circuit for 5 miles; 115 line shares 230 poles."/>
-        <tag k="Length_Fee" v="110683.54659046"/>
-        <tag k="OBJECTID" v="1329"/>
-        <tag k="REF1" v="000017"/>
-        <tag k="Type" v="OH"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367928" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2345071"/>
-        <nd ref="-2345183"/>
-        <nd ref="-2345181"/>
-        <nd ref="-2345179"/>
-        <nd ref="-2345177"/>
-        <nd ref="-2345167"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1359"/>
-        <tag k="Length_Mil" v="0"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="cables" v="3"/>
-        <tag k="ref" v="Bahia - Moraga"/>
-        <tag k="REF1" v="000002"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.117Z"/>
-        <tag k="circuits" v="1"/>
-        <tag k="location" v="overhead"/>
-        <tag k="frequency" v="60"/>
-        <tag k="Length_Fee" v="1395.33809178"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.0038305885618780001"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367920" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2349031"/>
-        <nd ref="-2346533"/>
-        <nd ref="-2349029"/>
-        <nd ref="-2349077"/>
-        <nd ref="-2349075"/>
-        <nd ref="-2349073"/>
-        <nd ref="-2349071"/>
-        <nd ref="-2349069"/>
-        <nd ref="-2349067"/>
-        <nd ref="-2349065"/>
-        <nd ref="-2349063"/>
-        <nd ref="-2349061"/>
-        <nd ref="-2345251"/>
-        <tag k="alt_name" v="Oleum - Martinez 115kV transmission line"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1235"/>
-        <tag k="Length_Mil" v="10"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="115000"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
-        <tag k="REF1" v="000071"/>
-        <tag k="REF2" v="000071"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.091Z"/>
-        <tag k="circuits" v="2"/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="55124.05488235"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.18038848370772501"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367913" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2349035"/>
-        <nd ref="-2367052"/>
-        <tag k="power" v="line"/>
-        <tag k="cables" v="3"/>
-        <tag k="wires" v="single"/>
-        <tag k="REF2" v="todo"/>
-    </way>
-    <way visible="true" id="-2367912" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2349035"/>
-        <nd ref="-2367049"/>
-        <nd ref="-2367007"/>
-        <nd ref="-2366844"/>
-        <nd ref="-2366768"/>
-        <tag k="power" v="line"/>
-        <tag k="cables" v="3"/>
-        <tag k="wires" v="single"/>
-        <tag k="REF2" v="todo"/>
-    </way>
-    <way visible="true" id="-2367911" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2345171"/>
-        <nd ref="-2345179"/>
-        <nd ref="-2361181"/>
-        <nd ref="-2361179"/>
-        <nd ref="-2361177"/>
-        <nd ref="-2361175"/>
-        <nd ref="-2361173"/>
-        <nd ref="-2361171"/>
-        <nd ref="-2361169"/>
-        <nd ref="-2361167"/>
-        <nd ref="-2361165"/>
-        <nd ref="-2361163"/>
-        <nd ref="-2361161"/>
-        <nd ref="-2360821"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="Length_Mil" v="1"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="power" v="line"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.026473919768262001"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="60000"/>
-        <tag k="Length_Fee" v="7641.75913657"/>
-        <tag k="OBJECTID" v="2397"/>
-        <tag k="REF1" v="00027f"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367908" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346707"/>
         <nd ref="-2347087"/>
         <nd ref="-2347085"/>
@@ -7843,12 +7808,17 @@
         <nd ref="-2347043"/>
         <nd ref="-2347041"/>
         <nd ref="-2347039"/>
+        <nd ref="-2347037"/>
+        <nd ref="-2346729"/>
+        <nd ref="-2346741"/>
+        <nd ref="-2346929"/>
         <tag k="owner" v="PG&amp;E"/>
         <tag k="OBJECTID" v="1295"/>
         <tag k="Length_Mil" v="6"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Parkway - Moraga/Bahia - Moraga"/>
@@ -7863,7 +7833,282 @@
         <tag k="Length_Fee" v="32315.51980185"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.099957525011448001"/>
+    </way>
+    <way visible="true" id="-2367929" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2345705"/>
+        <nd ref="-2345955"/>
+        <nd ref="-2345953"/>
+        <nd ref="-2345951"/>
+        <nd ref="-2345949"/>
+        <nd ref="-2345947"/>
+        <nd ref="-2345945"/>
+        <nd ref="-2345943"/>
+        <nd ref="-2345941"/>
+        <nd ref="-2345939"/>
+        <nd ref="-2345937"/>
+        <nd ref="-2345935"/>
+        <nd ref="-2345933"/>
+        <nd ref="-2345931"/>
+        <nd ref="-2345929"/>
+        <nd ref="-2345927"/>
+        <nd ref="-2345925"/>
+        <nd ref="-2345923"/>
+        <nd ref="-2345921"/>
+        <nd ref="-2345919"/>
+        <nd ref="-2345917"/>
+        <nd ref="-2345915"/>
+        <nd ref="-2345913"/>
+        <nd ref="-2345911"/>
+        <nd ref="-2345909"/>
+        <nd ref="-2345907"/>
+        <nd ref="-2345905"/>
+        <nd ref="-2345903"/>
+        <nd ref="-2345901"/>
+        <nd ref="-2345899"/>
+        <nd ref="-2345897"/>
+        <nd ref="-2345895"/>
+        <nd ref="-2345893"/>
+        <nd ref="-2345891"/>
+        <nd ref="-2345889"/>
+        <nd ref="-2345887"/>
+        <nd ref="-2345885"/>
+        <nd ref="-2345883"/>
+        <nd ref="-2345881"/>
+        <nd ref="-2345879"/>
+        <nd ref="-2345877"/>
+        <nd ref="-2345875"/>
+        <nd ref="-2345873"/>
+        <nd ref="-2345871"/>
+        <nd ref="-2345183"/>
+        <nd ref="-2345175"/>
+        <nd ref="-2345869"/>
+        <nd ref="-2345867"/>
+        <nd ref="-2345865"/>
+        <nd ref="-2345863"/>
+        <nd ref="-2345861"/>
+        <nd ref="-2345859"/>
+        <nd ref="-2345857"/>
+        <nd ref="-2345855"/>
+        <nd ref="-2345853"/>
+        <nd ref="-2345851"/>
+        <nd ref="-2345849"/>
+        <nd ref="-2345847"/>
+        <nd ref="-2345845"/>
+        <nd ref="-2345843"/>
+        <nd ref="-2345841"/>
+        <nd ref="-2345839"/>
+        <nd ref="-2345837"/>
+        <nd ref="-2345835"/>
+        <nd ref="-2345833"/>
+        <nd ref="-2345831"/>
+        <nd ref="-2365867"/>
+        <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1329"/>
+        <tag k="Length_Mil" v="21"/>
+        <tag k="status" v="operational"/>
+        <tag k="voltage" v="230000"/>
+        <tag k="Legend" v="PG&amp;E_230kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 230kV"/>
+        <tag k="cables" v="6"/>
+        <tag k="ref" v="Lakeville-Sobrante/Ignacio-Sobrante"/>
+        <tag k="REF1" v="000017"/>
+        <tag k="REF2" v="000017"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="230"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.111Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="comments" v="Triple circuit for 5 miles; 115 line shares 230 poles."/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="110683.54659046"/>
+        <tag k="frequency" v="60"/>
+        <tag k="wires" v="double"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.316891218278267"/>
+    </way>
+    <way visible="true" id="-2367928" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2345071"/>
+        <nd ref="-2345183"/>
+        <nd ref="-2345181"/>
+        <nd ref="-2345179"/>
+        <nd ref="-2345177"/>
+        <nd ref="-2345167"/>
+        <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1359"/>
+        <tag k="Length_Mil" v="0"/>
+        <tag k="status" v="operational"/>
+        <tag k="voltage" v="230000"/>
+        <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 230kV"/>
+        <tag k="cables" v="3"/>
+        <tag k="ref" v="Bahia - Moraga"/>
+        <tag k="REF1" v="000002"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="230"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.117Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="frequency" v="60"/>
+        <tag k="Length_Fee" v="1395.33809178"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.0038305885618780001"/>
+    </way>
+    <way visible="true" id="-2367927" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2361137"/>
+        <nd ref="-2361135"/>
+        <nd ref="-2345181"/>
+        <nd ref="-2345173"/>
+        <nd ref="-2361133"/>
+        <nd ref="-2345869"/>
+        <nd ref="-2338845"/>
+        <nd ref="-2361131"/>
+        <nd ref="-2361129"/>
+        <nd ref="-2361127"/>
+        <nd ref="-2361125"/>
+        <nd ref="-2361123"/>
+        <nd ref="-2361121"/>
+        <nd ref="-2361119"/>
+        <nd ref="-2361117"/>
+        <nd ref="-2361115"/>
+        <nd ref="-2361113"/>
+        <nd ref="-2361111"/>
+        <nd ref="-2361109"/>
+        <nd ref="-2361107"/>
+        <nd ref="-2367978"/>
+        <nd ref="-2361105"/>
+        <nd ref="-2361103"/>
+        <nd ref="-2361101"/>
+        <nd ref="-2361099"/>
+        <nd ref="-2361097"/>
+        <nd ref="-2361095"/>
+        <nd ref="-2361093"/>
+        <nd ref="-2361091"/>
+        <nd ref="-2361089"/>
+        <nd ref="-2361087"/>
+        <nd ref="-2361085"/>
+        <nd ref="-2361083"/>
+        <nd ref="-2361081"/>
+        <nd ref="-2361079"/>
+        <nd ref="-2361077"/>
+        <nd ref="-2361075"/>
+        <nd ref="-2361073"/>
+        <nd ref="-2361071"/>
+        <nd ref="-2361069"/>
+        <nd ref="-2361061"/>
+        <tag k="owner" v="PG&amp;E"/>
+        <tag k="tiger:upload_uuid" v="bulk_upload.pl-c06aeebd-526f-4861-b1a6-aa2b0d38e820"/>
+        <tag k="OBJECTID" v="2398"/>
+        <tag k="Length_Mil" v="3"/>
+        <tag k="status" v="operational"/>
+        <tag k="voltage" v="60000"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="tiger:cfcc" v="C20"/>
+        <tag k="REF1" v="00027e"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="tiger:county" v="Contra Costa, CA"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="18258.84326879"/>
+        <tag k="Type" v="OH"/>
+        <tag k="tiger:tlid" v="192077615:192090945:192117152"/>
+        <tag k="Shape__Len" v="0.061870607572109"/>
+        <tag k="tiger:source" v="tiger_import_dch_v0.6_20070809"/>
+    </way>
+    <way visible="true" id="-2367920" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2349031"/>
+        <nd ref="-2346533"/>
+        <nd ref="-2349029"/>
+        <nd ref="-2349077"/>
+        <nd ref="-2349075"/>
+        <nd ref="-2349073"/>
+        <nd ref="-2349071"/>
+        <nd ref="-2349069"/>
+        <nd ref="-2349067"/>
+        <nd ref="-2349065"/>
+        <nd ref="-2349063"/>
+        <nd ref="-2349061"/>
+        <nd ref="-2345251"/>
+        <tag k="alt_name" v="Oleum - Martinez 115kV transmission line"/>
+        <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1235"/>
+        <tag k="Length_Mil" v="10"/>
+        <tag k="status" v="operational"/>
+        <tag k="voltage" v="115000"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="000071"/>
+        <tag k="REF2" v="000071"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.091Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="55124.05488235"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.18038848370772501"/>
+    </way>
+    <way visible="true" id="-2367913" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2349035"/>
+        <nd ref="-2367052"/>
+        <tag k="power" v="line"/>
+        <tag k="cables" v="3"/>
+        <tag k="wires" v="single"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2367912" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2349035"/>
+        <nd ref="-2367049"/>
+        <nd ref="-2367007"/>
+        <nd ref="-2366844"/>
+        <nd ref="-2366768"/>
+        <tag k="power" v="line"/>
+        <tag k="cables" v="3"/>
+        <tag k="wires" v="single"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2367911" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2345171"/>
+        <nd ref="-2345179"/>
+        <nd ref="-2361181"/>
+        <nd ref="-2361179"/>
+        <nd ref="-2361177"/>
+        <nd ref="-2361175"/>
+        <nd ref="-2361173"/>
+        <nd ref="-2361171"/>
+        <nd ref="-2361169"/>
+        <nd ref="-2361167"/>
+        <nd ref="-2361165"/>
+        <nd ref="-2361163"/>
+        <nd ref="-2361161"/>
+        <nd ref="-2360821"/>
+        <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2397"/>
+        <tag k="Length_Mil" v="1"/>
+        <tag k="status" v="operational"/>
+        <tag k="voltage" v="60000"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="00027f"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.911Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="7641.75913657"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.026473919768262001"/>
     </way>
     <way visible="true" id="-2367903" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349013"/>
@@ -7898,6 +8143,34 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Moraga - Claremont"/>
         <tag k="REVIEW" v="000037"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2367887" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2346929"/>
+        <nd ref="-2347035"/>
+        <nd ref="-2347033"/>
+        <nd ref="-2347031"/>
+        <nd ref="-2345955"/>
+        <nd ref="-2346645"/>
+        <nd ref="-2345161"/>
+        <nd ref="-2339937"/>
+        <tag k="owner" v="PG&amp;E"/>
+        <tag k="Length_Mil" v="6"/>
+        <tag k="kV_Sort" v="230"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.101Z"/>
+        <tag k="Shape__Len" v="0.099957525011448001"/>
+        <tag k="circuits" v="2"/>
+        <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="power" v="line"/>
+        <tag k="location" v="overhead"/>
+        <tag k="name" v="PG&amp;E 230kV"/>
+        <tag k="status" v="operational"/>
+        <tag k="voltage" v="230000"/>
+        <tag k="Length_Fee" v="32315.51980185"/>
+        <tag k="OBJECTID" v="1295"/>
+        <tag k="REF1" v="000035"/>
+        <tag k="Type" v="OH"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367883" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2361061"/>
@@ -7936,6 +8209,7 @@
         <nd ref="-2367635"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367881" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367675"/>
@@ -7950,6 +8224,7 @@
         <nd ref="-2367675"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367880" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367645"/>
@@ -7963,6 +8238,7 @@
         <nd ref="-2367645"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367879" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367671"/>
@@ -7975,6 +8251,7 @@
         <nd ref="-2367671"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367878" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367641"/>
@@ -7986,6 +8263,7 @@
         <nd ref="-2367641"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367877" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367638"/>
@@ -7997,6 +8275,7 @@
         <nd ref="-2367638"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367876" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367618"/>
@@ -8006,6 +8285,7 @@
         <nd ref="-2367618"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367875" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367689"/>
@@ -8015,6 +8295,7 @@
         <nd ref="-2367689"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367874" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367685"/>
@@ -8024,6 +8305,7 @@
         <nd ref="-2367685"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367873" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367656"/>
@@ -8033,6 +8315,7 @@
         <nd ref="-2367656"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367872" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367654"/>
@@ -8042,6 +8325,7 @@
         <nd ref="-2367654"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367871" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367693"/>
@@ -8051,6 +8335,7 @@
         <nd ref="-2367693"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367870" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367623"/>
@@ -8068,6 +8353,7 @@
         <nd ref="-2367623"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367869" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367607"/>
@@ -8085,6 +8371,7 @@
         <nd ref="-2367607"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367868" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367558"/>
@@ -8098,6 +8385,7 @@
         <nd ref="-2367558"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367867" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367587"/>
@@ -8107,6 +8395,7 @@
         <nd ref="-2367587"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367866" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367590"/>
@@ -8116,6 +8405,7 @@
         <nd ref="-2367590"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367865" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367589"/>
@@ -8125,6 +8415,7 @@
         <nd ref="-2367589"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367864" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367548"/>
@@ -8134,6 +8425,7 @@
         <nd ref="-2367548"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367863" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367554"/>
@@ -8143,6 +8435,7 @@
         <nd ref="-2367554"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367862" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367550"/>
@@ -8152,6 +8445,7 @@
         <nd ref="-2367550"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367861" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367577"/>
@@ -8161,6 +8455,7 @@
         <nd ref="-2367577"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367860" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367598"/>
@@ -8170,6 +8465,7 @@
         <nd ref="-2367598"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367859" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367573"/>
@@ -8179,6 +8475,7 @@
         <nd ref="-2367573"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367858" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367597"/>
@@ -8188,6 +8485,7 @@
         <nd ref="-2367597"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367857" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367570"/>
@@ -8197,6 +8495,7 @@
         <nd ref="-2367570"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367856" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367581"/>
@@ -8206,6 +8505,7 @@
         <nd ref="-2367581"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367855" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367544"/>
@@ -8215,6 +8515,7 @@
         <nd ref="-2367544"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367854" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367534"/>
@@ -8224,6 +8525,7 @@
         <nd ref="-2367534"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367853" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367536"/>
@@ -8233,6 +8535,7 @@
         <nd ref="-2367536"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367852" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367540"/>
@@ -8242,6 +8545,7 @@
         <nd ref="-2367540"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367851" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367531"/>
@@ -8251,6 +8555,7 @@
         <nd ref="-2367531"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367850" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367506"/>
@@ -8260,6 +8565,7 @@
         <nd ref="-2367506"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367849" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367494"/>
@@ -8269,6 +8575,7 @@
         <nd ref="-2367494"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367848" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367522"/>
@@ -8278,6 +8585,7 @@
         <nd ref="-2367522"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367847" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367511"/>
@@ -8287,6 +8595,7 @@
         <nd ref="-2367511"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367846" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367520"/>
@@ -8296,6 +8605,7 @@
         <nd ref="-2367520"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367845" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367516"/>
@@ -8305,6 +8615,7 @@
         <nd ref="-2367516"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367844" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367512"/>
@@ -8314,6 +8625,7 @@
         <nd ref="-2367512"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367843" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367492"/>
@@ -8323,6 +8635,7 @@
         <nd ref="-2367492"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367842" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367501"/>
@@ -8332,6 +8645,7 @@
         <nd ref="-2367501"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367840" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367463"/>
@@ -8342,6 +8656,7 @@
         <tag k="power" v="generator"/>
         <tag k="name" v="NCPA Turbines"/>
         <tag k="building" v="commercial"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367839" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367451"/>
@@ -8358,6 +8673,7 @@
         <nd ref="-2367462"/>
         <nd ref="-2367451"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367838" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367437"/>
@@ -8367,6 +8683,7 @@
         <nd ref="-2367437"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367837" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367433"/>
@@ -8376,6 +8693,7 @@
         <nd ref="-2367433"/>
         <tag k="power" v="generator"/>
         <tag k="generator:source" v="solar"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367836" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367410"/>
@@ -8386,12 +8704,14 @@
         <nd ref="-2367415"/>
         <nd ref="-2367410"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367829" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346853"/>
         <nd ref="-2367354"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367827" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346791"/>
@@ -8401,12 +8721,14 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Sobrante - Claremont"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367826" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367351"/>
         <nd ref="-2347135"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367821" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366454"/>
@@ -8460,6 +8782,7 @@
         <tag k="cables" v="6"/>
         <tag k="ref" v="Standard Oil - Sobrante"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367820" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345075"/>
@@ -8491,6 +8814,7 @@
         <tag k="tiger:county" v="Contra Costa, CA"/>
         <tag k="tiger:cfcc" v="C20"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367819" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367222"/>
@@ -8505,6 +8829,7 @@
         <tag k="generator:source" v="oil"/>
         <tag k="plant:output:electricity" v="165 MW"/>
         <tag k="operator" v="Dynegy"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367818" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367335"/>
@@ -8513,6 +8838,7 @@
         <nd ref="-2367333"/>
         <nd ref="-2367335"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367817" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366767"/>
@@ -8522,6 +8848,7 @@
         <tag k="note" v="disconnected"/>
         <tag k="cables" v="6"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367816" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367320"/>
@@ -8531,6 +8858,7 @@
         <nd ref="-2367324"/>
         <tag k="power" v="minor_line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367814" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367298"/>
@@ -8540,6 +8868,7 @@
         <nd ref="-2367297"/>
         <nd ref="-2367298"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367813" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367265"/>
@@ -8552,6 +8881,7 @@
         <tag k="name" v="Arlington Substation"/>
         <tag k="addr:city" v="Berkeley"/>
         <tag k="addr:housenumber" v="1989"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367812" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2347177"/>
@@ -8561,6 +8891,7 @@
         <tag k="cables" v="3"/>
         <tag k="ref" v="East Portal-Claremont"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367811" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367240"/>
@@ -8581,6 +8912,7 @@
         <nd ref="-2367229"/>
         <nd ref="-2367240"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367809" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367207"/>
@@ -8598,6 +8930,7 @@
         <nd ref="-2367207"/>
         <tag k="power" v="substation"/>
         <tag k="name" v="Claremont Substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367808" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367164"/>
@@ -8626,6 +8959,7 @@
         <tag k="name" v="Oakland X Substation"/>
         <tag k="building" v="yes"/>
         <tag k="addr:housenumber" v="3729"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367806" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367106"/>
@@ -8633,6 +8967,7 @@
         <nd ref="-2367124"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367805" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367061"/>
@@ -8641,6 +8976,7 @@
         <nd ref="-2367060"/>
         <nd ref="-2367061"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366875"/>
@@ -8649,6 +8985,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367799" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367013"/>
@@ -8658,6 +8995,7 @@
         <tag k="voltage" v="230000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367798" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366898"/>
@@ -8667,6 +9005,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367796" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366838"/>
@@ -8675,6 +9014,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367793" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366081"/>
@@ -8686,6 +9026,7 @@
         <tag k="cables" v="3"/>
         <tag k="ref" v="Parkway - Moraga"/>
         <tag k="REVIEW" v="0002d5"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367790" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367003"/>
@@ -8695,6 +9036,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367789" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367041"/>
@@ -8708,6 +9050,7 @@
         <nd ref="-2366868"/>
         <nd ref="-2367041"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367787" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367020"/>
@@ -8718,6 +9061,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="double"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367786" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366798"/>
@@ -8729,6 +9073,7 @@
         <tag k="cables" v="3"/>
         <tag k="ref" v="Bahia-Moraga"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367784" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366801"/>
@@ -8738,6 +9083,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367782" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366819"/>
@@ -8747,6 +9093,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367779" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366848"/>
@@ -8756,6 +9103,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367777" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366936"/>
@@ -8765,6 +9113,7 @@
         <tag k="voltage" v="230000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367776" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2349035"/>
@@ -8773,6 +9122,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="single"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367774" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367016"/>
@@ -8782,12 +9132,14 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367773" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367034"/>
         <nd ref="-2339855"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367769" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366959"/>
@@ -8796,6 +9148,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367765" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366985"/>
@@ -8809,6 +9162,7 @@
         <nd ref="-2366985"/>
         <tag k="power" v="substation"/>
         <tag k="name" v="Oleum Substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367763" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366081"/>
@@ -8821,6 +9175,7 @@
         <tag k="ref" v="Bahia - Moraga"/>
         <tag k="operator" v="PG&amp;E"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367762" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366938"/>
@@ -8831,6 +9186,7 @@
         <tag k="cables" v="3"/>
         <tag k="wires" v="double"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367761" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366773"/>
@@ -8840,12 +9196,14 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367760" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366788"/>
         <nd ref="-2349039"/>
         <tag k="power" v="line"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367759" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366998"/>
@@ -8855,6 +9213,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367753" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2367046"/>
@@ -8864,6 +9223,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367750" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366796"/>
@@ -8873,6 +9233,7 @@
         <tag k="voltage" v="230000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367746" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366744"/>
@@ -8901,6 +9262,7 @@
         <nd ref="-2367074"/>
         <nd ref="-2366744"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367745" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366738"/>
@@ -8915,6 +9277,7 @@
         <tag k="area" v="yes"/>
         <tag k="power" v="substation"/>
         <tag k="barrier" v="wall"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367743" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366687"/>
@@ -8925,6 +9288,7 @@
         <nd ref="-2366690"/>
         <nd ref="-2366687"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367742" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366683"/>
@@ -8937,6 +9301,7 @@
         <nd ref="-2367315"/>
         <nd ref="-2366683"/>
         <tag k="power" v="substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367741" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366680"/>
@@ -8953,6 +9318,7 @@
         <tag k="name" v="El Cerrito Substation"/>
         <tag k="landuse" v="industrial"/>
         <tag k="note" v="electrical substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367739" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366578"/>
@@ -8964,6 +9330,7 @@
         <nd ref="-2366578"/>
         <tag k="power" v="station"/>
         <tag k="name" v="East Portal Substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367736" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366522"/>
@@ -8977,6 +9344,7 @@
         <tag k="power" v="plant"/>
         <tag k="name" v="Martinez Substation"/>
         <tag k="landuse" v="industrial"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367727" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366288"/>
@@ -8992,6 +9360,7 @@
         <nd ref="-2366288"/>
         <tag k="power" v="station"/>
         <tag k="name" v="Christie Substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367724" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366176"/>
@@ -9020,6 +9389,7 @@
         <nd ref="-2366176"/>
         <tag k="power" v="station"/>
         <tag k="name" v="Moraga Substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367723" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2366100"/>
@@ -9040,6 +9410,7 @@
         <nd ref="-2366100"/>
         <tag k="power" v="station"/>
         <tag k="name" v="Sobrante Substation"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367721" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346837"/>
@@ -9049,6 +9420,7 @@
         <tag k="voltage" v="115000"/>
         <tag k="cables" v="3"/>
         <tag k="REF2" v="todo"/>
+        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367708" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365882"/>
@@ -9098,76 +9470,6 @@
         <tag k="voltage" v="200000"/>
         <tag k="cables" v="1"/>
         <tag k="REF2" v="0002d8"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-2367695" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-2345705"/>
-        <nd ref="-2345955"/>
-        <nd ref="-2345953"/>
-        <nd ref="-2345951"/>
-        <nd ref="-2345949"/>
-        <nd ref="-2345947"/>
-        <nd ref="-2345945"/>
-        <nd ref="-2345943"/>
-        <nd ref="-2345941"/>
-        <nd ref="-2345939"/>
-        <nd ref="-2345937"/>
-        <nd ref="-2345935"/>
-        <nd ref="-2345933"/>
-        <nd ref="-2345931"/>
-        <nd ref="-2345929"/>
-        <nd ref="-2345927"/>
-        <nd ref="-2345925"/>
-        <nd ref="-2345923"/>
-        <nd ref="-2345921"/>
-        <nd ref="-2345919"/>
-        <nd ref="-2345917"/>
-        <nd ref="-2345915"/>
-        <nd ref="-2345913"/>
-        <nd ref="-2345911"/>
-        <nd ref="-2345909"/>
-        <nd ref="-2345907"/>
-        <nd ref="-2345905"/>
-        <nd ref="-2345903"/>
-        <nd ref="-2345901"/>
-        <nd ref="-2345899"/>
-        <nd ref="-2345897"/>
-        <nd ref="-2345895"/>
-        <nd ref="-2345893"/>
-        <nd ref="-2345891"/>
-        <nd ref="-2345889"/>
-        <nd ref="-2345887"/>
-        <nd ref="-2345885"/>
-        <nd ref="-2345883"/>
-        <nd ref="-2345881"/>
-        <nd ref="-2345879"/>
-        <nd ref="-2345877"/>
-        <nd ref="-2345875"/>
-        <nd ref="-2345873"/>
-        <nd ref="-2345871"/>
-        <nd ref="-2345183"/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1329"/>
-        <tag k="Length_Mil" v="21"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="cables" v="6"/>
-        <tag k="ref" v="Lakeville-Sobrante/Ignacio-Sobrante"/>
-        <tag k="REF1" v="000017"/>
-        <tag k="REF2" v="000017"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.111Z"/>
-        <tag k="circuits" v="2"/>
-        <tag k="comments" v="Triple circuit for 5 miles; 115 line shares 230 poles."/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="110683.54659046"/>
-        <tag k="frequency" v="60"/>
-        <tag k="wires" v="double"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.316891218278267"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367685" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9304,23 +9606,23 @@
         <nd ref="-2361287"/>
         <nd ref="-2361285"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="2394"/>
         <tag k="Length_Mil" v="4"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.910Z"/>
-        <tag k="Shape__Len" v="0.074740579573202001"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="power" v="line"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
-        <tag k="comments" v="Partially underground"/>
-        <tag k="Length_Fee" v="22482.46574138"/>
-        <tag k="OBJECTID" v="2394"/>
-        <tag k="REF1" v="000282"/>
-        <tag k="Type" v="OH"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="000282"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:48.910Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="comments" v="Partially underground"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="22482.46574138"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.074740579573202001"/>
     </way>
     <way visible="true" id="-2367679" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2336431"/>
@@ -9435,23 +9737,23 @@
         <nd ref="-2337393"/>
         <nd ref="-2365847"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="3047"/>
         <tag k="Length_Mil" v="3"/>
-        <tag k="kV_Sort" v="60"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.261Z"/>
-        <tag k="Legend" v="PG&amp;E_60_70kV"/>
-        <tag k="power" v="line"/>
-        <tag k="circuits" v="1"/>
-        <tag k="Shape__Len" v="0.048680834172666998"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
-        <tag k="comments" v="Partially underground"/>
-        <tag k="Length_Fee" v="15817.29817967"/>
-        <tag k="OBJECTID" v="3047"/>
-        <tag k="REF1" v="000202"/>
-        <tag k="Type" v="OH"/>
+        <tag k="Legend" v="PG&amp;E_60_70kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 60kV"/>
+        <tag k="REF1" v="000202"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="60"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.261Z"/>
+        <tag k="circuits" v="1"/>
+        <tag k="comments" v="Partially underground"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="15817.29817967"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.048680834172666998"/>
     </way>
     <way visible="true" id="-2367676" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2365846"/>
@@ -9744,6 +10046,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000259"/>
         <tag k="power" v="line"/>
@@ -9754,7 +10057,6 @@
         <tag k="Length_Fee" v="12729.30611994"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.040973389883196001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367457" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2359241"/>
@@ -10065,6 +10367,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="00010c"/>
         <tag k="power" v="line"/>
@@ -10075,7 +10378,6 @@
         <tag k="Length_Fee" v="370.10721274"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0011740595642910001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367275" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2355889"/>
@@ -10089,6 +10391,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="00010b"/>
         <tag k="power" v="line"/>
@@ -10099,7 +10402,6 @@
         <tag k="Length_Fee" v="1029.26725427"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0034788717134889998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2367017" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2350583"/>
@@ -10188,6 +10490,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="ref" v="Sobrante - East Portal"/>
         <tag k="REF1" v="000036"/>
@@ -10200,7 +10503,6 @@
         <tag k="Length_Fee" v="12893.72789489"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.038454877708572997"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366837" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346683"/>
@@ -10241,6 +10543,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Sobrante - Claremont"/>
@@ -10255,7 +10558,6 @@
         <tag k="Type" v="OH"/>
         <tag k="source" v="Bing"/>
         <tag k="Shape__Len" v="0.070849254504722001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366835" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346787"/>
@@ -10279,23 +10581,23 @@
         <nd ref="-2346753"/>
         <nd ref="-2346745"/>
         <tag k="owner" v="PG&amp;E"/>
+        <tag k="OBJECTID" v="1301"/>
         <tag k="Length_Mil" v="3"/>
-        <tag k="kV_Sort" v="115"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.106Z"/>
-        <tag k="power" v="line"/>
-        <tag k="Legend" v="PG&amp;E_115kV"/>
-        <tag k="circuits" v="2"/>
-        <tag k="Shape__Len" v="0.054506509548506998"/>
-        <tag k="location" v="overhead"/>
-        <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
-        <tag k="Length_Fee" v="17489.64316133"/>
-        <tag k="OBJECTID" v="1301"/>
-        <tag k="REF1" v="00002f"/>
-        <tag k="Type" v="OH"/>
-        <tag k="REF2" v="todo"/>
+        <tag k="Legend" v="PG&amp;E_115kV"/>
         <tag k="error:circular" v="15"/>
+        <tag k="name" v="PG&amp;E 115kV"/>
+        <tag k="REF1" v="00002f"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="power" v="line"/>
+        <tag k="kV_Sort" v="115"/>
+        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.106Z"/>
+        <tag k="circuits" v="2"/>
+        <tag k="location" v="overhead"/>
+        <tag k="Length_Fee" v="17489.64316133"/>
+        <tag k="Type" v="OH"/>
+        <tag k="Shape__Len" v="0.054506509548506998"/>
     </way>
     <way visible="true" id="-2366831" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346745"/>
@@ -10307,6 +10609,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="00002d"/>
         <tag k="power" v="line"/>
@@ -10317,7 +10620,6 @@
         <tag k="Length_Fee" v="104.68721825"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.00030172434563199998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366829" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346745"/>
@@ -10328,6 +10630,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="00002c"/>
         <tag k="power" v="line"/>
@@ -10338,7 +10641,6 @@
         <tag k="Length_Fee" v="43.8480917"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.00013731764811100001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366821" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346647"/>
@@ -10354,6 +10656,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="000028"/>
@@ -10366,7 +10669,6 @@
         <tag k="Length_Fee" v="1308.73903127"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.004280024664748"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366815" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2346537"/>
@@ -10377,6 +10679,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="PG&amp;E_115kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 115kV"/>
         <tag k="REF1" v="000025"/>
         <tag k="power" v="line"/>
@@ -10387,7 +10690,6 @@
         <tag k="Length_Fee" v="253.12090691"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.00087063638338400005"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366743" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345071"/>
@@ -10402,6 +10704,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="3"/>
         <tag k="ref" v="Parkway - Moraga"/>
@@ -10416,7 +10719,6 @@
         <tag k="Length_Fee" v="1392.56956838"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.003818398744309"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366741" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2345165"/>
@@ -10473,6 +10775,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="230000"/>
         <tag k="Legend" v="PG&amp;E_230kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 230kV"/>
         <tag k="cables" v="6"/>
         <tag k="ref" v="Parkway - Moraga/Bahia - Moraga"/>
@@ -10487,7 +10790,6 @@
         <tag k="Length_Fee" v="41236.59565289"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.121230177073769"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366383" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338113"/>
@@ -10503,6 +10805,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="cables" v="3"/>
         <tag k="REF1" v="00023d"/>
@@ -10516,7 +10819,6 @@
         <tag k="wires" v="single"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.0078526960764769994"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366379" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2338093"/>
@@ -10862,6 +11164,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="0001f8"/>
         <tag k="power" v="line"/>
@@ -10872,7 +11175,6 @@
         <tag k="Length_Fee" v="7087.31166597"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.023050725244027001"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366313" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2336963"/>
@@ -10883,6 +11185,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="0001f6"/>
         <tag k="power" v="line"/>
@@ -10893,7 +11196,6 @@
         <tag k="Length_Fee" v="48.63828844"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.000145698252638"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366311" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2336959"/>
@@ -10952,6 +11254,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="0001f2"/>
         <tag k="power" v="line"/>
@@ -10962,7 +11265,6 @@
         <tag k="Length_Fee" v="3574.18307038"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.010041998944611"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366307" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2336901"/>
@@ -11124,6 +11426,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="0001ea"/>
         <tag k="power" v="line"/>
@@ -11134,7 +11437,6 @@
         <tag k="Length_Fee" v="21527.23027944"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.063111101374870998"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366299" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2336713"/>
@@ -11367,6 +11669,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="60000"/>
         <tag k="Legend" v="PG&amp;E_60_70kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="PG&amp;E 60kV"/>
         <tag k="REF1" v="0001e2"/>
         <tag k="power" v="line"/>
@@ -11377,7 +11680,6 @@
         <tag k="Length_Fee" v="2165.05843758"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.007263167159856"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366287" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2336465"/>
@@ -11431,6 +11733,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="Other_110_161kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="AMP 115kV"/>
         <tag k="REF1" v="000370"/>
         <tag k="power" v="line"/>
@@ -11442,7 +11745,6 @@
         <tag k="Length_Fee" v="6135.61557739"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.019404863874129999"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-2366073" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-2332545"/>
@@ -11545,6 +11847,7 @@
         <tag k="status" v="operational"/>
         <tag k="voltage" v="115000"/>
         <tag k="Legend" v="Other_110_161kV"/>
+        <tag k="error:circular" v="15"/>
         <tag k="name" v="AMP 115kV"/>
         <tag k="REF1" v="00031a"/>
         <tag k="power" v="line"/>
@@ -11555,7 +11858,6 @@
         <tag k="Length_Fee" v="3807.24014248"/>
         <tag k="Type" v="OH"/>
         <tag k="Shape__Len" v="0.01074336131559"/>
-        <tag k="error:circular" v="15"/>
     </way>
     <relation visible="true" id="-963" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2382632" role=""/>
@@ -11565,30 +11867,8 @@
         <tag k="voltage" v="115000"/>
         <tag k="ref" v="Oleum - El Cerrito"/>
         <tag k="REF2" v="todo"/>
-        <tag k="type" v="multilinestring"/>
         <tag k="error:circular" v="15"/>
-    </relation>
-    <relation visible="true" id="-950" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-2367908" role=""/>
-        <member type="way" ref="-2382424" role=""/>
-        <tag k="owner" v="PG&amp;E"/>
-        <tag k="OBJECTID" v="1295"/>
-        <tag k="Length_Mil" v="6"/>
-        <tag k="status" v="operational"/>
-        <tag k="voltage" v="230000"/>
-        <tag k="Legend" v="PG&amp;E_230kV"/>
-        <tag k="name" v="PG&amp;E 230kV"/>
-        <tag k="REF1" v="000035"/>
-        <tag k="power" v="line"/>
-        <tag k="kV_Sort" v="230"/>
-        <tag k="source:ingest:datetime" v="2018-06-08T20:48:49.101Z"/>
-        <tag k="circuits" v="2"/>
-        <tag k="location" v="overhead"/>
-        <tag k="Length_Fee" v="32315.51980185"/>
-        <tag k="Type" v="OH"/>
-        <tag k="Shape__Len" v="0.099957525011448001"/>
         <tag k="type" v="multilinestring"/>
-        <tag k="error:circular" v="15"/>
     </relation>
     <relation visible="true" id="-919" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-2368029" role="reviewee"/>


### PR DESCRIPTION
When two ways are joined, one ID is lost.  If that happens to be a parent ID of another way there can be potential disconnects.  Added `UpdateWayParentVisitor` to update parent IDs to new ID when ways are joined.