### PR TITLE
Run copyright checks in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   archive-create:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-hoot-release@sha256:799f9bea926e15fe4a416c4c5c9f41a406ab8f9c7f1664ef56c6f5d8727ed172
+      - image: hootenanny/rpmbuild-hoot-release@sha256:aae16380c2f96744b658c383a6c40f1623285cd680666f908f5f7e96e79c0776
     steps:
       - checkout
       - run:
@@ -27,7 +27,7 @@ jobs:
   archive-upload:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:3188fdacecb7ae5659e0274828b66da4b000f37357ad6bd71478a82137c35eea
+      - image: hootenanny/rpmbuild-repo@sha256:27c86924043bae5d291bbc203702d2b2ed9f6970d9647462ecb8c73df5e012b4
         user: rpmbuild
     steps:
       - attach_workspace:
@@ -39,7 +39,7 @@ jobs:
   copyright:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-generic@sha256:15d3e188b3530c1dc8cb9c8b7ca67e97dfb1979796c8088966e63576550ed5c9
+      - image: hootenanny/rpmbuild-generic@sha256:9e64e3c20f8a5781ab61e0eec855d658c511c558d36eb41c4f2a45ad881bae93
         user: rpmbuild
         environment:
           HOOT_HOME: '/rpmbuild/hootenanny'

--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -161,6 +161,7 @@ sudo yum -y install \
     perl-XML-LibXML \
     libpostal-data \
     libpostal-devel \
+    parallel \
     postgresql95 \
     postgresql95-contrib \
     postgresql95-devel \

--- a/hoot-core/hoot-core.pro
+++ b/hoot-core/hoot-core.pro
@@ -36,7 +36,8 @@ OTHER_FILES = \
     ../conf/core/ConfigOptions.asciidoc \
     ../conf/core/*Conflation.conf \
     ../conf/core/*Algorithm.conf \
-    ../scripts/jenkins/Jenkinsfile
+    ../scripts/jenkins/Jenkinsfile \
+    $$files(../scripts/copyright/*, true)
 
 include(../Configure.pri)
 

--- a/scripts/copyright/UpdateAllCopyrightHeaders.sh
+++ b/scripts/copyright/UpdateAllCopyrightHeaders.sh
@@ -15,6 +15,7 @@
 #    9 = Unrecognized updateMode.
 #   10 = Python error(s) found.
 #   11 = Log file not found.
+#   12 = Search directory not found
 
 GetExitCodeText(){
     if [ $1 > 0 ]; then
@@ -55,6 +56,9 @@ GetExitCodeText(){
         "11")
             echo "    Error: Log file not found"
             ;;
+        "12")
+            echo "    Error: Search directory not found"
+            ;;
         *)
             echo "    Error: Unknown"
             ;;
@@ -62,46 +66,60 @@ GetExitCodeText(){
     fi
 }
 
+
+ExitScript() {
+    echo "Exit code: $1"
+    GetExitCodeText $1
+    exit $1
+}
+
 updateMode=false
 exitCode=0
 
 # Determine the log file name.
 NOW=$(date +"%Y-%m-%d_%H:%M:%S")
-logFile="$HOOT_HOME/updateCopyrightHeader_$NOW.log"
+logBase="$HOOT_HOME/updateCopyrightHeader_$NOW"
+logFile="$logBase.log"
+logJobs="$logBase.jobs.log"
 echo "logFile: " $logFile
-#exit 0
 
-# Updates all the copyright headers in all source directories.
-for i in $HOOT_HOME/hoot-cmd $HOOT_HOME/hoot-core $HOOT_HOME/hoot-core-test $HOOT_HOME/hoot-js $HOOT_HOME/hoot-rnd $HOOT_HOME/hoot-services $HOOT_HOME/hoot-test $HOOT_HOME/tbs $HOOT_HOME/tgs
-do
-    #echo $i
-    cd $i
-    if [ $# -eq 0 ]; then
-        # No arguments/parameters which means we are only CHECKING copyright headers.
-        updateMode=false
-        $HOOT_HOME/scripts/copyright/UpdateDirCopyrightHeaders.sh $logFile
-        exitCode=$?
+# Check the argument count and content
+if [ $# -eq 0 ]; then
+    updateMode=false
+    updateParam=""
+elif [ $# -eq 1 ]; then
+    if [ $1 == '--update' ] || [ $1 == '-u' ]; then
+        updateMode=true
+        updateParam='-u'
     else
-        if [ $? -eq 1 ]; then
-            if [ $1 == '--update' ] || [ $1 == '-u' ]; then
-                updateMode=true
-                $HOOT_HOME/scripts/copyright/UpdateDirCopyrightHeaders.sh $logFile $1
-                exitCode=$?
-            else
-                # Unrecognized parameter.
-                exitCode=6
-            fi
-        else
-            # Too many arguments.
-            exitCode=7
-        fi
+        ExitScript 6  # Unrecognized parameter
     fi
-    echo $i  "exitCode:" $exitCode
-    # Output the exit code message if non-zero.
-    if [[ $exitCode -ne 0 ]]; then
-        GetExitCodeText $exitCode
-    fi
-done
+else
+    ExitScript 7 # Too many arguments
+fi
+
+# Check for the existance of the license template
+if [ ! -f $HOOT_HOME/scripts/copyright/LicenseTemplate.txt ]; then
+    ExitScript 1 # LicenseTemplate.txt not found
+fi
+
+# Run the checks in parallel
+parallel --joblog $logJobs $HOOT_HOME/scripts/copyright/UpdateDirCopyrightHeaders.sh {} $logFile $updateParam ::: \
+  $HOOT_HOME/hoot-core \
+  $HOOT_HOME/hoot-core-test \
+  $HOOT_HOME/hoot-services \
+  $HOOT_HOME/tgs \
+  $HOOT_HOME/hoot-js \
+  $HOOT_HOME/hoot-rnd \
+  $HOOT_HOME/tbs \
+  $HOOT_HOME/hoot-test \
+  $HOOT_HOME/hoot-cmd
+
+# Get the first non-zero exit status from the parallel command
+codes=`tail -n +2 $logJobs | awk '{print $7}' | grep "[1-9]" | head -n 1`
+if [ -z "$codes" ]; then
+    exitCode=$codes
+fi
 
 # Now examine the log file contents only if exitCode is 0.
 if [[ $exitCode -eq 0 ]]; then
@@ -174,7 +192,4 @@ if [[ $exitCode -eq 0 ]]; then
     fi
 fi
 
-echo "exitCode:" $exitCode
-GetExitCodeText $exitCode
-exit $exitCode
-
+ExitScript $exitCode


### PR DESCRIPTION
Substituted bash for loop with the 'parallel' command to run copyright checks in parallel.

Local the copyright updates before:
```
real	6m51.342s
user	5m34.281s
sys	1m20.441s
```
and after with directories running in parallel:
```
real	3m38.778s
user	4m25.081s
sys	1m2.945s
```
Almost a 2x speed-up.