### PR TITLE
Fix json reader element type ordering bug

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -1747,6 +1747,15 @@ vs
 Output the GeoJSON in a format readable in Tasking Manager.  This includes
 per file or per feature `source` tags and compatible geometries.
 
+=== json.reader.require.strict.type.ordering
+
+* Data Type: bool
+* Default Value: `false`
+
+Requires that elements in input files be present in the order nodes --> ways --> relations. Elements
+that do not meet the requirement are not loaded. Temporary tag for changeset replacement support;
+see #3619.
+
 === json.perserve.empty.tags
 
 * Data Type: bool

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -51,6 +51,7 @@ class OsmJsonReaderTest : public HootTestFixture
   CPPUNIT_TEST(isSupportedTest);
   CPPUNIT_TEST(runBoundsTest);
   CPPUNIT_TEST(runBoundsLeaveConnectedOobWaysTest);
+  CPPUNIT_TEST(elementTypeUnorderedTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -335,9 +336,10 @@ public:
     CPPUNIT_ASSERT(TestUtils::compareMaps(pMap, pTestMap));
   }
 
-  // Try hitting the network to get some data...
   void urlTest()
   {
+    // Try hitting the network to get some data...
+
     // needed to suppress map crop missing element warnings
     DisableLog dl;
 
@@ -623,6 +625,24 @@ public:
     uut.close();
     OsmMapWriterFactory::write(map, _outputPath + "/" + testFileName, false, true);
 
+    HOOT_FILE_EQUALS(_inputPath + "/" + testFileName, _outputPath + "/" + testFileName);
+  }
+
+  void elementTypeUnorderedTest()
+  {
+    // This should load the elements even though child elements come after their parents.
+    // TODO: we need some relations in the test input
+
+    const QString testFileName = "elementTypeUnorderedTest.osm";
+
+    OsmJsonReader uut;
+    uut.setRequireStrictTypeOrdering(false);
+
+    OsmMapPtr map(new OsmMap());
+    uut.open(_inputPath + "elementTypeUnorderedTest-in.json");
+    uut.read(map);
+    uut.close();
+    OsmMapWriterFactory::write(map, _outputPath + "/" + testFileName, false, true);
     HOOT_FILE_EQUALS(_inputPath + "/" + testFileName, _outputPath + "/" + testFileName);
   }
 };

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -239,6 +239,9 @@ public:
 
   bool isValidJson(const QString& jsonStr);
 
+  // temporary: see #3619
+  void setRequireStrictTypeOrdering(bool require) { _requireStrictTypeOrdering = require; }
+
 protected:
 
   // Items to conform to OsmMapReader ifc
@@ -278,6 +281,9 @@ protected:
 
   int _missingNodeCount;
   int _missingWayCount;
