### PR TITLE
3755 - Remove script matching memory/processing bottleneck

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchBoundsCalculator.cpp
@@ -42,6 +42,11 @@ SearchBoundsCalculator::SearchBoundsCalculator(const SearchRadiusProviderPtr& ra
 Envelope SearchBoundsCalculator::calculateSearchBounds(const ConstOsmMapPtr& map,
   const ConstNodePtr& n) const
 {
+  // This is likely to cause some performance issues, but only seems to be called by Multiary code
+  // and not doing it here is causing ScriptMatchCreator crashes...so will deal with performance
+  // issue when necessary.
+  _radiusProvider->init(map);
+
   LOG_VART(map->getElementCount());
   LOG_VART(n->getElementId());
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchBoundsCalculator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "SearchBoundsCalculator.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SEARCHRADIUSPROVIDER_H
 #define SEARCHRADIUSPROVIDER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
@@ -42,6 +42,8 @@ public:
 
   ~SearchRadiusProvider() {}
 
+  virtual void init(const ConstOsmMapPtr& /*map*/) {}
+
   /**
    * Returns the search radius for the given element.
    */

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
@@ -42,6 +42,9 @@ public:
 
   ~SearchRadiusProvider() {}
 
+  /**
+   * Optional init
+   */
   virtual void init(const ConstOsmMapPtr& /*map*/) {}
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -327,7 +327,7 @@ void HighwayMatchCreator::createMatches(
 {
   QElapsedTimer timer;
   timer.start();
-  LOG_STATUS("Looking for matches with: " << className() << "...");
+  LOG_DEBUG("Looking for matches with: " << className() << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HIGHWAYMATCHCREATOR_H
 #define HIGHWAYMATCHCREATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -71,6 +71,8 @@ public:
 
   virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
+  virtual QString getName() const { return QString::fromStdString(className()); }
+
 private:
 
   std::shared_ptr<HighwayClassifier> _classifier;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef MATCHCREATOR_H
 #define MATCHCREATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -96,6 +96,8 @@ public:
    */
   QString getDescription() const { return _description; }
 
+  virtual QString getName() const = 0;
+
 protected:
 
   QString _description;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -96,6 +96,11 @@ public:
    */
   QString getDescription() const { return _description; }
 
+  /**
+   * Returns the name of the match creator
+   *
+   * @return a name string
+   */
   virtual QString getName() const = 0;
 
 protected:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
@@ -58,9 +58,12 @@ MatchPtr MatchFactory::createMatch(const ConstOsmMapPtr& map, ElementId eid1, El
 {
   LOG_VART(eid1);
   LOG_VART(eid2);
+  LOG_VART(_creators.size());
 
   for (size_t i = 0; i < _creators.size(); ++i)
   {
+    const QString name = _creators[i]->getName();
+    LOG_VART(name);
     MatchPtr m = _creators[i]->createMatch(map, eid1, eid2);
     if (m)
     {
@@ -314,5 +317,18 @@ void MatchFactory::reset()
   _creators.clear();
   _tagFilter = "";
 }
+
+QString MatchFactory::getCreatorsStr() const
+{
+  QString str;
+  for (size_t i = 0; i < _creators.size(); ++i)
+  {
+    const QString name = _creators[i]->getName();
+    str += name + ";";
+  }
+  str.chop(1);
+  return str;
+}
+
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
@@ -78,9 +78,11 @@ void MatchFactory::createMatches(const ConstOsmMapPtr& map, std::vector<ConstMat
   const Envelope& bounds, std::shared_ptr<const MatchThreshold> threshold) const
 {
   for (size_t i = 0; i < _creators.size(); ++i)
-  {
-    LOG_DEBUG("Launching match creator " << i + 1 << " / " << _creators.size() << "...");
+  { 
     std::shared_ptr<MatchCreator> matchCreator = _creators[i];
+    LOG_STATUS(
+      "Looking for matches with: " << matchCreator->getName() << " (" << i + 1 << " / " <<
+      _creators.size() << "): ...");
     _checkMatchCreatorBoundable(matchCreator, bounds);
     if (threshold.get())
     {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -95,8 +95,16 @@ public:
    */
   void registerCreator(const QString& c);
 
+  /**
+   * Removes all the creators from the factory
+   */
   void reset();
 
+  /**
+   * Returns a printable string with the names of all MatchCreators available from the factory
+   *
+   * @return a names string
+   */
   QString getCreatorsStr() const;
 
 private:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -86,7 +86,8 @@ public:
   /**
    * Registers the specified creator with the MergeFactory and takes ownership of the creator.
    */
-  void registerCreator(const std::shared_ptr<MatchCreator>& creator) { _creators.push_back(creator); }
+  void registerCreator(const std::shared_ptr<MatchCreator>& creator)
+  { _creators.push_back(creator); }
 
   /**
    * @brief registerCreator Register the specified creator by string (constructs the creator)
@@ -96,10 +97,16 @@ public:
 
   void reset();
 
+  QString getCreatorsStr() const;
+
 private:
 
   // allows for matching a subset of the input data
   QString _tagFilter;
+
+  static std::shared_ptr<MatchFactory> _theInstance;
+
+  std::vector<std::shared_ptr<MatchCreator>> _creators;
 
   MatchFactory();
 
@@ -109,10 +116,6 @@ private:
   static void _setTagFilter(QString filter) { _theInstance->_tagFilter = filter; }
 
   static void _tempFixDefaults();
-
-  static std::shared_ptr<MatchFactory> _theInstance;
-
-  std::vector<std::shared_ptr<MatchCreator>> _creators;
 
   friend class MatchCandidateCountVisitorTest;
   friend class MatchCandidateCountVisitorRndTest;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef MATCHFACTORY_H
 #define MATCHFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
@@ -92,7 +92,7 @@ void NetworkMatchCreator::createMatches(
 {
   QElapsedTimer timer;
   timer.start();
-  LOG_STATUS("Looking for matches with: " << className() << "...");
+  LOG_DEBUG("Looking for matches with: " << className() << "...");
   LOG_VART(threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef NETWORKMATCHCREATOR_H
 #define NETWORKMATCHCREATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.h
@@ -59,6 +59,8 @@ public:
 
   virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
+  virtual QString getName() const { return QString::fromStdString(className()); }
+
 private:
 
   std::shared_ptr<MatchThreshold> _matchThreshold;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -81,7 +81,7 @@ void PoiPolygonMatchCreator::createMatches(const ConstOsmMapPtr& map,
                                            std::vector<ConstMatchPtr>& matches,
                                            ConstMatchThresholdPtr threshold)
 {
-  LOG_STATUS("Looking for matches with: " << className() << "...");
+  LOG_DEBUG("Looking for matches with: " << className() << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -49,11 +49,11 @@ PoiPolygonMatchCreator::PoiPolygonMatchCreator()
 }
 
 MatchPtr PoiPolygonMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId eid1,
-                                           ElementId eid2)
+                                             ElementId eid2)
 {
   if (!_infoCache)
   {
-    LOG_TRACE("Initializing info cache...");
+    LOG_DEBUG("Initializing info cache...");
     _infoCache.reset(new PoiPolygonInfoCache(map));
   }
 
@@ -87,7 +87,7 @@ void PoiPolygonMatchCreator::createMatches(const ConstOsmMapPtr& map,
 
   if (!_infoCache)
   {
-    LOG_TRACE("Initializing info cache...");
+    LOG_DEBUG("Initializing info cache...");
     _infoCache.reset(new PoiPolygonInfoCache(map));
     _infoCache->setConfiguration(conf());
   }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.h
@@ -69,6 +69,8 @@ public:
 
   virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
+  virtual QString getName() const { return QString::fromStdString(className()); }
+
 private:
 
   std::shared_ptr<MatchThreshold> _matchThreshold;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -413,7 +413,7 @@ void BuildingMatchCreator::createMatches(const ConstOsmMapPtr& map,
 {
   QElapsedTimer timer;
   timer.start();
-  LOG_STATUS("Looking for matches with: " << className() << "...");
+  LOG_DEBUG("Looking for matches with: " << className() << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.h
@@ -67,6 +67,8 @@ public:
 
   virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
+  virtual QString getName() const { return QString::fromStdString(className()); }
+
 private:
 
   /// Don't use this directly. See below.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef BUILDINGMATCHCREATOR_H
 #define BUILDINGMATCHCREATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.cpp
@@ -191,7 +191,8 @@ void ReviewMarker::mark(const OsmMapPtr& map, const ElementPtr& e, const QString
   LOG_TRACE("Marking review with note: " << note);
 }
 
-void ReviewMarker::mark(const OsmMapPtr &map, const std::vector<ElementId>& ids, const QString& note,
+void ReviewMarker::mark(
+  const OsmMapPtr &map, const std::vector<ElementId>& ids, const QString& note,
   const QString& reviewType, double score, vector<QString> choices)
 {
   if (note.isEmpty())

--- a/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ReviewMarker.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef __ADD_HILBERT_REVIEW_SORT_ORDER_H__
 #define __ADD_HILBERT_REVIEW_SORT_ORDER_H__

--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
@@ -31,6 +31,7 @@
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/ops/OsmMapOperation.h>
 #include <hoot/core/info/OperationStatusInfo.h>
+#include <hoot/core/util/StringUtils.h>
 
 namespace hoot
 {
@@ -51,7 +52,7 @@ public:
   { return "Adding geospatial sorting tags to review relations..."; }
 
   virtual QString getCompletedStatusMessage() const
-  { return "Added " + QString::number(_numAffected) + " sorting tags"; }
+  { return "Added " + StringUtils::formatLargeNumber(_numAffected) + " sorting tags"; }
 
   virtual QString getDescription() const
   { return "Adds tags that enable sorting reviewable features geospatially"; }

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
@@ -79,8 +79,8 @@ void ManualMatchValidator::apply(const OsmMapPtr& map)
 
 void ManualMatchValidator::_validate(const ConstElementPtr& element)
 {
-  LOG_VARD(_requireRef1);
-  LOG_VARD(_allowUuidManualMatchIds);
+  LOG_VART(_requireRef1);
+  LOG_VART(_allowUuidManualMatchIds);
 
   // Just recording one error for each element for performance reasons, even if there are multiple.
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.cpp
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ManualMatchValidator.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.cpp
@@ -54,8 +54,8 @@ void RemoveDuplicateReviewsOp::apply(std::shared_ptr<OsmMap>& map)
   _map = map;
 
   // go through all the relations to get duplicate reviews
-
   LOG_DEBUG("Retrieving duplicate reviews...");
+
   int totalMembersToReview = 0;
   const RelationMap& relations = map->getRelations();
   QMap<set<ElementId>, QList<ReviewMarker::ReviewUid>> membersToReview;
@@ -73,16 +73,14 @@ void RemoveDuplicateReviewsOp::apply(std::shared_ptr<OsmMap>& map)
   LOG_VART(membersToReview);
 
   // loop through duplicate reviews
-
   LOG_DEBUG("Removing duplicate reviews...");
   LOG_VARD(MatchFactory::getInstance().getCreatorsStr());
+
   ReviewMarker reviewMarker;
   QMap<set<ElementId>, QList<ReviewMarker::ReviewUid>>::iterator it = membersToReview.begin();
   while (it != membersToReview.end())
   {
     set<ElementId> eids = it.key();
-
-    // remove duplicate reviews
 
     QList<ReviewMarker::ReviewUid> duplicateReviews = it.value();
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveDuplicateReviewsOp.cpp
@@ -75,6 +75,7 @@ void RemoveDuplicateReviewsOp::apply(std::shared_ptr<OsmMap>& map)
   // loop through duplicate reviews
 
   LOG_DEBUG("Removing duplicate reviews...");
+  LOG_VARD(MatchFactory::getInstance().getCreatorsStr());
   ReviewMarker reviewMarker;
   QMap<set<ElementId>, QList<ReviewMarker::ReviewUid>>::iterator it = membersToReview.begin();
   while (it != membersToReview.end())

--- a/hoot-core/src/main/cpp/hoot/core/ops/SearchRadiusCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SearchRadiusCalculator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "SearchRadiusCalculator.h"

--- a/hoot-core/src/main/cpp/hoot/core/ops/SearchRadiusCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SearchRadiusCalculator.cpp
@@ -31,13 +31,14 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
-#include <hoot/core/visitors/RemoveElementsVisitor.h>
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/criterion/ChainCriterion.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/StringUtils.h>
+#include <hoot/core/ops/CopyMapSubsetOp.h>
+#include <hoot/core/criterion/OrCriterion.h>
 
 using namespace std;
 
@@ -63,71 +64,35 @@ void SearchRadiusCalculator::setConfiguration(const Settings& conf)
 
 void SearchRadiusCalculator::apply(std::shared_ptr<OsmMap>& map)
 {
-  //make a copy of the map with previously conflated data removed, as the rubber sheeting can't
-  //use it
-  std::shared_ptr<OsmMap> mapWithOnlyUnknown1And2(new OsmMap(map));
-
   LOG_VARD(map->getElementCount());
-  LOG_DEBUG(
-    "Element count before search radius calculation filtering: " <<
-    StringUtils::formatLargeNumber(mapWithOnlyUnknown1And2->getElementCount()));
+
+  // We need to filter out feature that don't need to be included in the search radius calculation.
 
   // don't care about conflated data and invalid data
-  LOG_INFO("Removing invalid and previously conflated data for search radius calculation...");
-  size_t elementCountTemp = mapWithOnlyUnknown1And2->getElementCount();
-  RemoveElementsVisitor elementRemover1;
-  elementRemover1.setRecursive(true);
-  elementRemover1.addCriterion(ElementCriterionPtr(new StatusCriterion(Status::Conflated)));
-  mapWithOnlyUnknown1And2->visitRw(elementRemover1);
-  RemoveElementsVisitor elementRemover2;
-  elementRemover2.setRecursive(true);
-  elementRemover2.addCriterion(ElementCriterionPtr(new StatusCriterion(Status::Invalid)));
-  mapWithOnlyUnknown1And2->visitRw(elementRemover2);
-  if (mapWithOnlyUnknown1And2->getElementCount() < elementCountTemp)
+  ElementCriterionPtr crit;
+  ElementCriterionPtr unknownCrit(
+    new OrCriterion(
+      ElementCriterionPtr(new StatusCriterion(Status::Unknown1)),
+      ElementCriterionPtr(new StatusCriterion(Status::Unknown2))));
+  if (_elementCriterion.isEmpty())
   {
-    LOG_DEBUG(
-      "Filtered out: " <<
-      StringUtils::formatLargeNumber(elementCountTemp - mapWithOnlyUnknown1And2->getElementCount()) <<
-      " invalid or conflated elements.");
-    elementCountTemp = mapWithOnlyUnknown1And2->getElementCount();
+    crit = unknownCrit;
   }
-
-  // If a match candidate criterion was specified, filter out elements that don't fit the criterion.
-  // If no match candidate criterion was specified, then we'll use elements of all types.
-  // TODO: This logic doesn't support Generic Conflation calling scripts who implement the
-  // isMatchCandidate function. - see #3048
-  if (!_elementCriterion.isEmpty())
+  else
   {
-    LOG_DEBUG(
-      "Removing elements not satisfying: " << _elementCriterion <<
-      " for search radius calculation...");
-    std::shared_ptr<ElementCriterion> candidateCriterion(
+    // If a match candidate criterion was specified, filter out elements that don't fit the
+    // criterion. If no match candidate criterion was specified, then we'll use elements of all
+    // types.
+    // TODO: This logic doesn't support Generic Conflation calling scripts who implement the
+    // isMatchCandidate function. - see #3048
+    std::shared_ptr<ElementCriterion> candidateCrit(
       Factory::getInstance().constructObject<ElementCriterion>(_elementCriterion));
-    RemoveElementsVisitor elementRemover3(true);
-    elementRemover3.setRecursive(true);
-    elementRemover3.addCriterion(candidateCriterion);
-    mapWithOnlyUnknown1And2->visitRw(elementRemover3);
+    crit.reset(new ChainCriterion(unknownCrit, candidateCrit));
   }
-
-  LOG_VARD(map->getElementCount());
-  if (mapWithOnlyUnknown1And2->getElementCount() < elementCountTemp)
-  {
-    LOG_DEBUG(
-      "Filtered out: " <<
-      StringUtils::formatLargeNumber(elementCountTemp - mapWithOnlyUnknown1And2->getElementCount()) <<
-      " elements not satisfying " << _elementCriterion << ".");
-  }
-
-  if (map->getElementCount() > mapWithOnlyUnknown1And2->getElementCount())
-  {
-    //should this be a warning?
-    LOG_DEBUG(
-      "Skipping " <<
-      StringUtils::formatLargeNumber(map->getElementCount() - mapWithOnlyUnknown1And2->getElementCount()) <<
-      " features with conflated or invalid status out of " <<
-      StringUtils::formatLargeNumber(map->getElementCount()) << " total features.");
-  }
-  if (mapWithOnlyUnknown1And2->getElementCount() == 0)
+  CopyMapSubsetOp mapCopier(map, crit);
+  OsmMapPtr subsetMap(new OsmMap());
+  mapCopier.apply(subsetMap);
+  if (subsetMap->getElementCount() == 0)
   {
     _result = _circularError;
     LOG_INFO(
@@ -135,10 +100,9 @@ void SearchRadiusCalculator::apply(std::shared_ptr<OsmMap>& map)
       "filtered out. Using default search radius value = " << _result);
     return;
   }
-
   LOG_DEBUG(
     "Element count after search radius calculation filtering: " <<
-    StringUtils::formatLargeNumber(mapWithOnlyUnknown1And2->getElementCount()));
+    StringUtils::formatLargeNumber(subsetMap->getElementCount()));
 
   std::shared_ptr<RubberSheet> rubberSheet(new RubberSheet());
   rubberSheet->setReference(_rubberSheetRef);
@@ -147,7 +111,7 @@ void SearchRadiusCalculator::apply(std::shared_ptr<OsmMap>& map)
   rubberSheet->setLogWarningWhenRequirementsNotFound(false);
   try
   {
-    rubberSheet->calculateTransform(mapWithOnlyUnknown1And2);
+    rubberSheet->calculateTransform(/*mapWithOnlyUnknown1And2*/subsetMap);
   }
   catch (const HootException& e)
   {
@@ -159,13 +123,13 @@ void SearchRadiusCalculator::apply(std::shared_ptr<OsmMap>& map)
       "calculation.  Cleaning the data and attempting to calculate the transform again...");
     try
     {
-      MapCleaner().apply(mapWithOnlyUnknown1And2);
+      MapCleaner().apply(subsetMap);
       rubberSheet.reset(new RubberSheet());
       rubberSheet->setReference(_rubberSheetRef);
       rubberSheet->setMinimumTies(_minTies);
       rubberSheet->setFailWhenMinimumTiePointsNotFound(false);
       rubberSheet->setLogWarningWhenRequirementsNotFound(false);
-      rubberSheet->calculateTransform(mapWithOnlyUnknown1And2);
+      rubberSheet->calculateTransform(subsetMap);
     }
     catch (const HootException& e)
     {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
@@ -240,7 +240,7 @@ std::shared_ptr<Tgs::HilbertRTree>& PoiPolygonMatchVisitor::_getPolyIndex()
 {
   if (!_polyIndex)
   {
-    LOG_INFO("Creating polygon feature index...");
+    LOG_INFO("Creating POI/Polygon feature index...");
 
     // TODO: tune this? - see #3054
     std::shared_ptr<Tgs::MemoryPageStore> mps(new Tgs::MemoryPageStore(728));
@@ -257,7 +257,7 @@ std::shared_ptr<Tgs::HilbertRTree>& PoiPolygonMatchVisitor::_getPolyIndex()
     _getMap()->visitRelationsRo(v);
     v.finalizeIndex();
 
-    LOG_DEBUG("Polygon feature index created.");
+    LOG_DEBUG("POI/Polygon feature index created.");
   }
   return _polyIndex;
 }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
@@ -129,9 +129,9 @@ void ScriptMatch::_calculateClassification(const ConstOsmMapPtr& map, Handle<Obj
     {
       if (_explainText.isEmpty())
       {
-        throw IllegalArgumentException("If the match is a review an appropriate explanation must "
-                                       "be provided (E.g. { 'review': 1, "
-                                       "'explain': 'some reason' }.");
+        throw IllegalArgumentException(
+          "If the match is a review an appropriate explanation must be provided (E.g. "
+          "{ 'review': 1, 'explain': 'some reason' }.");
       }
     }
   }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -651,6 +651,11 @@ ScriptMatchCreator::~ScriptMatchCreator()
 {
 }
 
+void ScriptMatchCreator::init(const ConstOsmMapPtr& map)
+{
+  _getCachedVisitor(map)->initSearchRadiusInfo();
+}
+
 Meters ScriptMatchCreator::calculateSearchRadius(const ConstOsmMapPtr& map,
   const ConstElementPtr& e)
 {

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -102,27 +102,6 @@ public:
     // Calls to script functions/var are expensive, both memory-wise and processing-wise. Since this
     // constructor gets called repeatedly by createMatch, keep them out of this constructor.
 
-    // This sets up the search radius function, which gets called elsewhere. Needs to be done here
-    // or calls to ScriptMatchCreator::calculateSearchRadius will return inaccurate results when
-    // ScriptMatchCreator is called as a SearchBoundsCalculator.
-    Isolate* current = v8::Isolate::GetCurrent();
-    HandleScope handleScope(current);
-    Context::Scope context_scope(_script->getContext(current));
-    Handle<Object> plugin = getPlugin();
-    Handle<Value> value = plugin->Get(toV8("getSearchRadius"));
-    if (value->IsUndefined())
-    {
-      // pass
-    }
-    else if (value->IsFunction() == false)
-    {
-      throw HootException("getSearchRadius is not a function.");
-    }
-    else
-    {
-      _getSearchRadius.Reset(current, Handle<Function>::Cast(value));
-    }
-
     // Point/Polygon is not meant to conflate any polygons that are conflatable by other conflation
     // routines, hence the use of NonConflatableCriterion.
     std::shared_ptr<PolygonCriterion> polyCrit(new PolygonCriterion());
@@ -147,6 +126,20 @@ public:
     _customSearchRadius =
       getNumber(plugin, "searchRadius", -1.0, ConfigOptions().getCircularErrorDefaultValue());
     LOG_VART(_customSearchRadius);
+
+    Handle<Value> value = plugin->Get(toV8("getSearchRadius"));
+    if (value->IsUndefined())
+    {
+      // pass
+    }
+    else if (value->IsFunction() == false)
+    {
+      throw HootException("getSearchRadius is not a function.");
+    }
+    else
+    {
+      _getSearchRadius.Reset(current, Handle<Function>::Cast(value));
+    }
   }
 
   virtual QString getDescription() const { return ""; }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -46,6 +46,7 @@ class ScriptMatch;
  * Match creator for all generic conflation scripts
  *
  * @sa ScriptMatch
+ * @todo This class could use some refactoring after recent changes.
  */
 class ScriptMatchCreator : public MatchCreator, public SearchRadiusProvider
 {
@@ -102,7 +103,6 @@ private:
   QMap<QString, Meters> _cachedCustomSearchRadii;
   QMap<QString, double> _candidateDistanceSigmaCache;
   QMap<QString, CreatorDescription> _descriptionCache;
-  //QMap<QString, Persistent<Function>> _searchRadiusFunctionCache;
 
   std::shared_ptr<ChainCriterion> _pointPolyPolyCrit;
   std::shared_ptr<ChainCriterion> _pointPolyPointCrit;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -60,6 +60,9 @@ public:
 
   virtual ~ScriptMatchCreator();
 
+  /**
+   * @see SearchRadiusProvider
+   */
   virtual void init(const ConstOsmMapPtr& map) override;
 
   /**
@@ -68,7 +71,7 @@ public:
   virtual Meters calculateSearchRadius(const ConstOsmMapPtr& map, const ConstElementPtr& e) override;
 
   /**
-   * Not implemented.
+   * @see MatchCreator
    */
   virtual MatchPtr createMatch(const ConstOsmMapPtr&, ElementId, ElementId) override;
 
@@ -78,8 +81,14 @@ public:
   virtual void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
     ConstMatchThresholdPtr threshold) override;
 
+  /**
+   * @see MatchCreator
+   */
   virtual std::vector<CreatorDescription> getAllCreators() const override;
 
+  /**
+   * @see MatchCreator
+   */
   virtual void setArguments(QStringList args) override;
 
   /**
@@ -91,8 +100,14 @@ public:
    */
   virtual bool isMatchCandidate(ConstElementPtr element, const ConstOsmMapPtr& map) override;
 
+  /**
+   * @see MatchCreator
+   */
   virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
+  /**
+   * @see MatchCreator
+   */
   virtual QString getName() const override;
 
 private:

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -30,6 +30,7 @@
 #include <hoot/core/conflate/SearchRadiusProvider.h>
 #include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/criterion/ChainCriterion.h>
 
 #include <hoot/js/PluginContext.h>
 
@@ -86,16 +87,21 @@ public:
 
   virtual std::shared_ptr<MatchThreshold> getMatchThreshold() override;
 
+  virtual QString getName() const override;
+
 private:
 
   std::shared_ptr<PluginContext> _script;
   QString _scriptPath;
 
-  CreatorDescription _getScriptDescription(QString path) const;
-
   std::shared_ptr<ScriptMatchVisitor> _cachedScriptVisitor;
   std::shared_ptr<MatchThreshold> _matchThreshold;
   QMap<QString, Meters> _cachedCustomSearchRadii;
+
+  std::shared_ptr<ChainCriterion> _pointPolyPolyCrit;
+  std::shared_ptr<ChainCriterion> _pointPolyPointCrit;
+
+  CreatorDescription _getScriptDescription(QString path) const;
 
   std::shared_ptr<ScriptMatchVisitor> _getCachedVisitor(const ConstOsmMapPtr& map);
 };

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -60,6 +60,8 @@ public:
 
   virtual ~ScriptMatchCreator();
 
+  virtual void init(const ConstOsmMapPtr& map) override;
+
   /**
    * @see SearchRadiusProvider
    */

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -34,7 +34,7 @@
 
 #include <hoot/js/PluginContext.h>
 
-using namespace v8;
+//using namespace v8;
 
 namespace hoot
 {
@@ -106,12 +106,6 @@ private:
 
   std::shared_ptr<ChainCriterion> _pointPolyPolyCrit;
   std::shared_ptr<ChainCriterion> _pointPolyPointCrit;
-
-  // maps plugin script file path to a set of matches found by that script and recorded by
-  // ScriptMatchVisitor
-  QMap<QString, QHash<QString, std::shared_ptr<ScriptMatch>>> _matchCache;
-
-  QMap<QString, QHash<ElementId, bool>> _matchCandidateCache;
 
   CreatorDescription _getScriptDescription(QString path) const;
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -34,10 +34,13 @@
 
 #include <hoot/js/PluginContext.h>
 
+using namespace v8;
+
 namespace hoot
 {
 
 class ScriptMatchVisitor;
+class ScriptMatch;
 
 /**
  * Match creator for all generic conflation scripts
@@ -97,9 +100,18 @@ private:
   std::shared_ptr<ScriptMatchVisitor> _cachedScriptVisitor;
   std::shared_ptr<MatchThreshold> _matchThreshold;
   QMap<QString, Meters> _cachedCustomSearchRadii;
+  QMap<QString, double> _candidateDistanceSigmaCache;
+  QMap<QString, CreatorDescription> _descriptionCache;
+  //QMap<QString, Persistent<Function>> _searchRadiusFunctionCache;
 
   std::shared_ptr<ChainCriterion> _pointPolyPolyCrit;
   std::shared_ptr<ChainCriterion> _pointPolyPointCrit;
+
+  // maps plugin script file path to a set of matches found by that script and recorded by
+  // ScriptMatchVisitor
+  QMap<QString, QHash<QString, std::shared_ptr<ScriptMatch>>> _matchCache;
+
+  QMap<QString, QHash<ElementId, bool>> _matchCandidateCache;
 
   CreatorDescription _getScriptDescription(QString path) const;
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.h
@@ -30,11 +30,9 @@
 #include <hoot/core/conflate/SearchRadiusProvider.h>
 #include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/util/NotImplementedException.h>
-#include <hoot/core/criterion/ChainCriterion.h>
+#include <hoot/core/criterion/ElementCriterion.h>
 
 #include <hoot/js/PluginContext.h>
-
-//using namespace v8;
 
 namespace hoot
 {
@@ -121,8 +119,8 @@ private:
   QMap<QString, double> _candidateDistanceSigmaCache;
   QMap<QString, CreatorDescription> _descriptionCache;
 
-  std::shared_ptr<ChainCriterion> _pointPolyPolyCrit;
-  std::shared_ptr<ChainCriterion> _pointPolyPointCrit;
+  ElementCriterionPtr _pointPolyPolyCrit;
+  ElementCriterionPtr _pointPolyPointCrit;
 
   CreatorDescription _getScriptDescription(QString path) const;
 


### PR DESCRIPTION
* Removes a bottleneck exposed by `RemoveDuplicateReviewsOp` where the constructor of `ScriptMatchVisitor` was called repeatedly and had several script calls which are very expensives
* This fix prevents somalia 3 and poi 6 regression tests from failing.