### PR TITLE
add some logging around job cancel, don't show failed message

### DIFF
--- a/hoot-services/src/main/java/hoot/services/command/ExternalCommandRunnerImpl.java
+++ b/hoot-services/src/main/java/hoot/services/command/ExternalCommandRunnerImpl.java
@@ -333,6 +333,9 @@ public class ExternalCommandRunnerImpl implements ExternalCommandRunner {
     public void terminate() {
         if (!this.watchDog.killedProcess()) {
             this.watchDog.destroyProcess();
+            logger.info("destroy processd");
+        } else {
+            logger.info("process already killed");
         }
     }
 }

--- a/hoot-services/src/main/java/hoot/services/job/JobRunnable.java
+++ b/hoot-services/src/main/java/hoot/services/job/JobRunnable.java
@@ -81,7 +81,9 @@ class JobRunnable implements Runnable {
                 CommandResult result = command.execute();
 
                 if (result.failed()) {
-                    jobStatusManager.setFailed(job.getJobId(), "Command with ID = " + result.getId() + " caused the failure.");
+                    if (JobStatus.FAILED.equals(jobStatusManager.getJobStatusObj(job.getJobId()).getStatus())) {
+                        jobStatusManager.setFailed(job.getJobId(), "Command with ID = " + result.getId() + " caused the failure.");
+                    }
                     break;
                 }
                 else {


### PR DESCRIPTION
refs https://github.com/ngageoint/hootenanny-ui/issues/1729

adds some logging to see when the process terminate call is made vs when the executor receives the exit code.  For conflate commands (vs import or export) a ~30 second delay between the two has been observed.