### PR TITLE
Merge duplicate IDs in readers

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2089,6 +2089,16 @@ A setting of -1 is useful for tests where you do not have granular enough loggin
 A list of map operations to be applied to a map for cleaning purposes, in order.
 'hoot info --operators' displays information about the available transforms.
 
+=== map.merge.ignore.duplicate.ids
+
+* Data Type: bool
+* Default Value: `false`
+
+Option to allow for multiple datasets to be merged into one dataset, while ignoring
+duplicate element IDs.  This allows for two neighboring cells to contain the same way
+that spans both cells and is included in both datasets to not be duplicated when read
+into Hootenanny.
+
 [[match.creators]]
 === match.creators
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
@@ -49,7 +49,7 @@ class ApiDb;
 /**
  * Abstract parent class for reading from an API style OSM database
  */
-class ApiDbReader : public PartialOsmMapReader, public Boundable, public Configurable
+class ApiDbReader : public PartialOsmMapReader, public Boundable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef APIDBREADER_H
 #define APIDBREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
@@ -225,6 +225,7 @@ RelationPtr HootApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, 
 
 void HootApiDbReader::setConfiguration(const Settings& conf)
 {
+  ApiDbReader::setConfiguration(conf);
   ConfigOptions configOptions(conf);
   setMaxElementsPerMap(configOptions.getMaxElementsPerPartialMap());
   setUserEmail(configOptions.getApiDbEmail());

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "HootApiDbReader.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "OsmApiDbReader.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.cpp
@@ -244,6 +244,7 @@ RelationPtr OsmApiDbReader::_resultToRelation(const QSqlQuery& resultIterator, c
 
 void OsmApiDbReader::setConfiguration(const Settings& conf)
 {
+  ApiDbReader::setConfiguration(conf);
   ConfigOptions configOptions(conf);
   setMaxElementsPerMap(configOptions.getMaxElementsPerPartialMap());
   setUserEmail(configOptions.getApiDbEmail());

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -117,13 +117,19 @@ void OsmApiReader::read(const OsmMapPtr& map)
   LOG_VART(_keepStatusTag);
   LOG_VART(_preserveAllTags);
 
-  // clear node id maps in case the reader is used for multiple files
-  _nodeIdMap.clear();
-  _relationIdMap.clear();
-  _wayIdMap.clear();
+  //  Reusing the reader for multiple reads has two options, the first is the
+  //  default where the reader is reset and duplicates error out.  The second
+  //  is where duplicates are ignored in the same dataset and across datasets
+  //  so the ID maps aren't reset
+  if (!_ignoreDuplicates)
+  {
+    _nodeIdMap.clear();
+    _relationIdMap.clear();
+    _wayIdMap.clear();
 
-  _numRead = 0;
-  finalizePartial();
+    _numRead = 0;
+    finalizePartial();
+  }
   _map = map;
   _map->appendSource(_url);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmApiReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -320,6 +320,7 @@ OsmMapPtr OsmJsonReader::loadFromFile(const QString& path)
 
 void OsmJsonReader::setConfiguration(const Settings& conf)
 {
+  OsmMapReader::setConfiguration(conf);
   ConfigOptions opts(conf);
   _coordGridSize = opts.getReaderHttpBboxMaxSize();
   _threadCount = opts.getReaderHttpBboxThreadCount();

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmJsonReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -111,8 +111,7 @@ namespace hoot
  * keeps everything in memory. Be careful if you want to use it with large datasets.
  */
 
-class OsmJsonReader : public OsmMapReader, public Configurable, public Boundable,
-  private ParallelBoundedApiReader
+class OsmJsonReader : public OsmMapReader, public Boundable, private ParallelBoundedApiReader
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef OSM_JSON_READER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReader.h
@@ -29,11 +29,12 @@
 
 // hoot
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/util/Configurable.h>
 
 namespace hoot
 {
 
-class OsmMapReader
+class OsmMapReader : public Configurable
 {
 
 public:
@@ -99,10 +100,16 @@ public:
 
   void setWarnOnVersionZeroElement(bool warn) { _warnOnVersionZeroElement = warn; }
 
+  /** Configurable interface */
+  virtual void setConfiguration(const Settings& conf) override
+  {
+    _ignoreDuplicates =  ConfigOptions(conf).getMapMergeIgnoreDuplicateIds();
+  }
+
 protected:
 
   /**
-   * Ignore the duplicate IDs or throw an error
+   * Ignore the duplicate IDs when merging maps or throw an error
    */
   bool _ignoreDuplicates;
   /** Url of the map to open and read */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMMAPREADER_H
 #define OSMMAPREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmPbfReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
@@ -130,6 +130,7 @@ OsmPbfReader::~OsmPbfReader()
 
 void OsmPbfReader::setConfiguration(const Settings &conf)
 {
+  PartialOsmMapReader::setConfiguration(conf);
   ConfigOptions configOptions(conf);
   setMaxElementsPerMap(configOptions.getMaxElementsPerPartialMap());
   _addSourceDateTime = configOptions.getReaderAddSourceDatetime();

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef OSMPBFREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
@@ -63,7 +63,7 @@ class OsmPbfReaderData;
 /**
  * A reader for http://wiki.openstreetmap.org/wiki/PBF_Format
  */
-class OsmPbfReader : public PartialOsmMapReader, public Configurable
+class OsmPbfReader : public PartialOsmMapReader
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -90,6 +90,7 @@ OsmXmlReader::~OsmXmlReader()
 
 void OsmXmlReader::setConfiguration(const Settings& conf)
 {
+  PartialOsmMapReader::setConfiguration(conf);
   ConfigOptions configOptions(conf);
   setDefaultAccuracy(configOptions.getCircularErrorDefaultValue());
   setKeepStatusTag(configOptions.getReaderKeepStatusTag());
@@ -405,13 +406,19 @@ void OsmXmlReader::read(const OsmMapPtr& map)
   LOG_VART(_keepStatusTag);
   LOG_VART(_preserveAllTags);
 
-  // clear node id maps in case the reader is used for multiple files
-  _nodeIdMap.clear();
-  _relationIdMap.clear();
-  _wayIdMap.clear();
+  //  Reusing the reader for multiple files has two options, the first is the
+  //  default where the reader is reset and duplicates error out.  The second
+  //  is where duplicates are ignored in the same file and across files so the
+  //  ID maps aren't reset
+  if (!_ignoreDuplicates)
+  {
+    _nodeIdMap.clear();
+    _relationIdMap.clear();
+    _wayIdMap.clear();
 
-  _numRead = 0;
-  finalizePartial();
+    _numRead = 0;
+    finalizePartial();
+  }
   _map = map;
   _map->appendSource(_url);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmXmlReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMXMLREADER_H
 #define OSMXMLREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -31,7 +31,6 @@
 #include <hoot/core/elements/Tags.h>
 #include <hoot/core/io/PartialOsmMapReader.h>
 #include <hoot/core/util/Boundable.h>
-#include <hoot/core/util/Configurable.h>
 #include <hoot/core/util/Units.h>
 
 // Qt
@@ -52,8 +51,7 @@ class Element;
 /**
  * Reads in a .osm file into an OsmMap data structure.
  */
-class OsmXmlReader : public QXmlDefaultHandler, public PartialOsmMapReader, public Boundable,
-  public Configurable
+class OsmXmlReader : public QXmlDefaultHandler, public PartialOsmMapReader, public Boundable
 {
 public:
 

--- a/test-files/io/OsmXmlReaderTest/IgnoreDuplicateMergeTest-1.osm
+++ b/test-files/io/OsmXmlReaderTest/IgnoreDuplicateMergeTest-1.osm
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' upload='true' generator='JOSM'>
+  <node id='93' visible='true' version='1' lat='38.854932126188054' lon='-104.89790503334821' />
+  <node id='91' visible='true' version='1' lat='38.85495241856606' lon='-104.8987388916486' />
+  <node id='89' visible='true' version='1' lat='38.85405413708911' lon='-104.90243160996913' />
+  <node id='87' visible='true' version='1' lat='38.85412989620596' lon='-104.90230653122407' />
+  <node id='85' visible='true' version='1' lat='38.85433192012303' lon='-104.90178768605938' />
+  <node id='83' visible='true' version='1' lat='38.854820743476886' lon='-104.90080790255647' />
+  <node id='81' visible='true' version='1' lat='38.85492896959543' lon='-104.90052531724356' />
+  <node id='77' visible='true' version='1' lat='38.854907324384904' lon='-104.89618230526239' />
+  <node id='75' visible='true' version='1' lat='38.85490191308125' lon='-104.89643941157165' />
+  <node id='73' visible='true' version='1' lat='38.85486042640616' lon='-104.89685865699488' />
+  <node id='71' visible='true' version='1' lat='38.85471973228434' lon='-104.89732191160624' />
+  <node id='69' visible='true' version='1' lat='38.85460429074575' lon='-104.89777590112531' />
+  <node id='67' visible='true' version='1' lat='38.854429324306594' lon='-104.89806543525738' />
+  <node id='65' visible='true' version='1' lat='38.85423271202119' lon='-104.89831096020139' />
+  <node id='63' visible='true' version='1' lat='38.854176794666444' lon='-104.89870704289406' />
+  <node id='61' visible='true' version='1' lat='38.854133503780936' lon='-104.89889002846552' />
+  <node id='59' visible='true' version='1' lat='38.85395853618365' lon='-104.89891550746917' />
+  <node id='57' visible='true' version='1' lat='38.85372043525673' lon='-104.89872325680547' />
+  <node id='55' visible='true' version='1' lat='38.85361942250148' lon='-104.89870704289406' />
+  <node id='53' visible='true' version='1' lat='38.85355087805014' lon='-104.89883212163912' />
+  <node id='51' visible='true' version='1' lat='38.85356891607005' lon='-104.8990568001256' />
+  <node id='49' visible='true' version='1' lat='38.8535166057997' lon='-104.8992698972468' />
+  <node id='47' visible='true' version='1' lat='38.8533470481072' lon='-104.89936718071519' />
+  <node id='45' visible='true' version='1' lat='38.8533001490996' lon='-104.8994528828183' />
+  <node id='43' visible='true' version='1' lat='38.853242427201664' lon='-104.899686826397' />
+  <node id='41' visible='true' version='1' lat='38.85325834778415' lon='-104.89975429288518' />
+  <node id='39' visible='true' version='1' lat='38.85362484566662' lon='-104.8996934957528' />
+  <node id='37' visible='true' version='1' lat='38.85395255229987' lon='-104.89968403931628' />
+  <node id='35' visible='true' version='1' lat='38.85426184706307' lon='-104.89971713684409' />
+  <node id='33' visible='true' version='1' lat='38.85457850459384' lon='-104.89971713684409' />
+  <node id='31' visible='true' version='1' lat='38.854961437398885' lon='-104.89971240862585' />
+  <node id='23' visible='true' version='1' lat='38.85416700189076' lon='-104.89970698747904' />
+  <way id='801' visible='true' version='1'>
+    <nd ref='31' />
+    <nd ref='91' />
+    <nd ref='93' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='1' />
+  </way>
+  <way id='797' visible='true' version='1'>
+    <nd ref='89' />
+    <nd ref='87' />
+    <nd ref='85' />
+    <nd ref='83' />
+    <nd ref='81' />
+    <nd ref='31' />
+    <nd ref='33' />
+    <nd ref='35' />
+    <nd ref='23' />
+    <nd ref='37' />
+    <nd ref='39' />
+    <nd ref='41' />
+    <nd ref='43' />
+    <nd ref='45' />
+    <nd ref='47' />
+    <nd ref='49' />
+    <nd ref='51' />
+    <nd ref='53' />
+    <nd ref='55' />
+    <nd ref='57' />
+    <nd ref='59' />
+    <nd ref='61' />
+    <nd ref='63' />
+    <nd ref='65' />
+    <nd ref='67' />
+    <nd ref='69' />
+    <nd ref='71' />
+    <nd ref='73' />
+    <nd ref='75' />
+    <nd ref='77' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='0' />
+  </way>
+</osm>

--- a/test-files/io/OsmXmlReaderTest/IgnoreDuplicateMergeTest-2.osm
+++ b/test-files/io/OsmXmlReaderTest/IgnoreDuplicateMergeTest-2.osm
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' upload='true' generator='JOSM'>
+  <node id='89' visible='true' version='1' lat='38.85405413708911' lon='-104.90243160996913' />
+  <node id='87' visible='true' version='1' lat='38.85412989620596' lon='-104.90230653122407' />
+  <node id='85' visible='true' version='1' lat='38.85433192012303' lon='-104.90178768605938' />
+  <node id='83' visible='true' version='1' lat='38.854820743476886' lon='-104.90080790255647' />
+  <node id='81' visible='true' version='1' lat='38.85492896959543' lon='-104.90052531724356' />
+  <node id='79' visible='true' version='1' lat='38.854851407560524' lon='-104.90056932643164' />
+  <node id='77' visible='true' version='1' lat='38.854907324384904' lon='-104.89618230526239' />
+  <node id='75' visible='true' version='1' lat='38.85490191308125' lon='-104.89643941157165' />
+  <node id='73' visible='true' version='1' lat='38.85486042640616' lon='-104.89685865699488' />
+  <node id='71' visible='true' version='1' lat='38.85471973228434' lon='-104.89732191160624' />
+  <node id='69' visible='true' version='1' lat='38.85460429074575' lon='-104.89777590112531' />
+  <node id='67' visible='true' version='1' lat='38.854429324306594' lon='-104.89806543525738' />
+  <node id='65' visible='true' version='1' lat='38.85423271202119' lon='-104.89831096020139' />
+  <node id='63' visible='true' version='1' lat='38.854176794666444' lon='-104.89870704289406' />
+  <node id='61' visible='true' version='1' lat='38.854133503780936' lon='-104.89889002846552' />
+  <node id='59' visible='true' version='1' lat='38.85395853618365' lon='-104.89891550746917' />
+  <node id='57' visible='true' version='1' lat='38.85372043525673' lon='-104.89872325680547' />
+  <node id='55' visible='true' version='1' lat='38.85361942250148' lon='-104.89870704289406' />
+  <node id='53' visible='true' version='1' lat='38.85355087805014' lon='-104.89883212163912' />
+  <node id='51' visible='true' version='1' lat='38.85356891607005' lon='-104.8990568001256' />
+  <node id='49' visible='true' version='1' lat='38.8535166057997' lon='-104.8992698972468' />
+  <node id='47' visible='true' version='1' lat='38.8533470481072' lon='-104.89936718071519' />
+  <node id='45' visible='true' version='1' lat='38.8533001490996' lon='-104.8994528828183' />
+  <node id='43' visible='true' version='1' lat='38.853242427201664' lon='-104.899686826397' />
+  <node id='41' visible='true' version='1' lat='38.85325834778415' lon='-104.89975429288518' />
+  <node id='39' visible='true' version='1' lat='38.85362484566662' lon='-104.8996934957528' />
+  <node id='37' visible='true' version='1' lat='38.85395255229987' lon='-104.89968403931628' />
+  <node id='35' visible='true' version='1' lat='38.85426184706307' lon='-104.89971713684409' />
+  <node id='33' visible='true' version='1' lat='38.85457850459384' lon='-104.89971713684409' />
+  <node id='31' visible='true' version='1' lat='38.854961437398885' lon='-104.89971240862585' />
+  <node id='29' visible='true' version='1' lat='38.854259968774734' lon='-104.90057951047994' />
+  <node id='27' visible='true' version='1' lat='38.85424711877152' lon='-104.90107886370333' />
+  <node id='25' visible='true' version='1' lat='38.85408510736308' lon='-104.90144766472771' />
+  <node id='23' visible='true' version='1' lat='38.85416700189076' lon='-104.89970698747904' />
+  <way id='799' visible='true' version='1'>
+    <nd ref='29' />
+    <nd ref='79' />
+    <nd ref='81' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='3' />
+  </way>
+  <way id='797' visible='true' version='1'>
+    <nd ref='89' />
+    <nd ref='87' />
+    <nd ref='85' />
+    <nd ref='83' />
+    <nd ref='81' />
+    <nd ref='31' />
+    <nd ref='33' />
+    <nd ref='35' />
+    <nd ref='23' />
+    <nd ref='37' />
+    <nd ref='39' />
+    <nd ref='41' />
+    <nd ref='43' />
+    <nd ref='45' />
+    <nd ref='47' />
+    <nd ref='49' />
+    <nd ref='51' />
+    <nd ref='53' />
+    <nd ref='55' />
+    <nd ref='57' />
+    <nd ref='59' />
+    <nd ref='61' />
+    <nd ref='63' />
+    <nd ref='65' />
+    <nd ref='67' />
+    <nd ref='69' />
+    <nd ref='71' />
+    <nd ref='73' />
+    <nd ref='75' />
+    <nd ref='77' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='0' />
+  </way>
+  <way id='795' visible='true' version='1'>
+    <nd ref='25' />
+    <nd ref='27' />
+    <nd ref='29' />
+    <nd ref='35' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='2' />
+  </way>
+</osm>

--- a/test-files/io/OsmXmlReaderTest/IgnoreDuplicateMergeTest.osm
+++ b/test-files/io/OsmXmlReaderTest/IgnoreDuplicateMergeTest.osm
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324242720166" minlon="-104.9024316099691" maxlat="38.85496143739888" maxlon="-104.8961823052624"/>
+    <node visible="true" id="23" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907581" lon="-104.8997069874790355"/>
+    <node visible="true" id="25" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540851073630833" lon="-104.9014476647277121"/>
+    <node visible="true" id="27" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542471187715179" lon="-104.9010788637033329"/>
+    <node visible="true" id="29" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542599687747341" lon="-104.9005795104799432"/>
+    <node visible="true" id="31" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452"/>
+    <node visible="true" id="33" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938388" lon="-104.8997171368440888"/>
+    <node visible="true" id="35" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630714" lon="-104.8997171368440888"/>
+    <node visible="true" id="37" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998730" lon="-104.8996840393162842"/>
+    <node visible="true" id="39" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666229" lon="-104.8996934957527998"/>
+    <node visible="true" id="41" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841484" lon="-104.8997542928851772"/>
+    <node visible="true" id="43" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016641" lon="-104.8996868263970015"/>
+    <node visible="true" id="45" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951"/>
+    <node visible="true" id="47" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481072030" lon="-104.8993671807151884"/>
+    <node visible="true" id="49" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057996975" lon="-104.8992698972467963"/>
+    <node visible="true" id="51" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700528" lon="-104.8990568001256065"/>
+    <node visible="true" id="53" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501431" lon="-104.8988321216391171"/>
+    <node visible="true" id="55" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598"/>
+    <node visible="true" id="57" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679"/>
+    <node visible="true" id="59" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836473" lon="-104.8989155074691695"/>
+    <node visible="true" id="61" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809361" lon="-104.8988900284655159"/>
+    <node visible="true" id="63" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598"/>
+    <node visible="true" id="65" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013855"/>
+    <node visible="true" id="67" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794"/>
+    <node visible="true" id="69" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457476" lon="-104.8977759011253141"/>
+    <node visible="true" id="71" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410"/>
+    <node visible="true" id="73" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061623" lon="-104.8968586569948798"/>
+    <node visible="true" id="75" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812496" lon="-104.8964394115716487"/>
+    <node visible="true" id="77" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856"/>
+    <node visible="true" id="79" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548514075605240" lon="-104.9005693264316363"/>
+    <node visible="true" id="81" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954272" lon="-104.9005253172435630"/>
+    <node visible="true" id="83" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564655"/>
+    <node visible="true" id="85" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788"/>
+    <node visible="true" id="87" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703"/>
+    <node visible="true" id="89" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276"/>
+    <node visible="true" id="91" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054"/>
+    <node visible="true" id="93" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880536" lon="-104.8979050333482093"/>
+    <way visible="true" id="795" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="25"/>
+        <nd ref="27"/>
+        <nd ref="29"/>
+        <nd ref="35"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="2"/>
+    </way>
+    <way visible="true" id="797" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="89"/>
+        <nd ref="87"/>
+        <nd ref="85"/>
+        <nd ref="83"/>
+        <nd ref="81"/>
+        <nd ref="31"/>
+        <nd ref="33"/>
+        <nd ref="35"/>
+        <nd ref="23"/>
+        <nd ref="37"/>
+        <nd ref="39"/>
+        <nd ref="41"/>
+        <nd ref="43"/>
+        <nd ref="45"/>
+        <nd ref="47"/>
+        <nd ref="49"/>
+        <nd ref="51"/>
+        <nd ref="53"/>
+        <nd ref="55"/>
+        <nd ref="57"/>
+        <nd ref="59"/>
+        <nd ref="61"/>
+        <nd ref="63"/>
+        <nd ref="65"/>
+        <nd ref="67"/>
+        <nd ref="69"/>
+        <nd ref="71"/>
+        <nd ref="73"/>
+        <nd ref="75"/>
+        <nd ref="77"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+    </way>
+    <way visible="true" id="799" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="29"/>
+        <nd ref="79"/>
+        <nd ref="81"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="3"/>
+    </way>
+    <way visible="true" id="801" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="31"/>
+        <nd ref="91"/>
+        <nd ref="93"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+    </way>
+</osm>


### PR DESCRIPTION
It was requested to allow readers to open multiple datasets that share overlapping elements, for example a way that spans both bounding boxes and is contained in both datasets.  If the elements are overlapping (checked by type and ID only) then all instances after the first are completely ignored.  There is no comparisons, conflating, or merging done, everything after the first instance is dropped.  In the use case, matching IDs indicate it is the same exact element and nothing has changed with it.  In order to enable this option add `-D map.merge.ignore.duplicate.ids=true` to the `hoot` command.