### PR TITLE
Delete if unused in changesets

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -309,7 +309,8 @@ public:
     HOOT_STR_EQUALS(
           FileUtils::readFully(_inputPath + "ToyTestAConflicts.osc")
             .replace("timestamp=\"\"", "timestamp=\"\" changeset=\"0\"")
-            .replace("    ", "\t"),
+            .replace("    ", "\t")
+            .replace("<delete>", "<delete if-unused=\"true\">"),
       writer.getFailedChangeset());
     //  Check the stats
     checkStats(writer.getStats(), 3, 2, 0, 2, 1, 2, 5);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -1480,9 +1480,10 @@ QString XmlChangeset::getChangeset(ChangesetInfoPtr changeset, long changeset_id
     category = "delete";
   if (changeset->size(ElementType::Node, type) > 0 || changeset->size(ElementType::Way, type) > 0 || changeset->size(ElementType::Relation, type) > 0)
   {
-    ts << "\t<" << category << ">\n";
+    ts << "\t<" << category;
     if (type != ChangesetType::TypeDelete)
     {
+      ts << ">\n";
       //  Nodes go first in each category
       writeNodes(changeset, ts, type, changeset_id);
       //  Followed by ways
@@ -1492,6 +1493,7 @@ QString XmlChangeset::getChangeset(ChangesetInfoPtr changeset, long changeset_id
     }
     else
     {
+      ts << " if-unused=\"true\">\n";
       //  Relations first for deletes
       writeRelations(changeset, ts, type, changeset_id);
       //  Followed by ways

--- a/test-files/io/OsmChangesetElementTest/ChangesetErrorFixErrors.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetErrorFixErrors.osc
@@ -15,7 +15,7 @@
 			<tag k="error:circular" v="15"/>
 		</way>
 	</modify>
-	<delete>
+	<delete if-unused="true">
 		<relation id="-10" version="0" timestamp="" changeset="0">
 			<member type="node" ref="17" role="role1"/>
 			<member type="way" ref="13" role="role2"/>

--- a/test-files/io/OsmChangesetElementTest/ChangesetMergeExpected.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetMergeExpected.osc
@@ -25,7 +25,7 @@
 			<tag k="error:circular" v="15"/>
 		</way>
 	</modify>
-	<delete>
+	<delete if-unused="true">
 		<relation id="1" version="1" timestamp="" changeset="1">
 			<member type="node" ref="7" role="role1"/>
 			<member type="way" ref="3" role="role2"/>

--- a/test-files/io/OsmChangesetElementTest/DeleteSplit1.osc
+++ b/test-files/io/OsmChangesetElementTest/DeleteSplit1.osc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
-	<delete>
+	<delete if-unused="true">
 		<way id="1" version="1" timestamp="" changeset="1">
 			<nd ref="1"/>
 			<nd ref="2"/>

--- a/test-files/io/OsmChangesetElementTest/DeleteSplit3.osc
+++ b/test-files/io/OsmChangesetElementTest/DeleteSplit3.osc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
-	<delete>
+	<delete if-unused="true">
 		<node id="8" version="1" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp="" changeset="3"/>
 		<node id="9" version="1" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="3"/>
 		<node id="10" version="1" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp="" changeset="3"/>

--- a/test-files/io/OsmChangesetElementTest/DeleteSplit4.osc
+++ b/test-files/io/OsmChangesetElementTest/DeleteSplit4.osc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
-	<delete>
+	<delete if-unused="true">
 		<node id="16" version="1" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp="" changeset="4"/>
 		<node id="17" version="1" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp="" changeset="4"/>
 		<node id="18" version="1" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp="" changeset="4"/>

--- a/test-files/io/OsmChangesetElementTest/RetryConflictExpected-error.osc
+++ b/test-files/io/OsmChangesetElementTest/RetryConflictExpected-error.osc
@@ -19,7 +19,7 @@
 			<tag k="highway" v="road"/>
 		</way>
 	</modify>
-	<delete>
+	<delete if-unused="true">
 		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="0">
 			<tag k="node" v="Should fail"/>
 		</node>


### PR DESCRIPTION
Added 'if-unused' argument to all 'delete' sections of changesets when they are pushed to the OSM API.