### PR TITLE
Changeset upload improve memory footprint

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
@@ -36,15 +36,15 @@ namespace hoot
 class OsmApiChangesetElementTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmApiChangesetElementTest);
-  CPPUNIT_TEST(runXmlNodeTest);
-  CPPUNIT_TEST(runNonAsciiXmlNodeTest);
-  CPPUNIT_TEST(runXmlWayTest);
-  CPPUNIT_TEST(runXmlRelationTest);
+  CPPUNIT_TEST(runChangesetNodeTest);
+  CPPUNIT_TEST(runNonAsciiChangesetNodeTest);
+  CPPUNIT_TEST(runChangesetWayTest);
+  CPPUNIT_TEST(runChangesetRelationTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
 
-  void runXmlNodeTest()
+  void runChangesetNodeTest()
   {
     QXmlStreamAttributes attributes;
     attributes.append("id", "-1");
@@ -54,7 +54,7 @@ public:
     XmlObject n;
     n.first = "node";
     n.second = attributes;
-    XmlNode node(n, NULL);
+    ChangesetNode node(n, NULL);
 
     HOOT_STR_EQUALS("\t\t<node id=\"-1\" version=\"0\" "
                     "lat=\"38.8549321261880536\" lon=\"-104.8979050333482093\" changeset=\"1\"/>\n",
@@ -75,7 +75,7 @@ public:
                     node.toString(1));
   }
 
-  void runNonAsciiXmlNodeTest()
+  void runNonAsciiChangesetNodeTest()
   {
     QXmlStreamAttributes attributes;
     attributes.append("id", "-1");
@@ -85,7 +85,7 @@ public:
     XmlObject n;
     n.first = "node";
     n.second = attributes;
-    XmlNode node(n, NULL);
+    ChangesetNode node(n, NULL);
     //  Name tags taken from OSM node in Djibouti
     QXmlStreamAttributes tagAttributesAr;
     tagAttributesAr.append("k", "name:ar");
@@ -118,7 +118,7 @@ public:
                     node.toString(1));
   }
 
-  void runXmlWayTest()
+  void runChangesetWayTest()
   {
     QXmlStreamAttributes attributes;
     attributes.append("id", "-1");
@@ -127,7 +127,7 @@ public:
     XmlObject w;
     w.first = "way";
     w.second = attributes;
-    XmlWay way(w, NULL);
+    ChangesetWay way(w, NULL);
 
     HOOT_STR_EQUALS("\t\t<way id=\"-1\" version=\"0\" timestamp=\"\" changeset=\"1\">\n\t\t</way>\n",
                     way.toString(1));
@@ -157,7 +157,7 @@ public:
                     way.toString(1));
   }
 
-  void runXmlRelationTest()
+  void runChangesetRelationTest()
   {
     QXmlStreamAttributes attributes;
     attributes.append("id", "-1");
@@ -166,7 +166,7 @@ public:
     XmlObject w;
     w.first = "relation";
     w.second = attributes;
-    XmlRelation relation(w, NULL);
+    ChangesetRelation relation(w, NULL);
 
     HOOT_STR_EQUALS("\t\t<relation id=\"-1\" version=\"0\" timestamp=\"\" changeset=\"1\">\n\t\t</relation>\n",
                     relation.toString(1));

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 //  Hoot

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef ELEMENTTYPE_H
 #define ELEMENTTYPE_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
@@ -48,8 +48,8 @@ public:
     Unknown
   } Type;
 
