### PR TITLE
Error processing for OsmApiWriter

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 //  Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -214,6 +214,7 @@ public:
     bool found = false;
     long id = 0;
     long id2 = 0;
+    std::vector<long> ids;
     ElementType::Type type = ElementType::Unknown;
     ElementType::Type type2 = ElementType::Unknown;
     QString hint;
@@ -236,7 +237,7 @@ public:
     id2 = 0;
     type = ElementType::Unknown;
     type2 = ElementType::Unknown;
-    hint = "Placeholder Way not found for reference -12257 in relation -51";
+    hint = "Placeholder Way not found for reference -12257 in Relation -51";
     found = changeset.matchesPlaceholderFailure(hint, id, type, id2, type2);
     CPPUNIT_ASSERT_EQUAL(true, found);
     CPPUNIT_ASSERT_EQUAL(-12257L, id);
@@ -278,6 +279,21 @@ public:
     CPPUNIT_ASSERT_EQUAL(122L, id);
     CPPUNIT_ASSERT_EQUAL(7699L, id2);
     CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
+
+    //  Test multi relation failure with relation ID
+    id = 0;
+    ids.clear();
+    type = ElementType::Unknown;
+    hint = "Relation -2 requires the relations with id in 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700, which either do not exist, or are not visible.";
+    found = changeset.matchesMultiRelationFailure(hint, id, ids, type);
+    std::vector<long> expected_ids { 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700 };
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(-2L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type);
+    CPPUNIT_ASSERT_EQUAL(11, (int)ids.size());
+    for (int i = 0; i < (int)ids.size(); ++i)
+      CPPUNIT_ASSERT_EQUAL(expected_ids[i], ids[i]);
+
 
     //  Test relation failure with empty string
     id = 0;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmApiWriterTestServer.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -85,7 +85,7 @@ bool RetryConflictsTestServer::respond(HttpConnection::HttpConnectionPtr& connec
     response.reset(new HttpResponse(405));
     response->add_header("Allow", "GET");
   }
