### PR TITLE
Make building search radius configurable

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -4159,6 +4159,13 @@ debugging tests which may hang on a remote build server.
 
 The search radius, in meters, to use when conflating areas. See `search.radius.default`
 
+=== search.radius.building
+
+* Data Type: double
+* Default Value: `${search.radius.default}`
+
+The search radius, in meters, to use when conflating buildings. See `search.radius.default`.
+
 === search.radius.calculator.element.criterion
 
 * Data Type: string

--- a/conf/services/conflationTypes.json
+++ b/conf/services/conflationTypes.json
@@ -2,6 +2,7 @@
     "General": {
         "members": {
             "add.review.tags.to.features": "Add review tags to individual features",
+            "circular.error.default.value": "Default accuracy for loaded data; default to 15m. Generally the higher the value, more matches may be found but the longer the conflate time.",
             "corner.splitter.rounded.split": "Round corners when splitting",
             "overwrite.tag.merger.exclude": "Tag overwrite exclude list",
             "review.score.criterion.max.threshold": "Maximum review score",
@@ -59,7 +60,8 @@
             "building.match.threshold": "Score threshold for matching",
             "building.merge.many.to.many.matches": "Always merge many to many matches",
             "building.review.if.secondary.newer": "Review if secondary feature is newer",
-            "building.review.matches.other.than.one.to.one": "Review matches that are not one to one"
+            "building.review.matches.other.than.one.to.one": "Review matches that are not one to one",
+            "search.radius.building": "Building search radius (m)"
         }
     },
     "GenericLines": {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -327,7 +327,19 @@ void HighwayMatchCreator::createMatches(
 {
   QElapsedTimer timer;
   timer.start();
-  LOG_DEBUG("Looking for matches with: " << className() << "...");
+
+  QString searchRadiusStr;
+  const double searchRadius = ConfigOptions().getSearchRadiusHighway();
+  if (searchRadius < 0)
+  {
+    searchRadiusStr = "within a feature dependent search radius";
+  }
+  else
+  {
+    searchRadiusStr =
+      "within a search radius of " + QString::number(searchRadius, 'g', 2) + " meters";
+  }
+  LOG_STATUS("Looking for matches with: " << className() << " " << searchRadiusStr << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
@@ -92,7 +92,19 @@ void NetworkMatchCreator::createMatches(
 {
   QElapsedTimer timer;
   timer.start();
-  LOG_DEBUG("Looking for matches with: " << className() << "...");
+
+  QString searchRadiusStr;
+  const double searchRadius = ConfigOptions().getSearchRadiusHighway();
+  if (searchRadius < 0)
+  {
+    searchRadiusStr = "within a feature dependent search radius";
+  }
+  else
+  {
+    searchRadiusStr =
+      "within a search radius of " + QString::number(searchRadius, 'g', 2) + " meters";
+  }
+  LOG_STATUS("Looking for matches with: " << className() << " " << searchRadiusStr << "...");
   LOG_VART(threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -81,7 +81,24 @@ void PoiPolygonMatchCreator::createMatches(const ConstOsmMapPtr& map,
                                            std::vector<ConstMatchPtr>& matches,
                                            ConstMatchThresholdPtr threshold)
 {
-  LOG_DEBUG("Looking for matches with: " << className() << "...");
+  QElapsedTimer timer;
+  timer.start();
+
+  //poi.polygon.additional.search.distance
+  //poi.polygon.match.distance.threshold
+  QString searchRadiusStr;
+  const double additionalDistance = ConfigOptions().getPoiPolygonAdditionalSearchDistance();
+  if (additionalDistance <= 0)
+  {
+    searchRadiusStr = "within a feature dependent search radius";
+  }
+  else
+  {
+    searchRadiusStr =
+      "within a feature dependent search radius plus an additional distance of " +
+      QString::number(additionalDistance, 'g', 2) + " meters";
+  }
+  LOG_STATUS("Looking for matches with: " << className() << " " << searchRadiusStr << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 
@@ -94,8 +111,6 @@ void PoiPolygonMatchCreator::createMatches(const ConstOsmMapPtr& map,
 
   PoiPolygonMatch::resetMatchDistanceInfo();
 
-  QElapsedTimer timer;
-  timer.start();
   PoiPolygonMatchVisitor matchVis(map, matches, threshold, _getRf(), _infoCache, _filter);
   map->visitNodesRo(matchVis);
   const int matchesSizeAfter = matches.size();

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -104,6 +104,7 @@ public:
     _numElementsVisited = 0;
     _numMatchCandidatesVisited = 0;
     _taskStatusUpdateInterval = ConfigOptions().getTaskStatusUpdateInterval();
+    _searchRadius = ConfigOptions().getSearchRadiusBuilding();
   }
 
   ~BuildingMatchVisitor()
@@ -190,8 +191,17 @@ public:
 
   Meters getSearchRadius(const std::shared_ptr<const Element>& e) const
   {
-    LOG_VART(e->getCircularError());
-    return e->getCircularError();
+    Meters searchRadius;
+    if (_searchRadius >= 0)
+    {
+      searchRadius = _searchRadius;
+    }
+    else
+    {
+      searchRadius = e->getCircularError();
+    }
+    LOG_VART(searchRadius);
+    return searchRadius;
   }
 
   virtual void visit(const ConstElementPtr& e)
@@ -276,6 +286,7 @@ private:
   int _neighborCountSum;
   int _elementsEvaluated;
   size_t _maxGroupSize;
+  Meters _searchRadius;
   /// reject any manipulation with a miss score >= _rejectScore
   double _rejectScore;
 
@@ -413,7 +424,19 @@ void BuildingMatchCreator::createMatches(const ConstOsmMapPtr& map,
 {
   QElapsedTimer timer;
   timer.start();
-  LOG_DEBUG("Looking for matches with: " << className() << "...");
+
+  QString searchRadiusStr;
+  const double searchRadius = ConfigOptions().getSearchRadiusBuilding();
+  if (searchRadius < 0)
+  {
+    searchRadiusStr = "within a feature dependent search radius";
+  }
+  else
+  {
+    searchRadiusStr =
+      "within a search radius of " + QString::number(searchRadius, 'g', 2) + " meters";
+  }
+  LOG_STATUS("Looking for matches with: " << className() << " " << searchRadiusStr << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 


### PR DESCRIPTION
It was the only one left that wasn't. Also exposed `error.circular.default` in the adv opts.