### PR TITLE
Fixed #3648. store tags in job status such as parent job id and inputs

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
@@ -96,7 +96,7 @@ public:
   /**
    * This value should be updated after the DB is upgraded and all tests run successfully.
    */
-  static QString expectedHootDbVersion() { return "28:bobby.simic"; }
+  static QString expectedHootDbVersion() { return "29:bobby.simic"; }
   static int maximumChangeSetEdits() { return 50000; }
 
   static const Status DEFAULT_ELEMENT_STATUS;

--- a/hoot-services/src/main/java/hoot/services/controllers/conflation/ConflateResource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/conflation/ConflateResource.java
@@ -27,6 +27,7 @@
 package hoot.services.controllers.conflation;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -116,7 +117,12 @@ public class ConflateResource {
 
             Command[] workflow = { conflateCommand, updateTagsCommand, setFolderCommand };
 
-            jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow, JobType.CONFLATE));
+            Map<String, Object> jobStatusTags = new HashMap<>();
+            jobStatusTags.put("bbox", params.getBounds());
+            jobStatusTags.put("input1", params.getInput1());
+            jobStatusTags.put("input2", params.getInput2());
+
+            jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow, JobType.CONFLATE, jobStatusTags));
         }
         catch (IllegalArgumentException iae) {
             throw new WebApplicationException(iae, Response.status(Response.Status.BAD_REQUEST).entity(iae.getMessage()).build());

--- a/hoot-services/src/main/java/hoot/services/controllers/grail/GrailResource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/GrailResource.java
@@ -430,13 +430,12 @@ public class GrailResource {
                 }
             }
 
-            // The parents parents of the current job is the conflate job which contains the resource id of the merged layer
-            String grandparentJobId = DbUtils.getParentId(reqParams.getParentId());
-            Long resourceId = DbUtils.getMapIdByJobId(grandparentJobId); // the merged layer
+            Map<String, String> tags = DbUtils.getJobTags(reqParams.getParentId());
+            String resourceId = tags.get("input1");
 
             if(resourceId != null) {
                 // Setup workflow to refresh rails data after the push
-                long referenceId = DbUtils.getMergedReference(resourceId);
+                long referenceId = Long.parseLong(resourceId);
                 Long parentFolderId = DbUtils.getParentFolder(referenceId);
                 Map<String, String> mapTags = DbUtils.getMapsTableTags(referenceId);
 
@@ -455,7 +454,11 @@ public class GrailResource {
                 }
             }
 
-            jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.UPLOAD_CHANGESET, reqParams.getParentId()));
+            Map<String, Object> jobStatusTags = new HashMap<>();
+            jobStatusTags.put("bbox", reqParams.getBounds());
+            jobStatusTags.put("parentId", reqParams.getParentId());
+
+            jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.UPLOAD_CHANGESET, jobStatusTags));
         }
         catch (WebApplicationException wae) {
             throw wae;
@@ -537,8 +540,14 @@ public class GrailResource {
             ExternalCommand makeChangeset = grailCommandFactory.build(mainJobId, params, debugLevel, (replacement) ? DeriveChangesetReplacementCommand.class : DeriveChangesetCommand.class, this.getClass());
             workflow.add(makeChangeset);
 
+            Map<String, Object> jobStatusTags = new HashMap<>();
+            jobStatusTags.put("bbox", reqParams.getBounds());
+            jobStatusTags.put("input1", input1);
+            jobStatusTags.put("input2", input2);
+            jobStatusTags.put("parentId", reqParams.getParentId());
+
             // Now roll the dice and run everything.....
-            jobProcessor.submitAsync(new Job(mainJobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.DERIVE_CHANGESET, reqParams.getParentId()));
+            jobProcessor.submitAsync(new Job(mainJobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.DERIVE_CHANGESET, jobStatusTags));
         }
         catch (WebApplicationException wae) {
             throw wae;
@@ -630,7 +639,10 @@ public class GrailResource {
         InternalCommand setFolder = updateParentCommandFactory.build(jobId, folderId, layerName, user, this.getClass());
         workflow.add(setFolder);
 
-        jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.IMPORT));
+        Map<String, Object> jobStatusTags = new HashMap<>();
+        jobStatusTags.put("bbox", bbox);
+
+        jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.IMPORT, jobStatusTags));
 
         ResponseBuilder responseBuilder = Response.ok(json.toJSONString());
         response = responseBuilder.build();
