### PR TITLE
Split OsmMap objects into smaller maps using tiles

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/elements/Element.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Element.h
@@ -92,6 +92,8 @@ public:
    */
   virtual geos::geom::Envelope* getEnvelope(
     const std::shared_ptr<const ElementProvider>& ep) const = 0;
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const = 0;
 
   long getId() const { return _getElementData().getId(); }
   void setId(long id) { _getElementData().setId(id); }
@@ -194,6 +196,11 @@ protected:
 
   void _postGeometryChange();
   void _preGeometryChange();
+
+  /**
+   * This envelope may be cached, but it also may not be exact.
+   */
+  mutable geos::geom::Envelope _cachedEnvelope;
 };
 
 typedef std::shared_ptr<Element> ElementPtr;

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
@@ -84,6 +84,12 @@ Envelope* Node::getEnvelope(const std::shared_ptr<const ElementProvider>& /*ep*/
   return new Envelope(getX(), getX(), getY(), getY());
 }
 
+const Envelope& Node::getEnvelopeInternal(const std::shared_ptr<const ElementProvider>& /*ep*/) const
+{
+  _cachedEnvelope = Envelope(getX(), getX(), getY(), getY());
+  return _cachedEnvelope;
+}
+
 void Node::setX(double x)
 {
   _nodeData.setX(x);

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.h
@@ -103,7 +103,11 @@ public:
    */
   std::shared_ptr<Node> cloneSp() const;
 
-  virtual geos::geom::Envelope* getEnvelope(const std::shared_ptr<const ElementProvider>& ep) const;
+  virtual geos::geom::Envelope* getEnvelope(
+      const std::shared_ptr<const ElementProvider>& ep) const override;
+
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
   double getX() const { return _nodeData.getX(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
@@ -151,12 +151,11 @@ Envelope* Relation::getEnvelope(const std::shared_ptr<const ElementProvider>& ep
   return new Envelope(getEnvelopeInternal(ep));
 }
 
-Envelope Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvider>& ep) const
+const Envelope& Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvider>& ep) const
 {
   LOG_VART(ep.get());
 
-  Envelope result;
-  result.init();
+  _cachedEnvelope.init();
 
   const vector<RelationData::Entry>& members = getMembers();
 
@@ -169,8 +168,8 @@ Envelope Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvid
     if (ep->containsElement(m.getElementId()) == false)
     {
       LOG_TRACE(m.getElementId() << " missing.  Returning empty envelope...");
-      result.setToNull();
-      return result;
+      _cachedEnvelope.setToNull();
+      return _cachedEnvelope;
     }
 
     const std::shared_ptr<const Element> e = ep->getElement(m.getElementId());
@@ -180,15 +179,15 @@ Envelope Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvid
     if (childEnvelope->isNull())
     {
       LOG_TRACE("Child envelope for " << m.getElementId() << " null.  Returning empty envelope...");
-      result.setToNull();
-      return result;
+      _cachedEnvelope.setToNull();
+      return _cachedEnvelope;
     }
 
-    result.expandToInclude(childEnvelope.get());
+    _cachedEnvelope.expandToInclude(childEnvelope.get());
   }
 
-  LOG_VART(result);
-  return result;
+  LOG_VART(_cachedEnvelope);
+  return _cachedEnvelope;
 }
 
 void Relation::_makeWritable()

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -94,10 +94,10 @@ public:
   { return _relationData->getElements(); }
 
   virtual geos::geom::Envelope* getEnvelope(
-    const std::shared_ptr<const ElementProvider>& ep) const;
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
-  geos::geom::Envelope getEnvelopeInternal(
-    const std::shared_ptr<const ElementProvider>& ep) const;
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
   virtual ElementType getElementType() const { return ElementType(ElementType::Relation); }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -104,15 +104,15 @@ public:
   /**
    * Returns the same result as getEnvelopeInternal, but copied so the caller gets ownership.
    */
-  virtual geos::geom::Envelope* getEnvelope(const std::shared_ptr<const ElementProvider>& ep) const
+  virtual geos::geom::Envelope* getEnvelope(const std::shared_ptr<const ElementProvider>& ep) const override
   { return new geos::geom::Envelope(getEnvelopeInternal(ep)); }
 
   /**
    * Returns the envelope for this way. This is guaranteed to be exact. If any of the nodes for
    * this way are not loaded into RAM then the behavior is undefined (probably an assert).
    */
-  const geos::geom::Envelope& getEnvelopeInternal(
-    const std::shared_ptr<const ElementProvider>& ep) const;
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
   /**
    * Returns the index of the first time this node occurs in the way. It is possible that the node
@@ -229,11 +229,6 @@ protected:
 private:
 
   std::shared_ptr<WayData> _wayData;
-
-  /**
-   * This envelope may be cached, but it also may not be exact.
-   */
-  mutable geos::geom::Envelope _cachedEnvelope;
 
   // for debugging only; SLOW - We don't check for duplicated nodes (outside of start/end) at
   // runtime due to the performance hit. So, use this to debug when that occurs.


### PR DESCRIPTION
Refs #3587 
The other PR is having some real issues with un-reproducible unit test failures.  Here is the first set of changes to commit.  Updated elements to use virtual envelope functions.