-  ElementType() { _type = Unknown; }
-  ElementType(Type type) { _type = type; }
+  ElementType() : _type(Unknown) { }
+  ElementType(Type type) : _type(type) { }
 
   bool operator==(ElementType t) const { return t._type == _type; }
   bool operator!=(ElementType t) const { return t._type != _type; }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -146,46 +146,46 @@ void XmlChangeset::loadOsmAsChangeset(QXmlStreamReader& reader)
 
 void XmlChangeset::loadElements(QXmlStreamReader& reader, ChangesetType changeset_type)
 {
-  XmlElementPtr element;
+  ChangesetElementPtr element;
   while (!reader.atEnd() && !reader.hasError())
   {
     QXmlStreamReader::TokenType type = reader.readNext();
-    QStringRef name = reader.name();
+    QString name = reader.name().toString().toLower();
     //  Start element for nodes/ways/relations and tags/nds/members
     if (type == QXmlStreamReader::StartElement)
     {
       if (name == "node")
       {
-        element.reset(new XmlNode(XmlObject("node", reader.attributes()), &_idMap));
+        element.reset(new ChangesetNode(XmlObject(name, reader.attributes()), &_idMap));
         long id = reader.attributes().value("id").toString().toLong();
         _idMap.addId(ElementType::Node, id);
       }
       else if (name == "way")
       {
-        element.reset(new XmlWay(XmlObject("way", reader.attributes()), &_idMap));
+        element.reset(new ChangesetWay(XmlObject(name, reader.attributes()), &_idMap));
         long id = reader.attributes().value("id").toString().toLong();
         _idMap.addId(ElementType::Way, id);
       }
       else if (name == "relation")
       {
-        element.reset(new XmlRelation(XmlObject("relation", reader.attributes()), &_idMap));
+        element.reset(new ChangesetRelation(XmlObject(name, reader.attributes()), &_idMap));
         long id = reader.attributes().value("id").toString().toLong();
         _idMap.addId(ElementType::Relation, id);
       }
       else if (name == "tag")
-        element->addTag(XmlObject("tag", reader.attributes()));
+        element->addTag(XmlObject(name, reader.attributes()));
       else if (name == "nd")
       {
         long id = reader.attributes().value("ref").toString().toLong();
-        std::dynamic_pointer_cast<XmlWay>(element)->addNode(id);
+        std::dynamic_pointer_cast<ChangesetWay>(element)->addNode(id);
         //  Update the node to way map
         _nodeIdsToWays[id].insert(element->id());
       }
       else if (name == "member")
       {
-        std::shared_ptr<XmlRelation> relation = std::dynamic_pointer_cast<XmlRelation>(element);
+        std::shared_ptr<ChangesetRelation> relation = std::dynamic_pointer_cast<ChangesetRelation>(element);
         relation->addMember(reader.attributes());
-        XmlMember& member = relation->getMember(relation->getMemberCount() - 1);
+        ChangesetRelationMember& member = relation->getMember(relation->getMemberCount() - 1);
         //  Update the node/way/relation to relation maps
         if (member.isNode())
           _nodeIdsToRelations[member.getRef()].insert(element->id());
@@ -227,13 +227,13 @@ void XmlChangeset::splitLongWays(long maxWayNodes)
   //  Iterate all of the changeset types except delete
   for (int type = TypeCreate; type < TypeDelete; ++type)
   {
-    for (XmlElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
     {
-      XmlWay* way = dynamic_cast<XmlWay*>(it->second.get());
+      ChangesetWay* way = dynamic_cast<ChangesetWay*>(it->second.get());
       while (way->getNodeCount() > maxWayNodes)
       {
         //  Create a copy of the way
-        XmlWayPtr newWay(new XmlWay(*way));
+        ChangesetWayPtr newWay(new ChangesetWay(*way));
         newWay->changeId(getNextWayId());
         //  Remove maxWayNodes from the original and add them to this way
         way->removeNodes(0, maxWayNodes - 1);
@@ -250,7 +250,7 @@ void XmlChangeset::splitLongWays(long maxWayNodes)
 void XmlChangeset::fixMalformedInput()
 {
   //  Element adds cannot have a positive ID, must be negative
-  for (XmlElementMap::iterator it = _relations[TypeCreate].begin(); it != _relations[TypeCreate].end(); ++it)
+  for (ChangesetElementMap::iterator it = _relations[TypeCreate].begin(); it != _relations[TypeCreate].end(); ++it)
   {
     long old_id = it->first;
     if (old_id > 0)
@@ -261,7 +261,7 @@ void XmlChangeset::fixMalformedInput()
       replaceRelationId(old_id, new_id);
     }
   }
-  for (XmlElementMap::iterator it = _ways[TypeCreate].begin(); it != _ways[TypeCreate].end(); ++it)
+  for (ChangesetElementMap::iterator it = _ways[TypeCreate].begin(); it != _ways[TypeCreate].end(); ++it)
   {
     long old_id = it->first;
     if (old_id > 0)
@@ -272,7 +272,7 @@ void XmlChangeset::fixMalformedInput()
       replaceWayId(old_id, new_id);
     }
   }
-  for (XmlElementMap::iterator it = _nodes[TypeCreate].begin(); it != _nodes[TypeCreate].end(); ++it)
+  for (ChangesetElementMap::iterator it = _nodes[TypeCreate].begin(); it != _nodes[TypeCreate].end(); ++it)
   {
     long old_id = it->first;
     if (old_id > 0)
@@ -287,21 +287,21 @@ void XmlChangeset::fixMalformedInput()
   //  Nothing can be done about an element modify/delete if the ID is negative
   for (int type = TypeModify; type < TypeMax; ++type)
   {
-    for (XmlElementMap::iterator it = _nodes[type].begin(); it != _nodes[type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _nodes[type].begin(); it != _nodes[type].end(); ++it)
     {
       long node_id = it->first;
       //  Set the node's status to failed if negative
       if (node_id < 1)
         failNode(node_id, true);
     }
-    for (XmlElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
     {
       long way_id = it->first;
       //  Set the node's status to failed if negative
       if (way_id < 1)
         failWay(way_id, true);
     }
-    for (XmlElementMap::iterator it = _relations[type].begin(); it != _relations[type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _relations[type].begin(); it != _relations[type].end(); ++it)
     {
       long relation_id = it->first;
       //  Set the node's status to failed if negative
@@ -435,17 +435,17 @@ bool XmlChangeset::addNodes(ChangesetInfoPtr& changeset, ChangesetType type)
 {
   bool added = false;
   //  Iterate all of the nodes of "type" in the changeset
-  for (XmlElementMap::iterator it = _nodes[type].begin(); it != _nodes[type].end(); ++it)
+  for (ChangesetElementMap::iterator it = _nodes[type].begin(); it != _nodes[type].end(); ++it)
   {
     //  Add nodes up until the max changeset
     if (changeset->size() < (size_t)_maxChangesetSize)
-      added |= addNode(changeset, type, dynamic_cast<XmlNode*>(it->second.get()));
+      added |= addNode(changeset, type, dynamic_cast<ChangesetNode*>(it->second.get()));
   }
   //  Return true if something was added
   return added;
 }
 
-bool XmlChangeset::addNode(ChangesetInfoPtr& changeset, ChangesetType type, XmlNode* node)
+bool XmlChangeset::addNode(ChangesetInfoPtr& changeset, ChangesetType type, ChangesetNode* node)
 {
   //  Only add the nodes that are "sendable"
   if (canSend(node))
@@ -485,7 +485,7 @@ bool XmlChangeset::addNode(ChangesetInfoPtr& changeset, ChangesetType type, XmlN
   return false;
 }
 
-void XmlChangeset::moveOrRemoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlNode* node)
+void XmlChangeset::moveOrRemoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetNode* node)
 {
   //  Move the node from source to destination if possible, or remove it from the source
   if (canMoveNode(source, destination, type, node))
@@ -498,11 +498,11 @@ void XmlChangeset::moveOrRemoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& 
     //  Remove only the node
     source->remove(ElementType::Node, type, node->id());
     //  Set the node to available
-    node->setStatus(XmlElement::ElementStatus::Available);
+    node->setStatus(ChangesetElement::ElementStatus::Available);
   }
 }
 
-bool XmlChangeset::moveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlNode* node)
+bool XmlChangeset::moveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetNode* node)
 {
   //  Add the node to the destination and remove from the source
   destination->add(ElementType::Node, type, node->id());
@@ -510,7 +510,7 @@ bool XmlChangeset::moveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destinat
   return true;
 }
 
-bool XmlChangeset::canMoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& /*destination*/, ChangesetType /*type*/, XmlNode* /*node*/)
+bool XmlChangeset::canMoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& /*destination*/, ChangesetType /*type*/, ChangesetNode* /*node*/)
 {
   return source->size() != 1;
 }
@@ -519,17 +519,17 @@ bool XmlChangeset::addWays(ChangesetInfoPtr& changeset, ChangesetType type)
 {
   bool added = false;
   //  Iterate all of the ways of "type" in the changeset
-  for (XmlElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
+  for (ChangesetElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
   {
     //  Add ways up until the max changeset
     if (changeset->size() < (size_t)_maxChangesetSize)
-      added |= addWay(changeset, type, dynamic_cast<XmlWay*>(it->second.get()));
+      added |= addWay(changeset, type, dynamic_cast<ChangesetWay*>(it->second.get()));
   }
   //  Return true if something was added
   return added;
 }
 
-bool XmlChangeset::addWay(ChangesetInfoPtr& changeset, ChangesetType type, XmlWay* way)
+bool XmlChangeset::addWay(ChangesetInfoPtr& changeset, ChangesetType type, ChangesetWay* way)
 {
   if (canSend(way))
   {
@@ -543,7 +543,7 @@ bool XmlChangeset::addWay(ChangesetInfoPtr& changeset, ChangesetType type, XmlWa
         //  Negative IDs from the ID map are for created nodes
         if (_idMap.getNewId(ElementType::Node, way->getNode(i)) < 0)
         {
-          XmlNode* node = dynamic_cast<XmlNode*>(_allNodes[way->getNode(i)].get());
+          ChangesetNode* node = dynamic_cast<ChangesetNode*>(_allNodes[way->getNode(i)].get());
           addNode(changeset, ChangesetType::TypeCreate, node);
         }
       }
@@ -576,26 +576,26 @@ bool XmlChangeset::addParentWays(ChangesetInfoPtr& changeset, const std::set<lon
     //  The relation is either a modify or a delete, add it to the changeset
     if (_ways[ChangesetType::TypeModify].find(wayId) != _ways[ChangesetType::TypeModify].end())
     {
-      XmlWay* way = dynamic_cast<XmlWay*>(_allWays[wayId].get());
+      ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[wayId].get());
       //  Check ways that aren't already in this changeset or finished
       if (!changeset->contains(ElementType::Way, ChangesetType::TypeModify, way->id()) &&
-          way->getStatus() != XmlElement::Finalized)
+          way->getStatus() != ChangesetElement::Finalized)
       {
         if (canSend(way))
         {
           changeset->add(ElementType::Way, ChangesetType::TypeModify, wayId);
           markBuffered(way);
         }
-        else if (way->getStatus() != XmlElement::Finalized)
+        else if (way->getStatus() != ChangesetElement::Finalized)
           sendable = false;
       }
     }
     else if (_ways[ChangesetType::TypeDelete].find(wayId) != _ways[ChangesetType::TypeDelete].end())
     {
-      XmlWay* way = dynamic_cast<XmlWay*>(_allWays[wayId].get());
+      ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[wayId].get());
       //  Check ways that aren't already in this changeset or finished
       if (!changeset->contains(ElementType::Way, ChangesetType::TypeDelete, way->id()) &&
-          way->getStatus() != XmlElement::Finalized)
+          way->getStatus() != ChangesetElement::Finalized)
       {
         if (canSend(way))
         {
@@ -610,7 +610,7 @@ bool XmlChangeset::addParentWays(ChangesetInfoPtr& changeset, const std::set<lon
   return sendable;
 }
 
-void XmlChangeset::moveOrRemoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way)
+void XmlChangeset::moveOrRemoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetWay* way)
 {
   if (canMoveWay(source, destination, type, way))
   {
@@ -622,11 +622,11 @@ void XmlChangeset::moveOrRemoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& d
     //  Remove only the way from the changeset, not its nodes
     source->remove(ElementType::Way, type, way->id());
     //  Set the way to available
-    way->setStatus(XmlElement::ElementStatus::Available);
+    way->setStatus(ChangesetElement::ElementStatus::Available);
   }
 }
 
-bool XmlChangeset::moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way)
+bool XmlChangeset::moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetWay* way)
 {
   //  Don't worry about the contents of a delete operation
   if (type != ChangesetType::TypeDelete)
@@ -638,7 +638,7 @@ bool XmlChangeset::moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destinati
       for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
       {
         if (source->contains(ElementType::Node, (ChangesetType)current_type, id))
-          moveNode(source, destination, (ChangesetType)current_type, dynamic_cast<XmlNode*>(_allNodes[id].get()));
+          moveNode(source, destination, (ChangesetType)current_type, dynamic_cast<ChangesetNode*>(_allNodes[id].get()));
       }
     }
   }
@@ -648,7 +648,7 @@ bool XmlChangeset::moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destinati
   return true;
 }
 
-bool XmlChangeset::canMoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& /*destination*/, ChangesetType type, XmlWay* way)
+bool XmlChangeset::canMoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& /*destination*/, ChangesetType type, ChangesetWay* way)
 {
   //  Deleting a way will only contain the way itself
   if (type == ChangesetType::TypeDelete)
@@ -663,17 +663,17 @@ bool XmlChangeset::addRelations(ChangesetInfoPtr& changeset, ChangesetType type)
 {
   bool added = false;
   //  Iterate all of the ways of "type" in the changeset
-  for (XmlElementMap::iterator it = _relations[type].begin(); it != _relations[type].end(); ++it)
+  for (ChangesetElementMap::iterator it = _relations[type].begin(); it != _relations[type].end(); ++it)
   {
     //  Add relations up until the max changeset
     if (changeset->size() < (size_t)_maxChangesetSize)
-      added |= addRelation(changeset, type, dynamic_cast<XmlRelation*>(it->second.get()));
+      added |= addRelation(changeset, type, dynamic_cast<ChangesetRelation*>(it->second.get()));
   }
   //  Return true if something was added
   return added;
 }
 
-bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, XmlRelation* relation)
+bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, ChangesetRelation* relation)
 {
   if (canSend(relation))
   {
@@ -684,7 +684,7 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
       //  Add any relation members that need to be added
       for (int i = 0; i < relation->getMemberCount(); ++i)
       {
-        XmlMember& member = relation->getMember(i);
+        ChangesetRelationMember& member = relation->getMember(i);
         //  Negative IDs are for added members
         if (member.getRef() < 0)
         {
@@ -694,7 +694,7 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
             //  Make sure that the ID is negative (create) in the ID map
             if (_idMap.getNewId(ElementType::Node, member.getRef()) < 0)
             {
-              XmlNode* node = dynamic_cast<XmlNode*>(_allNodes[member.getRef()].get());
+              ChangesetNode* node = dynamic_cast<ChangesetNode*>(_allNodes[member.getRef()].get());
               addNode(changeset, type, node);
             }
           }
@@ -703,7 +703,7 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
             //  Make sure that the ID is negative (create) in the ID map
             if (_idMap.getNewId(ElementType::Way, member.getRef()) < 0)
             {
-              XmlWay* way = dynamic_cast<XmlWay*>(_allWays[member.getRef()].get());
+              ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[member.getRef()].get());
               addWay(changeset, type, way);
             }
           }
@@ -712,7 +712,7 @@ bool XmlChangeset::addRelation(ChangesetInfoPtr& changeset, ChangesetType type, 
             //  Make sure that the ID is negative (create) in the ID map
             if (_idMap.getNewId(ElementType::Relation, member.getRef()) < 0)
             {
-              XmlRelation* relation_member = dynamic_cast<XmlRelation*>(_allRelations[member.getRef()].get());
+              ChangesetRelation* relation_member = dynamic_cast<ChangesetRelation*>(_allRelations[member.getRef()].get());
               //  Don't re-add self referencing relations
               if (relation->id() != relation_member->id())
                 addRelation(changeset, type, relation_member);
@@ -749,10 +749,10 @@ bool XmlChangeset::addParentRelations(ChangesetInfoPtr& changeset, const std::se
     //  The relation is either a modify or a delete, add it to the changeset
     if (_relations[ChangesetType::TypeModify].find(relationId) != _relations[ChangesetType::TypeModify].end())
     {
-      XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[relationId].get());
+      ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[relationId].get());
       //  Relations in this changeset or ones that are done don't need to be added
       if (!changeset->contains(ElementType::Relation, ChangesetType::TypeModify, relation->id()) &&
-          relation->getStatus() != XmlElement::Finalized)
+          relation->getStatus() != ChangesetElement::Finalized)
       {
         if (canSend(relation))
         {
@@ -765,10 +765,10 @@ bool XmlChangeset::addParentRelations(ChangesetInfoPtr& changeset, const std::se
     }
     else if (_relations[ChangesetType::TypeDelete].find(relationId) != _relations[ChangesetType::TypeDelete].end())
     {
-      XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[relationId].get());
+      ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[relationId].get());
       //  Relations in this changeset or ones that are done don't need to be added
       if (!changeset->contains(ElementType::Relation, ChangesetType::TypeDelete, relation->id()) &&
-          relation->getStatus() != XmlElement::Finalized)
+          relation->getStatus() != ChangesetElement::Finalized)
       {
         if (canSend(relation))
         {
@@ -784,7 +784,7 @@ bool XmlChangeset::addParentRelations(ChangesetInfoPtr& changeset, const std::se
 
 }
 
-void XmlChangeset::moveOrRemoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation)
+void XmlChangeset::moveOrRemoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetRelation* relation)
 {
   if (canMoveRelation(source, destination, type, relation))
   {
@@ -796,11 +796,11 @@ void XmlChangeset::moveOrRemoveRelation(ChangesetInfoPtr& source, ChangesetInfoP
     //  Remove only the relation from the changeset, not its members
     source->remove(ElementType::Relation, type, relation->id());
     //  Set the relation to available
-    relation->setStatus(XmlElement::ElementStatus::Available);
+    relation->setStatus(ChangesetElement::ElementStatus::Available);
   }
 }
 
-bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation)
+bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetRelation* relation)
 {
   //  Don't worry about the contents of a delete operation
   if (type != ChangesetType::TypeDelete)
@@ -808,7 +808,7 @@ bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& dest
     //  Iterate all of the nodes that exist in the changeset and move them
     for (int i = 0; i < relation->getMemberCount(); ++i)
     {
-      XmlMember& member = relation->getMember(i);
+      ChangesetRelationMember& member = relation->getMember(i);
       long id = member.getRef();
       //  Each member type iterates the changeset types looking for this element, then moves it
       //  using the corresponding move function
@@ -817,7 +817,7 @@ bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& dest
         for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
         {
           if (source->contains(ElementType::Node, (ChangesetType)current_type, id))
-            moveNode(source, destination, (ChangesetType)current_type, dynamic_cast<XmlNode*>(_allNodes[id].get()));
+            moveNode(source, destination, (ChangesetType)current_type, dynamic_cast<ChangesetNode*>(_allNodes[id].get()));
         }
       }
       else if (member.isWay())
@@ -825,7 +825,7 @@ bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& dest
         for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
         {
           if (source->contains(ElementType::Way, (ChangesetType)current_type, id))
-            moveWay(source, destination, (ChangesetType)current_type, dynamic_cast<XmlWay*>(_allWays[id].get()));
+            moveWay(source, destination, (ChangesetType)current_type, dynamic_cast<ChangesetWay*>(_allWays[id].get()));
         }
       }
       else if (member.isRelation())
@@ -836,7 +836,7 @@ bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& dest
           for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
           {
             if (source->contains(ElementType::Relation, (ChangesetType)current_type, id))
-              moveRelation(source, destination, (ChangesetType)current_type, dynamic_cast<XmlRelation*>(_allRelations[id].get()));
+              moveRelation(source, destination, (ChangesetType)current_type, dynamic_cast<ChangesetRelation*>(_allRelations[id].get()));
           }
         }
       }
@@ -848,7 +848,7 @@ bool XmlChangeset::moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& dest
   return true;
 }
 
