### PR TITLE
3768 - Remove unnecessary feature copying from diff conflate

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "DiffConflator.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -59,6 +59,7 @@
 #include <hoot/core/io/OsmChangesetFileWriterFactory.h>
 #include <hoot/core/io/OsmChangesetFileWriter.h>
 #include <hoot/core/ops/CopyMapSubsetOp.h>
+#include <hoot/core/criterion/NotCriterion.h>
 
 // standard
 #include <algorithm>
@@ -296,10 +297,10 @@ void DiffConflator::storeOriginalMap(OsmMapPtr& pMap)
   _pOriginalMap.reset(new OsmMap(pMap));
 
   // We're storing this off for potential use later on if any roads get snapped after conflation.
-  // Just keep ref1. See additional comments in _getChangesetFromMap.
-  // TODO: Can we filter this down even more to roads or whatever feature type the snapping is
-  // configured for?
-  ElementCriterionPtr crit(new TagKeyCriterion(MetadataTags::Ref1()));
+  // Get rid of ref2 and children. See additional comments in _getChangesetFromMap.
+  // TODO: Can we filter this down to whatever feature type the snapping is configured for?
+  std::shared_ptr<NotCriterion> crit(
+    new NotCriterion(ElementCriterionPtr(new TagKeyCriterion(MetadataTags::Ref2()))));
   CopyMapSubsetOp mapCopier(pMap, crit);
   _pOriginalRef1Map.reset(new OsmMap());
   mapCopier.apply(_pOriginalRef1Map);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -58,6 +58,7 @@
 #include <hoot/core/visitors/RemoveElementsVisitor.h>
 #include <hoot/core/io/OsmChangesetFileWriterFactory.h>
 #include <hoot/core/io/OsmChangesetFileWriter.h>
+#include <hoot/core/ops/CopyMapSubsetOp.h>
 
 // standard
 #include <algorithm>
@@ -291,17 +292,17 @@ void DiffConflator::storeOriginalMap(OsmMapPtr& pMap)
       "elements. ");
   }
 
-  // Use the copy constructor
+  // Use the copy constructor to copy the entire map.
   _pOriginalMap.reset(new OsmMap(pMap));
 
   // We're storing this off for potential use later on if any roads get snapped after conflation.
-  // See additional comments in _getChangesetFromMap.
-  _pOriginalRef1Map.reset(new OsmMap(pMap));
-  ElementCriterionPtr pTagKeyCrit(new TagKeyCriterion(MetadataTags::Ref2()));
-  RemoveElementsVisitor removeRef2Visitor;
-  removeRef2Visitor.setRecursive(true);
-  removeRef2Visitor.addCriterion(pTagKeyCrit);
-  _pOriginalRef1Map->visitRw(removeRef2Visitor);
+  // Just keep ref1. See additional comments in _getChangesetFromMap.
+  // TODO: Can we filter this down even more to roads or whatever feature type the snapping is
+  // configured for?
+  ElementCriterionPtr crit(new TagKeyCriterion(MetadataTags::Ref1()));
+  CopyMapSubsetOp mapCopier(pMap, crit);
+  _pOriginalRef1Map.reset(new OsmMap());
+  mapCopier.apply(_pOriginalRef1Map);
 }
 
 void DiffConflator::markInputElements(OsmMapPtr pMap)


### PR DESCRIPTION
The part which saves off the map to make the way snapping work in the output changeset was copying more features than it needed to.