### PR TITLE
Copyright scripts, new decade, new problems

### DIFF
--- a/scripts/copyright/UpdateAllCopyrightHeaders.sh
+++ b/scripts/copyright/UpdateAllCopyrightHeaders.sh
@@ -87,10 +87,25 @@ echo "logFile: " $logFile
 if [ $# -eq 0 ]; then
     updateMode=false
     updateParam=""
+    debugParam=""
 elif [ $# -eq 1 ]; then
     if [ $1 == '--update' ] || [ $1 == '-u' ]; then
         updateMode=true
         updateParam='-u'
+    elif [ $1 == '--debug' ] || [ $1 == '-d' ]; then
+        debugParam='-d'
+    else
+        ExitScript 6  # Unrecognized parameter
+    fi
+elif [ $# -eq 2 ]; then
+    if [ $1 == '--update' ] || [ $2 == '--update' ] || [ $1 == '-u' ] || [ $2 == '-u' ]; then
+        updateMode=true
+        updateParam='-u'
+    else
+        ExitScript 6  # Unrecognized parameter
+    fi
+    if [ $1 == '--debug' ] || [ $2 == '--debug' ] || [ $1 == '-d' ] || [ $2 == '-d' ]; then
+        debugParam='-d'
     else
         ExitScript 6  # Unrecognized parameter
     fi
@@ -104,7 +119,7 @@ if [ ! -f $HOOT_HOME/scripts/copyright/LicenseTemplate.txt ]; then
 fi
 
 # Run the checks in parallel
-parallel --joblog $logJobs $HOOT_HOME/scripts/copyright/UpdateDirCopyrightHeaders.sh {} $logFile $updateParam ::: \
+parallel --joblog $logJobs $HOOT_HOME/scripts/copyright/UpdateDirCopyrightHeaders.sh {} $logFile $updateParam $debugParam ::: \
   $HOOT_HOME/hoot-core \
   $HOOT_HOME/hoot-core-test \
   $HOOT_HOME/hoot-services \

--- a/scripts/copyright/UpdateCopyrightHeader.py
+++ b/scripts/copyright/UpdateCopyrightHeader.py
@@ -15,7 +15,7 @@ import traceback
 def findCopyrightYears(fileName, debugMode):
     dates = run(["git", "log", "--date=short", "--format=format:%ad", fileName]).split()
     years = set()
-    print(("\tfileName: " + fileName) if debugMode else '')
+    print("\tfileName: " + fileName if debugMode else '')
     for l in dates:
         print("\tl: " + l  if debugMode else '')
         years.add(l[0:4])

--- a/scripts/copyright/UpdateDirCopyrightHeaders.sh
+++ b/scripts/copyright/UpdateDirCopyrightHeaders.sh
@@ -9,7 +9,7 @@ case $# in
     0|1)
         exit 2 # Need at least two args log filename and search directory
         ;;
-    2|3)
+    2|3|4)
         if [ ! -d $1 ]; then
             exit 12 # Search directory not found
         fi
@@ -19,10 +19,24 @@ case $# in
         fi
         logFilename=$2
         if [ $# -eq 3 ]; then
-            if [ $3 != '--update' ] && [ $3 != '-u' ]; then
-                exit 4  # Unrecognized update argument
-            else
+            if [ $3 == '--update' ] || [ $3 == '-u' ]; then
                 updateMode=1
+            elif [ $3 == '--debug' ] || [ $3 == '-d' ]; then
+                debugMode='--debug'
+            else
+                exit 4  # Unrecognized argument
+            fi
+        fi
+        if [ $# -eq 4 ]; then
+            if [ $3 == '--update' ] || [ $4 == '--update' ] || [ $3 == '-u' ] || [ $4 == '-u' ]; then
+                updateMode=1
+            else
+                exit 4  # Unrecognized argument
+            fi
+            if [ $3 == '--debug' ] || [ $4 == '--debug' ] || [ $3 == '-d' ] || [ $4 == '-d' ]; then
+                debugMode='--debug'
+            else
+                exit 4  # Unrecognized argument
             fi
         fi
         ;;
@@ -32,7 +46,7 @@ case $# in
 esac
 
 cd $searchDir
-find . -type f -and \( \( -name \*.js -or -name \*.java -or -name \*.cpp -or -name \*.h \) -and -not \( -wholename \*/db2/\* -or -wholename \*/target/\* -or -wholename \*/tmp/\* -or -name \*.pb.h -or -wholename \*/schema/__init__.js -or -wholename \*/etds\*/__init__.js \) \) -exec $HOOT_HOME/scripts/copyright/UpdateCopyrightHeader.py --copyright-header=$LICENSE_TEMPLATE --file={} --update-mode=$updateMode \; >> $logFilename
+find . -type f -and \( \( -name \*.js -or -name \*.java -or -name \*.cpp -or -name \*.h \) -and -not \( -wholename \*/db2/\* -or -wholename \*/target/\* -or -wholename \*/tmp/\* -or -name \*.pb.h -or -wholename \*/schema/__init__.js -or -wholename \*/etds\*/__init__.js \) \) -exec $HOOT_HOME/scripts/copyright/UpdateCopyrightHeader.py --copyright-header=$LICENSE_TEMPLATE --file={} --update-mode=$updateMode $debugMode \; >> $logFilename
 cd ..
 
 echo "Complete: $searchDir"


### PR DESCRIPTION
Updated copyright scripts with debug mode and better year checking logic.  https://github.com/ngageoint/hootenanny/pull/3689 is failing because of bad copyright year logic.  The files are fine but the scripts are saying that they need to be updated.