-bool XmlChangeset::canMoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& /*destination*/, ChangesetType type, XmlRelation* relation)
+bool XmlChangeset::canMoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& /*destination*/, ChangesetType type, ChangesetRelation* relation)
 {
   //  Deleting a relation will only contain the relation itself
   if (type == ChangesetType::TypeDelete)
@@ -859,7 +859,7 @@ bool XmlChangeset::canMoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& /
   return source->size() != count;
 }
 
-size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& /*changeset*/, XmlNode* node)
+size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& /*changeset*/, ChangesetNode* node)
 {
   if (node == NULL)
     return 0;
@@ -867,7 +867,7 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& /*changeset*/, XmlNode* no
   return 1;
 }
 
-size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlWay* way)
+size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, ChangesetWay* way)
 {
   if (way == NULL)
     return 0;
@@ -885,7 +885,7 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlWay* way)
   return count;
 }
 
-size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* relation)
+size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, ChangesetRelation* relation)
 {
   if (relation == NULL)
     return 0;
@@ -893,7 +893,7 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* re
   size_t count = 1;
   for (int i = 0; i < relation->getMemberCount(); ++i)
   {
-    XmlMember& member = relation->getMember(i);
+    ChangesetRelationMember& member = relation->getMember(i);
     long id = member.getRef();
     //  Each member type iterates the changeset types looking for this element, then counts it
     if (member.isNode())
@@ -901,7 +901,7 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* re
       for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
       {
         if (changeset->contains(ElementType::Node, (ChangesetType)current_type, id))
-          count += getObjectCount(changeset, dynamic_cast<XmlNode*>(_allNodes[id].get()));
+          count += getObjectCount(changeset, dynamic_cast<ChangesetNode*>(_allNodes[id].get()));
       }
     }
     else if (member.isWay())
@@ -909,7 +909,7 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* re
       for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
       {
         if (changeset->contains(ElementType::Way, (ChangesetType)current_type, id))
-          count += getObjectCount(changeset, dynamic_cast<XmlWay*>(_allWays[id].get()));
+          count += getObjectCount(changeset, dynamic_cast<ChangesetWay*>(_allWays[id].get()));
       }
     }
     else if (member.isRelation())
@@ -920,7 +920,7 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* re
         for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
         {
           if (changeset->contains(ElementType::Relation, (ChangesetType)current_type, id))
-            count += getObjectCount(changeset, dynamic_cast<XmlRelation*>(_allRelations[id].get()));
+            count += getObjectCount(changeset, dynamic_cast<ChangesetRelation*>(_allRelations[id].get()));
         }
       }
     }
@@ -928,32 +928,32 @@ size_t XmlChangeset::getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* re
   return count;
 }
 
-bool XmlChangeset::isSent(XmlElement* element)
+bool XmlChangeset::isSent(ChangesetElement* element)
 {
   if (element == NULL)
     return false;
   else
     //  Sent means Buffering, Sent, or Finalized
-    return element->getStatus() == XmlElement::ElementStatus::Buffering ||
-           (element->getStatus() == XmlElement::ElementStatus::Sent && element->id() > 0) ||
-           element->getStatus() == XmlElement::ElementStatus::Finalized;
+    return element->getStatus() == ChangesetElement::ElementStatus::Buffering ||
+           (element->getStatus() == ChangesetElement::ElementStatus::Sent && element->id() > 0) ||
+           element->getStatus() == ChangesetElement::ElementStatus::Finalized;
 }
 
-bool XmlChangeset::canSend(XmlNode* node)
+bool XmlChangeset::canSend(ChangesetNode* node)
 {
   //  Able to send means Available
   if (node == NULL)
     return false;
   else
-    return node->getStatus() == XmlElement::Available;
+    return node->getStatus() == ChangesetElement::Available;
 }
 
-bool XmlChangeset::canSend(XmlWay* way)
+bool XmlChangeset::canSend(ChangesetWay* way)
 {
   //  Able to send means Available
   if (way == NULL)
     return false;
-  else if (way->getStatus() != XmlElement::Available)
+  else if (way->getStatus() != ChangesetElement::Available)
     return false;
   else
   {
@@ -963,26 +963,26 @@ bool XmlChangeset::canSend(XmlWay* way)
       long id = way->getNode(i);
       if (_allNodes.find(id) != _allNodes.end() &&
           !isSent(_allNodes[id].get()) &&
-          !canSend(dynamic_cast<XmlNode*>(_allNodes[id].get())))
+          !canSend(dynamic_cast<ChangesetNode*>(_allNodes[id].get())))
         return false;
     }
   }
   return true;
 }
 
