### PR TITLE
Remove the IP address from log messages to UI

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
@@ -36,6 +36,7 @@
 // Qt
 #include <QFile>
 #include <QFileInfo>
+#include <QHostAddress>
 
 using namespace std;
 
@@ -98,8 +99,11 @@ public:
       QUrl osm;
       osm.setUrl(args[args.size() - 1]);
 
-      //  Create a URL without user info for logging
+      //  Create a URL without IP and user info for logging
       QString printableUrl = osm.toString(QUrl::RemoveUserInfo);
+      QHostAddress host(osm.host());
+      if (!host.isNull())
+        printableUrl.replace(osm.host(), "<host>");
 
       const int maxFilePrintLength = ConfigOptions().getProgressVarPrintLengthMax();
 


### PR DESCRIPTION
Remove IP address from changeset-apply command in the LOG_STATUS message.