### PR TITLE
Ignore duplicate IDs bulk insert

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -64,9 +64,10 @@ namespace hoot
 int HootApiDb::logWarnCount = 0;
 
 HootApiDb::HootApiDb() :
-_precision(ConfigOptions().getWriterPrecision()),
-_createIndexesOnClose(true),
-_flushOnClose(true)
+  _ignoreInsertConflicts(ConfigOptions().getMapMergeIgnoreDuplicateIds()),
+  _precision(ConfigOptions().getWriterPrecision()),
+  _createIndexesOnClose(true),
+  _flushOnClose(true)
 {
   _init();
 }
@@ -803,7 +804,7 @@ bool HootApiDb::insertNode(const long id, const double lat, const double lon, co
     columns << "id" << "latitude" << "longitude" << "changeset_id" << "timestamp" <<
                "tile" << "version" << "tags";
 
-    _nodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentNodesTableName(mapId), columns));
+    _nodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentNodesTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;
@@ -899,7 +900,7 @@ bool HootApiDb::insertRelation(const long relationId, const Tags &tags)
     QStringList columns;
     columns << "id" << "changeset_id" << "timestamp" << "version" << "tags";
 
-    _relationBulkInsert.reset(new SqlBulkInsert(_db, getCurrentRelationsTableName(mapId), columns));
+    _relationBulkInsert.reset(new SqlBulkInsert(_db, getCurrentRelationsTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;
@@ -2250,7 +2251,7 @@ bool HootApiDb::insertWay(const long wayId, const Tags &tags)
     QStringList columns;
     columns << "id" << "changeset_id" << "timestamp" << "version" << "tags";
 
-    _wayBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWaysTableName(mapId), columns));
+    _wayBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWaysTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;
@@ -2294,7 +2295,7 @@ void HootApiDb::insertWayNodes(long wayId, const vector<long>& nodeIds)
     QStringList columns;
     columns << "way_id" << "node_id" << "sequence_id";
 
-    _wayNodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWayNodesTableName(mapId), columns));
+    _wayNodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWayNodesTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "HootApiDb.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -629,6 +629,9 @@ private:
   std::shared_ptr<QSqlQuery> _getJobStatusResourceId;
   std::shared_ptr<QSqlQuery> _updateIdSequence;
 
+  /** Ignore any insertion conflicts and continue with the rest */
+  bool _ignoreInsertConflicts;
+
   std::shared_ptr<BulkInsert> _nodeBulkInsert;
   long _nodesPerBulkInsert;
   double _nodesInsertElapsed;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HOOTAPIDB_H
 #define HOOTAPIDB_H

--- a/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "SqlBulkInsert.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.cpp
@@ -43,10 +43,11 @@ namespace hoot
 {
 
 SqlBulkInsert::SqlBulkInsert(QSqlDatabase& db, const QString &tableName,
-  const QStringList &columns) :
+  const QStringList &columns, bool ignoreConflict) :
     _db(db),
     _tableName(tableName),
-    _columns(columns)
+    _columns(columns),
+    _ignoreConflict(ignoreConflict)
 {
   _time = 0;
   _true = "TRUE";
@@ -139,6 +140,11 @@ void SqlBulkInsert::flush()
 
       sql.append(closeParen);
     }
+
+    //  ON CONFLICT DO NOTHING simply ignores each inserted row that violates an
+    //  arbiter constraint or index
+    if (_ignoreConflict)
+      sql.append(" ON CONFLICT DO NOTHING");
 
     LOG_VART(sql);
     QSqlQuery q(_db);

--- a/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SQLBULKINSERT_H
 #define SQLBULKINSERT_H

--- a/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.h
@@ -44,7 +44,7 @@ namespace hoot
 class SqlBulkInsert : public BulkInsert
 {
 public:
-  SqlBulkInsert(QSqlDatabase& db, const QString& tableName, const QStringList& columns);
+  SqlBulkInsert(QSqlDatabase& db, const QString& tableName, const QStringList& columns, bool ignoreConflict = false);
 
   virtual ~SqlBulkInsert();
 
@@ -62,6 +62,7 @@ private:
   QSqlDatabase _db;
   QString _tableName;
   QStringList _columns;
+  bool _ignoreConflict;
   double _time;
   QString _true, _false;
 


### PR DESCRIPTION
Added `ON CONFLICT DO NOTHING` to bulk inserts so that conflicting IDs are ignored.

See [this](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT) for more information.