-bool XmlChangeset::canSend(XmlRelation* relation)
+bool XmlChangeset::canSend(ChangesetRelation* relation)
 {
   //  Able to send means Available
   if (relation == NULL)
     return false;
-  else if (relation->getStatus() != XmlElement::Available)
+  else if (relation->getStatus() != ChangesetElement::Available)
     return false;
   else
   {
     //  All members have to be Available or Finalized
     for (int i = 0; i < relation->getMemberCount(); ++i)
     {
-      XmlMember& member = relation->getMember(i);
+      ChangesetRelationMember& member = relation->getMember(i);
       //  First check the member type, these are separated to reduce the comparisons
       //  since these are called frequently
       if (member.isNode())
@@ -996,7 +996,7 @@ bool XmlChangeset::canSend(XmlRelation* relation)
         //  then we can't send this relation
         else if (_allNodes.find(member.getRef()) != _allNodes.end() &&
             !isSent(_allNodes[member.getRef()].get()) &&
-            !canSend(dynamic_cast<XmlNode*>(_allNodes[member.getRef()].get())))
+            !canSend(dynamic_cast<ChangesetNode*>(_allNodes[member.getRef()].get())))
         {
           return false;
         }
@@ -1009,7 +1009,7 @@ bool XmlChangeset::canSend(XmlRelation* relation)
         //  Check if the way exists and can't be sent
         else if (_allWays.find(member.getRef()) != _allWays.end() &&
             !isSent(_allWays[member.getRef()].get()) &&
-            !canSend(dynamic_cast<XmlWay*>(_allWays[member.getRef()].get())))
+            !canSend(dynamic_cast<ChangesetWay*>(_allWays[member.getRef()].get())))
         {
           return false;
         }
@@ -1025,7 +1025,7 @@ bool XmlChangeset::canSend(XmlRelation* relation)
         //  Check if the relation exists and can't be sent
         else if (_allRelations.find(member.getRef()) != _allWays.end() &&
             !isSent(_allRelations[member.getRef()].get()) &&
-            !canSend(dynamic_cast<XmlRelation*>(_allRelations[member.getRef()].get())))
+            !canSend(dynamic_cast<ChangesetRelation*>(_allRelations[member.getRef()].get())))
         {
           return false;
         }
@@ -1035,12 +1035,12 @@ bool XmlChangeset::canSend(XmlRelation* relation)
   return true;
 }
 
-void XmlChangeset::markBuffered(XmlElement* element)
+void XmlChangeset::markBuffered(ChangesetElement* element)
 {
   if (element != NULL)
   {
     //  Mark buffering
-    element->setStatus(XmlElement::Buffering);
+    element->setStatus(ChangesetElement::Buffering);
     //  Add to the buffer for lookup within this subset
     _sendBuffer.push_back(element);
     _sentCount++;
@@ -1085,8 +1085,8 @@ bool XmlChangeset::calculateChangeset(ChangesetInfoPtr& changeset)
     type = static_cast<ChangesetType>(type + 1);
   }
   //  Move all elements from buffered to sending
-  for (vector<XmlElement*>::iterator it = _sendBuffer.begin(); it != _sendBuffer.end(); ++it)
-    (*it)->setStatus(XmlElement::Sent);
+  for (vector<ChangesetElement*>::iterator it = _sendBuffer.begin(); it != _sendBuffer.end(); ++it)
+    (*it)->setStatus(ChangesetElement::Sent);
   _sendBuffer.clear();
   //  Return true if there is anything in this changeset
   return changeset->size() > 0;
@@ -1231,7 +1231,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
         {
           if (element_type == ElementType::Way)
           {
-            XmlWay* way = dynamic_cast<XmlWay*>(_allWays[element_id].get());
+            ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[element_id].get());
             //  Add the way to the split and remove from the changeset
             split->add(element_type, (ChangesetType)current_type, way->id());
             changeset->remove(element_type, (ChangesetType)current_type, way->id());
@@ -1239,7 +1239,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
           }
           else if (element_type == ElementType::Relation)
           {
-            XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[element_id].get());
+            ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[element_id].get());
             //  Add the relation to the split and remove from the changeset
             split->add(element_type, (ChangesetType)current_type, relation->id());
             changeset->remove(element_type, (ChangesetType)current_type, relation->id());
@@ -1258,7 +1258,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
         {
           if (changeset->contains(member_type, (ChangesetType)current_type, element_id))
           {
-            XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[element_id].get());
+            ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[element_id].get());
             //  Add the relation to the split and remove from the changeset
             split->add(ElementType::Relation, (ChangesetType)current_type, relation->id());
             changeset->remove(ElementType::Relation, (ChangesetType)current_type, relation->id());
@@ -1271,9 +1271,9 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
         //  If no relation id is found, move all relations that contain the id/type combination to the split
         for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
         {
-          for (XmlElementMap::iterator it = _relations[current_type].begin(); it != _relations[current_type].end(); ++it)
+          for (ChangesetElementMap::iterator it = _relations[current_type].begin(); it != _relations[current_type].end(); ++it)
           {
-            XmlRelation* relation = dynamic_cast<XmlRelation*>(it->second.get());
+            ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(it->second.get());
             //  Make sure that the changeset contains this relation and this relation contains the problematic element
             if (relation->hasMember(member_type, member_id) &&
                 changeset->contains(ElementType::Relation, (ChangesetType)current_type, relation->id()))
@@ -1307,7 +1307,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
               //  Add the way to the split so that they can be processed together
               if (_allWays.find(element_id) != _allWays.end())
               {
-                XmlWay* way = dynamic_cast<XmlWay*>(_allWays[element_id].get());
+                ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[element_id].get());
                 addWay(split, (ChangesetType)blocking_type, way);
               }
             }
@@ -1316,7 +1316,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
               //  Add the relation to the split so that they can be processed together
               if (_allRelations.find(element_id) != _allRelations.end())
               {
-                XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[element_id].get());
+                ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[element_id].get());
                 addRelation(split, (ChangesetType)blocking_type, relation);
               }
             }
@@ -1336,7 +1336,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
     while (changeset->size(ElementType::Relation, (ChangesetType)current_type) > 0)
     {
       long id = changeset->getFirst(ElementType::Relation, (ChangesetType)current_type);
-      XmlRelation* relation = dynamic_cast<XmlRelation*>(_allRelations[id].get());
+      ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[id].get());
       //  Move the relation to the new changeset if possible or remove it and make it available again
       moveOrRemoveRelation(changeset, split, (ChangesetType)current_type, relation);
       //  If the split is big enough, end the operation
@@ -1351,7 +1351,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
     while (changeset->size(ElementType::Way, (ChangesetType)current_type) > 0)
     {
       long id = changeset->getFirst(ElementType::Way, (ChangesetType)current_type);
-      XmlWay* way = dynamic_cast<XmlWay*>(_allWays[id].get());
+      ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[id].get());
       //  Move the way to the new changeset if possible or remove it and make it available again
       moveOrRemoveWay(changeset, split, (ChangesetType)current_type, way);
       //  If the split is big enough, end the operation
