### PR TITLE
Keep changesets open until they near the 50k limit

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -502,8 +502,8 @@ for the reference dataset will be ignored and not added to changeset output.
 * Data Type: long
 * Default Value: `1000`
 
-This is the maximum number of elements to write to an OSM API database in a changeset. This value
-is used when splitting a changeset into smaller pieces.
+This is the maximum number of elements to write to an OSM API database in a changeset push.
+This value is used when splitting a changeset into smaller pieces.
 
 NOTE: This is different to `changeset.max.size` which is the maximum number of elements that the
 database can handle in a single changeset.

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -129,7 +129,7 @@ public:
 
     //  Four elements max will divide the changeset into four changesets
     //  one for each way, with its corresponding nodes
-    changeset.setMaxSize(4);
+    changeset.setMaxPushSize(4);
 
     QStringList expectedFiles;
     expectedFiles.append(_inputPath + "ToyTestASplit1.osc");
@@ -297,7 +297,7 @@ public:
     changeset.loadChangeset(_inputPath + "DeleteSplit.osc");
 
     //  8 elements max will divide the changeset into 4 changesets
-    changeset.setMaxSize(8);
+    changeset.setMaxPushSize(8);
 
     QStringList expectedFiles;
     expectedFiles.append(_inputPath + "DeleteSplit1.osc");

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -49,7 +49,7 @@ XmlChangeset::XmlChangeset()
   : _nodes(ChangesetType::TypeMax),
     _ways(ChangesetType::TypeMax),
     _relations(ChangesetType::TypeMax),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
     _sentCount(0),
     _processedCount(0),
     _failedCount(0)
@@ -60,7 +60,7 @@ XmlChangeset::XmlChangeset(const QList<QString> &changesets)
   : _nodes(ChangesetType::TypeMax),
     _ways(ChangesetType::TypeMax),
     _relations(ChangesetType::TypeMax),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
     _sentCount(0),
     _processedCount(0),
     _failedCount(0)
@@ -439,7 +439,7 @@ bool XmlChangeset::addNodes(ChangesetInfoPtr& changeset, ChangesetType type)
   for (ChangesetElementMap::iterator it = _nodes[type].begin(); it != _nodes[type].end(); ++it)
   {
     //  Add nodes up until the max changeset
-    if (changeset->size() < (size_t)_maxChangesetSize)
+    if (changeset->size() < (size_t)_maxPushSize)
       added |= addNode(changeset, type, dynamic_cast<ChangesetNode*>(it->second.get()));
   }
   //  Return true if something was added
@@ -523,7 +523,7 @@ bool XmlChangeset::addWays(ChangesetInfoPtr& changeset, ChangesetType type)
   for (ChangesetElementMap::iterator it = _ways[type].begin(); it != _ways[type].end(); ++it)
   {
     //  Add ways up until the max changeset
-    if (changeset->size() < (size_t)_maxChangesetSize)
+    if (changeset->size() < (size_t)_maxPushSize)
       added |= addWay(changeset, type, dynamic_cast<ChangesetWay*>(it->second.get()));
   }
   //  Return true if something was added
@@ -667,7 +667,7 @@ bool XmlChangeset::addRelations(ChangesetInfoPtr& changeset, ChangesetType type)
   for (ChangesetElementMap::iterator it = _relations[type].begin(); it != _relations[type].end(); ++it)
   {
     //  Add relations up until the max changeset
-    if (changeset->size() < (size_t)_maxChangesetSize)
+    if (changeset->size() < (size_t)_maxPushSize)
       added |= addRelation(changeset, type, dynamic_cast<ChangesetRelation*>(it->second.get()));
   }
   //  Return true if something was added
@@ -1054,10 +1054,10 @@ bool XmlChangeset::calculateChangeset(ChangesetInfoPtr& changeset)
   if (!changeset)
     changeset.reset(new ChangesetInfo());
   changeset->clear();