+
+  // requires that elements be type ordering in input; if not, they're skipped; temporary: see #3619
+  bool _requireStrictTypeOrdering;
 
   /**
    * @brief _loadJSON Loads JSON into a boost property tree

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
@@ -75,7 +75,6 @@ public:
 protected:
 
   OsmMap* _map;
-  //const OsmMap* _constMap;
   int _maxReport;
   int _missingCount;
   bool _removeMissing;

--- a/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
+++ b/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
@@ -122,8 +122,8 @@ export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
 
-GENERAL_OPTS="--warn -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+GENERAL_OPTS="--trace -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter=OsmJsonWriter -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
+DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D json.reader.require.strict.type.ordering=true"
 CROP_OPTS="-D crop.bounds=$CROP_AOI"
 PERTY_OPTS="-D random.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops= "
 CHANGESET_DERIVE_OPTS="-D changeset.user.id=1 -D bounds.output.file=$OUT_DIR/$TEST_NAME-bounds.osm -D snap.unconnected.ways.existing.way.node.tolerance=$EXISTING_WAY_NODE_TOLERANCE -D snap.unconnected.ways.snap.tolerance=$WAY_SNAP_TOLERANCE"

--- a/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
+++ b/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
@@ -122,6 +122,7 @@ export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
 
+# json.reader.require.strict.type.ordering=true is temporary; see #3619
 GENERAL_OPTS="--warn -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false -D json.reader.require.strict.type.ordering=true"
 DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 CROP_OPTS="-D crop.bounds=$CROP_AOI"

--- a/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
+++ b/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
@@ -122,8 +122,8 @@ export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
 
-GENERAL_OPTS="--warn -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D json.reader.require.strict.type.ordering=true"
+GENERAL_OPTS="--warn -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false -D json.reader.require.strict.type.ordering=true"
+DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 CROP_OPTS="-D crop.bounds=$CROP_AOI"
 PERTY_OPTS="-D random.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops= "
 CHANGESET_DERIVE_OPTS="-D changeset.user.id=1 -D bounds.output.file=$OUT_DIR/$TEST_NAME-bounds.osm -D snap.unconnected.ways.existing.way.node.tolerance=$EXISTING_WAY_NODE_TOLERANCE -D snap.unconnected.ways.snap.tolerance=$WAY_SNAP_TOLERANCE"

--- a/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
+++ b/test-files/cmd/glacial/serial/RndServiceChangesetReplacement.sh.off
@@ -122,7 +122,7 @@ export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
 
-GENERAL_OPTS="--trace -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter=OsmJsonWriter -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
+GENERAL_OPTS="--warn -C UnifyingAlgorithm.conf -C Testing.conf -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
 DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D json.reader.require.strict.type.ordering=true"
 CROP_OPTS="-D crop.bounds=$CROP_AOI"
 PERTY_OPTS="-D random.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops= "

--- a/test-files/io/OsmJsonReaderTest/elementTypeUnorderedTest-in.json
+++ b/test-files/io/OsmJsonReaderTest/elementTypeUnorderedTest-in.json
@@ -1,0 +1,176 @@
+{
+  "version": 0.6,
+  "generator": "Overpass API 0.7.55.7 8b86ff77",
+  "osm3s": {
+    "timestamp_osm_base": "2019-11-06T19:49:02Z",
+    "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+  },
+  "elements": [
+
+{
+  "type": "way",
+  "id": 236155436,
+  "nodes": [
+    2442180393,
+    2442180394,
+    2442180395,
+    2442180396,
+    2442180393
+  ],
+  "tags": {
+    "building": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 236155437,
+  "nodes": [
+    2442180397,
+    2442180398,
+    2442180399,
+    2442180400,
+    2442180401,
+    2442180402,
+    2442180403,
+    2442180404,
+    2442180397
+  ],
+  "tags": {
+    "building": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 2442180393,
+  "lat": 39.0359918,
+  "lon": -77.1171137,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180394,
+  "lat": 39.0359796,
+  "lon": -77.1170996,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180395,
+  "lat": 39.0359583,
+  "lon": -77.1171301,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180396,
+  "lat": 39.0359705,
+  "lon": -77.1171442,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180397,
+  "lat": 39.0356300,
+  "lon": -77.1166456,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180398,
+  "lat": 39.0355948,
+  "lon": -77.1165775,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180399,
+  "lat": 39.0355663,
+  "lon": -77.1166019,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180400,
+  "lat": 39.0355288,
+  "lon": -77.1165293,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180401,
+  "lat": 39.0354544,
+  "lon": -77.1165932,
+  "timestamp": "2013-09-02T04:24:46Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180402,
+  "lat": 39.0355160,
+  "lon": -77.1167123,
+  "timestamp": "2013-09-02T04:24:47Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180403,
+  "lat": 39.0355870,
+  "lon": -77.1166513,
+  "timestamp": "2013-09-02T04:24:47Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+},
+{
+  "type": "node",
+  "id": 2442180404,
+  "lat": 39.0355982,
+  "lon": -77.1166729,
+  "timestamp": "2013-09-02T04:24:47Z",
+  "version": 1,
+  "changeset": 17629418,
+  "user": "ElliottPlack",
+  "uid": 105946
+}
+
+  ]
+}

--- a/test-files/io/OsmJsonReaderTest/elementTypeUnorderedTest.osm
+++ b/test-files/io/OsmJsonReaderTest/elementTypeUnorderedTest.osm
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="39.0354544" minlon="-77.1171442" maxlat="39.0359918" maxlon="-77.1165293"/>
+    <node visible="true" id="2442180393" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0359917999999979" lon="-77.1171137000000044">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180393"/>
+    </node>
+    <node visible="true" id="2442180394" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0359795999999974" lon="-77.1170996000000031">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180394"/>
+    </node>
+    <node visible="true" id="2442180395" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0359582999999972" lon="-77.1171300999999971">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180395"/>
+    </node>
+    <node visible="true" id="2442180396" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0359704999999977" lon="-77.1171441999999985">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180396"/>
+    </node>
+    <node visible="true" id="2442180397" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0356299999999976" lon="-77.1166455999999982">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180397"/>
+    </node>
+    <node visible="true" id="2442180398" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0355947999999984" lon="-77.1165775000000053">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180398"/>
+    </node>
+    <node visible="true" id="2442180399" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0355662999999993" lon="-77.1166019000000063">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180399"/>
+    </node>
+    <node visible="true" id="2442180400" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0355288000000016" lon="-77.1165292999999963">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180400"/>
+    </node>
+    <node visible="true" id="2442180401" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0354543999999990" lon="-77.1165931999999970">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180401"/>
+    </node>
+    <node visible="true" id="2442180402" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0355160000000012" lon="-77.1167123000000032">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180402"/>
+    </node>
+    <node visible="true" id="2442180403" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0355869999999996" lon="-77.1166513000000009">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180403"/>
+    </node>
+    <node visible="true" id="2442180404" timestamp="1970-01-01T00:00:00Z" version="1" changeset="17629418" user="ElliottPlack" uid="105946" lat="39.0355982000000026" lon="-77.1166728999999975">
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="2442180404"/>
+    </node>
+    <way visible="true" id="236155436" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="2442180393"/>
+        <nd ref="2442180394"/>
+        <nd ref="2442180395"/>
+        <nd ref="2442180396"/>
+        <nd ref="2442180393"/>
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="236155436"/>
+        <tag k="building" v="yes"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="236155437" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="2442180397"/>
+        <nd ref="2442180398"/>
+        <nd ref="2442180399"/>
+        <nd ref="2442180400"/>
+        <nd ref="2442180401"/>
+        <nd ref="2442180402"/>
+        <nd ref="2442180403"/>
+        <nd ref="2442180404"/>
+        <nd ref="2442180397"/>
+        <tag k="hoot:status" v="0"/>
+        <tag k="hoot:id" v="236155437"/>
+        <tag k="building" v="yes"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+</osm>


### PR DESCRIPTION
Child elements aren't guaranteed to come before parent elements in Overpass JSON, so remove some erroneous related checks in `OsmJsonReader` by default. Added a temporary option, `json.reader.require.strict.type.ordering`, turned off by default. The changeset replacement derivation tests blow up when is isn't enabled. #3619 will deal with fixing them and removing the config option entirely.