### PR TITLE
Split OsmMap objects into smaller maps using tiles

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/OsmMapSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/OsmMapSplitter.cpp
@@ -1,0 +1,180 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "OsmMapSplitter.h"
+
+//  Hoot
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/ops/CopyMapSubsetOp.h>
+#include <hoot/core/util/StringUtils.h>
+
+//  Qt
+#include <QElapsedTimer>
+#include <QFileInfo>
+
+using geos::geom::Envelope;
+using std::vector;
+
+namespace hoot
+{
+
+OsmMapSplitter::OsmMapSplitter(const OsmMapPtr &map, const OsmMapPtr &tiles)
+  : _map(map),
+    _tiles(tiles),
+    _statusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval() * 10)
+{
+}
+
+void OsmMapSplitter::setConfiguration(const Settings& conf)
+{
+  ConfigOptions configOptions(conf);
+  _statusUpdateInterval = configOptions.getTaskStatusUpdateInterval() * 10;
+}
+
+void OsmMapSplitter::apply()
+{
+  QElapsedTimer timer;
+  timer.start();
+  //  First build up the tile map
+  const WayMap& tiles = _tiles->getWays();
+  for (WayMap::const_iterator tile_it = tiles.begin(); tile_it != tiles.end(); ++tile_it)
+  {
+    _tileEnvelopes.push_back(tile_it->second->getEnvelopeInternal(_tiles));
+    _tileMaps.push_back(OsmMapPtr(new OsmMap(_map->getProjection())));
+  }
+  //  Iterate all of the elements in the map and copy them to the corresponding map by envelope
+  //  Start with relations
+  const RelationMap& relations = _map->getRelations();
+  for (RelationMap::const_iterator relation_it = relations.begin(); relation_it != relations.end(); ++relation_it)
+    _placeElementInMap(relation_it->second);
+
+  //  Then ways that haven't already been copied
+  const WayMap& ways = _map->getWays();
+  for (WayMap::const_iterator way_it = ways.begin(); way_it != ways.end(); ++way_it)
+    _placeElementInMap(way_it->second);
+
+  //  Finally nodes that haven't already been copied
+  const NodeMap& nodes = _map->getNodes();
+  for (NodeMap::const_iterator node_it = nodes.begin(); node_it != nodes.end(); ++node_it)
+    _placeElementInMap(node_it->second);
+
+  LOG_INFO(
+    "Sorted " << StringUtils::formatLargeNumber(_eidsCompleted.size()) <<
+    " elements in: " << StringUtils::millisecondsToDhms(timer.elapsed()) << ".");
+}
+
+void OsmMapSplitter::_placeElementInMap(const ElementPtr& element)
+{
+  //  Check if the element has already been assigned a tile
+  if (_eidsCompleted.find(element->getElementId()) != _eidsCompleted.end())
+    return;
+  //  Get the envelope of the element and start comparing it
+  const Envelope& env = element->getEnvelopeInternal(_map);
+  if (env.isNull())
+  {
+    LOG_WARN("Element " << element->getElementId() << " returned NULL envelope, ignoring.");
+    return;
+  }
+  Envelope maxIntersectEnvelope;
+  long maxEnvelopeIndex = -1;
+  for (long tile_index = 0; tile_index < (long)_tileEnvelopes.size(); ++tile_index)
+  {
+    Envelope& renv = _tileEnvelopes[tile_index];
+    //  Find the best envelope for this element
+    if (renv.contains(env))
+    {
+      //  This element is completely contained within the tile envelope, no further calculations needed
+      maxEnvelopeIndex = tile_index;
+      break;
+    }
+    else if (renv.intersects(env))
+    {
+      //  Partial intersection requires that we find the envelope that contains the highest percentage
+      //  overlap, that can be done by finding the envelope with the highest area of intersection
+      Envelope e;
+      renv.intersection(env, e);
+      if (maxIntersectEnvelope.isNull() || e.getArea() > maxIntersectEnvelope.getArea())
+      {
+        maxIntersectEnvelope = e;
+        maxEnvelopeIndex = tile_index;
+      }
+    }
+  }
+  //  This should never happen, all elements should intersect with at least one envelope, if not more
+  if (maxEnvelopeIndex < 0)
+  {
+    QString error = "Error: " + element->getElementId().toString() + " does not intersect any tile bounds.";
+    LOG_ERROR(error);
+    throw HootException(error);
+  }
+  //  Copy the relation (and all of its children) to the destination map
+  OsmMapPtr tile = _tileMaps[maxEnvelopeIndex];
+  CopyMapSubsetOp op(_map, element->getElementId());
+  op.apply(tile);
+  //  Update the list of elements already copied to maps
+  std::set<ElementId>& eids = op.getEidsCopied();
+  _eidsCompleted.insert(eids.begin(), eids.end());
+
+  if (_eidsCompleted.size() % _statusUpdateInterval == 0)
+  {
+    PROGRESS_INFO("Sorted " << StringUtils::formatLargeNumber(_eidsCompleted.size()) << " elements.");
+  }
+}
+
+void OsmMapSplitter::writeMaps(const QString& filename)
+{
+  vector<QString> outputFilenames;
+  //  Use the filename for the first output
+  outputFilenames.push_back(filename);
+  QUrl url(filename);
+  if (url.scheme() == MetadataTags::HootApiDbScheme())
+  {
+    //  For Hoot databases, just add the tile number to the map name
+    for (size_t i = 1; i < _tileMaps.size(); ++i)
+      outputFilenames.push_back(QString("%1-%2").arg(filename).arg(i, 5, 10, QChar('0')));
+  }
+  else if (url.scheme() == "")
+  {
+    QFileInfo info(filename);
+    QString ext = info.completeSuffix();
+    QString filepath = filename.left(filename.size() - (ext.size() + 1));
+    //  For local files, add the tile number before the extension
+    for (size_t i = 1; i < _tileMaps.size(); ++i)
+      outputFilenames.push_back(QString("%1-%2.%3").arg(filepath).arg(i, 5, 10, QChar('0')).arg(ext));
+  }
+  else
+  {
+    LOG_ERROR("OsmMapSplitter - Unsupported file type: " << filename);
+    return;
+  }
+  //  Now save off each map
+  for (size_t index = 0; index < outputFilenames.size(); ++index)
+    OsmMapWriterFactory::write(_tileMaps[index], outputFilenames[index]);
+}
+
+}
+

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/OsmMapSplitter.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/OsmMapSplitter.h
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef OSM_MAP_SPLITTER
+#define OSM_MAP_SPLITTER
+
+//  Hoot
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/util/Configurable.h>
+
+//  Geos
+#include <geos/geom/Envelope.h>
+
+//  Std
+#include <set>
+#include <vector>
+
+namespace hoot
+{
+
+/**
+ * @brief The OsmMapSplitter class splits a map up into multiple maps based on preprocessed
+ * tile boundaries.  Elements that span tiles will only be assigned to one tile output map
+ * so that they aren't duplicated in conflation campaigns.
+ */
+class OsmMapSplitter : public Configurable
+{
+public:
+  OsmMapSplitter(const OsmMapPtr& map, const OsmMapPtr& tiles);
+
+  virtual void setConfiguration(const Settings& conf) override;
+
+  void apply();
+  /**
+   * @brief writeMaps Write all maps to disk with only their corresponding elements
+   * @param filename Base filename for all files in the format:
+   *   output-00001.osm
+   *   ...
+   *   output-0000n.osm
+   */
+  void writeMaps(const QString& filename);
+
+private:
+
+  /**
+   * @brief _placeElementInMap Take an element from the original map and find the tile map that
+   *  that it falls into and then copy it to the new map
+   * @param element Element to copy into tile map
+   */
+  void _placeElementInMap(const ElementPtr& element);
+
+  typedef QMap<geos::geom::Envelope, OsmMapPtr> TileMap;
+  /** Original map to split up */
+  OsmMapPtr _map;
+  /** Map of polygon ways that indicate tile divisions */
+  OsmMapPtr _tiles;
+  /** Vector of tile envelopes to check new elements against */
+  std::vector<geos::geom::Envelope> _tileEnvelopes;
+  /** Vector of maps whose index corresponds to the tile envelopes above */
+  std::vector<OsmMapPtr> _tileMaps;
+  /** Set of all elements that have already been processed so that no elements are repeated */
+  std::set<ElementId> _eidsCompleted;
+
+  long _statusUpdateInterval;
+};
+
+}
+
+#endif  //  OSM_MAP_SPLITTER

