### PR TITLE
3738 - Error out early if bad operator class names are provided for select config opts

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/SettingsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ClosePointHash.h"

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
@@ -69,12 +69,9 @@ vector<long> ClosePointHash::getMatchesFor(long id)
 {
   vector<long> ids;
 
-  const std::vector<int64_t> bins = _idTobin[id];
-  for (std::vector<int64_t>::const_iterator it = bins.begin(); it != bins.end(); ++it)
+  foreach (int64_t binIx, _idTobin[id])
   {
-    const int64_t binIx = *it;
-    const std::vector<long> binIds = _bins[binIx];
-    ids.insert(ids.end(), binIds.begin(), binIds.end());
+    ids.insert(ids.end(), _bins[binIx].begin(), _bins[binIx].end());
   }
 
   // remove duplicates

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
@@ -69,9 +69,12 @@ vector<long> ClosePointHash::getMatchesFor(long id)
 {
   vector<long> ids;
 
-  foreach (int64_t binIx, _idTobin[id])
+  const std::vector<int64_t> bins = _idTobin[id];
+  for (std::vector<int64_t>::const_iterator it = bins.begin(); it != bins.end(); ++it)
   {
-    ids.insert(ids.end(), _bins[binIx].begin(), _bins[binIx].end());
+    const int64_t binIx = *it;
+    const std::vector<long> binIds = _bins[binIx];
+    ids.insert(ids.end(), binIds.begin(), binIds.end());
   }
 
   // remove duplicates

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
@@ -145,10 +145,12 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
       {
         bool replace = false;
         double calcdDistanceSquared = -1.0;
-        if (matchIdI != v[j] && map->containsNode(v[j]))
+        const long matchIdJ = v[j];
+
+        if (matchIdI != matchIdJ && map->containsNode(matchIdJ))
         {
           const NodePtr& n1 = planar->getNode(matchIdI);
-          const NodePtr& n2 = planar->getNode(v[j]);
+          const NodePtr& n2 = planar->getNode(matchIdJ);
           LOG_VART(n1);
           LOG_VART(n2);
 
@@ -168,7 +170,7 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               else
               {
                 const NodePtr& g1 = wgs84->getNode(matchIdI);
-                const NodePtr& g2 = wgs84->getNode(v[j]);
+                const NodePtr& g2 = wgs84->getNode(matchIdJ);
                 if (_bounds.contains(g1->getX(), g1->getY()) &&
                     _bounds.contains(g2->getX(), g2->getY()))
                 {
@@ -186,9 +188,9 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               if (replace)
               {
                 LOG_TRACE(
-                  "Merging nodes: " << ElementId(ElementType::Node, v[j]) << " and " <<
+                  "Merging nodes: " << ElementId(ElementType::Node, matchIdJ) << " and " <<
                   ElementId(ElementType::Node, matchIdI) << "...");
-                map->replaceNode(v[j], matchIdI);
+                map->replaceNode(matchIdJ, matchIdI);
                 _numAffected++;
               }
             }
@@ -201,12 +203,12 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
           if (calcdDistanceSquared != -1.0)
           {
             _logMergeResult(
-              matchIdI, v[j], map, replace, std::sqrt(distanceSquared),
+              matchIdI, matchIdJ, map, replace, std::sqrt(distanceSquared),
               std::sqrt(calcdDistanceSquared));
           }
           else
           {
-            _logMergeResult(matchIdI, v[j], map, replace);
+            _logMergeResult(matchIdI, matchIdJ, map, replace);
           }
         }
       }

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
@@ -127,25 +127,27 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
   LOG_VART(cph.size());
 
   double distanceSquared = _distance * _distance;
-
   int processedCount = 0;
   cph.resetIterator();
   ExactTagDifferencer tagDiff;
+
   while (cph.next())
   {
     const std::vector<long>& v = cph.getMatch();
 
     for (size_t i = 0; i < v.size(); i++)
     {
-      if (!map->containsNode(v[i])) continue;
+      const long matchIdI = v[i];
+
+      if (!map->containsNode(matchIdI)) continue;
 
       for (size_t j = 0; j < v.size(); j++)
       {
         bool replace = false;
         double calcdDistanceSquared = -1.0;
-        if (v[i] != v[j] && map->containsNode(v[j]))
+        if (matchIdI != v[j] && map->containsNode(v[j]))
         {
-          const NodePtr& n1 = planar->getNode(v[i]);
+          const NodePtr& n1 = planar->getNode(matchIdI);
           const NodePtr& n2 = planar->getNode(v[j]);
           LOG_VART(n1);
           LOG_VART(n2);
@@ -165,7 +167,7 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               // if the geographic bounds are specified, then make sure both points are inside.
               else
               {
-                const NodePtr& g1 = wgs84->getNode(v[i]);
+                const NodePtr& g1 = wgs84->getNode(matchIdI);
                 const NodePtr& g2 = wgs84->getNode(v[j]);
                 if (_bounds.contains(g1->getX(), g1->getY()) &&
                     _bounds.contains(g2->getX(), g2->getY()))
@@ -185,8 +187,8 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               {
                 LOG_TRACE(
                   "Merging nodes: " << ElementId(ElementType::Node, v[j]) << " and " <<
-                  ElementId(ElementType::Node, v[i]) << "...");
-                map->replaceNode(v[j], v[i]);
+                  ElementId(ElementType::Node, matchIdI) << "...");
+                map->replaceNode(v[j], matchIdI);
                 _numAffected++;
               }
             }
@@ -199,12 +201,12 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
           if (calcdDistanceSquared != -1.0)
           {
             _logMergeResult(
-              v[i], v[j], map, replace, std::sqrt(distanceSquared),
+              matchIdI, v[j], map, replace, std::sqrt(distanceSquared),
               std::sqrt(calcdDistanceSquared));
           }
           else
           {
-            _logMergeResult(v[i], v[j], map, replace);
+            _logMergeResult(matchIdI, v[j], map, replace);
           }
         }
       }

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
@@ -127,30 +127,26 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
   LOG_VART(cph.size());
 
   double distanceSquared = _distance * _distance;
+
   int processedCount = 0;
   cph.resetIterator();
   ExactTagDifferencer tagDiff;
-
   while (cph.next())
   {
     const std::vector<long>& v = cph.getMatch();
 
     for (size_t i = 0; i < v.size(); i++)
     {
-      const long matchI = v[i];
-
-      if (!map->containsNode(matchI)) continue;
+      if (!map->containsNode(v[i])) continue;
 
       for (size_t j = 0; j < v.size(); j++)
       {
         bool replace = false;
         double calcdDistanceSquared = -1.0;
-        const long matchJ = v[j];
-
-        if (matchI != matchJ && map->containsNode(matchJ))
+        if (v[i] != v[j] && map->containsNode(v[j]))
         {
-          const NodePtr& n1 = planar->getNode(matchI);
-          const NodePtr& n2 = planar->getNode(matchJ);
+          const NodePtr& n1 = planar->getNode(v[i]);
+          const NodePtr& n2 = planar->getNode(v[j]);
           LOG_VART(n1);
           LOG_VART(n2);
 
@@ -169,8 +165,8 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               // if the geographic bounds are specified, then make sure both points are inside.
               else
               {
-                const NodePtr& g1 = wgs84->getNode(matchI);
-                const NodePtr& g2 = wgs84->getNode(matchJ);
+                const NodePtr& g1 = wgs84->getNode(v[i]);
+                const NodePtr& g2 = wgs84->getNode(v[j]);
                 if (_bounds.contains(g1->getX(), g1->getY()) &&
                     _bounds.contains(g2->getX(), g2->getY()))
                 {
@@ -188,9 +184,9 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               if (replace)
               {
                 LOG_TRACE(
-                  "Merging nodes: " << ElementId(ElementType::Node, matchJ) << " and " <<
-                  ElementId(ElementType::Node, matchI) << "...");
-                map->replaceNode(matchI, matchJ);
+                  "Merging nodes: " << ElementId(ElementType::Node, v[j]) << " and " <<
+                  ElementId(ElementType::Node, v[i]) << "...");
+                map->replaceNode(v[j], v[i]);
                 _numAffected++;
               }
             }
@@ -203,12 +199,12 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
           if (calcdDistanceSquared != -1.0)
           {
             _logMergeResult(
-              matchI, matchJ, map, replace, std::sqrt(distanceSquared),
+              v[i], v[j], map, replace, std::sqrt(distanceSquared),
               std::sqrt(calcdDistanceSquared));
           }
           else
           {
-            _logMergeResult(matchI, matchJ, map, replace);
+            _logMergeResult(v[i], v[j], map, replace);
           }
         }
       }

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef CONFIGURATION_H

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -101,7 +101,8 @@ public:
 
   double getDouble(const QString& key) const;
   double getDouble(const QString& key, double defaultValue) const;
-  double getDouble(const QString& key, double defaultValue, double minValue, double maxValue ) const;
+  double getDouble(const QString& key, double defaultValue, double minValue,
+                   double maxValue ) const;
   /**
    * Returns the double represented in the supplied string. Where necessary variables will be
    * resolved.
@@ -136,10 +137,11 @@ public:
    * Parses common arguments (e.g. "-D foo=bar --debug")
    * Any arguments parsed are removed from args.
    */
-  static void parseCommonArguments(QStringList &args);
+  static void parseCommonArguments(QStringList& args);
 
   void set(const QString& key, const char* value) { set(key, QString(value)); }
-  void set(const QString& key, const std::string& value) { set(key, QString::fromStdString(value)); }
+  void set(const QString& key, const std::string& value)
+  { set(key, QString::fromStdString(value)); }
   void set(const QString& key, const QString& value);
   void set(const QString& key, double value) { _settings[key] = QVariant(value); }
   void set(const QString& key, int value) { _settings[key] = QVariant(value); }
@@ -176,6 +178,12 @@ private:
   QString _replaceVariables(const QString& key, std::set<QString> used) const;
   QString _replaceVariablesValue(QString value) const;
   QString _replaceVariablesValue(QString value, std::set<QString> used) const;
+
+  /*
+   * This validates input for options that take a list of hoot operators (factory configurable
+   * ElementVisitor or OsmMapOperation)
+   */
+  static void _validateOperatorRefs(const QStringList& operators);
 };
 
 inline Settings& conf() { return Settings::getInstance(); }

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdditionalFiltersChainedTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdditionalFiltersChainedTest.sh
@@ -9,5 +9,7 @@ set -e
 # - Should see "Sanchez Elementary School" in the reference data conflated with "Sanchez Preschool" in the secondary data, since "Sanchez 
 #   Elementary School" in the ref data overlaps with that school in the sec data. 
 # - Nothing else in the reference dataset should be modified or removed. Nothing else from the secondary dataset should have been added.
+#
+# TODO: change all of these scripts to assign a variable name for each input beforehand to make this easier to read
 
 test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdditionalFiltersChainedTest" "test-files/cmd/glacial/PoiPolygonConflateStandaloneTest/PoiPolygon1.osm" "test-files/cmd/glacial/PoiPolygonConflateStandaloneTest/PoiPolygon2.osm" "-122.43208,37.76075,-122.42892,37.7647" "-122.43384,37.76069,-122.42742,37.76869" "false" "true" "hoot::PoiCriterion" "hoot::TagCriterion;hoot::TagContainsCriterion" "true" "tag.criterion.kvps='amenity=school';tag.contains.criterion.kvps='name=Preschool'" "hoot::TagCriterion;hoot::TagContainsCriterion" "true" "tag.criterion.kvps='amenity=school';tag.contains.criterion.kvps='name=School'" "xml"

--- a/test-files/cmd/quick/ConflateUnknownOptionTest.sh
+++ b/test-files/cmd/quick/ConflateUnknownOptionTest.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-hoot conflate -D conflate.post.ops-=hoot::unknownoption input1.osm input2.osm output.osm

--- a/test-files/cmd/quick/ConflateUnknownOptionTest.sh.stderr
+++ b/test-files/cmd/quick/ConflateUnknownOptionTest.sh.stderr
@@ -1,2 +1,0 @@
-Error running conflate:
-Unknown default value: (hoot::unknownoption)


### PR DESCRIPTION
* Validates that class inputs are either a `OsmMapOperation`, `ElementVisitor`, or `ElementCriterion` for the following opts:
  * `convert.ops`
  * `conflate.pre.ops`
  * `conflate.post.ops`
* Moved test functionality from `ConflateUnknownOptionTest.sh` into `SettingsTest`