@@ -1366,7 +1366,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
     while (changeset->size(ElementType::Node, (ChangesetType)current_type) > 0)
     {
       long id = changeset->getFirst(ElementType::Node, (ChangesetType)current_type);
-      XmlNode* node = dynamic_cast<XmlNode*>(_allNodes[id].get());
+      ChangesetNode* node = dynamic_cast<ChangesetNode*>(_allNodes[id].get());
       //  Move the node to the new changeset if possible or remove it and make it available again
       moveOrRemoveNode(changeset, split, (ChangesetType)current_type, node);
       //  If the split is big enough, end the operation
@@ -1436,27 +1436,27 @@ QString XmlChangeset::getFailedChangesetString()
   for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
   {
     //  Iterate all of the nodes in the changeset looking for failed elements
-    for (XmlElementMap::iterator it = _nodes[current_type].begin(); it != _nodes[current_type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _nodes[current_type].begin(); it != _nodes[current_type].end(); ++it)
     {
-      XmlNode* node = dynamic_cast<XmlNode*>(it->second.get());
+      ChangesetNode* node = dynamic_cast<ChangesetNode*>(it->second.get());
       //  Add only the failed nodes
-      if (node->getStatus() == XmlElement::ElementStatus::Failed)
+      if (node->getStatus() == ChangesetElement::ElementStatus::Failed)
         changeset->add(ElementType::Node, (ChangesetType)current_type, node->id());
     }
     //  Iterate all of the ways in the changeset looking for failed elements
-    for (XmlElementMap::iterator it = _ways[current_type].begin(); it != _ways[current_type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _ways[current_type].begin(); it != _ways[current_type].end(); ++it)
     {
-      XmlWay* way = dynamic_cast<XmlWay*>(it->second.get());
+      ChangesetWay* way = dynamic_cast<ChangesetWay*>(it->second.get());
       //  Add only the failed ways
-      if (way->getStatus() == XmlElement::ElementStatus::Failed)
+      if (way->getStatus() == ChangesetElement::ElementStatus::Failed)
         changeset->add(ElementType::Way, (ChangesetType)current_type, way->id());
     }
     //  Iterate all of the relations in the changeset looking for failed elements
-    for (XmlElementMap::iterator it = _relations[current_type].begin(); it != _relations[current_type].end(); ++it)
+    for (ChangesetElementMap::iterator it = _relations[current_type].begin(); it != _relations[current_type].end(); ++it)
     {
-      XmlRelation* relation = dynamic_cast<XmlRelation*>(it->second.get());
+      ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(it->second.get());
       //  Add only the failed relations
-      if (relation->getStatus() == XmlElement::ElementStatus::Failed)
+      if (relation->getStatus() == ChangesetElement::ElementStatus::Failed)
         changeset->add(ElementType::Relation, (ChangesetType)current_type, relation->id());
     }
   }
@@ -1517,13 +1517,13 @@ void XmlChangeset::updateElement(ChangesetTypeMap& map, long old_id, long new_id
   else                        //  Otherwise it was a modify and nothing needs updating
     changeset_type = ChangesetType::TypeModify;
   //  Find the element by the old ID
-  XmlElementMap& type = map[changeset_type];
-  XmlElementMap::iterator position = type.find(old_id);
+  ChangesetElementMap& type = map[changeset_type];
+  ChangesetElementMap::iterator position = type.find(old_id);
   if (position != type.end())
   {
-    XmlElementPtr element = type[old_id];
+    ChangesetElementPtr element = type[old_id];
     //  Finalize the element
-    element->setStatus(XmlElement::Finalized);
+    element->setStatus(ChangesetElement::Finalized);
     //  Update the ID in the map with a new ID for elements that were created
     if (changeset_type == ChangesetType::TypeCreate)
       _idMap.updateId(element->getType(), old_id, new_id);
@@ -1543,11 +1543,11 @@ bool XmlChangeset::fixElement(ChangesetTypeMap& map, long id, long version, QMap
   //  Find the affected element
   for (int type = 0; type < ChangesetType::TypeMax; ++type)
   {
-    XmlElementMap::iterator position = map[type].find(id);
+    ChangesetElementMap::iterator position = map[type].find(id);
     if (position != map[type].end())
     {
       //  Found the element, now update it
-      XmlElementPtr element = map[type][id];
+      ChangesetElementPtr element = map[type][id];
       //  Only update the version if it is out of sync
       if (element->getVersion() != version)
       {
@@ -1626,7 +1626,7 @@ void XmlChangeset::replaceRelationId(long old_id, long new_id)
 void XmlChangeset::failNode(long id, bool beforeSend)
 {
   //  Set the node's status to failed
-  _allNodes[id]->setStatus(XmlElement::ElementStatus::Failed);
+  _allNodes[id]->setStatus(ChangesetElement::ElementStatus::Failed);
   //  Update the failed count once
   ++_failedCount;
   //  Update sent count as if we already sent it and it failed
@@ -1637,7 +1637,7 @@ void XmlChangeset::failNode(long id, bool beforeSend)
 void XmlChangeset::failWay(long id, bool beforeSend)
 {
   //  Set the way's status to failed
-  _allWays[id]->setStatus(XmlElement::ElementStatus::Failed);
+  _allWays[id]->setStatus(ChangesetElement::ElementStatus::Failed);
   //  Update the failed count once
   ++_failedCount;
   //  Update sent count as if we already sent it and it failed
@@ -1648,7 +1648,7 @@ void XmlChangeset::failWay(long id, bool beforeSend)
 void XmlChangeset::failRelation(long id, bool beforeSend)
 {
   //  Set the relation's status to failed
-  _allRelations[id]->setStatus(XmlElement::ElementStatus::Failed);
+  _allRelations[id]->setStatus(ChangesetElement::ElementStatus::Failed);
   //  Update the failed count once
   ++_failedCount;
   //  Update sent count as if we already sent it and it failed
@@ -1659,7 +1659,7 @@ void XmlChangeset::failRelation(long id, bool beforeSend)
 
 void XmlChangeset::getNodes(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id)
 {
-  XmlElementMap& nodes = _nodes[type];
+  ChangesetElementMap& nodes = _nodes[type];
   for (ElementIdToIdMap::iterator it = _idMap.begin(ElementType::Node); it != _idMap.end(ElementType::Node); ++it)
   {
     if (nodes.find(it->second) != nodes.end() && changeset->contains(ElementType::Node, type, it->second))
@@ -1669,7 +1669,7 @@ void XmlChangeset::getNodes(const ChangesetInfoPtr& changeset, QTextStream& ts, 
 
 void XmlChangeset::getWays(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id)
 {
-  XmlElementMap& ways = _ways[type];
+  ChangesetElementMap& ways = _ways[type];
   for (ElementIdToIdMap::iterator it = _idMap.begin(ElementType::Way); it != _idMap.end(ElementType::Way); ++it)
   {
     if (ways.find(it->second) != ways.end() && changeset->contains(ElementType::Way, type, it->second))
@@ -1679,7 +1679,7 @@ void XmlChangeset::getWays(const ChangesetInfoPtr& changeset, QTextStream& ts, C
 
 void XmlChangeset::getRelations(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id)
 {
-  XmlElementMap& relations = _relations[type];
+  ChangesetElementMap& relations = _relations[type];
   for (ElementIdToIdMap::iterator it = _idMap.begin(ElementType::Relation); it != _idMap.end(ElementType::Relation); ++it)
   {
     if (relations.find(it->second) != relations.end() && changeset->contains(ElementType::Relation, type, it->second))

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -430,15 +430,18 @@ private:
   void failWay(long id, bool beforeSend = false);
   void failRelation(long id, bool beforeSend = false);
   /**
-   * @brief getNodes/Ways/Relations Output node/way/relation text to the text stream
+   * @brief writeNodes/Ways/Relations Output node/way/relation text to the text stream
    * @param changeset Pointer to the changeset to output
    * @param ts TextStream to output the element to
    * @param type Changeset type (create, modify, delete)
    * @param changeset_id ID of the changeset to write to the element attribute
    */
-  void getNodes(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
-  void getWays(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
-  void getRelations(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
+  void writeNodes(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
+  void writeWays(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
+  void writeRelations(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
+  void writeElements(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id,
+                     ElementType::Type elementType, const ChangesetElementMap& elements);
+
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
   ChangesetElementMap _allNodes;
   /** Sorted map of all ways, original node ID and a pointer to the element object */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -53,8 +53,8 @@ namespace hoot
 class ChangesetInfo;
 /** Helpful typedefs for pointers and vectors of maps */
 typedef std::shared_ptr<ChangesetInfo> ChangesetInfoPtr;
-typedef std::map<long, XmlElementPtr, osm_id_sort> XmlElementMap;
-typedef QVector<XmlElementMap> ChangesetTypeMap;
+typedef std::map<long, ChangesetElementPtr, osm_id_sort> ChangesetElementMap;
+typedef std::vector<ChangesetElementMap> ChangesetTypeMap;
 typedef std::map<long, std::set<long>> NodeIdToWayIdMap;
 typedef std::map<long, std::set<long>> NodeIdToRelationIdMap;
 typedef std::map<long, std::set<long>> WayIdToRelationIdMap;
@@ -329,9 +329,9 @@ private:
    * @param node/way/relation Pointer to the element that is being added
    * @return success
    */
-  bool addNode(ChangesetInfoPtr& changeset, ChangesetType type, XmlNode* node);
-  bool addWay(ChangesetInfoPtr& changeset, ChangesetType type, XmlWay* way);
-  bool addRelation(ChangesetInfoPtr& changeset, ChangesetType type, XmlRelation* relation);
+  bool addNode(ChangesetInfoPtr& changeset, ChangesetType type, ChangesetNode* node);
+  bool addWay(ChangesetInfoPtr& changeset, ChangesetType type, ChangesetWay* way);
+  bool addRelation(ChangesetInfoPtr& changeset, ChangesetType type, ChangesetRelation* relation);
   /**
    * @brief addParentWays/Relations Add any parents (ways, relations) to the changeset if needed
    *  by a modify or delete operation.  For example, to delete a node, any way or relation parent
@@ -351,9 +351,9 @@ private:
    * @param node/way/relation Pointer to the element to be moved
    * @return
    */
-  bool moveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlNode* node);
-  bool moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way);
-  bool moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation);
+  bool moveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetNode* node);
+  bool moveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetWay* way);
+  bool moveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetRelation* relation);
   /**
    * @brief moveOrRemoveNode/Way/Relation Move an element from one subset to another, or if all related elements aren't
    *   able to be moved, the element is removed from the subset and returned to the `available` state
@@ -362,9 +362,9 @@ private:
    * @param type Type of operation (create/modify/delete)
    * @param node/way/relation Pointer to the element to be moved
    */
-  void moveOrRemoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlNode* node);
-  void moveOrRemoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way);
-  void moveOrRemoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation);
+  void moveOrRemoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetNode* node);
+  void moveOrRemoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetWay* way);
+  void moveOrRemoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetRelation* relation);
   /**
    * @brief canMoveNode/Way/Relation Query if a node/way/relation can be moved.  This checks downstream relations, ways,
    *  and nodes to see if they can also be moved.
@@ -374,37 +374,37 @@ private:
    * @param node/way/relation Pointer to the element to be checked
    * @return
    */
-  bool canMoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlNode* node);
-  bool canMoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlWay* way);
-  bool canMoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, XmlRelation* relation);
+  bool canMoveNode(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetNode* node);
+  bool canMoveWay(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetWay* way);
+  bool canMoveRelation(ChangesetInfoPtr& source, ChangesetInfoPtr& destination, ChangesetType type, ChangesetRelation* relation);
   /**
    * @brief getObjectCount Get the number of elements affected by this node/way/relation
    * @param changeset Subset containing the element
    * @param node/way/relation Pointer to the element to count
    * @return total number of elements within this element
    */
-  size_t getObjectCount(ChangesetInfoPtr& changeset, XmlNode* node);
-  size_t getObjectCount(ChangesetInfoPtr& changeset, XmlWay* way);
-  size_t getObjectCount(ChangesetInfoPtr& changeset, XmlRelation* relation);
+  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetNode* node);
+  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetWay* way);
+  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetRelation* relation);
   /**
    * @brief isSent Check if this element's status is buffering, sent, or finalized
    * @param element Pointer to the element to check
    * @return true if the element has been sent to the API
    */
-  bool isSent(XmlElement* element);
+  bool isSent(ChangesetElement* element);
   /**
    * @brief canSend Check if the node/way/relation can be sent (if it is available) along with all of its downstream elements
    * @param node/way/relation Pointer to the element to check
    * @return true if element and all downstream elements are available to send
    */
-  bool canSend(XmlNode* node);
-  bool canSend(XmlWay* way);
-  bool canSend(XmlRelation* relation);
+  bool canSend(ChangesetNode* node);
+  bool canSend(ChangesetWay* way);
+  bool canSend(ChangesetRelation* relation);
   /**
    * @brief markBuffered Mark the element as buffered
    * @param element Pointer to the element to mark
    */
-  void markBuffered(XmlElement* element);
+  void markBuffered(ChangesetElement* element);
   /**
    * @brief getNextNode/Way/RelationId searches the Create section of the changeset to find the next available ID
    *  for the desired element type
@@ -440,11 +440,11 @@ private:
   void getWays(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
   void getRelations(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
-  XmlElementMap _allNodes;
+  ChangesetElementMap _allNodes;
   /** Sorted map of all ways, original node ID and a pointer to the element object */
-  XmlElementMap _allWays;
+  ChangesetElementMap _allWays;
   /** Sorted map of all relations, original node ID and a pointer to the element object */
-  XmlElementMap _allRelations;
+  ChangesetElementMap _allRelations;
   /** Three element (create/modify/delete) vector of node IDs */
   ChangesetTypeMap _nodes;
   /** Three element (create/modify/delete) vector of way IDs */
@@ -462,7 +462,7 @@ private:
   /** Count of elements that failed to upload */
   long _failedCount;
   /** Buffer of elements that are about to be pushed into a subset */
-  std::vector<XmlElement*> _sendBuffer;
+  std::vector<ChangesetElement*> _sendBuffer;
   /** Negative ID generator */
   DefaultIdGenerator _idGen;
   /** Reverse ID to ID maps for deleting elements validation */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -36,6 +36,14 @@
 namespace hoot
 {
 
+/** Custom ID sort order */
+bool id_sort_order(long lhs, long rhs)
+{
+  if (lhs > 0 && rhs > 0)       return lhs < rhs; //  Positive numbers count up
+  else if (lhs < 0 && rhs < 0)  return lhs > rhs; //  Negative numbers count down
+  else                          return lhs < rhs; //  Negative numbers come before positive
+}
+
 ChangesetElement::ChangesetElement(const XmlObject& object, ElementIdToIdMap* idMap)
   : _type(ElementType::Unknown),
     _id(object.second.value("id").toString().toLong()),

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -36,17 +36,18 @@
 namespace hoot
 {
 
-XmlElement::XmlElement(const XmlObject& object, ElementIdToIdMap* idMap)
+ChangesetElement::ChangesetElement(const XmlObject& object, ElementIdToIdMap* idMap)
   : _type(ElementType::Unknown),
     _id(object.second.value("id").toString().toLong()),
     _version(object.second.value("version").toString().toLong()),
-    _object(object),
     _idMap(idMap),
-    _status(XmlElement::Available)
+    _status(ChangesetElement::Available)
 {
+  for (QXmlStreamAttributes::const_iterator it = object.second.begin(); it != object.second.end(); ++it)
+    _object.push_back(std::make_pair(it->name().toString(), it->value().toString()));
 }
 
-XmlElement::XmlElement(const XmlElement& element)
+ChangesetElement::ChangesetElement(const ChangesetElement& element)
   : _type(element._type),
     _id(element._id),
     _version(element._version),
@@ -57,58 +58,73 @@ XmlElement::XmlElement(const XmlElement& element)
 {
 }
 
-void XmlElement::addTag(const XmlObject& tag)
+void ChangesetElement::addTag(const XmlObject& tag)
 {
   //  Make sure that the object is in fact a tag before adding it
   if (tag.first == "tag")
-    _tags.push_back(tag);
+  {
+    QString key;
+    QString value;
+    for (QXmlStreamAttributes::const_iterator it = tag.second.begin(); it != tag.second.end(); ++it)
+    {
+      if (it->name() == "k")
+        key = it->value().toString();
+      else if (it->name() == "v")
+        value = it->value().toString();
+    }
+    if (key != "" and value != "")
+      _tags.push_back(std::make_pair(key, value));
+  }
 }
 
-QString XmlElement::getTagKey(int index)
+QString ChangesetElement::getTagKey(int index)
 {
-  if (index < 0 || index >= _tags.size() || !_tags[index].second.hasAttribute("k"))
+  if (index < 0 || index >= (int)_tags.size())
     throw IllegalArgumentException();
-  return _tags[index].second.value("k").toString();
+  return _tags[index].first;
 }
 
-QString XmlElement::getTagValue(int index)
+QString ChangesetElement::getTagValue(int index)
 {
-  if (index < 0 || index >= _tags.size() || !_tags[index].second.hasAttribute("v"))
+  if (index < 0 || index >= (int)_tags.size())
     throw IllegalArgumentException();
-  return _tags[index].second.value("v").toString();
+  return _tags[index].second;
 }
 
-QString XmlElement::toString(const QXmlStreamAttributes& attributes, long changesetId) const
+QString ChangesetElement::toString(const ElementAttributes& attributes, long changesetId) const
 {
   QString buffer;
   QTextStream ts(&buffer);
   //  Setting the codec to UTF-8 is the special sauce for foreign characters
   ts.setCodec("UTF-8");
-  for (int i = 0; i < attributes.size(); ++i)
+  bool hasChangeset = false;
+  for (ElementAttributes::const_iterator it = attributes.begin(); it != attributes.end(); ++it)
   {
-    const QXmlStreamAttribute& attribute = attributes.at(i);
-    QStringRef name = attribute.name();
+    QString name = it->first;
     if (name == "action")
       continue;
-    ts << name.toString() << "=\"";
+    ts << name << "=\"";
     //  Some attributes need to be overridden
     if (name == "changeset")    //  Changeset ID is provided by the OSM API
+    {
       ts << changesetId;
+      hasChangeset = true;
+    }
     else if (name == "id")      //  Element ID could be different than provided in the file, could be from the API
       ts << (_idMap ? _idMap->getNewId(_type, _id) : _id);
     else if (name == "version") //  Versions are updated by the API
       ts << _version;
     else
-      ts << attribute.value().toString();
+      ts << it->second;
     ts << "\" ";
   }
   //  Add the changeset attribute if the original data didn't include it
-  if (!attributes.hasAttribute("changeset"))
+  if (!hasChangeset)
     ts << "changeset=\"" << changesetId << "\"";
   return ts.readAll();
 }
 
-QString& XmlElement::escapeString(QString& value) const
+QString& ChangesetElement::escapeString(QString& value) const
 {
   //  Simple XML encoding of some problematic characters
   return value.replace("&", "&amp;")
@@ -118,18 +134,18 @@ QString& XmlElement::escapeString(QString& value) const
               .replace("<", "&lt;");
 }
 
-QString XmlElement::toTagString(const QXmlStreamAttributes& attributes) const
+QString ChangesetElement::toTagString(const ElementTag& tag) const
 {
   QString buffer;
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
-  QString key(attributes.value("k").toString());
-  QString value(attributes.value("v").toString());
+  QString key(tag.first);
+  QString value(tag.second);
   //  Tag values of length 255 need to be truncated
   QString newValue(ApiTagTruncateVisitor::truncateTag(key, value));
 
   //  Make sure to XML encode the value
-  ts << "\t\t\t<tag k=\"" << attributes.value("k").toString() << "\" v=\"";
+  ts << "\t\t\t<tag k=\"" << key << "\" v=\"";
   if (newValue != "")
     ts << escapeString(newValue);
   else
@@ -138,29 +154,29 @@ QString XmlElement::toTagString(const QXmlStreamAttributes& attributes) const
   return ts.readAll();
 }
 
-XmlNode::XmlNode(const XmlObject& node, ElementIdToIdMap* idMap)
-  : XmlElement(node, idMap)
+ChangesetNode::ChangesetNode(const XmlObject& node, ElementIdToIdMap* idMap)
+  : ChangesetElement(node, idMap)
 {
   //  Override the type
   _type = ElementType::Node;
 }
 
-XmlNode::XmlNode(const XmlNode &node)
-  : XmlElement(node)
+ChangesetNode::ChangesetNode(const ChangesetNode &node)
+  : ChangesetElement(node)
 {
 }
 
-QString XmlNode::toString(long changesetId) const
+QString ChangesetNode::toString(long changesetId) const
 {
   QString buffer;
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
-  ts << "\t\t<node " << XmlElement::toString(_object.second, changesetId);
+  ts << "\t\t<node " << ChangesetElement::toString(_object, changesetId);
   if (_tags.size() > 0)
   {
     ts << ">\n";
-    for (QVector<XmlObject>::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
-      ts << toTagString(it->second);
+    for (ElementTags::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
+      ts << toTagString(*it);
     ts << "\t\t</node>\n";
   }
   else
@@ -168,20 +184,20 @@ QString XmlNode::toString(long changesetId) const
   return ts.readAll();
 }
 
-XmlWay::XmlWay(const XmlObject& way, ElementIdToIdMap* idMap)
-  : XmlElement(way, idMap)
+ChangesetWay::ChangesetWay(const XmlObject& way, ElementIdToIdMap* idMap)
+  : ChangesetElement(way, idMap)
 {
   //  Override the type
   _type = ElementType::Way;
 }
 
-XmlWay::XmlWay(const XmlWay &way)
-  : XmlElement(way),
+ChangesetWay::ChangesetWay(const ChangesetWay &way)
+  : ChangesetElement(way),
     _nodes(way._nodes)
 {
 }
 
-void XmlWay::removeNodes(int position, int count)
+void ChangesetWay::removeNodes(int position, int count)
 {
   if (position < 0 || count == 0 || _nodes.size() < 1)
     return;
@@ -190,40 +206,40 @@ void XmlWay::removeNodes(int position, int count)
   _nodes.remove(position, count);
 }
 
-QString XmlWay::toString(long changesetId) const
+QString ChangesetWay::toString(long changesetId) const
 {
   QString buffer;
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
-  ts << "\t\t<way " << XmlElement::toString(_object.second, changesetId) << ">\n";
+  ts << "\t\t<way " << ChangesetElement::toString(_object, changesetId) << ">\n";
   for (QVector<long>::const_iterator it = _nodes.begin(); it != _nodes.end(); ++it)
     ts << "\t\t\t<nd ref=\"" << (_idMap ? _idMap->getNewId(ElementType::Node, *it) : *it) << "\"/>\n";
   if (_tags.size() > 0)
   {
-    for (QVector<XmlObject>::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
-      ts << toTagString(it->second);
+    for (ElementTags::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
+      ts << toTagString(*it);
   }
   ts << "\t\t</way>\n";
   return ts.readAll();
 }
 
-XmlRelation::XmlRelation(const XmlObject& relation, ElementIdToIdMap* idMap)
-  : XmlElement(relation, idMap)
+ChangesetRelation::ChangesetRelation(const XmlObject& relation, ElementIdToIdMap* idMap)
+  : ChangesetElement(relation, idMap)
 {
   //  Override the type
   _type = ElementType::Relation;
 }
 
-XmlRelation::XmlRelation(const XmlRelation &relation)
-  : XmlElement(relation),
+ChangesetRelation::ChangesetRelation(const ChangesetRelation &relation)
+  : ChangesetElement(relation),
     _members(relation._members)
 {
 }
 
-bool XmlRelation::hasMember(ElementType::Type type, long id)
+bool ChangesetRelation::hasMember(ElementType::Type type, long id)
 {
   //  Iterate all of the members
-  for (QList<XmlMember>::iterator it = _members.begin(); it != _members.end(); ++it)
+  for (QList<ChangesetRelationMember>::iterator it = _members.begin(); it != _members.end(); ++it)
   {
     switch (type)
     {
@@ -249,41 +265,40 @@ bool XmlRelation::hasMember(ElementType::Type type, long id)
   return false;
 }
 
-QString XmlRelation::toString(long changesetId) const
+QString ChangesetRelation::toString(long changesetId) const
 {
   QString buffer;
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
-  ts << "\t\t<relation " << XmlElement::toString(_object.second, changesetId) << ">\n";
-  for (QList<XmlMember>::const_iterator it = _members.begin(); it != _members.end(); ++it)
+  ts << "\t\t<relation " << ChangesetElement::toString(_object, changesetId) << ">\n";
+  for (QList<ChangesetRelationMember>::const_iterator it = _members.begin(); it != _members.end(); ++it)
     ts << it->toString();
   if (_tags.size() > 0)
   {
-    for (QVector<XmlObject>::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
-      ts << toTagString(it->second);
+    for (ElementTags::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
+      ts << toTagString(*it);
   }
   ts << "\t\t</relation>\n";
   return ts.readAll();
 }
 
-XmlMember::XmlMember(const QXmlStreamAttributes& member, ElementIdToIdMap* idMap)
-  : _type(member.value("type").toString()),
+ChangesetRelationMember::ChangesetRelationMember(const QXmlStreamAttributes& member, ElementIdToIdMap* idMap)
+  : _type(ElementType::fromString(member.value("type").toString().toLower())),
     _ref(member.value("ref").toString().toLong()),
     _role(member.value("role").toString()),
     _idMap(idMap)
 {
 }
 
-QString XmlMember::toString() const
+QString ChangesetRelationMember::toString() const
 {
   QString buffer;
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
-  ts << "\t\t\t<member type=\"" << _type << "\" ref=\""
-     << (_idMap ? _idMap->getNewId(ElementType::fromString(_type),_ref) : _ref)
+  ts << "\t\t\t<member type=\"" << ElementType(_type).toString().toLower() << "\" ref=\""
+     << (_idMap ? _idMap->getNewId(_type, _ref) : _ref)
      << "\" role=\"" << _role << "\"/>\n";
   return ts.readAll();
 }
-
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -119,7 +119,7 @@ QString ChangesetElement::toString(const ElementAttributes& attributes, long cha
       hasChangeset = true;
     }
     else if (name == "id")      //  Element ID could be different than provided in the file, could be from the API
-      ts << (_idMap ? _idMap->getNewId(_type, _id) : _id);
+      ts << (_idMap ? _idMap->getId(_type, _id) : _id);
     else if (name == "version") //  Versions are updated by the API
       ts << _version;
     else
@@ -221,7 +221,7 @@ QString ChangesetWay::toString(long changesetId) const
   ts.setCodec("UTF-8");
   ts << "\t\t<way " << ChangesetElement::toString(_object, changesetId) << ">\n";
   for (QVector<long>::const_iterator it = _nodes.begin(); it != _nodes.end(); ++it)
-    ts << "\t\t\t<nd ref=\"" << (_idMap ? _idMap->getNewId(ElementType::Node, *it) : *it) << "\"/>\n";
+    ts << "\t\t\t<nd ref=\"" << (_idMap ? _idMap->getId(ElementType::Node, *it) : *it) << "\"/>\n";
   if (_tags.size() > 0)
   {
     for (ElementTags::const_iterator it = _tags.begin(); it != _tags.end(); ++it)
@@ -304,7 +304,7 @@ QString ChangesetRelationMember::toString() const
   QTextStream ts(&buffer);
   ts.setCodec("UTF-8");
   ts << "\t\t\t<member type=\"" << ElementType(_type).toString().toLower() << "\" ref=\""
-     << (_idMap ? _idMap->getNewId(_type, _ref) : _ref)
+     << (_idMap ? _idMap->getId(_type, _ref) : _ref)
      << "\" role=\"" << _role << "\"/>\n";
   return ts.readAll();
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -349,14 +349,13 @@ private:
 typedef std::shared_ptr<ChangesetRelation> ChangesetRelationPtr;
 
 /** Custom sorting function to sort IDs from -1 to -n followed by 1 to m */
+bool id_sort_order(long lhs, long rhs);
 class osm_id_sort
 {
 public:
   bool operator() (long lhs, long rhs) const
   {
-    if (lhs > 0 && rhs > 0)       return lhs < rhs; //  Positive numbers count up
-    else if (lhs < 0 && rhs < 0)  return lhs > rhs; //  Negative numbers count down
-    else                          return lhs < rhs; //  Negative numbers come before positive
+    return id_sort_order(lhs, rhs);
   }
 };
 /** Handy typedef for a vector of sorted ID maps */
@@ -414,6 +413,8 @@ public:
     else
       return _newIdToOld[type][new_id];
   }
+  bool containsOldId(ElementType::Type type, long new_id)
+  { return _newIdToOld[type].find(new_id) != _newIdToOld[type].end(); }
   /**
    * @brief getNewId Get the new ID from the old ID
    * @param type Element type (node/way/relation)
@@ -427,6 +428,8 @@ public:
     else
       return _oldIdToNew[type][old_id];
   }
+  bool containsNewId(ElementType::Type type, long old_id)
+  { return _oldIdToNew[type].find(old_id) != _oldIdToNew[type].end(); }
   /**
    * @brief begin Get beginning iterator
    * @param type Element type (node/way/relation)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -50,9 +50,12 @@ class ElementIdToIdMap;
 
 /** Object that matches an XML tag to its XML attributes */
 typedef QPair<QString, QXmlStreamAttributes> XmlObject;
+typedef std::vector<std::pair<QString, QString>> ElementAttributes;
+typedef std::pair<QString, QString> ElementTag;
+typedef std::vector<ElementTag> ElementTags;
 
 /** Changeset element abstraction for simplified nodes, ways, and relations */
-class XmlElement
+class ChangesetElement
 {
 public:
   /**
@@ -60,12 +63,12 @@ public:
    * @param object XML tag name and attributes
    * @param idMap ID to ID Map for updated IDs
    */
-  XmlElement(const XmlObject& object, ElementIdToIdMap* idMap);
+  ChangesetElement(const XmlObject& object, ElementIdToIdMap* idMap);
   /**
    * @brief XmlElement copy constructor
    * @param element XmlElement object to copy
    */
-  XmlElement(const XmlElement& element);
+  ChangesetElement(const ChangesetElement& element);
   /**
    * @brief addTag  Add a tag to the element
    * @param tag XML tag with key and value attributes
@@ -131,13 +134,13 @@ protected:
    * @param changesetId ID of the changeset to insert into the attributes
    * @return XML string
    */
-  QString toString(const QXmlStreamAttributes& attributes, long changesetId) const;
+  QString toString(const ElementAttributes& attributes, long changesetId) const;
   /**
    * @brief toTagString Get the XML string of a single tag with key/value pair
-   * @param attributes Key/value attributes
+   * @param tag Key/value pair from tag
    * @return XML string
    */
-  QString toTagString(const QXmlStreamAttributes& attributes) const;
+  QString toTagString(const ElementTag& tag) const;
   /**
    * @brief escapeString XML encode certain characters in value
    * @param value String value
@@ -151,34 +154,34 @@ protected:
   /** Element version */
   long _version;
   /** Element attributes */
-  XmlObject _object;
+  ElementAttributes _object;
   /** Element tag list */
-  QVector<XmlObject> _tags;
+  ElementTags _tags;
   /** Pointer to the ID to ID map */
   ElementIdToIdMap* _idMap;
   /** Element status */
   ElementStatus _status;
 };
 /** Handy typedef for element shared pointer */
-typedef std::shared_ptr<XmlElement> XmlElementPtr;
+typedef std::shared_ptr<ChangesetElement> ChangesetElementPtr;
 
 /** Simplified changeset node abstraction */
-class XmlNode : public XmlElement
+class ChangesetNode : public ChangesetElement
 {
 public:
   /**
-   * @brief XmlNode constructor
+   * @brief ChangesetNode constructor
    * @param node XML node tag and attributes
    * @param idMap ID to ID Map for updated IDs
    */
-  XmlNode(const XmlObject& node, ElementIdToIdMap* idMap);
+  ChangesetNode(const XmlObject& node, ElementIdToIdMap* idMap);
   /**
-   * @brief XmlNode copy constructor
-   * @param node XmlNode object to copy
+   * @brief ChangesetNode copy constructor
+   * @param node ChangesetNode object to copy
    */
-  XmlNode(const XmlNode& node);
+  ChangesetNode(const ChangesetNode& node);
   /** Virtual destructor */
-  virtual ~XmlNode() { }
+  virtual ~ChangesetNode() { }
   /**
    * @brief toString Get the XML string equivalent for the node
    * @param changesetId ID of the changeset to insert into the node
@@ -187,25 +190,25 @@ public:
   virtual QString toString(long changesetId) const;
 };
 /** Handy typedef for node shared pointer */
-typedef std::shared_ptr<XmlNode> XmlNodePtr;
+typedef std::shared_ptr<ChangesetNode> ChangesetNodePtr;
 
 /** Simplified changeset way abstraction */
-class XmlWay : public XmlElement
+class ChangesetWay : public ChangesetElement
 {
 public:
   /**
-   * @brief XmlWay constructor
+   * @brief ChangesetWay constructor
    * @param way XML way tag and attributes
    * @param idMap ID to ID Map for updated IDs
    */
-  XmlWay(const XmlObject& way, ElementIdToIdMap* idMap);
+  ChangesetWay(const XmlObject& way, ElementIdToIdMap* idMap);
   /**
-   * @brief XmlWay copy constructor
-   * @param way XmlWay object to copy
+   * @brief ChangesetWay copy constructor
+   * @param way ChangesetWay object to copy
    */
-  XmlWay(const XmlWay& way);
+  ChangesetWay(const ChangesetWay& way);
   /** Virtual destructor */
-  virtual ~XmlWay() { }
+  virtual ~ChangesetWay() { }
   /**
    * @brief addNode Add a node ID to the node (in order)
    * @param id Node ID
@@ -240,30 +243,30 @@ private:
   QVector<long> _nodes;
 };
 /** Handy typedef for way shared pointer */
-typedef std::shared_ptr<XmlWay> XmlWayPtr;
+typedef std::shared_ptr<ChangesetWay> ChangesetWayPtr;
 
 /** Simplified changeset relation member abstraction */
-class XmlMember
+class ChangesetRelationMember
 {
 public:
   /**
-   * @brief XmlMember constructor
+   * @brief ChangesetRelationMember constructor
    * @param member Member attributes
    * @param idMap ID to ID Map for updated IDs
    */
-  XmlMember(const QXmlStreamAttributes& member, ElementIdToIdMap* idMap);
+  ChangesetRelationMember(const QXmlStreamAttributes& member, ElementIdToIdMap* idMap);
   /**
    * @brief isNode/Way/Relation
    * @return true if relation member is node/way/relation
    */
-  bool isNode()     { return _type == "node"; }
-  bool isWay()      { return _type == "way"; }
-  bool isRelation() { return _type == "relation"; }
+  bool isNode()     { return _type == ElementType::Node; }
+  bool isWay()      { return _type == ElementType::Way; }
+  bool isRelation() { return _type == ElementType::Relation; }
   /**
    * @brief getType Get the relation member type
-   * @return relation type as a string
+   * @return relation type as an enumeration
    */
-  QString getType() { return _type; }
+  ElementType::Type getType() { return _type; }
   /**
    * @brief getRef ID of the member referenced
    * @return Element ID
@@ -282,7 +285,7 @@ public:
 
 private:
   /** Member type (node/way/relation) */
-  QString _type;
+  ElementType::Type _type;
   /** Member element ID */
   long _ref;
   /** Member role */
@@ -292,33 +295,33 @@ private:
 };
 
 /** Simplified changeset relation abstraction */
-class XmlRelation : public XmlElement
+class ChangesetRelation : public ChangesetElement
 {
 public:
   /**
-   * @brief XmlRelation constructor
+   * @brief ChangesetRelation constructor
    * @param relation XML relation tag and attributes
    * @param idMap ID to ID Map for updated IDs
    */
-  XmlRelation(const XmlObject& relation, ElementIdToIdMap* idMap);
+  ChangesetRelation(const XmlObject& relation, ElementIdToIdMap* idMap);
   /**
-   * @brief XmlRelation copy constructor
-   * @param relation XmlRelation object to copy
+   * @brief ChangesetRelation copy constructor
+   * @param relation ChangesetRelation object to copy
    */
-  XmlRelation(const XmlRelation& relation);
+  ChangesetRelation(const ChangesetRelation& relation);
   /** Virtual destructor */
-  virtual ~XmlRelation() { }
+  virtual ~ChangesetRelation() { }
   /**
    * @brief addMember Add relation member
    * @param member XML attributes of the relation member
    */
-  void addMember(const QXmlStreamAttributes& member) {  _members.append(XmlMember(member, _idMap)); }
+  void addMember(const QXmlStreamAttributes& member) {  _members.append(ChangesetRelationMember(member, _idMap)); }
   /**
    * @brief getMember Get the member at index
    * @param index Index in the member vector
    * @return relation member
    */
-  XmlMember& getMember(int index) { return _members[index]; }
+  ChangesetRelationMember& getMember(int index) { return _members[index]; }
   /**
    * @brief getMemberCount Get the number of relation members
    * @return relation member count
@@ -340,10 +343,10 @@ public:
 
 private:
   /** List of relation members */
-  QList<XmlMember> _members;
+  QList<ChangesetRelationMember> _members;
 };
 /** Handy typedef for relation shared pointer */
-typedef std::shared_ptr<XmlRelation> XmlRelationPtr;
+typedef std::shared_ptr<ChangesetRelation> ChangesetRelationPtr;
 
 /** Custom sorting function to sort IDs from -1 to -n followed by 1 to m */
 class osm_id_sort
@@ -357,7 +360,7 @@ public:
   }
 };
 /** Handy typedef for a vector of sorted ID maps */
-typedef QVector<std::map<long, long, osm_id_sort>> XmlElementIdMap;
+typedef std::vector<std::map<long, long, osm_id_sort>> ChangesetElementIdMap;
 
 /** Class for storing ID to ID associations, this is required because elements that are created in
  *  a changeset have negative IDs until they are processed by the OSM API.  If a node is used in a
@@ -439,9 +442,9 @@ public:
 
 private:
   /** Old ID to new ID mapping */
-  XmlElementIdMap _oldIdToNew;
+  ChangesetElementIdMap _oldIdToNew;
   /** New ID to old ID mapping */
-  XmlElementIdMap _newIdToOld;
+  ChangesetElementIdMap _newIdToOld;
 };
 
 }


### PR DESCRIPTION
PR consists of two major changes (and some renaming of classes and functions).
1. Read strings from file and save them in the changeset element objects instead of using `QXmlStreamAttributes` objects as they are read from the XML stream.
2. Reduced the number of ID to ID maps to keep track of old and new IDs as negative IDs are replaced by positive IDs as the upload process goes on.
I ran a couple of tests on different sized files and the results are below.  The toy test shows some big changes and also shows the approximate minimum memory footprint (approx. 81 MB) for a `changeset-apply` operation.  The Djibouti dataset shows the memory savings in dramatic fashion.
```
ToyTestA.osc (All adds)
5.4 KB changeset file
Before:
105 MB memory usage
After:
81 MB memory usage

Djibouti-latest (All adds)
28 MB changeset file
Before:
631 MB memory usage
After:
307 MB memory usage
```
(These memory usages were gathered using `htop` from the `RES` column)