--- a/hoot-core/src/main/cpp/hoot/core/cmd/SplitMapCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/SplitMapCmd.cpp
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+//  Hoot
+#include <hoot/core/algorithms/splitter/OsmMapSplitter.h>
+#include <hoot/core/cmd/BaseCommand.h>
+#include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/Factory.h>
+
+using namespace std;
+
+namespace hoot
+{
+
+class SplitMapCmd : public BaseCommand
+{
+public:
+
+  static string className() { return "hoot::SplitMapCmd"; }
+
+  SplitMapCmd() { }
+
+  virtual QString getName() const override { return "split-map"; }
+
+  virtual QString getDescription() const override
+  { return "Split a map geospatially into tiled maps."; }
+
+  virtual int runSimple(QStringList& args) override
+  {
+    if (args.size() != 3)
+    {
+      LOG_VARD(args);
+      cout << getHelp() << endl << endl;
+      throw HootException(QString("%1 takes three parameters.").
+                          arg(getName()));
+    }
+    //  Load the tile map ignoring the file IDs
+    OsmMapPtr tile_map(new OsmMap());
+    IoUtils::loadMap(tile_map, args[0], false);
+    //  Don't introduce source:datetime or source:ingest:datetime
+    conf().set(ConfigOptions::getReaderAddSourceDatetimeKey(), false);
+    //  Load the actual map and use the file IDs
+    OsmMapPtr map(new OsmMap());
+    IoUtils::loadMap(map, args[1], true, Status::Unknown1);
+    //  Split the map up into smaller maps
+    OsmMapSplitter mapSplitter(map, tile_map);
+    mapSplitter.apply();
+    //  Don't include error:circular
+    conf().set(ConfigOptions::getWriterIncludeCircularErrorTagsKey(), false);
+    //  Write the maps out to disk
+    mapSplitter.writeMaps(args[2]);
+
+    return 0;
+  }
+};
+
+HOOT_FACTORY_REGISTER(Command, SplitMapCmd)
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/elements/Element.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Element.h
@@ -92,6 +92,8 @@ public:
    */
   virtual geos::geom::Envelope* getEnvelope(
     const std::shared_ptr<const ElementProvider>& ep) const = 0;
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const = 0;
 
   long getId() const { return _getElementData().getId(); }
   void setId(long id) { _getElementData().setId(id); }
@@ -194,6 +196,11 @@ protected:
 
   void _postGeometryChange();
   void _preGeometryChange();
+
+  /**
+   * This envelope may be cached, but it also may not be exact.
+   */
+  mutable geos::geom::Envelope _cachedEnvelope;
 };
 
 typedef std::shared_ptr<Element> ElementPtr;

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
@@ -84,6 +84,12 @@ Envelope* Node::getEnvelope(const std::shared_ptr<const ElementProvider>& /*ep*/
   return new Envelope(getX(), getX(), getY(), getY());
 }
 