@@ -754,7 +766,6 @@ public class GrailResource {
             throw new BadRequestException("Record with name : " + layerName + " already exists.  Please try a different name.");
         }
 
-        Response response;
         JSONObject json = new JSONObject();
         json.put("jobid", jobId);
 
@@ -771,12 +782,12 @@ public class GrailResource {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(exc.getMessage()).build();
         }
 
-        jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.IMPORT));
+        Map<String, Object> jobStatusTags = new HashMap<>();
+        jobStatusTags.put("bbox", reqParams.getBounds());
 
-        ResponseBuilder responseBuilder = Response.ok(json.toJSONString());
-        response = responseBuilder.build();
+        jobProcessor.submitAsync(new Job(jobId, user.getId(), workflow.toArray(new Command[workflow.size()]), JobType.IMPORT, jobStatusTags));
 
-        return response;
+        return Response.ok(json.toJSONString()).build();
     }
 
     private List<Command> setupRailsPull(String jobId, GrailParams params, Long parentFolderId) throws UnavailableException {

--- a/hoot-services/src/main/java/hoot/services/job/Job.java
+++ b/hoot-services/src/main/java/hoot/services/job/Job.java
@@ -27,7 +27,9 @@
 package hoot.services.job;
 
 
+import java.util.Map;
 import hoot.services.command.Command;
+import hoot.services.utils.PostgresUtils;
 
 
 public class Job {
@@ -36,31 +38,27 @@ public class Job {
     private Long mapId;
     private Command[] commands;
     private JobType jobType;
-    private String parentId;
+    private Object tags;
 
-    public Job(String jobId, Long userId, Command[] commands, JobType jobType, Long mapId, String parentId) {
+    public Job(String jobId, Long userId, Command[] commands, JobType jobType, Long mapId, Map<String, Object> tags) {
         this.jobId = jobId;
         this.userId = userId;
         this.commands = commands;
         this.jobType = jobType;
         this.mapId = mapId;
-        this.parentId = parentId;
-    }
-
-    public Job(String jobId, Long userId, Command[] commands, JobType jobType) {
-        this(jobId, userId, commands, jobType, null, null);
+        this.tags = tags;
     }
 
     public Job(String jobId, Long userId, Command[] commands, JobType jobType, Long mapId) {
         this(jobId, userId, commands, jobType, mapId, null);
     }
 
-    public Job(String jobId, Long userId, Command[] commands, JobType jobType, String parentId) {
-        this(jobId, userId, commands, jobType, null, parentId);
+    public Job(String jobId, Long userId, Command[] commands, JobType jobType, Map<String, Object> tags) {
+        this(jobId, userId, commands, jobType, null, tags);
     }
 
-    public Job(String jobId) {
-        this.jobId = jobId;
+    public Job(String jobId, Long userId, Command[] commands, JobType jobType) {
+        this(jobId, userId, commands, jobType, null, null);
     }
 
     public String getJobId() {
@@ -103,11 +101,11 @@ public class Job {
         this.mapId = mapId;
     }
 
-    public void setParentId(String parentId) {
-        this.parentId = parentId;
+    public void setTags(Object tags) {
+        this.tags = tags;
     }
 
-    public String getParentId() {
-        return parentId;
+    public Map<String, String> getTags() {
+        return PostgresUtils.postgresObjToHStore(tags);
     }
 }

--- a/hoot-services/src/main/java/hoot/services/job/JobRunnable.java
+++ b/hoot-services/src/main/java/hoot/services/job/JobRunnable.java
@@ -95,7 +95,7 @@ class JobRunnable implements Runnable {
             jobStatusManager.setCompleted(job.getJobId(), "FULLY PROCESSED");
 
             if(job.getJobType().equals(JobType.UPLOAD_CHANGESET)){
-                DbUtils.setStale(job.getParentId());
+                DbUtils.setStale(job.getTags().get("parentId"));
             }
         }
         catch (Exception e) {

--- a/hoot-services/src/main/java/hoot/services/job/JobStatusManagerImpl.java
+++ b/hoot-services/src/main/java/hoot/services/job/JobStatusManagerImpl.java
@@ -71,7 +71,7 @@ public class JobStatusManagerImpl implements JobStatusManager {
             newJobStatus.setResourceId(job.getMapId());
             Timestamp ts = new Timestamp(System.currentTimeMillis());  //Is this UTC?
             newJobStatus.setStart(ts);
-            newJobStatus.setParentId(job.getParentId());
+            newJobStatus.setTags(job.getTags());
 
             // We only get the external command count because they take the longest to run so they have
             // the biggest impact on the math for job progress

--- a/hoot-services/src/main/java/hoot/services/models/db/JobStatus.java
+++ b/hoot-services/src/main/java/hoot/services/models/db/JobStatus.java
@@ -54,7 +54,7 @@ public class JobStatus {
 
     private Integer trackableCommandCount;
 
-    private String parentId;
+    private Object tags;
 
     public java.sql.Timestamp getEnd() {
         return end;
@@ -136,12 +136,12 @@ public class JobStatus {
         this.trackableCommandCount = commandCount;
     }
 
-    public String getParentId() {
-        return parentId;
+    public Object getTags() {
+        return tags;
     }
 
-    public void setParentId(String parentId) {
-        this.parentId = parentId;
+    public void setTags(Object tags) {
+        this.tags = tags;
     }
 }
 

--- a/hoot-services/src/main/java/hoot/services/models/db/QJobStatus.java
+++ b/hoot-services/src/main/java/hoot/services/models/db/QJobStatus.java
@@ -36,6 +36,7 @@ import com.querydsl.core.types.Path;
 import com.querydsl.core.types.PathMetadata;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.SimplePath;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.sql.ColumnMetadata;
 
@@ -74,7 +75,7 @@ public class QJobStatus extends com.querydsl.sql.RelationalPathBase<JobStatus> {
 
     public final NumberPath<Integer> trackableCommandCount = createNumber("trackableCommandCount", Integer.class);
 
-    public final StringPath parentId = createString("parentId");
+    public final SimplePath<Object> tags = createSimple("tags", Object.class);
 
     public QJobStatus(String variable) {
         super(JobStatus.class, forVariable(variable), "public", "job_status");
@@ -107,7 +108,7 @@ public class QJobStatus extends com.querydsl.sql.RelationalPathBase<JobStatus> {
         addMetadata(userId, ColumnMetadata.named("user_id").withIndex(8).ofType(Types.BIGINT).withSize(19).notNull());
         addMetadata(jobType, ColumnMetadata.named("job_type").withIndex(9).ofType(Types.INTEGER).withSize(10));
         addMetadata(trackableCommandCount, ColumnMetadata.named("trackable_command_count").withIndex(10).ofType(Types.INTEGER).withSize(10));
-        addMetadata(parentId, ColumnMetadata.named("parent_id").withIndex(11).ofType(Types.VARCHAR).withSize(64).notNull());
+        addMetadata(tags, ColumnMetadata.named("tags").withIndex(11).ofType(Types.OTHER).withSize(2147483647));
     }
 
 }

--- a/hoot-services/src/main/resources/db/changelogs/029-AddJobStatusTags.xml
+++ b/hoot-services/src/main/resources/db/changelogs/029-AddJobStatusTags.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <changeSet author="bobby.simic" id="29" context="default">
+        <comment>
+            This change adds tags hstore to job_status which will contain info on the job such as inputs used and parent job id
+        </comment>
+
+        <addColumn tableName="job_status">
+            <column name="tags" type="hstore" />
+        </addColumn>
+
+        <!-- sets a default value for future rows inserted into the column -->
+        <addDefaultValue tableName="job_status" columnName="tags" defaultValue="" />
+
+        <!-- change the value of already existing rows to '' -->
+        <addNotNullConstraint tableName="job_status" columnName="tags" defaultNullValue="" />
+
+        <dropColumn tableName="job_status" columnName="parent_id" />
+
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
these extra tags get used when pushing the changeset for actions such as refreshing input1 of the job or setting the parent jobs to stale

ref #3648 