### PR TITLE
Disable services tests when no services are enabled

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/auth/ServicesHootServicesLoginManagerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/auth/ServicesHootServicesLoginManagerTest.cpp
@@ -228,6 +228,8 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServicesHootServicesLoginManagerTest, "slow");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/auth/ServicesHootServicesLoginManagerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/auth/ServicesHootServicesLoginManagerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -152,6 +152,8 @@ private:
   QString _testName;
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceHootApiDbBulkInserterTest, "slow");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbReaderTest.cpp
@@ -991,6 +991,8 @@ private:
   QString _testName;
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceHootApiDbReaderTest, "slow");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -659,6 +659,8 @@ public:
 
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceHootApiDbTest, "slow");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -553,6 +553,8 @@ private:
   QString _testName;
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceHootApiDbWriterTest, "slow");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
@@ -661,7 +661,9 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbBulkInserterTest, "slow");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbBulkInserterTest, "serial");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbBulkInserterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbReaderTest.cpp
@@ -433,7 +433,9 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbReaderTest, "slow");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbReaderTest, "serial");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
@@ -284,7 +284,9 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbSqlChangesetApplierTest, "slow");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbSqlChangesetApplierTest, "serial");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetApplierTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbSqlChangesetFileWriterTest.cpp
@@ -76,7 +76,9 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbSqlChangesetFileWriterTest, "quick");
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbSqlChangesetFileWriterTest, "serial");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
@@ -62,6 +62,8 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceOsmApiDbTest, "slow");
+#endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceOsmApiDbTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -46,6 +46,8 @@
 // Tgs
 #include <tgs/StreamUtils.h>
 
+#ifdef HOOT_HAVE_SERVICES
+
 using namespace std;
 using namespace Tgs;
 
@@ -364,3 +366,4 @@ std::shared_ptr<HootNetworkCookieJar> ServicesDbTestUtils::getTestSessionCookie(
 
 }
 
+#endif  // HOOT_HAVE_SERVICES

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ServicesDbTestUtils.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SERVICESDBTESTUTILS_H
 #define SERVICESDBTESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
@@ -37,6 +37,8 @@
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/io/HootNetworkCookieJar.h>
 
+#ifdef HOOT_HAVE_SERVICES
+
 namespace hoot
 {
 
@@ -105,5 +107,7 @@ private:
 };
 
 }
+
+#endif // HOOT_HAVE_SERVICES
 
 #endif // SERVICESDBTESTUTILS_H

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageDetectorClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageDetectorClientTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageDetectorClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageDetectorClientTest.cpp
@@ -118,7 +118,9 @@ private:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(HootServicesLanguageDetectorClientTest, "quick");
+#endif  // HOOT_HAVE_SERVICES
 
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoClientTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoClientTest.cpp
@@ -59,7 +59,9 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(HootServicesLanguageInfoClientTest, "quick");
+#endif  // HOOT_HAVE_SERVICES
 
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoResponseParserTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoResponseParserTest.cpp
@@ -115,7 +115,9 @@ public:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(HootServicesLanguageInfoResponseParserTest, "quick");
+#endif  // HOOT_HAVE_SERVICES
 
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoResponseParserTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesLanguageInfoResponseParserTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesTranslatorClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesTranslatorClientTest.cpp
@@ -142,7 +142,9 @@ private:
   }
 };
 
+#ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(HootServicesTranslatorClientTest, "quick");
+#endif  // HOOT_HAVE_SERVICES
 
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesTranslatorClientTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/language/HootServicesTranslatorClientTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -475,8 +475,10 @@ bool OsmApiWriter::queryCapabilities(HootNetworkRequestPtr request)
     capabilities.setPath(API_PATH_CAPABILITIES);
     request->networkRequest(capabilities);
     QString responseXml = QString::fromUtf8(request->getResponseContent().data());
-    LOG_DEBUG("Capabilities: " << capabilities.toString(QUrl::RemoveUserInfo));
-    LOG_DEBUG("Response: " << responseXml);
+    QString printableUrl = capabilities.toString(QUrl::RemoveUserInfo);
+    HootNetworkRequest::removeIpFromUrlString(printableUrl, capabilities);
+    LOG_TRACE("Capabilities: " << printableUrl);
+    LOG_TRACE("Response: " << responseXml);
     _capabilities = _parseCapabilities(responseXml);
   }
   catch (const HootException& ex)
@@ -558,7 +560,7 @@ bool OsmApiWriter::_parsePermissions(const QString& permissions)
 {
   QXmlStreamReader reader(permissions);
 
-  LOG_DEBUG("Permissions: " << permissions);
+  LOG_TRACE("Permissions: " << permissions);
 
   while (!reader.atEnd() && !reader.hasError())
   {


### PR DESCRIPTION
Quite a few of the services tests are still enabled when `--with-services` isn't provided to configure this is causing issues in the `TestConfigure.sh` script where the database isn't created but is needed for these tests.