+const Envelope& Node::getEnvelopeInternal(const std::shared_ptr<const ElementProvider>& /*ep*/) const
+{
+  _cachedEnvelope = Envelope(getX(), getX(), getY(), getY());
+  return _cachedEnvelope;
+}
+
 void Node::setX(double x)
 {
   _nodeData.setX(x);

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.h
@@ -103,7 +103,11 @@ public:
    */
   std::shared_ptr<Node> cloneSp() const;
 
-  virtual geos::geom::Envelope* getEnvelope(const std::shared_ptr<const ElementProvider>& ep) const;
+  virtual geos::geom::Envelope* getEnvelope(
+      const std::shared_ptr<const ElementProvider>& ep) const override;
+
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
   double getX() const { return _nodeData.getX(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
@@ -151,12 +151,11 @@ Envelope* Relation::getEnvelope(const std::shared_ptr<const ElementProvider>& ep
   return new Envelope(getEnvelopeInternal(ep));
 }
 
-Envelope Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvider>& ep) const
+const Envelope& Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvider>& ep) const
 {
   LOG_VART(ep.get());
 
-  Envelope result;
-  result.init();
+  _cachedEnvelope.init();
 
   const vector<RelationData::Entry>& members = getMembers();
 
@@ -169,8 +168,8 @@ Envelope Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvid
     if (ep->containsElement(m.getElementId()) == false)
     {
       LOG_TRACE(m.getElementId() << " missing.  Returning empty envelope...");
-      result.setToNull();
-      return result;
+      _cachedEnvelope.setToNull();
+      return _cachedEnvelope;
     }
 
     const std::shared_ptr<const Element> e = ep->getElement(m.getElementId());
@@ -180,15 +179,15 @@ Envelope Relation::getEnvelopeInternal(const std::shared_ptr<const ElementProvid
     if (childEnvelope->isNull())
     {
       LOG_TRACE("Child envelope for " << m.getElementId() << " null.  Returning empty envelope...");
-      result.setToNull();
-      return result;
+      _cachedEnvelope.setToNull();
+      return _cachedEnvelope;
     }
 
-    result.expandToInclude(childEnvelope.get());
+    _cachedEnvelope.expandToInclude(childEnvelope.get());
   }
 
-  LOG_VART(result);
-  return result;
+  LOG_VART(_cachedEnvelope);
+  return _cachedEnvelope;
 }
 
 void Relation::_makeWritable()

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -94,10 +94,10 @@ public:
   { return _relationData->getElements(); }
 
   virtual geos::geom::Envelope* getEnvelope(
-    const std::shared_ptr<const ElementProvider>& ep) const;
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
-  geos::geom::Envelope getEnvelopeInternal(
-    const std::shared_ptr<const ElementProvider>& ep) const;
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
   virtual ElementType getElementType() const { return ElementType(ElementType::Relation); }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -104,15 +104,15 @@ public:
   /**
    * Returns the same result as getEnvelopeInternal, but copied so the caller gets ownership.
    */
-  virtual geos::geom::Envelope* getEnvelope(const std::shared_ptr<const ElementProvider>& ep) const
+  virtual geos::geom::Envelope* getEnvelope(const std::shared_ptr<const ElementProvider>& ep) const override
   { return new geos::geom::Envelope(getEnvelopeInternal(ep)); }
 
   /**
    * Returns the envelope for this way. This is guaranteed to be exact. If any of the nodes for
    * this way are not loaded into RAM then the behavior is undefined (probably an assert).
    */
-  const geos::geom::Envelope& getEnvelopeInternal(
-    const std::shared_ptr<const ElementProvider>& ep) const;
+  virtual const geos::geom::Envelope& getEnvelopeInternal(
+    const std::shared_ptr<const ElementProvider>& ep) const override;
 
   /**
    * Returns the index of the first time this node occurs in the way. It is possible that the node
@@ -229,11 +229,6 @@ protected:
 private:
 
   std::shared_ptr<WayData> _wayData;
-
-  /**
-   * This envelope may be cached, but it also may not be exact.
-   */
-  mutable geos::geom::Envelope _cachedEnvelope;
 
   // for debugging only; SLOW - We don't check for duplicated nodes (outside of start/end) at
   // runtime due to the performance hit. So, use this to debug when that occurs.

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
@@ -28,8 +28,8 @@
 
 #include <hoot/core/elements/ConstElementVisitor.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/visitors/UniqueElementIdVisitor.h>
 #include <hoot/core/visitors/FilteredVisitor.h>
+#include <hoot/core/visitors/UniqueElementIdVisitor.h>
 
 using namespace std;
 
@@ -70,17 +70,24 @@ public:
         _from->getElement(eid)->visitRo(*_from, v);
         // finally, add this element to the map.
         _to->addElement(ee);
+        //  Add all of the elements affected
+        _elementsAdded.insert(v._elementsAdded.begin(), v._elementsAdded.end());
       }