-  else if (headers.find("/close/"))
+  else if (headers.find(QString(OsmApiWriter::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()))
   {
     response.reset(new HttpResponse(200));
     continue_processing = false;
@@ -129,7 +129,7 @@ bool RetryVersionTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
   else if (headers.find(OsmApiWriter::API_PATH_CREATE_CHANGESET) != std::string::npos)
     response.reset(new HttpResponse(200, "1"));
   //  Upload changeset 1
-  else if (headers.find("/api/0.6/changeset/1/upload/") != std::string::npos)
+  else if (headers.find(QString(OsmApiWriter::API_PATH_UPLOAD_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     //  The first time through, the 'version' of element 1 should fail.
     if (!_has_error)
@@ -141,10 +141,10 @@ bool RetryVersionTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
       response.reset(new HttpResponse(200, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_1_RESPONSE));
   }
   //  Get way 1's updated version
-  else if (headers.find("/api/0.6/way/1") != std::string::npos)
+  else if (headers.find(QString(OsmApiWriter::API_PATH_GET_ELEMENT).arg("way").arg(1).toStdString()) != std::string::npos)
     response.reset(new HttpResponse(200, OsmApiSampleRequestResponse::SAMPLE_ELEMENT_1_GET_RESPONSE));
   //  Close changeset
-  else if (headers.find("/close/"))
+  else if (headers.find(QString(OsmApiWriter::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()))
   {
     response.reset(new HttpResponse(200));
     continue_processing = false;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -324,6 +324,11 @@ void XmlChangeset::updateChangeset(const QString &changes)
   QXmlStreamReader reader(changes);
   //  Make sure that the XML provided starts with the <diffResult> tag
   QXmlStreamReader::TokenType type = reader.readNext();
+  if (type == QXmlStreamReader::Invalid)
+  {
+    LOG_ERROR("Invalid changeset response.");
+    return;
+  }
   if (type == QXmlStreamReader::StartDocument)
     type = reader.readNext();
   if (type == QXmlStreamReader::StartElement && reader.name() != "diffResult")
@@ -1318,7 +1323,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(ChangesetInfoPtr changeset, const 
         }
       }
     }
-    //  See if the hint is something like:
+    //  See if the hint is something like: Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible.
     else if (matchesMultiRelationFailure(splitHint, element_id, member_ids, member_type))
     {
       //  If there is a relation id, move just that relation to the split

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmApiChangeset.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef OSM_API_CHANGESET_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -213,28 +213,33 @@ public:
    * @return True if the message matches and was parsed
    */
   static bool matchesPlaceholderFailure(const QString& hint,
-                                 long& member_id, ElementType::Type& member_type,
-                                 long& element_id, ElementType::Type& element_type);
+                                        long& member_id, ElementType::Type& member_type,
+                                        long& element_id, ElementType::Type& element_type);
   /**
    * @brief matchesRelationFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Relation with id  cannot be saved due to Relation with id 1707699"
    * @param hint Error message from OSM API
    * @param element_id ID of the element that failed
    * @param member_id ID of the member element that caused the element to fail
    * @param member_type Type of the member element that caused the element to fail
    * @return True if the message matches and was parsed
    */
-  static bool matchesRelationFailure(const QString& hint, long& element_id, long& member_id, ElementType::Type& member_type);
+  static bool matchesRelationFailure(const QString& hint, long& element_id,
+                                     long& member_id, ElementType::Type& member_type);
   /**
-   * @brief matchesMultiRelationFailure
-   * @param hint
-   * @param element_id
-   * @param member_ids
-   * @param member_type
-   * @return
+   * @brief matchesMultiRelationFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible."
+   * @param hint Error message from OSM API
+   * @param element_id ID of the element that failed
+   * @param member_ids IDs of the member elements that caused the element to fail
+   * @param member_type Type of the member element that caused the element to fail
+   * @return True if the message matches and was parsed
    */
-  static bool matchesMultiRelationFailure(const QString& hint, long& element_id, std::vector<long>& member_ids, ElementType::Type& member_type);
+  static bool matchesMultiRelationFailure(const QString& hint, long& element_id,
+                                          std::vector<long>& member_ids, ElementType::Type& member_type);
   /**
-   * @brief matchesChangesetPreconditionFailure
+   * @brief matchesChangesetPreconditionFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Precondition failed: Node 55 is still used by ways 123"
    * @param hint Error message from OSM API
    * @param member_id ID of the member element that caused the element to fail
    * @param member_type Type of the member element that caused the element to fail
@@ -243,20 +248,21 @@ public:
    * @return True if the message matches and was parsed
    */
   static bool matchesChangesetPreconditionFailure(const QString& hint,
-                                           long& member_id, ElementType::Type& member_type,
-                                           long& element_id, ElementType::Type& element_type);
+                                                  long& member_id, ElementType::Type& member_type,
+                                                  long& element_id, ElementType::Type& element_type);
   /**
-   * @brief matchesChangesetConflictVersionMismatchFailure
-   * @param hint
-   * @param element_id
-   * @param element_type
-   * @param version_old
-   * @param version_new
-   * @return
+   * @brief matchesChangesetConflictVersionMismatchFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616"
+   * @param hint Error message from OSM API
+   * @param member_id ID of the member element that caused the element to fail
+   * @param member_type Type of the member element that caused the element to fail
+   * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
+   * @return True if the message matches and was parsed
    */
   static bool matchesChangesetConflictVersionMismatchFailure(const QString& hint,
-                                                      long& element_id, ElementType::Type& element_type,
-                                                      long& version_old, long& version_new);
+                                                             long& element_id, ElementType::Type& element_type,
+                                                             long& version_old, long& version_new);
   /**
    * @brief setErrorPathname Record the pathname of the error changeset
    * @param path Pathname

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -225,6 +225,15 @@ public:
    */
   static bool matchesRelationFailure(const QString& hint, long& element_id, long& member_id, ElementType::Type& member_type);
   /**
+   * @brief matchesMultiRelationFailure
+   * @param hint
+   * @param element_id
+   * @param member_ids
+   * @param member_type
+   * @return
+   */
+  static bool matchesMultiRelationFailure(const QString& hint, long& element_id, std::vector<long>& member_ids, ElementType::Type& member_type);
+  /**
    * @brief matchesChangesetPreconditionFailure
    * @param hint Error message from OSM API
    * @param member_id ID of the member element that caused the element to fail

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmApiWriter.h"


### PR DESCRIPTION
There is a difference between `cgimap` and rails port error messages.  Update the `OsmApiWriter` to recognize both of them so that error handling works better.  Also `cgimap` requires the trailing `/` in the API calls to not be there.  Both work without, so they are removed.