-  //  Build up the changeset to be around the MAX changeset size
+  //  Build up the changeset to be around the MAX changeset push size
   ChangesetType type = ChangesetType::TypeCreate;
   while (type != ChangesetType::TypeMax &&
-         changeset->size() < (size_t)_maxChangesetSize &&
+         changeset->size() < (size_t)_maxPushSize &&
          hasElementsToSend())
   {
     /**
@@ -1070,17 +1070,17 @@ bool XmlChangeset::calculateChangeset(ChangesetInfoPtr& changeset)
     //  Start with the relations
     addRelations(changeset, type);
     //  Break out of the loop once the changeset is big enough
-    if (changeset->size() >= (size_t)_maxChangesetSize)
+    if (changeset->size() >= (size_t)_maxPushSize)
       continue;
     //  Then the ways
     addWays(changeset, type);
     //  Break out of the loop once the changeset is big enough
-    if (changeset->size() >= (size_t)_maxChangesetSize)
+    if (changeset->size() >= (size_t)_maxPushSize)
       continue;
     //  Finally the nodes
     addNodes(changeset, type);
     //  Break out of the loop once the changeset is big enough
-    if (changeset->size() >= (size_t)_maxChangesetSize)
+    if (changeset->size() >= (size_t)_maxPushSize)
       continue;
     //  Go to the next type and loop back around
     type = static_cast<ChangesetType>(type + 1);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -147,11 +147,11 @@ public:
    */
   QString getFailedChangesetString();
   /**
-   * @brief setMaxSize Set the soft maximum size of the changeset.  Max is soft because if while creating a way there are still
+   * @brief setMaxPushSize Set the maximum size of the push changeset.  Max is soft because if while creating a way there are still
    *  more required nodes to add and the max is hit, those nodes are added to the changeset to make it atomic
    * @param size - Number of elements in the soft max size
    */
-  void setMaxSize(long size) { _maxChangesetSize = size; }
+  void setMaxPushSize(long size) { _maxPushSize = size; }
   /**
    * @brief hasFailedElements
    * @return true if any elements failed upload
@@ -456,8 +456,8 @@ private:
   ChangesetTypeMap _relations;
   /** Element ID to ID data structure for checking old ID to new ID and new ID to old ID lookups */
   ElementIdToIdMap _idMap;
-  /** Soft maximum changeset size */
-  long _maxChangesetSize;
+  /** Maximum changeset push size */
+  long _maxPushSize;
   /** Count of elements that have been sent */
   long _sentCount;
   /** Count of elements that have been processed */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -58,10 +58,16 @@ const char* OsmApiWriter::API_PATH_GET_ELEMENT = "/api/0.6/%1/%2/";
 OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
   : _description(ConfigOptions().getChangesetDescription()),
     _maxWriters(ConfigOptions().getChangesetApidbWritersMax()),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxChangesetSize(ConfigOptions().getChangesetMaxSize()),
     _throttleWriters(ConfigOptions().getChangesetApidbWritersThrottle()),
     _throttleTime(ConfigOptions().getChangesetApidbWritersThrottleTime()),
-    _showProgress(false)
+    _showProgress(false),
+    _consumerKey(ConfigOptions().getHootOsmAuthConsumerKey()),
+    _consumerSecret(ConfigOptions().getHootOsmAuthConsumerSecret()),
+    _accessToken(ConfigOptions().getHootOsmAuthAccessToken()),
+    _secretToken(ConfigOptions().getHootOsmAuthAccessTokenSecret()),
+    _changesetCount(0)
 {
   _changesets.push_back(changeset);
   if (isSupported(url))
@@ -72,14 +78,16 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
   : _changesets(changesets),
     _description(ConfigOptions().getChangesetDescription()),
     _maxWriters(ConfigOptions().getChangesetApidbWritersMax()),
-    _maxChangesetSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxChangesetSize(ConfigOptions().getChangesetMaxSize()),
     _throttleWriters(ConfigOptions().getChangesetApidbWritersThrottle()),
     _throttleTime(ConfigOptions().getChangesetApidbWritersThrottleTime()),
     _showProgress(false),
     _consumerKey(ConfigOptions().getHootOsmAuthConsumerKey()),
     _consumerSecret(ConfigOptions().getHootOsmAuthConsumerSecret()),
     _accessToken(ConfigOptions().getHootOsmAuthAccessToken()),
-    _secretToken(ConfigOptions().getHootOsmAuthAccessTokenSecret())
+    _secretToken(ConfigOptions().getHootOsmAuthAccessTokenSecret()),
+    _changesetCount(0)
 {
   if (isSupported(url))
     _url = url;
@@ -101,6 +109,8 @@ bool OsmApiWriter::apply()
   //  pushed across multiple processing threads out performed larger (50k element) datasets
   if (_maxChangesetSize > _capabilities.getChangesets())
     _maxChangesetSize = _capabilities.getChangesets();
+  if (_maxPushSize > _maxChangesetSize)
+    _maxPushSize = _maxChangesetSize / 5;
   //  Setup the network request object with OAuth or with username/password authentication
   request = createNetworkRequest(true);
   //  Validate API permissions
@@ -112,7 +122,7 @@ bool OsmApiWriter::apply()
   _stats.append(SingleStat("API Permissions Query Time (sec)", timer.getElapsedAndRestart()));
   bool success = true;
   //  Load all of the changesets into memory
-  _changeset.setMaxSize(_maxChangesetSize);
+  _changeset.setMaxPushSize(_maxPushSize);
   for (int i = 0; i < _changesets.size(); ++i)
   {
     LOG_INFO("Loading changeset: " << _changesets[i]);
@@ -191,6 +201,7 @@ bool OsmApiWriter::apply()
   LOG_INFO("Upload progress: 100%");
   //  Keep some stats
   _stats.append(SingleStat("API Upload Time (sec)", timer.getElapsedAndRestart()));
+  _stats.append(SingleStat("Total OSM Changesets Uploaded", _changesetCount));
   _stats.append(SingleStat("Total Nodes in Changeset", _changeset.getTotalNodeCount()));
   _stats.append(SingleStat("Total Ways in Changeset", _changeset.getTotalWayCount()));
   _stats.append(SingleStat("Total Relations in Changeset", _changeset.getTotalRelationCount()));
@@ -207,6 +218,7 @@ void OsmApiWriter::_changesetThreadFunc()
   //  Setup the network request object with OAuth or with username/password authentication
   HootNetworkRequestPtr request = createNetworkRequest(true);
   long id = -1;
+  long changesetSize = 0;
   //  Iterate until all elements are sent and updated
   while (!_changeset.isDone())
   {
@@ -224,7 +236,10 @@ void OsmApiWriter::_changesetThreadFunc()
     {
       //  Create the changeset ID if required
       if (id < 1)
+      {
         id = _createChangeset(request, _description);
+        changesetSize = 0;
+      }
       //  An ID of less than 1 isn't valid, try to fix it
       if (id < 1)
       {
@@ -250,10 +265,17 @@ void OsmApiWriter::_changesetThreadFunc()
         _changesetMutex.lock();
         _changeset.updateChangeset(QString(request->getResponseContent()));
         _changesetMutex.unlock();
-        //  Close the changeset
-        _closeChangeset(request, id);
-        //  Signal for a new changeset id
-        id = -1;
+        //  Update the size of the current changeset that is open
+        changesetSize += workInfo->size();
+        //  When the current changeset is nearing the 50k max (or the specified max), close the changeset
+        //  otherwise keep it open and go again
+        if (changesetSize > _maxChangesetSize - _maxPushSize)
+        {
+          //  Close the changeset
+          _closeChangeset(request, id);
+          //  Signal for a new changeset id
+          id = -1;
+        }
         //  Throttle the input rate if desired
         if (_throttleWriters && !_changeset.isDone())
           this_thread::sleep_for(chrono::seconds(_throttleTime));
@@ -343,7 +365,8 @@ void OsmApiWriter::setConfiguration(const Settings& conf)
 {
   ConfigOptions options(conf);
   _description = options.getChangesetDescription();
-  _maxChangesetSize = options.getChangesetApidbSizeMax();
+  _maxPushSize = options.getChangesetApidbSizeMax();
+  _maxChangesetSize = options.getChangesetMaxSize();
   _maxWriters = options.getChangesetApidbWritersMax();
   _throttleWriters = options.getChangesetApidbWritersThrottle();
   _throttleTime = options.getChangesetApidbWritersThrottleTime();
@@ -529,6 +552,9 @@ void OsmApiWriter::_closeChangeset(HootNetworkRequestPtr request, long id)
       break;
     case 200:
       //  Changeset closed successfully
+      _changesetCountMutex.lock();
+      _changesetCount++;
+      _changesetCountMutex.unlock();
       break;
     default:
       LOG_WARN("Uknown HTTP response code: " << request->getHttpStatus());

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -269,7 +269,7 @@ void OsmApiWriter::_changesetThreadFunc()
         changesetSize += workInfo->size();
         //  When the current changeset is nearing the 50k max (or the specified max), close the changeset
         //  otherwise keep it open and go again
-        if (changesetSize > _maxChangesetSize - _maxPushSize)
+        if (changesetSize > _maxChangesetSize - (int)(_maxPushSize * 1.5))
         {
           //  Close the changeset
           _closeChangeset(request, id);
@@ -298,6 +298,8 @@ void OsmApiWriter::_changesetThreadFunc()
               continue;
             }
             //  Fall through here to split the changeset and retry
+            //  This includes when the changeset is too big, i.e.:
+            //    The changeset <id> was closed at <dtg> UTC
           }
         case 400:   //  Placeholder ID is missing or not unique
         case 404:   //  Diff contains elements where the given ID could not be found

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -254,7 +254,12 @@ private:
   /** Maximum number of writer threads processing changesets, loaded with 'changeset.apidb.max.writers' option */
   int _maxWriters;
   /** Soft maximum number of elements per changeset, size could be larger than the soft max in order to include
-   *  the entirety of a way or relation, loaded with 'changeset.apidb.max.size' option
+   *  the entirety of a way or relation, loaded with 'changeset.apidb.size.max' option
+   */
+  long _maxPushSize;
+  /** Maximum size of a changeset read from the API itself.  This allows for the potential of multiple
+   *  pushes per changeset to increase the speed of the upload.  That way less requests for new changeset
+   *  opens/closes are required but the pushes can be an optimal size still.
    */
   long _maxChangesetSize;
   /** Flag to turn on OSM API writer throttling */
@@ -278,6 +283,10 @@ private:
   QString _secretToken;
   /** Full pathname of the error file changeset, if any errors occur */
   QString _errorPathname;
+  /** Number of changesets written to API */
+  int _changesetCount;
+  /** Mutex for changeset count */
+  std::mutex _changesetCountMutex;
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */


### PR DESCRIPTION
An OSM API changeset (`/api/0.6/changeset/create`) can include multiple `osmChange` uploads (`/api/0.6/changeset/#id/upload`) before closing it (`/api/0.6/changeset/#id/close`).  So this opens a changeset and commits multiple uploads to it before hitting the 50k limit before closing it.  This reduces the number of changesets committed and the overhead associated with opening and closing so many changesets.