+      //  Add this element to the list
+      _elementsAdded.insert(eid);
     }
   }
 
   virtual QString getDescription() const { return ""; }
+
+  std::set<ElementId>& getElementsAdded() { return _elementsAdded; }
 
 private:
 
   ConstOsmMapPtr _from;
   OsmMapPtr _to;
   ElementId _exempt;
+  std::set<ElementId> _elementsAdded;
 };
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, const set<ElementId>& eids) :
@@ -100,6 +107,12 @@ CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, const vector<long>&
       _eids.insert(ElementId(ElementType::Way, *it));
     }
   }
+}
+
+CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid)
+  : _from(from)
+{
+  _eids.insert(eid);
 }
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid1, ElementId eid2) :
@@ -134,6 +147,8 @@ void CopyMapSubsetOp::apply(OsmMapPtr &map)
     }
     _from->getElement(*it)->visitRo(*_from, v);
   }
+  std::set<ElementId> eids = v.getElementsAdded();
+  _eidsCopied.insert(eids.begin(), eids.end());
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
@@ -28,9 +28,9 @@
 #define COPYMAPSUBSETOP_H
 
 // hoot
+#include <hoot/core/criterion/ElementCriterion.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/ops/OsmMapOperation.h>
-#include <hoot/core/criterion/ElementCriterion.h>
 
 namespace hoot
 {
@@ -48,6 +48,7 @@ public:
 
   CopyMapSubsetOp(const ConstOsmMapPtr& from, const std::set<ElementId>& eids);
   CopyMapSubsetOp(const ConstOsmMapPtr& from, const std::vector<long>& wayIds);
+  CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid);
   CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid1, ElementId eid2);
   CopyMapSubsetOp(const ConstOsmMapPtr& from, const ElementCriterionPtr& crit);
 
@@ -62,11 +63,13 @@ public:
 
   virtual QString getDescription() const { return "Copies a subset of the map into a new map"; }
 
+  std::set<ElementId>& getEidsCopied() { return _eidsCopied; }
 private:
 
   std::set<ElementId> _eids;
   ConstOsmMapPtr _from;
   ElementCriterionPtr _crit;
+  std::set<ElementId> _eidsCopied;
 };
 
 }


### PR DESCRIPTION
Refs #3587
The other PR is having some real issues with un-reproducible unit test failures. Here is the first set of changes to commit.  Created split-map command.