### PR TITLE
Write Error file to disk as errors occur

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
@@ -114,8 +114,15 @@ public:
         changesets.append(args[i]);
       }
 
+      //  Get the error changeset pathname to pass to the writer
+      QFileInfo path(args[0]);
+      QString errorFilename =
+        path.absolutePath() + QDir::separator() +
+        path.baseName() + "-error." + path.completeSuffix();
+
       //  Do the actual splitting and uploading
       OsmApiWriter writer(osm, changesets);
+      writer.setErrorPathname(errorFilename);
       writer.showProgress(showProgress);
       if (showProgress)
       {
@@ -133,13 +140,9 @@ public:
       if (writer.containsFailed())
       {
         //  Output the errors from 'changeset.osc' to 'changeset-error.osc'
-        QFileInfo path(args[0]);
-        QString errorFilename =
-          path.absolutePath() + QDir::separator() +
-          path.baseName() + "-error." + path.completeSuffix();
         LOG_ERROR(
           QString("Some changeset elements failed to upload. Stored in %1.").arg(errorFilename));
-        FileUtils::writeFully(errorFilename, writer.getFailedChangeset());
+        writer.writeErrorFile();
       }
 
       //  Output the stats if requested

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -1183,6 +1183,20 @@ bool XmlChangeset::matchesChangesetConflictVersionMismatchFailure(const QString&
   return false;
 }
 
+bool XmlChangeset::writeErrorFile()
+{
+  //  Validate the pathname
+  if (_errorPathname.isEmpty())
+    return false;
+  //  Don't write an empty file
+  QString errorChangeset = getFailedChangesetString();
+  if (errorChangeset.isEmpty())
+    return false;
+  //  Write out the file
+  FileUtils::writeFully(_errorPathname, errorChangeset);
+  return true;
+}
+
 ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const QString& splitHint)
 {
   ChangesetInfoPtr split(new ChangesetInfo());
@@ -1380,6 +1394,8 @@ void XmlChangeset::updateFailedChangeset(ChangesetInfoPtr changeset, bool forceF
          it != changeset->end(ElementType::Node, (ChangesetType)current_type); ++it)
       failNode(*it);
   }
+  //  Re-write the failed changeset to disk each time a new changeset is added
+  writeErrorFile();
 }
 
 QString XmlChangeset::getChangesetString(ChangesetInfoPtr changeset, long changeset_id)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -309,6 +309,8 @@ void XmlChangeset::fixMalformedInput()
         failRelation(relation_id, true);
     }
   }
+  //  Output the error file if there are errors
+  writeErrorFile();
 }
 
 void XmlChangeset::updateChangeset(const QString &changes)
@@ -1188,12 +1190,18 @@ bool XmlChangeset::writeErrorFile()
   //  Validate the pathname
   if (_errorPathname.isEmpty())
     return false;
+  if (!hasFailedElements())
+    return false;
   //  Don't write an empty file
   QString errorChangeset = getFailedChangesetString();
   if (errorChangeset.isEmpty())
     return false;
+  //  Lock the mutex for writing
+  _errorMutex.lock();
   //  Write out the file
   FileUtils::writeFully(_errorPathname, errorChangeset);
+  //  Unlock the mutex
+  _errorMutex.unlock();
   return true;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -247,6 +247,16 @@ public:
   static bool matchesChangesetConflictVersionMismatchFailure(const QString& hint,
                                                       long& element_id, ElementType::Type& element_type,
                                                       long& version_old, long& version_new);
+  /**
+   * @brief setErrorPathname Record the pathname of the error changeset
+   * @param path Pathname
+   */
+  void setErrorPathname(const QString& path) { _errorPathname = path; }
+  /**
+   * @brief writeErrorFile Writes our the error changeset
+   * @return true if the file was written successfully
+   */
+  bool writeErrorFile();
 
 private:
   /**
@@ -459,6 +469,8 @@ private:
   NodeIdToRelationIdMap _nodeIdsToRelations;
   WayIdToRelationIdMap _wayIdsToRelations;
   RelationIdToRelationIdMap _relationIdsToRelations;
+  /** Full pathname of the error file changeset, if any errors occur */
+  QString _errorPathname;
 };
 
 /** Atomic subset of IDs that are sent to the OSM API, header only class */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -38,6 +38,7 @@
 //  Standard
 #include <array>
 #include <map>
+#include <mutex>
 #include <set>
 #include <vector>
 
@@ -471,6 +472,7 @@ private:
   RelationIdToRelationIdMap _relationIdsToRelations;
   /** Full pathname of the error file changeset, if any errors occur */
   QString _errorPathname;
+  std::mutex _errorMutex;
 };
 
 /** Atomic subset of IDs that are sent to the OSM API, header only class */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -130,6 +130,16 @@ public:
    * @see ProgressReporter
    */
   virtual unsigned int getNumSteps() const { return 1; }
+  /**
+   * @brief setErrorPathname Record the pathname of the error changeset
+   * @param path Pathname
+   */
+  void setErrorPathname(const QString& path) { _changeset.setErrorPathname(path); }
+  /**
+   * @brief writeErrorFile Writes our the error changeset
+   * @return true if the file was written successfully
+   */
+  bool writeErrorFile() { return _changeset.writeErrorFile(); }
 
 private:
   /**
@@ -266,6 +276,8 @@ private:
   QString _accessToken;
   /** OAuth 1.0 secret token granted through OAuth authorization */
   QString _secretToken;
+  /** Full pathname of the error file changeset, if any errors occur */
+  QString _errorPathname;
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */

--- a/test-files/io/OsmChangesetElementTest/ChangesetConflictExpected-error.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetConflictExpected-error.osc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<delete>
+		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="0">
+			<tag k="node" v="Should fail"/>
+		</node>
+		<node id="2" version="1" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="0"/>
+	</delete>
+</osmChange>

--- a/test-files/io/OsmChangesetElementTest/RetryConflictExpected-error.osc
+++ b/test-files/io/OsmChangesetElementTest/RetryConflictExpected-error.osc
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-37" version="0" lat="38.8545553856" lon="-104.9005792841" timestamp="" changeset="0"/>
+		<way id="-5" version="0" timestamp="" changeset="0">
+			<nd ref="-37"/>
+			<nd ref="31"/>
+			<tag k="note" v="new"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+	<modify>
+		<way id="2" version="1" timestamp="" changeset="0">
+			<nd ref="33"/>
+			<nd ref="-37"/>
+			<nd ref="8"/>
+			<nd ref="7"/>
+			<tag k="note" v="3"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</modify>
+	<delete>
+		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="0">
+			<tag k="node" v="Should fail"/>
+		</node>
+		<node id="2" version="1" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="0"/>
+	</delete>
+</osmChange>


### PR DESCRIPTION
When changeset uploads hang or error out, sometimes the error changeset isn't written.  Have `OsmApiChangeset` write out the error changeset each time it is updated so that errors show up for debugging.